### PR TITLE
test: add project dump e2e tests

### DIFF
--- a/integration_testing/project_dump_test.go
+++ b/integration_testing/project_dump_test.go
@@ -1,0 +1,201 @@
+package integration_testing_test
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	sonargo "github.com/boxboxjason/sonarqube-client-go/sonar"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+)
+
+var _ = Describe("ProjectDump Service", Ordered, func() {
+	var (
+		client  *sonargo.Client
+		cleanup *helpers.CleanupManager
+	)
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+		cleanup = helpers.NewCleanupManager(client)
+	})
+
+	AfterAll(func() {
+		cleanup.Cleanup()
+	})
+
+	// =========================================================================
+	// Export
+	// =========================================================================
+	Describe("Export", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.ProjectDump.Export(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+
+			It("should fail without required key", func() {
+				result, resp, err := client.ProjectDump.Export(&sonargo.ProjectDumpExportOption{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Key"))
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should fail for non-existent project", func() {
+				result, resp, err := client.ProjectDump.Export(&sonargo.ProjectDumpExportOption{
+					Key: "non-existent-project-key",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+				Expect(result).To(BeNil())
+			})
+
+			It("should successfully trigger export for existing project", func() {
+				// Create a project for testing
+				projectKey := helpers.UniqueResourceName("dump-export")
+				_, resp, err := client.Projects.Create(&sonargo.ProjectsCreateOption{
+					Name:    projectKey,
+					Project: projectKey,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				cleanup.RegisterCleanup("project", projectKey, func() error {
+					_, err := client.Projects.Delete(&sonargo.ProjectsDeleteOption{Project: projectKey})
+					return err
+				})
+
+				// Trigger export
+				result, resp, err := client.ProjectDump.Export(&sonargo.ProjectDumpExportOption{
+					Key: projectKey,
+				})
+
+				// Export may succeed or fail depending on server configuration
+				// Community edition may not support project export
+				if err != nil {
+					// Accept that export may not be available
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(Equal(http.StatusOK))
+					Expect(result).NotTo(BeNil())
+					Expect(result.ProjectKey).To(Equal(projectKey))
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Status
+	// =========================================================================
+	Describe("Status", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.ProjectDump.Status(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+
+			It("should fail without id or key", func() {
+				result, resp, err := client.ProjectDump.Status(&sonargo.ProjectDumpStatusOption{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("ID or Key"))
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should fail for non-existent project by key", func() {
+				result, resp, err := client.ProjectDump.Status(&sonargo.ProjectDumpStatusOption{
+					Key: "non-existent-project-key",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+				Expect(result).To(BeNil())
+			})
+
+			It("should get status for existing project by key", func() {
+				// Create a project for testing
+				projectKey := helpers.UniqueResourceName("dump-status")
+				_, resp, err := client.Projects.Create(&sonargo.ProjectsCreateOption{
+					Name:    projectKey,
+					Project: projectKey,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				cleanup.RegisterCleanup("project", projectKey, func() error {
+					_, err := client.Projects.Delete(&sonargo.ProjectsDeleteOption{Project: projectKey})
+					return err
+				})
+
+				// Get status
+				result, resp, err := client.ProjectDump.Status(&sonargo.ProjectDumpStatusOption{
+					Key: projectKey,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				Expect(result).NotTo(BeNil())
+				// CanBeExported may be true or false depending on server edition
+			})
+		})
+	})
+
+	// =========================================================================
+	// Full Workflow
+	// =========================================================================
+	Describe("Full Workflow", func() {
+		Context("Project Export Status Lifecycle", func() {
+			It("should handle project dump status workflow", func() {
+				// Create a project
+				projectKey := helpers.UniqueResourceName("dump-workflow")
+				_, resp, err := client.Projects.Create(&sonargo.ProjectsCreateOption{
+					Name:    projectKey,
+					Project: projectKey,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				cleanup.RegisterCleanup("project", projectKey, func() error {
+					_, err := client.Projects.Delete(&sonargo.ProjectsDeleteOption{Project: projectKey})
+					return err
+				})
+
+				// Check initial status
+				status, resp, err := client.ProjectDump.Status(&sonargo.ProjectDumpStatusOption{
+					Key: projectKey,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				Expect(status).NotTo(BeNil())
+
+				// If export is available, try to trigger it
+				if status.CanBeExported {
+					result, resp, err := client.ProjectDump.Export(&sonargo.ProjectDumpExportOption{
+						Key: projectKey,
+					})
+					if err == nil {
+						Expect(resp.StatusCode).To(Equal(http.StatusOK))
+						Expect(result).NotTo(BeNil())
+						Expect(result.ProjectKey).To(Equal(projectKey))
+					}
+				}
+			})
+		})
+	})
+})


### PR DESCRIPTION
### Description of your changes

Create complete, comprehensive e2e tests for the Project Dump Service.

Closes #108 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
