### PR TITLE
chore(deps): bump sonarqube version to 2026.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ target_dir := sonar
 endpoint := http://127.0.0.1:9000
 username := admin
 password := admin
-sonarqube_version := 26.1.0.118079-community
+sonarqube_version := 26.2.0.119303-community
 
 # Automatically detect container engine (docker or podman)
 ifeq ($(shell command -v docker 2>/dev/null),)

--- a/assets/api.json
+++ b/assets/api.json
@@ -3007,6 +3007,10 @@
           "hasResponseExample": true,
           "changelog": [
             {
+              "description": "Param \u0027complianceStandards\u0027 has been added",
+              "version": "2025.6"
+            },
+            {
               "description": "Added parameter \u0027stig-ASD_V5R3\u0027 and \u0027casa\u0027",
               "version": "10.7"
             },
@@ -3053,6 +3057,14 @@
               "since": "10.7",
               "required": false,
               "internal": false
+            },
+            {
+              "key": "complianceStandards",
+              "description": "Comma-separated list of compliance standards",
+              "since": "2025.6",
+              "required": false,
+              "internal": false,
+              "exampleValue": "asvs:4.0.3\u003d6.1.2"
             },
             {
               "key": "cwe",

--- a/sonar/hotspots_service.go
+++ b/sonar/hotspots_service.go
@@ -400,6 +400,9 @@ type HotspotsSearchOption struct {
 	// Casa is a comma-separated list of CASA categories.
 	// This field is optional. Since: 10.7.
 	Casa []string `url:"casa,omitempty,comma"`
+	// ComplianceStandards is a list of compliance standards.
+	// This field is optional. Since: 2025.6.
+	ComplianceStandards []string `url:"complianceStandards,omitempty,comma"`
 	// Cwe is a comma-separated list of CWE numbers.
 	// This field is optional. Since: 8.8.
 	Cwe []string `url:"cwe,omitempty,comma"`


### PR DESCRIPTION
### Description of your changes

This PR migrates sonarqube from 2026.1 to 2026.2.

There was a single change to the API spec: in `GET api/hotspots/search`, the parameter `complianceStandards` was added (it does not require changing the unit tests or e2e tests)


I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [ ] Added unit tests to cover the code changes.
- [ ] Added end-to-end tests if necessary.
