### PR TITLE
test: add l10n e2e tests

### DIFF
--- a/integration_testing/l10n_test.go
+++ b/integration_testing/l10n_test.go
@@ -1,18 +1,21 @@
 package integration_testing_test
 
 import (
-"net/http"
+	"net/http"
+	"time"
 
-. "github.com/onsi/ginkgo/v2"
-. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
-sonargo "github.com/boxboxjason/sonarqube-client-go/sonar"
+	sonargo "github.com/boxboxjason/sonarqube-client-go/sonar"
 
-"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
 )
 
 var _ = Describe("L10N Service", Ordered, func() {
-	var client *sonargo.Client
+	var (
+		client *sonargo.Client
+	)
 
 	BeforeAll(func() {
 		var err error
@@ -25,7 +28,20 @@ var _ = Describe("L10N Service", Ordered, func() {
 	// Index
 	// =========================================================================
 	Describe("Index", func() {
-		Context("Functional Tests", func() {
+		Context("Parameter Validation", func() {
+			It("should work with nil options", func() {
+				result, resp, err := client.L10N.Index(nil)
+				// Skip if API not available
+				if resp != nil && resp.StatusCode == http.StatusNotFound {
+					Skip("L10N API is not available in this SonarQube version")
+				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				Expect(result).NotTo(BeNil())
+			})
+		})
+
+		Context("Default Locale", func() {
 			It("should get localization messages with default locale", func() {
 				result, resp, err := client.L10N.Index(nil)
 				// Skip if API not available
@@ -35,9 +51,26 @@ var _ = Describe("L10N Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
-				Expect(result.Messages).NotTo(BeEmpty())
-			})
 
+				// Verify locale if returned (some SonarQube versions may not include it)
+				if result.Locale != "" {
+					Expect(result.Locale).To(Equal("en"))
+				}
+				Expect(result.Messages).NotTo(BeEmpty())
+
+				// Check for common translation keys
+				_, hasCommonKey := result.Messages["quality_gates.operator.LT"]
+				if !hasCommonKey {
+					_, hasCommonKey = result.Messages["projects.create_project"]
+				}
+				if !hasCommonKey {
+					_, hasCommonKey = result.Messages["issues.type.BUG"]
+				}
+				Expect(hasCommonKey).To(BeTrue(), "Should contain at least one common translation key")
+			})
+		})
+
+		Context("Specific Locale", func() {
 			It("should get localization messages for specific locale", func() {
 				result, resp, err := client.L10N.Index(&sonargo.L10NIndexOption{
 					Locale: "en",
@@ -49,12 +82,57 @@ var _ = Describe("L10N Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
+
+				// Verify locale if returned (some SonarQube versions may not include it)
+				if result.Locale != "" {
+					Expect(result.Locale).To(Equal("en"))
+				}
 				Expect(result.Messages).NotTo(BeEmpty())
 			})
+		})
 
+		Context("Compare Different Locales", func() {
+			It("should return different translations for different locales if available", func() {
+				// Get English locale
+				resultEN, respEN, err := client.L10N.Index(&sonargo.L10NIndexOption{
+					Locale: "en",
+				})
+				// Skip if API not available
+				if respEN != nil && respEN.StatusCode == http.StatusNotFound {
+					Skip("L10N API is not available in this SonarQube version")
+				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(respEN.StatusCode).To(Equal(http.StatusOK))
+
+				// Try to get French locale
+				resultFR, respFR, err := client.L10N.Index(&sonargo.L10NIndexOption{
+					Locale: "fr",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(respFR.StatusCode).To(Equal(http.StatusOK))
+
+				// If locales are returned and French is available, verify they differ
+				if resultEN.Locale != "" && resultFR.Locale != "" && resultFR.Locale == "fr" {
+					Expect(resultEN.Locale).NotTo(Equal(resultFR.Locale))
+					// Find a common key and compare translations if possible
+					for key := range resultEN.Messages {
+						if valFR, exists := resultFR.Messages[key]; exists {
+							// If the same key exists in both, the structure is valid
+							// (translations may or may not differ depending on the key)
+							_ = valFR
+							break
+						}
+					}
+				}
+			})
+		})
+
+		Context("With Timestamp", func() {
 			It("should get localization messages with timestamp", func() {
+				// Use a recent timestamp (1 year ago)
+				oneYearAgo := time.Now().AddDate(-1, 0, 0).Format("2006-01-02T15:04:05-0700")
 				result, resp, err := client.L10N.Index(&sonargo.L10NIndexOption{
-					Timestamp: "2020-01-01T00:00:00+0000",
+					Timestamp: oneYearAgo,
 				})
 				// Skip if API not available
 				if resp != nil && resp.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
### Description of your changes

Create complete, comprehensive e2e tests for the L10N  Service.

Closes #122 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
