### PR TITLE
test: add projects e2e tests

### DIFF
--- a/integration_testing/helpers/cleanup.go
+++ b/integration_testing/helpers/cleanup.go
@@ -8,6 +8,25 @@ import (
 	sonargo "github.com/boxboxjason/sonarqube-client-go/sonar"
 )
 
+// IgnoreNotFoundError returns nil if the error indicates a resource was not found,
+// otherwise returns the original error. This is useful in cleanup functions where
+// the resource may have already been deleted by the test itself.
+func IgnoreNotFoundError(err error) error {
+	if err == nil {
+		return nil
+	}
+	// Check if the error message contains "not found" or similar patterns
+	// that indicate the resource doesn't exist
+	errStr := strings.ToLower(err.Error())
+	if strings.Contains(errStr, "not found") ||
+		strings.Contains(errStr, "does not exist") ||
+		strings.Contains(errStr, "404") {
+		return nil
+	}
+
+	return err
+}
+
 // CleanupManager manages cleanup of e2e test resources.
 type CleanupManager struct {
 	client    *sonargo.Client


### PR DESCRIPTION
### Description of your changes

Create complete, comprehensive e2e tests for the Projects Service.

Closes #83 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
