### PR TITLE
test: add github provisioning e2e tests

### DIFF
--- a/integration_testing/github_provisioning_test.go
+++ b/integration_testing/github_provisioning_test.go
@@ -1,14 +1,14 @@
 package integration_testing_test
 
 import (
-"net/http"
+	"net/http"
 
-. "github.com/onsi/ginkgo/v2"
-. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
-sonargo "github.com/boxboxjason/sonarqube-client-go/sonar"
+	sonargo "github.com/boxboxjason/sonarqube-client-go/sonar"
 
-"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
 )
 
 var _ = Describe("GithubProvisioning Service", Ordered, func() {
@@ -24,6 +24,8 @@ var _ = Describe("GithubProvisioning Service", Ordered, func() {
 	// =========================================================================
 	// Check
 	// =========================================================================
+	// Note: The GithubProvisioning service only exposes the Check() method.
+	// Enable/disable flows mentioned in issue #121 are not available via the API.
 	Describe("Check", func() {
 		Context("Functional Tests", func() {
 			It("should check GitHub provisioning configuration", func() {
@@ -38,6 +40,33 @@ var _ = Describe("GithubProvisioning Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
+			})
+
+			It("should return valid provisioning status structure", func() {
+				result, resp, err := client.GithubProvisioning.Check()
+				// Skip if GitHub integration is not configured
+				if resp != nil && (resp.StatusCode == http.StatusNotFound ||
+					resp.StatusCode == http.StatusBadRequest ||
+					resp.StatusCode == http.StatusUnauthorized ||
+					resp.StatusCode == http.StatusForbidden) {
+					Skip("GitHub provisioning is not configured or API not available in this SonarQube instance")
+				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				Expect(result).NotTo(BeNil())
+
+				// Verify Application level status exists and has proper structure
+				Expect(result.Application.AutoProvisioning.Status).NotTo(BeNil())
+				Expect(result.Application.Jit.Status).NotTo(BeNil())
+
+				// If installations are present, verify their structure
+				if len(result.Installations) > 0 {
+					for _, installation := range result.Installations {
+						Expect(installation.Organization).NotTo(BeEmpty())
+						Expect(installation.AutoProvisioning.Status).NotTo(BeNil())
+						Expect(installation.Jit.Status).NotTo(BeNil())
+					}
+				}
 			})
 		})
 	})


### PR DESCRIPTION
### Description of your changes

Create complete, comprehensive e2e tests for the GitHub provisionning Service.

Closes #121 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
