### PR TITLE
style!: rename Option structs to Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ func main() {
  url := "https://your-sonarqube-instance.com"
  token := "your-sonarqube-token"
 
- client, err := sonar.NewClient(&sonar.ClientCreateOption{
+ client, err := sonar.NewClient(&sonar.ClientCreateOptions{
   URL:   &url,
   Token: &token,
  })
@@ -246,7 +246,7 @@ func main() {
  }
 
  // Search for projects
- projects, _, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOption{
+ projects, _, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
   Ps: sonar.Int(10),
  })
  if err != nil {
@@ -259,7 +259,7 @@ func main() {
  }
 
  // Search for open issues
- issues, _, err := client.Issues.Search(context.Background(), &sonar.IssuesSearchOption{
+ issues, _, err := client.Issues.Search(context.Background(), &sonar.IssuesSearchOptions{
   Projects: sonar.String("my-project-key"),
   Statuses: sonar.String("OPEN,CONFIRMED"),
  })
@@ -276,7 +276,7 @@ func main() {
 **Token authentication (recommended):**
 
 ```go
-client, err := sonar.NewClient(&sonar.ClientCreateOption{
+client, err := sonar.NewClient(&sonar.ClientCreateOptions{
  URL:   &url,
  Token: &token,
 })
@@ -285,7 +285,7 @@ client, err := sonar.NewClient(&sonar.ClientCreateOption{
 **Username/password authentication:**
 
 ```go
-client, err := sonar.NewClient(&sonar.ClientCreateOption{
+client, err := sonar.NewClient(&sonar.ClientCreateOptions{
  URL:      &url,
  Username: &username,
  Password: &password,
@@ -302,7 +302,7 @@ import "time"
 
 httpClient := &http.Client{Timeout: 60 * time.Second}
 
-client, err := sonar.NewClient(&sonar.ClientCreateOption{
+client, err := sonar.NewClient(&sonar.ClientCreateOptions{
  URL:        &url,
  Token:      &token,
  HttpClient: httpClient,
@@ -312,7 +312,7 @@ client, err := sonar.NewClient(&sonar.ClientCreateOption{
 **Quality gate status:**
 
 ```go
-status, _, err := client.Qualitygates.ProjectStatus(ctx, &sonar.QualitygatesProjectStatusOption{
+status, _, err := client.Qualitygates.ProjectStatus(ctx, &sonar.QualitygatesProjectStatusOptions{
  ProjectKey: sonar.String("my-project"),
 })
 fmt.Printf("Quality Gate: %s\n", status.ProjectStatus.Status)
@@ -321,7 +321,7 @@ fmt.Printf("Quality Gate: %s\n", status.ProjectStatus.Status)
 **User management:**
 
 ```go
-users, _, err := client.Users.Search(&sonar.UsersSearchOption{
+users, _, err := client.Users.Search(&sonar.UsersSearchOptions{
  Query: "john",
 })
 for _, user := range users.Users {

--- a/integration_testing/alm_integrations_test.go
+++ b/integration_testing/alm_integrations_test.go
@@ -32,7 +32,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				_, resp, err := client.AlmIntegrations.CheckPat(&sonar.AlmIntegrationsCheckPatOption{})
+				_, resp, err := client.AlmIntegrations.CheckPat(&sonar.AlmIntegrationsCheckPatOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -40,7 +40,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 
 			It("should fail with almSetting too long", func() {
 				longKey := string(make([]byte, 201))
-				_, resp, err := client.AlmIntegrations.CheckPat(&sonar.AlmIntegrationsCheckPatOption{
+				_, resp, err := client.AlmIntegrations.CheckPat(&sonar.AlmIntegrationsCheckPatOptions{
 					AlmSetting: longKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -64,7 +64,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.GetGithubClientId(&sonar.AlmIntegrationsGetGithubClientIdOption{})
+				result, resp, err := client.AlmIntegrations.GetGithubClientId(&sonar.AlmIntegrationsGetGithubClientIdOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -86,7 +86,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required projectName", func() {
-				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOption{
+				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOptions{
 					RepositoryName: "test-repo",
 				})
 				Expect(err).To(HaveOccurred())
@@ -95,7 +95,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required repositoryName", func() {
-				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOption{
+				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOptions{
 					ProjectName: "test-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -104,7 +104,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail with invalid newCodeDefinitionType", func() {
-				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOption{
+				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOptions{
 					ProjectName:           "test-project",
 					RepositoryName:        "test-repo",
 					NewCodeDefinitionType: "INVALID_TYPE",
@@ -115,7 +115,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail with NUMBER_OF_DAYS type and invalid days value", func() {
-				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOption{
+				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOptions{
 					ProjectName:            "test-project",
 					RepositoryName:         "test-repo",
 					NewCodeDefinitionType:  "NUMBER_OF_DAYS",
@@ -127,7 +127,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail with NUMBER_OF_DAYS type and days value too high", func() {
-				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOption{
+				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOptions{
 					ProjectName:            "test-project",
 					RepositoryName:         "test-repo",
 					NewCodeDefinitionType:  "NUMBER_OF_DAYS",
@@ -153,14 +153,14 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required repositorySlug", func() {
-				resp, err := client.AlmIntegrations.ImportBitbucketCloudRepo(&sonar.AlmIntegrationsImportBitbucketCloudRepoOption{})
+				resp, err := client.AlmIntegrations.ImportBitbucketCloudRepo(&sonar.AlmIntegrationsImportBitbucketCloudRepoOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("RepositorySlug"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid newCodeDefinitionType", func() {
-				resp, err := client.AlmIntegrations.ImportBitbucketCloudRepo(&sonar.AlmIntegrationsImportBitbucketCloudRepoOption{
+				resp, err := client.AlmIntegrations.ImportBitbucketCloudRepo(&sonar.AlmIntegrationsImportBitbucketCloudRepoOptions{
 					RepositorySlug:        "test-slug",
 					NewCodeDefinitionType: "INVALID_TYPE",
 				})
@@ -184,7 +184,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required projectKey", func() {
-				resp, err := client.AlmIntegrations.ImportBitbucketServerProject(&sonar.AlmIntegrationsImportBitbucketServerProjectOption{
+				resp, err := client.AlmIntegrations.ImportBitbucketServerProject(&sonar.AlmIntegrationsImportBitbucketServerProjectOptions{
 					RepositorySlug: "test-slug",
 				})
 				Expect(err).To(HaveOccurred())
@@ -193,7 +193,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required repositorySlug", func() {
-				resp, err := client.AlmIntegrations.ImportBitbucketServerProject(&sonar.AlmIntegrationsImportBitbucketServerProjectOption{
+				resp, err := client.AlmIntegrations.ImportBitbucketServerProject(&sonar.AlmIntegrationsImportBitbucketServerProjectOptions{
 					ProjectKey: "test-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -216,7 +216,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required repositoryKey", func() {
-				resp, err := client.AlmIntegrations.ImportGithubProject(&sonar.AlmIntegrationsImportGithubProjectOption{})
+				resp, err := client.AlmIntegrations.ImportGithubProject(&sonar.AlmIntegrationsImportGithubProjectOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("RepositoryKey"))
 				Expect(resp).To(BeNil())
@@ -224,7 +224,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 
 			It("should fail with repositoryKey too long", func() {
 				longKey := string(make([]byte, 257))
-				resp, err := client.AlmIntegrations.ImportGithubProject(&sonar.AlmIntegrationsImportGithubProjectOption{
+				resp, err := client.AlmIntegrations.ImportGithubProject(&sonar.AlmIntegrationsImportGithubProjectOptions{
 					RepositoryKey: longKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -247,7 +247,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required gitlabProjectId", func() {
-				resp, err := client.AlmIntegrations.ImportGitlabProject(&sonar.AlmIntegrationsImportGitlabProjectOption{})
+				resp, err := client.AlmIntegrations.ImportGitlabProject(&sonar.AlmIntegrationsImportGitlabProjectOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("GitlabProjectId"))
 				Expect(resp).To(BeNil())
@@ -269,7 +269,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.ListAzureProjects(&sonar.AlmIntegrationsListAzureProjectsOption{})
+				result, resp, err := client.AlmIntegrations.ListAzureProjects(&sonar.AlmIntegrationsListAzureProjectsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -292,7 +292,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.ListBitbucketServerProjects(&sonar.AlmIntegrationsListBitbucketServerProjectsOption{})
+				result, resp, err := client.AlmIntegrations.ListBitbucketServerProjects(&sonar.AlmIntegrationsListBitbucketServerProjectsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -315,7 +315,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.ListGithubOrganizations(&sonar.AlmIntegrationsListGithubOrganizationsOption{})
+				result, resp, err := client.AlmIntegrations.ListGithubOrganizations(&sonar.AlmIntegrationsListGithubOrganizationsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -338,7 +338,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.ListGithubRepositories(&sonar.AlmIntegrationsListGithubRepositoriesOption{
+				result, resp, err := client.AlmIntegrations.ListGithubRepositories(&sonar.AlmIntegrationsListGithubRepositoriesOptions{
 					Organization: "test-org",
 				})
 				Expect(err).To(HaveOccurred())
@@ -348,7 +348,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required organization", func() {
-				result, resp, err := client.AlmIntegrations.ListGithubRepositories(&sonar.AlmIntegrationsListGithubRepositoriesOption{
+				result, resp, err := client.AlmIntegrations.ListGithubRepositories(&sonar.AlmIntegrationsListGithubRepositoriesOptions{
 					AlmSetting: "test-github",
 				})
 				Expect(err).To(HaveOccurred())
@@ -373,7 +373,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.SearchAzureRepos(&sonar.AlmIntegrationsSearchAzureReposOption{})
+				result, resp, err := client.AlmIntegrations.SearchAzureRepos(&sonar.AlmIntegrationsSearchAzureReposOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -396,7 +396,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.SearchBitbucketCloudRepos(&sonar.AlmIntegrationsSearchBitbucketCloudReposOption{})
+				result, resp, err := client.AlmIntegrations.SearchBitbucketCloudRepos(&sonar.AlmIntegrationsSearchBitbucketCloudReposOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -419,7 +419,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.SearchBitbucketServerRepos(&sonar.AlmIntegrationsSearchBitbucketServerReposOption{})
+				result, resp, err := client.AlmIntegrations.SearchBitbucketServerRepos(&sonar.AlmIntegrationsSearchBitbucketServerReposOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -442,7 +442,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.SearchGitlabRepos(&sonar.AlmIntegrationsSearchGitlabReposOption{})
+				result, resp, err := client.AlmIntegrations.SearchGitlabRepos(&sonar.AlmIntegrationsSearchGitlabReposOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -464,7 +464,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required pat", func() {
-				resp, err := client.AlmIntegrations.SetPat(&sonar.AlmIntegrationsSetPatOption{
+				resp, err := client.AlmIntegrations.SetPat(&sonar.AlmIntegrationsSetPatOptions{
 					AlmSetting: "test-alm",
 				})
 				Expect(err).To(HaveOccurred())
@@ -474,7 +474,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 
 			It("should fail with pat too long", func() {
 				longPat := string(make([]byte, 2001))
-				resp, err := client.AlmIntegrations.SetPat(&sonar.AlmIntegrationsSetPatOption{
+				resp, err := client.AlmIntegrations.SetPat(&sonar.AlmIntegrationsSetPatOptions{
 					AlmSetting: "test-alm",
 					Pat:        longPat,
 				})

--- a/integration_testing/alm_settings_test.go
+++ b/integration_testing/alm_settings_test.go
@@ -26,14 +26,14 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 
 		// Create a test project
 		projectKey = helpers.UniqueResourceName("alm")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    "AlmSettings Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -72,7 +72,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should list ALM settings for a project", func() {
-				result, resp, err := client.AlmSettings.List(&sonar.AlmSettingsListOption{
+				result, resp, err := client.AlmSettings.List(&sonar.AlmSettingsListOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -96,7 +96,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required project", func() {
-				result, resp, err := client.AlmSettings.GetBinding(&sonar.AlmSettingsGetBindingOption{})
+				result, resp, err := client.AlmSettings.GetBinding(&sonar.AlmSettingsGetBindingOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Project"))
 				Expect(result).To(BeNil())
@@ -106,7 +106,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 
 		Context("Non-Bound Project", func() {
 			It("should fail for project without ALM binding", func() {
-				result, resp, err := client.AlmSettings.GetBinding(&sonar.AlmSettingsGetBindingOption{
+				result, resp, err := client.AlmSettings.GetBinding(&sonar.AlmSettingsGetBindingOptions{
 					Project: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -132,7 +132,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmSettings.CountBinding(&sonar.AlmSettingsCountBindingOption{})
+				result, resp, err := client.AlmSettings.CountBinding(&sonar.AlmSettingsCountBindingOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(result).To(BeNil())
@@ -142,7 +142,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 
 		Context("Non-Existent ALM Setting", func() {
 			It("should fail for non-existent ALM setting", func() {
-				result, resp, err := client.AlmSettings.CountBinding(&sonar.AlmSettingsCountBindingOption{
+				result, resp, err := client.AlmSettings.CountBinding(&sonar.AlmSettingsCountBindingOptions{
 					AlmSetting: "non-existent-alm-setting",
 				})
 				Expect(err).To(HaveOccurred())
@@ -167,7 +167,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.Delete(&sonar.AlmSettingsDeleteOption{})
+				resp, err := client.AlmSettings.Delete(&sonar.AlmSettingsDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(resp).To(BeNil())
@@ -176,7 +176,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 
 		Context("Non-Existent ALM Setting", func() {
 			It("should fail for non-existent ALM setting", func() {
-				resp, err := client.AlmSettings.Delete(&sonar.AlmSettingsDeleteOption{
+				resp, err := client.AlmSettings.Delete(&sonar.AlmSettingsDeleteOptions{
 					Key: "non-existent-alm-setting",
 				})
 				Expect(err).To(HaveOccurred())
@@ -200,7 +200,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.CreateAzure(&sonar.AlmSettingsCreateAzureOption{
+				resp, err := client.AlmSettings.CreateAzure(&sonar.AlmSettingsCreateAzureOptions{
 					PersonalAccessToken: "test-token",
 				})
 				Expect(err).To(HaveOccurred())
@@ -209,7 +209,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required personalAccessToken", func() {
-				resp, err := client.AlmSettings.CreateAzure(&sonar.AlmSettingsCreateAzureOption{
+				resp, err := client.AlmSettings.CreateAzure(&sonar.AlmSettingsCreateAzureOptions{
 					Key: "test-azure",
 				})
 				Expect(err).To(HaveOccurred())
@@ -232,7 +232,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.CreateGithub(&sonar.AlmSettingsCreateGithubOption{
+				resp, err := client.AlmSettings.CreateGithub(&sonar.AlmSettingsCreateGithubOptions{
 					AppID:        "test-app-id",
 					ClientID:     "test-client-id",
 					ClientSecret: "test-client-secret",
@@ -245,7 +245,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required appId", func() {
-				resp, err := client.AlmSettings.CreateGithub(&sonar.AlmSettingsCreateGithubOption{
+				resp, err := client.AlmSettings.CreateGithub(&sonar.AlmSettingsCreateGithubOptions{
 					Key:          "test-github",
 					ClientID:     "test-client-id",
 					ClientSecret: "test-client-secret",
@@ -258,7 +258,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required privateKey", func() {
-				resp, err := client.AlmSettings.CreateGithub(&sonar.AlmSettingsCreateGithubOption{
+				resp, err := client.AlmSettings.CreateGithub(&sonar.AlmSettingsCreateGithubOptions{
 					Key:          "test-github",
 					AppID:        "test-app-id",
 					ClientID:     "test-client-id",
@@ -271,7 +271,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required URL", func() {
-				resp, err := client.AlmSettings.CreateGithub(&sonar.AlmSettingsCreateGithubOption{
+				resp, err := client.AlmSettings.CreateGithub(&sonar.AlmSettingsCreateGithubOptions{
 					Key:          "test-github",
 					AppID:        "test-app-id",
 					ClientID:     "test-client-id",
@@ -298,7 +298,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.CreateGitlab(&sonar.AlmSettingsCreateGitlabOption{
+				resp, err := client.AlmSettings.CreateGitlab(&sonar.AlmSettingsCreateGitlabOptions{
 					PersonalAccessToken: "test-token",
 				})
 				Expect(err).To(HaveOccurred())
@@ -307,7 +307,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required personalAccessToken", func() {
-				resp, err := client.AlmSettings.CreateGitlab(&sonar.AlmSettingsCreateGitlabOption{
+				resp, err := client.AlmSettings.CreateGitlab(&sonar.AlmSettingsCreateGitlabOptions{
 					Key: "test-gitlab",
 				})
 				Expect(err).To(HaveOccurred())
@@ -330,7 +330,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.CreateBitbucket(&sonar.AlmSettingsCreateBitbucketOption{
+				resp, err := client.AlmSettings.CreateBitbucket(&sonar.AlmSettingsCreateBitbucketOptions{
 					PersonalAccessToken: "test-token",
 					URL:                 "https://bitbucket.example.com",
 				})
@@ -340,7 +340,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required URL", func() {
-				resp, err := client.AlmSettings.CreateBitbucket(&sonar.AlmSettingsCreateBitbucketOption{
+				resp, err := client.AlmSettings.CreateBitbucket(&sonar.AlmSettingsCreateBitbucketOptions{
 					Key:                 "test-bitbucket",
 					PersonalAccessToken: "test-token",
 				})
@@ -350,7 +350,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required personalAccessToken", func() {
-				resp, err := client.AlmSettings.CreateBitbucket(&sonar.AlmSettingsCreateBitbucketOption{
+				resp, err := client.AlmSettings.CreateBitbucket(&sonar.AlmSettingsCreateBitbucketOptions{
 					Key: "test-bitbucket",
 					URL: "https://bitbucket.example.com",
 				})
@@ -374,7 +374,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.CreateBitbucketCloud(&sonar.AlmSettingsCreateBitbucketCloudOption{
+				resp, err := client.AlmSettings.CreateBitbucketCloud(&sonar.AlmSettingsCreateBitbucketCloudOptions{
 					ClientID:     "test-client-id",
 					ClientSecret: "test-client-secret",
 					Workspace:    "test-workspace",
@@ -385,7 +385,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required clientId", func() {
-				resp, err := client.AlmSettings.CreateBitbucketCloud(&sonar.AlmSettingsCreateBitbucketCloudOption{
+				resp, err := client.AlmSettings.CreateBitbucketCloud(&sonar.AlmSettingsCreateBitbucketCloudOptions{
 					Key:          "test-bitbucket-cloud",
 					ClientSecret: "test-client-secret",
 					Workspace:    "test-workspace",
@@ -396,7 +396,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required clientSecret", func() {
-				resp, err := client.AlmSettings.CreateBitbucketCloud(&sonar.AlmSettingsCreateBitbucketCloudOption{
+				resp, err := client.AlmSettings.CreateBitbucketCloud(&sonar.AlmSettingsCreateBitbucketCloudOptions{
 					Key:       "test-bitbucket-cloud",
 					ClientID:  "test-client-id",
 					Workspace: "test-workspace",
@@ -407,7 +407,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required workspace", func() {
-				resp, err := client.AlmSettings.CreateBitbucketCloud(&sonar.AlmSettingsCreateBitbucketCloudOption{
+				resp, err := client.AlmSettings.CreateBitbucketCloud(&sonar.AlmSettingsCreateBitbucketCloudOptions{
 					Key:          "test-bitbucket-cloud",
 					ClientID:     "test-client-id",
 					ClientSecret: "test-client-secret",
@@ -432,7 +432,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.UpdateAzure(&sonar.AlmSettingsUpdateAzureOption{})
+				resp, err := client.AlmSettings.UpdateAzure(&sonar.AlmSettingsUpdateAzureOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(resp).To(BeNil())
@@ -453,7 +453,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.UpdateGithub(&sonar.AlmSettingsUpdateGithubOption{
+				resp, err := client.AlmSettings.UpdateGithub(&sonar.AlmSettingsUpdateGithubOptions{
 					AppID:    "test-app-id",
 					ClientID: "test-client-id",
 					URL:      "https://api.github.com",
@@ -464,7 +464,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required appId", func() {
-				resp, err := client.AlmSettings.UpdateGithub(&sonar.AlmSettingsUpdateGithubOption{
+				resp, err := client.AlmSettings.UpdateGithub(&sonar.AlmSettingsUpdateGithubOptions{
 					Key:      "test-github",
 					ClientID: "test-client-id",
 					URL:      "https://api.github.com",
@@ -475,7 +475,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required URL", func() {
-				resp, err := client.AlmSettings.UpdateGithub(&sonar.AlmSettingsUpdateGithubOption{
+				resp, err := client.AlmSettings.UpdateGithub(&sonar.AlmSettingsUpdateGithubOptions{
 					Key:      "test-github",
 					AppID:    "test-app-id",
 					ClientID: "test-client-id",
@@ -500,7 +500,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.UpdateGitlab(&sonar.AlmSettingsUpdateGitlabOption{})
+				resp, err := client.AlmSettings.UpdateGitlab(&sonar.AlmSettingsUpdateGitlabOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(resp).To(BeNil())
@@ -521,7 +521,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.UpdateBitbucket(&sonar.AlmSettingsUpdateBitbucketOption{
+				resp, err := client.AlmSettings.UpdateBitbucket(&sonar.AlmSettingsUpdateBitbucketOptions{
 					URL: "https://bitbucket.example.com",
 				})
 				Expect(err).To(HaveOccurred())
@@ -530,7 +530,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required URL", func() {
-				resp, err := client.AlmSettings.UpdateBitbucket(&sonar.AlmSettingsUpdateBitbucketOption{
+				resp, err := client.AlmSettings.UpdateBitbucket(&sonar.AlmSettingsUpdateBitbucketOptions{
 					Key: "test-bitbucket",
 				})
 				Expect(err).To(HaveOccurred())
@@ -553,7 +553,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.UpdateBitbucketCloud(&sonar.AlmSettingsUpdateBitbucketCloudOption{
+				resp, err := client.AlmSettings.UpdateBitbucketCloud(&sonar.AlmSettingsUpdateBitbucketCloudOptions{
 					ClientID:  "test-client-id",
 					Workspace: "test-workspace",
 				})
@@ -563,7 +563,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required workspace", func() {
-				resp, err := client.AlmSettings.UpdateBitbucketCloud(&sonar.AlmSettingsUpdateBitbucketCloudOption{
+				resp, err := client.AlmSettings.UpdateBitbucketCloud(&sonar.AlmSettingsUpdateBitbucketCloudOptions{
 					Key:      "test-bitbucket-cloud",
 					ClientID: "test-client-id",
 				})

--- a/integration_testing/analysis_cache_test.go
+++ b/integration_testing/analysis_cache_test.go
@@ -27,13 +27,13 @@ var _ = Describe("AnalysisCache Service", Ordered, func() {
 
 		// Create a test project for analysis cache operations
 		projectKey := helpers.UniqueResourceName("analysis-cache")
-		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    projectKey,
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		cleanupManager.RegisterCleanup("project", testProject.Project.Key, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: testProject.Project.Key,
 			})
 			return err
@@ -59,13 +59,13 @@ var _ = Describe("AnalysisCache Service", Ordered, func() {
 			})
 
 			It("should clear all cached data with empty options", func() {
-				resp, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOption{})
+				resp, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 			})
 
 			It("should clear cached data for a specific project", func() {
-				resp, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOption{
+				resp, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOptions{
 					Project: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -73,7 +73,7 @@ var _ = Describe("AnalysisCache Service", Ordered, func() {
 			})
 
 			It("should clear cached data for a specific project branch", func() {
-				resp, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOption{
+				resp, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOptions{
 					Project: testProject.Project.Key,
 					Branch:  "main",
 				})
@@ -84,14 +84,14 @@ var _ = Describe("AnalysisCache Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail when branch is specified without project", func() {
-				_, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOption{
+				_, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOptions{
 					Branch: "main",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should succeed with non-existent project (idempotent)", func() {
-				resp, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOption{
+				resp, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOptions{
 					Project: "non-existent-project-12345",
 				})
 				// Clear is idempotent - should succeed even for non-existent project
@@ -107,7 +107,7 @@ var _ = Describe("AnalysisCache Service", Ordered, func() {
 	Describe("Get", func() {
 		Context("Functional Tests", func() {
 			It("should get cached data for a project", func() {
-				resp, err := client.AnalysisCache.Get(&sonar.AnalysisCacheGetOption{
+				resp, err := client.AnalysisCache.Get(&sonar.AnalysisCacheGetOptions{
 					Project: testProject.Project.Key,
 				})
 				// May return 404 if no cache exists yet (project not analyzed)
@@ -126,7 +126,7 @@ var _ = Describe("AnalysisCache Service", Ordered, func() {
 			})
 
 			It("should get cached data for a specific branch", func() {
-				resp, err := client.AnalysisCache.Get(&sonar.AnalysisCacheGetOption{
+				resp, err := client.AnalysisCache.Get(&sonar.AnalysisCacheGetOptions{
 					Project: testProject.Project.Key,
 					Branch:  "main",
 				})
@@ -153,12 +153,12 @@ var _ = Describe("AnalysisCache Service", Ordered, func() {
 			})
 
 			It("should fail with missing project", func() {
-				_, err := client.AnalysisCache.Get(&sonar.AnalysisCacheGetOption{})
+				_, err := client.AnalysisCache.Get(&sonar.AnalysisCacheGetOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with non-existent project", func() {
-				resp, err := client.AnalysisCache.Get(&sonar.AnalysisCacheGetOption{
+				resp, err := client.AnalysisCache.Get(&sonar.AnalysisCacheGetOptions{
 					Project: "non-existent-project-12345",
 				})
 				Expect(err).To(HaveOccurred())

--- a/integration_testing/authentication_test.go
+++ b/integration_testing/authentication_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(loginClient).NotTo(BeNil())
 
-				opt := &sonar.AuthenticationLoginOption{
+				opt := &sonar.AuthenticationLoginOptions{
 					Login:    cfg.Username,
 					Password: cfg.Password,
 				}
@@ -103,7 +103,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(loginClient).NotTo(BeNil())
 
-				opt := &sonar.AuthenticationLoginOption{
+				opt := &sonar.AuthenticationLoginOptions{
 					Login:    cfg.Username,
 					Password: "wrongpassword",
 				}
@@ -124,7 +124,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(loginClient).NotTo(BeNil())
 
-				opt := &sonar.AuthenticationLoginOption{
+				opt := &sonar.AuthenticationLoginOptions{
 					Login:    "nonexistentuser",
 					Password: "somepassword",
 				}
@@ -146,7 +146,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 			})
 
 			It("should fail with missing Login field", func() {
-				opt := &sonar.AuthenticationLoginOption{
+				opt := &sonar.AuthenticationLoginOptions{
 					Password: "somepassword",
 				}
 
@@ -156,7 +156,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 			})
 
 			It("should fail with missing Password field", func() {
-				opt := &sonar.AuthenticationLoginOption{
+				opt := &sonar.AuthenticationLoginOptions{
 					Login: "someuser",
 				}
 
@@ -166,7 +166,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 			})
 
 			It("should fail with empty Login field", func() {
-				opt := &sonar.AuthenticationLoginOption{
+				opt := &sonar.AuthenticationLoginOptions{
 					Login:    "",
 					Password: "somepassword",
 				}
@@ -177,7 +177,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 			})
 
 			It("should fail with empty Password field", func() {
-				opt := &sonar.AuthenticationLoginOption{
+				opt := &sonar.AuthenticationLoginOptions{
 					Login:    "someuser",
 					Password: "",
 				}
@@ -204,7 +204,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 				Expect(sessionClient).NotTo(BeNil())
 
 				// Login first
-				loginOpt := &sonar.AuthenticationLoginOption{
+				loginOpt := &sonar.AuthenticationLoginOptions{
 					Login:    cfg.Username,
 					Password: cfg.Password,
 				}
@@ -261,7 +261,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 			Expect(result.Valid).To(BeFalse())
 
 			// Step 2: Login
-			loginOpt := &sonar.AuthenticationLoginOption{
+			loginOpt := &sonar.AuthenticationLoginOptions{
 				Login:    cfg.Username,
 				Password: cfg.Password,
 			}

--- a/integration_testing/batch_test.go
+++ b/integration_testing/batch_test.go
@@ -28,13 +28,13 @@ var _ = Describe("Batch Service", Ordered, func() {
 
 		// Create a test project for batch operations
 		projectKey := helpers.UniqueResourceName("batch")
-		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    "Batch Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		cleanupManager.RegisterCleanup("project", testProject.Project.Key, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: testProject.Project.Key,
 			})
 			return err
@@ -116,7 +116,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 					for _, line := range lines {
 						parts := strings.Split(strings.TrimSpace(line), "|")
 						if len(parts) > 0 && strings.HasSuffix(parts[0], ".jar") {
-							result, resp, err := client.Batch.File(&sonar.BatchFileOption{
+							result, resp, err := client.Batch.File(&sonar.BatchFileOptions{
 								Name: parts[0],
 							})
 							Expect(err).NotTo(HaveOccurred())
@@ -143,7 +143,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent file", func() {
-				_, resp, err := client.Batch.File(&sonar.BatchFileOption{
+				_, resp, err := client.Batch.File(&sonar.BatchFileOptions{
 					Name: "non-existent-file.jar",
 				})
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
@@ -165,7 +165,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 	Describe("Project", func() {
 		Context("Functional Tests", func() {
 			It("should get project batch info with valid key", func() {
-				result, resp, err := client.Batch.Project(&sonar.BatchProjectOption{
+				result, resp, err := client.Batch.Project(&sonar.BatchProjectOptions{
 					Key: testProject.Project.Key,
 				})
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
@@ -194,12 +194,12 @@ var _ = Describe("Batch Service", Ordered, func() {
 			})
 
 			It("should fail with missing key", func() {
-				_, _, err := client.Batch.Project(&sonar.BatchProjectOption{})
+				_, _, err := client.Batch.Project(&sonar.BatchProjectOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with non-existent project", func() {
-				_, resp, err := client.Batch.Project(&sonar.BatchProjectOption{
+				_, resp, err := client.Batch.Project(&sonar.BatchProjectOptions{
 					Key: "non-existent-project-12345",
 				})
 				if resp != nil && resp.StatusCode == http.StatusNotFound {

--- a/integration_testing/ce_test.go
+++ b/integration_testing/ce_test.go
@@ -27,13 +27,13 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 		// Create a test project for CE operations
 		projectName := helpers.UniqueResourceName("ce-test-project")
-		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    projectName,
 			Project: projectName,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		cleanupManager.RegisterCleanup("project", testProject.Project.Key, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: testProject.Project.Key,
 			})
 			return err
@@ -60,7 +60,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should list CE tasks with pagination", func() {
-				result, resp, err := client.Ce.Activity(&sonar.CeActivityOption{
+				result, resp, err := client.Ce.Activity(&sonar.CeActivityOptions{
 					CePaginationArgs: sonar.CePaginationArgs{
 						Page:     1,
 						PageSize: 10,
@@ -73,7 +73,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should list CE tasks filtered by component", func() {
-				result, resp, err := client.Ce.Activity(&sonar.CeActivityOption{
+				result, resp, err := client.Ce.Activity(&sonar.CeActivityOptions{
 					Component: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -82,7 +82,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should list CE tasks filtered by status", func() {
-				result, resp, err := client.Ce.Activity(&sonar.CeActivityOption{
+				result, resp, err := client.Ce.Activity(&sonar.CeActivityOptions{
 					Statuses: []string{"SUCCESS"},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -91,7 +91,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should list CE tasks filtered by type", func() {
-				result, resp, err := client.Ce.Activity(&sonar.CeActivityOption{
+				result, resp, err := client.Ce.Activity(&sonar.CeActivityOptions{
 					Type: "REPORT",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -100,7 +100,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should list CE tasks with onlyCurrents filter", func() {
-				result, resp, err := client.Ce.Activity(&sonar.CeActivityOption{
+				result, resp, err := client.Ce.Activity(&sonar.CeActivityOptions{
 					OnlyCurrents: true,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -109,7 +109,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should search CE tasks by query", func() {
-				result, resp, err := client.Ce.Activity(&sonar.CeActivityOption{
+				result, resp, err := client.Ce.Activity(&sonar.CeActivityOptions{
 					Query: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -120,21 +120,21 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with invalid status", func() {
-				_, _, err := client.Ce.Activity(&sonar.CeActivityOption{
+				_, _, err := client.Ce.Activity(&sonar.CeActivityOptions{
 					Statuses: []string{"INVALID_STATUS"},
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with invalid type", func() {
-				_, _, err := client.Ce.Activity(&sonar.CeActivityOption{
+				_, _, err := client.Ce.Activity(&sonar.CeActivityOptions{
 					Type: "INVALID_TYPE",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with invalid page size", func() {
-				_, _, err := client.Ce.Activity(&sonar.CeActivityOption{
+				_, _, err := client.Ce.Activity(&sonar.CeActivityOptions{
 					CePaginationArgs: sonar.CePaginationArgs{
 						PageSize: 10000,
 					},
@@ -157,7 +157,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should get activity status for specific component", func() {
-				result, resp, err := client.Ce.ActivityStatus(&sonar.CeActivityStatusOption{
+				result, resp, err := client.Ce.ActivityStatus(&sonar.CeActivityStatusOptions{
 					Component: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -173,7 +173,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("AnalysisStatus", func() {
 		Context("Functional Tests", func() {
 			It("should get analysis status for component", func() {
-				result, resp, err := client.Ce.AnalysisStatus(&sonar.CeAnalysisStatusOption{
+				result, resp, err := client.Ce.AnalysisStatus(&sonar.CeAnalysisStatusOptions{
 					Component: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -184,7 +184,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing component", func() {
-				_, _, err := client.Ce.AnalysisStatus(&sonar.CeAnalysisStatusOption{})
+				_, _, err := client.Ce.AnalysisStatus(&sonar.CeAnalysisStatusOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -194,7 +194,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent component", func() {
-				_, resp, err := client.Ce.AnalysisStatus(&sonar.CeAnalysisStatusOption{
+				_, resp, err := client.Ce.AnalysisStatus(&sonar.CeAnalysisStatusOptions{
 					Component: "non-existent-project-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -210,7 +210,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("Cancel", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing task ID", func() {
-				_, err := client.Ce.Cancel(&sonar.CeCancelOption{})
+				_, err := client.Ce.Cancel(&sonar.CeCancelOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -221,7 +221,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 			It("should handle non-existent task ID gracefully", func() {
 				// SonarQube returns 204 even for non-existent task IDs
-				resp, err := client.Ce.Cancel(&sonar.CeCancelOption{
+				resp, err := client.Ce.Cancel(&sonar.CeCancelOptions{
 					ID: "non-existent-task-id",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -250,7 +250,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("Component", func() {
 		Context("Functional Tests", func() {
 			It("should get component CE status", func() {
-				result, resp, err := client.Ce.Component(&sonar.CeComponentOption{
+				result, resp, err := client.Ce.Component(&sonar.CeComponentOptions{
 					Component: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -261,7 +261,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing component", func() {
-				_, _, err := client.Ce.Component(&sonar.CeComponentOption{})
+				_, _, err := client.Ce.Component(&sonar.CeComponentOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -271,7 +271,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent component", func() {
-				_, resp, err := client.Ce.Component(&sonar.CeComponentOption{
+				_, resp, err := client.Ce.Component(&sonar.CeComponentOptions{
 					Component: "non-existent-project-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -287,14 +287,14 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("DismissAnalysisWarning", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing component", func() {
-				_, err := client.Ce.DismissAnalysisWarning(&sonar.CeDismissAnalysisWarningOption{
+				_, err := client.Ce.DismissAnalysisWarning(&sonar.CeDismissAnalysisWarningOptions{
 					Warning: "some-warning",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing warning", func() {
-				_, err := client.Ce.DismissAnalysisWarning(&sonar.CeDismissAnalysisWarningOption{
+				_, err := client.Ce.DismissAnalysisWarning(&sonar.CeDismissAnalysisWarningOptions{
 					Component: testProject.Project.Key,
 				})
 				Expect(err).To(HaveOccurred())
@@ -306,7 +306,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent warning", func() {
-				resp, err := client.Ce.DismissAnalysisWarning(&sonar.CeDismissAnalysisWarningOption{
+				resp, err := client.Ce.DismissAnalysisWarning(&sonar.CeDismissAnalysisWarningOptions{
 					Component: testProject.Project.Key,
 					Warning:   "non-existent-warning",
 				})
@@ -369,14 +369,14 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("Submit", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing project key", func() {
-				_, _, err := client.Ce.Submit(&sonar.CeSubmitOption{
+				_, _, err := client.Ce.Submit(&sonar.CeSubmitOptions{
 					Report: "dummy-report",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing report", func() {
-				_, _, err := client.Ce.Submit(&sonar.CeSubmitOption{
+				_, _, err := client.Ce.Submit(&sonar.CeSubmitOptions{
 					ProjectKey: testProject.Project.Key,
 				})
 				Expect(err).To(HaveOccurred())
@@ -389,7 +389,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 			It("should fail with project key too long", func() {
 				longKey := string(make([]byte, 500))
-				_, _, err := client.Ce.Submit(&sonar.CeSubmitOption{
+				_, _, err := client.Ce.Submit(&sonar.CeSubmitOptions{
 					ProjectKey: longKey,
 					Report:     "dummy-report",
 				})
@@ -405,7 +405,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 		Context("Functional Tests", func() {
 			It("should get task details when tasks exist", func() {
 				// First get any existing task from activity
-				activity, _, err := client.Ce.Activity(&sonar.CeActivityOption{
+				activity, _, err := client.Ce.Activity(&sonar.CeActivityOptions{
 					CePaginationArgs: sonar.CePaginationArgs{
 						PageSize: 1,
 					},
@@ -414,7 +414,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 				if len(activity.Tasks) > 0 {
 					taskID := activity.Tasks[0].ID
-					result, resp, err := client.Ce.Task(&sonar.CeTaskOption{
+					result, resp, err := client.Ce.Task(&sonar.CeTaskOptions{
 						ID: taskID,
 					})
 					Expect(err).NotTo(HaveOccurred())
@@ -428,7 +428,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 			It("should get task details with additional fields", func() {
 				// First get any existing task from activity
-				activity, _, err := client.Ce.Activity(&sonar.CeActivityOption{
+				activity, _, err := client.Ce.Activity(&sonar.CeActivityOptions{
 					CePaginationArgs: sonar.CePaginationArgs{
 						PageSize: 1,
 					},
@@ -437,7 +437,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 				if len(activity.Tasks) > 0 {
 					taskID := activity.Tasks[0].ID
-					result, resp, err := client.Ce.Task(&sonar.CeTaskOption{
+					result, resp, err := client.Ce.Task(&sonar.CeTaskOptions{
 						ID:               taskID,
 						AdditionalFields: []string{"warnings"},
 					})
@@ -452,7 +452,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing task ID", func() {
-				_, _, err := client.Ce.Task(&sonar.CeTaskOption{})
+				_, _, err := client.Ce.Task(&sonar.CeTaskOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -462,7 +462,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should fail with invalid additional fields", func() {
-				_, _, err := client.Ce.Task(&sonar.CeTaskOption{
+				_, _, err := client.Ce.Task(&sonar.CeTaskOptions{
 					ID:               "some-task-id",
 					AdditionalFields: []string{"invalid_field"},
 				})
@@ -470,7 +470,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent task ID", func() {
-				_, resp, err := client.Ce.Task(&sonar.CeTaskOption{
+				_, resp, err := client.Ce.Task(&sonar.CeTaskOptions{
 					ID: "non-existent-task-id",
 				})
 				Expect(err).To(HaveOccurred())

--- a/integration_testing/components_test.go
+++ b/integration_testing/components_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Components Service", Ordered, func() {
 	// =========================================================================
 	Describe("Search", func() {
 		It("should search for projects", func() {
-			result, resp, err := client.Components.Search(&sonar.ComponentsSearchOption{
+			result, resp, err := client.Components.Search(&sonar.ComponentsSearchOptions{
 				Qualifiers: []string{"TRK"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -46,7 +46,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should search projects with pagination", func() {
-			result, resp, err := client.Components.Search(&sonar.ComponentsSearchOption{
+			result, resp, err := client.Components.Search(&sonar.ComponentsSearchOptions{
 				Qualifiers: []string{"TRK"},
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 5,
@@ -60,14 +60,14 @@ var _ = Describe("Components Service", Ordered, func() {
 		It("should search projects by query", func() {
 			// First create a project to search for
 			projectKey := helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -80,7 +80,7 @@ var _ = Describe("Components Service", Ordered, func() {
 			}
 
 			// Search for it
-			result, resp, err := client.Components.Search(&sonar.ComponentsSearchOption{
+			result, resp, err := client.Components.Search(&sonar.ComponentsSearchOptions{
 				Qualifiers: []string{"TRK"},
 				Query:      query,
 			})
@@ -97,7 +97,7 @@ var _ = Describe("Components Service", Ordered, func() {
 			})
 
 			It("should fail with missing qualifiers", func() {
-				_, resp, err := client.Components.Search(&sonar.ComponentsSearchOption{})
+				_, resp, err := client.Components.Search(&sonar.ComponentsSearchOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -109,14 +109,14 @@ var _ = Describe("Components Service", Ordered, func() {
 	// =========================================================================
 	Describe("SearchProjects", func() {
 		It("should search for projects", func() {
-			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOption{})
+			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
 		})
 
 		It("should search projects with pagination", func() {
-			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOption{
+			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOptions{
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 5,
 				},
@@ -129,14 +129,14 @@ var _ = Describe("Components Service", Ordered, func() {
 		It("should search projects with filter by name", func() {
 			// First create a project to search for
 			projectKey := helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -149,7 +149,7 @@ var _ = Describe("Components Service", Ordered, func() {
 			}
 
 			// Search with filter
-			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOption{
+			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOptions{
 				Filter: "query = \"" + filterPrefix + "\"",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -158,7 +158,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should search projects with facets", func() {
-			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOption{
+			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOptions{
 				Facets: []string{"languages", "tags"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -167,7 +167,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should search projects sorted by name", func() {
-			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOption{
+			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOptions{
 				Sort:      "name",
 				Ascending: true,
 			})
@@ -194,14 +194,14 @@ var _ = Describe("Components Service", Ordered, func() {
 		BeforeAll(func() {
 			// Create a project for Show tests
 			projectKey = helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -209,7 +209,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should show component details", func() {
-			result, resp, err := client.Components.Show(&sonar.ComponentsShowOption{
+			result, resp, err := client.Components.Show(&sonar.ComponentsShowOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -220,7 +220,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should return ancestors for project", func() {
-			result, resp, err := client.Components.Show(&sonar.ComponentsShowOption{
+			result, resp, err := client.Components.Show(&sonar.ComponentsShowOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -237,13 +237,13 @@ var _ = Describe("Components Service", Ordered, func() {
 			})
 
 			It("should fail with missing component", func() {
-				_, resp, err := client.Components.Show(&sonar.ComponentsShowOption{})
+				_, resp, err := client.Components.Show(&sonar.ComponentsShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with non-existent component", func() {
-				_, resp, err := client.Components.Show(&sonar.ComponentsShowOption{
+				_, resp, err := client.Components.Show(&sonar.ComponentsShowOptions{
 					Component: "non-existent-component-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -261,14 +261,14 @@ var _ = Describe("Components Service", Ordered, func() {
 		BeforeAll(func() {
 			// Create a project for Tree tests
 			projectKey = helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -276,7 +276,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get component tree", func() {
-			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOption{
+			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -286,7 +286,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get tree with all strategy", func() {
-			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOption{
+			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
 				Component: projectKey,
 				Strategy:  "all",
 			})
@@ -296,7 +296,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get tree with children strategy", func() {
-			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOption{
+			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
 				Component: projectKey,
 				Strategy:  "children",
 			})
@@ -306,7 +306,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get tree with leaves strategy", func() {
-			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOption{
+			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
 				Component: projectKey,
 				Strategy:  "leaves",
 			})
@@ -316,7 +316,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get tree with pagination", func() {
-			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOption{
+			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
 				Component: projectKey,
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 10,
@@ -328,7 +328,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get tree with qualifiers filter", func() {
-			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOption{
+			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
 				Component:  projectKey,
 				Qualifiers: []string{"FIL", "DIR"},
 			})
@@ -338,7 +338,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get tree sorted by name", func() {
-			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOption{
+			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
 				Component: projectKey,
 				Sort:      []string{"name"},
 				Ascending: true,
@@ -356,13 +356,13 @@ var _ = Describe("Components Service", Ordered, func() {
 			})
 
 			It("should fail with missing component", func() {
-				_, resp, err := client.Components.Tree(&sonar.ComponentsTreeOption{})
+				_, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid strategy", func() {
-				_, resp, err := client.Components.Tree(&sonar.ComponentsTreeOption{
+				_, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
 					Component: projectKey,
 					Strategy:  "invalid-strategy",
 				})
@@ -377,7 +377,7 @@ var _ = Describe("Components Service", Ordered, func() {
 	// =========================================================================
 	Describe("Suggestions", func() {
 		It("should get suggestions without search query", func() {
-			result, resp, err := client.Components.Suggestions(&sonar.ComponentsSuggestionsOption{})
+			result, resp, err := client.Components.Suggestions(&sonar.ComponentsSuggestionsOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -386,14 +386,14 @@ var _ = Describe("Components Service", Ordered, func() {
 		It("should get suggestions with search query", func() {
 			// First create a project
 			projectKey := helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -406,7 +406,7 @@ var _ = Describe("Components Service", Ordered, func() {
 			}
 
 			// Search for suggestions
-			result, resp, err := client.Components.Suggestions(&sonar.ComponentsSuggestionsOption{
+			result, resp, err := client.Components.Suggestions(&sonar.ComponentsSuggestionsOptions{
 				Search: searchQuery, // Min 2 chars
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -415,7 +415,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get more suggestions for TRK qualifier", func() {
-			result, resp, err := client.Components.Suggestions(&sonar.ComponentsSuggestionsOption{
+			result, resp, err := client.Components.Suggestions(&sonar.ComponentsSuggestionsOptions{
 				More: "TRK",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -431,7 +431,7 @@ var _ = Describe("Components Service", Ordered, func() {
 			})
 
 			It("should fail with invalid more qualifier", func() {
-				_, resp, err := client.Components.Suggestions(&sonar.ComponentsSuggestionsOption{
+				_, resp, err := client.Components.Suggestions(&sonar.ComponentsSuggestionsOptions{
 					More: "INVALID",
 				})
 				Expect(err).To(HaveOccurred())
@@ -449,14 +449,14 @@ var _ = Describe("Components Service", Ordered, func() {
 		BeforeAll(func() {
 			// Create a project for App tests
 			projectKey = helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -464,7 +464,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get app data for component", func() {
-			result, resp, err := client.Components.App(&sonar.ComponentsAppOption{
+			result, resp, err := client.Components.App(&sonar.ComponentsAppOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -474,7 +474,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should return component info", func() {
-			result, resp, err := client.Components.App(&sonar.ComponentsAppOption{
+			result, resp, err := client.Components.App(&sonar.ComponentsAppOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -491,13 +491,13 @@ var _ = Describe("Components Service", Ordered, func() {
 			})
 
 			It("should fail with missing component", func() {
-				_, resp, err := client.Components.App(&sonar.ComponentsAppOption{})
+				_, resp, err := client.Components.App(&sonar.ComponentsAppOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with both branch and pullRequest", func() {
-				_, resp, err := client.Components.App(&sonar.ComponentsAppOption{
+				_, resp, err := client.Components.App(&sonar.ComponentsAppOptions{
 					Component:   projectKey,
 					Branch:      "main",
 					PullRequest: "123",

--- a/integration_testing/developers_test.go
+++ b/integration_testing/developers_test.go
@@ -28,13 +28,13 @@ var _ = Describe("Developers Service", Ordered, func() {
 
 		// Create a uniquely named test project for developer events to avoid collisions across runs.
 		projectKey := helpers.UniqueResourceName("developers")
-		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    projectKey,
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		cleanupManager.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: testProject.Project.Key,
 			})
 			return err
@@ -55,7 +55,7 @@ var _ = Describe("Developers Service", Ordered, func() {
 		Context("Functional Tests", func() {
 			It("should search developer events with valid parameters", func() {
 				fromDate := time.Now().UTC().Add(-24 * time.Hour).Format("2006-01-02T15:04:05-0700")
-				result, resp, err := client.Developers.SearchEvents(&sonar.DevelopersSearchEventsOption{
+				result, resp, err := client.Developers.SearchEvents(&sonar.DevelopersSearchEventsOptions{
 					From:     []string{fromDate},
 					Projects: []string{testProject.Project.Key},
 				})
@@ -77,7 +77,7 @@ var _ = Describe("Developers Service", Ordered, func() {
 
 		Context("Error Handling", func() {
 			It("should fail with missing from date", func() {
-				_, resp, err := client.Developers.SearchEvents(&sonar.DevelopersSearchEventsOption{
+				_, resp, err := client.Developers.SearchEvents(&sonar.DevelopersSearchEventsOptions{
 					Projects: []string{testProject.Project.Key},
 				})
 				Expect(err).To(HaveOccurred())
@@ -86,7 +86,7 @@ var _ = Describe("Developers Service", Ordered, func() {
 
 			It("should fail with missing projects", func() {
 				fromDate := time.Now().UTC().Add(-24 * time.Hour).Format("2006-01-02T15:04:05-0700")
-				_, resp, err := client.Developers.SearchEvents(&sonar.DevelopersSearchEventsOption{
+				_, resp, err := client.Developers.SearchEvents(&sonar.DevelopersSearchEventsOptions{
 					From: []string{fromDate},
 				})
 				Expect(err).To(HaveOccurred())

--- a/integration_testing/dismiss_message_test.go
+++ b/integration_testing/dismiss_message_test.go
@@ -26,14 +26,14 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 
 		// Create a test project for dismiss message operations
 		projectKey = helpers.UniqueResourceName("dms")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    "DismissMessage Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -53,7 +53,7 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 	Describe("Check", func() {
 		Context("Valid Requests", func() {
 			It("should check message dismissal status", func() {
-				result, resp, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOption{
+				result, resp, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOptions{
 					MessageType: "PROJECT_NCD_90",
 					ProjectKey:  projectKey,
 				})
@@ -69,14 +69,14 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing message type", func() {
-				_, _, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOption{
+				_, _, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOptions{
 					ProjectKey: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing project key", func() {
-				_, _, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOption{
+				_, _, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOptions{
 					MessageType: "PROJECT_NCD_90",
 				})
 				Expect(err).To(HaveOccurred())
@@ -95,7 +95,7 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 	Describe("Dismiss", func() {
 		Context("Valid Requests", func() {
 			It("should dismiss a message", func() {
-				resp, err := client.DismissMessage.Dismiss(&sonar.DismissMessageDismissOption{
+				resp, err := client.DismissMessage.Dismiss(&sonar.DismissMessageDismissOptions{
 					MessageType: "PROJECT_NCD_90",
 					ProjectKey:  projectKey,
 				})
@@ -110,14 +110,14 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing message type", func() {
-				_, err := client.DismissMessage.Dismiss(&sonar.DismissMessageDismissOption{
+				_, err := client.DismissMessage.Dismiss(&sonar.DismissMessageDismissOptions{
 					ProjectKey: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing project key", func() {
-				_, err := client.DismissMessage.Dismiss(&sonar.DismissMessageDismissOption{
+				_, err := client.DismissMessage.Dismiss(&sonar.DismissMessageDismissOptions{
 					MessageType: "PROJECT_NCD_90",
 				})
 				Expect(err).To(HaveOccurred())
@@ -136,7 +136,7 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 	Describe("Full Workflow", func() {
 		It("should verify message is dismissed after dismissal", func() {
 			// Check message is not dismissed initially
-			initialCheck, resp, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOption{
+			initialCheck, resp, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOptions{
 				MessageType: "PROJECT_NCD_90",
 				ProjectKey:  projectKey,
 			})
@@ -149,7 +149,7 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 			Expect(initialCheck).NotTo(BeNil())
 
 			// Dismiss the message
-			resp, err = client.DismissMessage.Dismiss(&sonar.DismissMessageDismissOption{
+			resp, err = client.DismissMessage.Dismiss(&sonar.DismissMessageDismissOptions{
 				MessageType: "PROJECT_NCD_90",
 				ProjectKey:  projectKey,
 			})
@@ -157,7 +157,7 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 			Expect(resp.StatusCode).To(SatisfyAny(Equal(http.StatusOK), Equal(http.StatusNoContent)))
 
 			// Check message is now dismissed
-			finalCheck, resp, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOption{
+			finalCheck, resp, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOptions{
 				MessageType: "PROJECT_NCD_90",
 				ProjectKey:  projectKey,
 			})

--- a/integration_testing/duplications_test.go
+++ b/integration_testing/duplications_test.go
@@ -26,14 +26,14 @@ var _ = Describe("Duplications Service", Ordered, func() {
 
 		// Create a test project for duplications-related operations
 		projectKey = helpers.UniqueResourceName("dup")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    "Duplications Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -61,7 +61,7 @@ var _ = Describe("Duplications Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				result, resp, err := client.Duplications.Show(&sonar.DuplicationsShowOption{})
+				result, resp, err := client.Duplications.Show(&sonar.DuplicationsShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(result).To(BeNil())
@@ -71,7 +71,7 @@ var _ = Describe("Duplications Service", Ordered, func() {
 
 		Context("Non-Existent File", func() {
 			It("should fail for non-existent file key", func() {
-				result, resp, err := client.Duplications.Show(&sonar.DuplicationsShowOption{
+				result, resp, err := client.Duplications.Show(&sonar.DuplicationsShowOptions{
 					Key: "non-existent-file-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -84,7 +84,7 @@ var _ = Describe("Duplications Service", Ordered, func() {
 
 		Context("Project Key", func() {
 			It("should work with project key (empty duplications)", func() {
-				result, resp, err := client.Duplications.Show(&sonar.DuplicationsShowOption{
+				result, resp, err := client.Duplications.Show(&sonar.DuplicationsShowOptions{
 					Key: projectKey,
 				})
 				// May succeed with empty result or fail if the project doesn't have analyzed files

--- a/integration_testing/emails_test.go
+++ b/integration_testing/emails_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Emails Service", Ordered, func() {
 			})
 
 			It("should fail with missing to address", func() {
-				resp, err := client.Emails.Send(&sonar.EmailsSendOption{
+				resp, err := client.Emails.Send(&sonar.EmailsSendOptions{
 					Message: "Test message",
 				})
 				Expect(resp).To(BeNil())
@@ -44,7 +44,7 @@ var _ = Describe("Emails Service", Ordered, func() {
 			})
 
 			It("should fail with missing message", func() {
-				resp, err := client.Emails.Send(&sonar.EmailsSendOption{
+				resp, err := client.Emails.Send(&sonar.EmailsSendOptions{
 					To: "test@example.com",
 				})
 				Expect(resp).To(BeNil())
@@ -57,7 +57,7 @@ var _ = Describe("Emails Service", Ordered, func() {
 			It("should attempt to send test email with valid parameters", func() {
 				// Email sending requires SMTP to be configured
 				// If not configured, the API returns an error
-				resp, err := client.Emails.Send(&sonar.EmailsSendOption{
+				resp, err := client.Emails.Send(&sonar.EmailsSendOptions{
 					To:      "test@example.com",
 					Message: "Test message from e2e tests",
 					Subject: "Test Subject",

--- a/integration_testing/favorites_test.go
+++ b/integration_testing/favorites_test.go
@@ -36,14 +36,14 @@ var _ = Describe("Favorites Service", Ordered, func() {
 
 		// Create a test project for favorites-related operations
 		projectKey = helpers.UniqueResourceName("fav")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    "Favorites Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -70,7 +70,7 @@ var _ = Describe("Favorites Service", Ordered, func() {
 			})
 
 			It("should search favorites with pagination", func() {
-				result, resp, err := client.Favorites.Search(&sonar.FavoritesSearchOption{
+				result, resp, err := client.Favorites.Search(&sonar.FavoritesSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 10,
 						Page:     1,
@@ -96,7 +96,7 @@ var _ = Describe("Favorites Service", Ordered, func() {
 			})
 
 			It("should fail without required component", func() {
-				resp, err := client.Favorites.Add(&sonar.FavoritesAddOption{})
+				resp, err := client.Favorites.Add(&sonar.FavoritesAddOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Component"))
 				Expect(resp).To(BeNil())
@@ -105,14 +105,14 @@ var _ = Describe("Favorites Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should add a project as favorite", func() {
-				resp, err := client.Favorites.Add(&sonar.FavoritesAddOption{
+				resp, err := client.Favorites.Add(&sonar.FavoritesAddOptions{
 					Component: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Clean up: remove the favorite
-				_, _ = client.Favorites.Remove(&sonar.FavoritesRemoveOption{
+				_, _ = client.Favorites.Remove(&sonar.FavoritesRemoveOptions{
 					Component: projectKey,
 				})
 			})
@@ -120,7 +120,7 @@ var _ = Describe("Favorites Service", Ordered, func() {
 
 		Context("Non-Existent Component", func() {
 			It("should fail for non-existent component", func() {
-				resp, err := client.Favorites.Add(&sonar.FavoritesAddOption{
+				resp, err := client.Favorites.Add(&sonar.FavoritesAddOptions{
 					Component: "non-existent-component",
 				})
 				Expect(err).To(HaveOccurred())
@@ -144,7 +144,7 @@ var _ = Describe("Favorites Service", Ordered, func() {
 			})
 
 			It("should fail without required component", func() {
-				resp, err := client.Favorites.Remove(&sonar.FavoritesRemoveOption{})
+				resp, err := client.Favorites.Remove(&sonar.FavoritesRemoveOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Component"))
 				Expect(resp).To(BeNil())
@@ -154,13 +154,13 @@ var _ = Describe("Favorites Service", Ordered, func() {
 		Context("Valid Requests", func() {
 			It("should remove a project from favorites", func() {
 				// First add the project as favorite
-				_, err := client.Favorites.Add(&sonar.FavoritesAddOption{
+				_, err := client.Favorites.Add(&sonar.FavoritesAddOptions{
 					Component: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Now remove it
-				resp, err := client.Favorites.Remove(&sonar.FavoritesRemoveOption{
+				resp, err := client.Favorites.Remove(&sonar.FavoritesRemoveOptions{
 					Component: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -170,7 +170,7 @@ var _ = Describe("Favorites Service", Ordered, func() {
 
 		Context("Non-Existent Component", func() {
 			It("should fail for non-existent component", func() {
-				resp, err := client.Favorites.Remove(&sonar.FavoritesRemoveOption{
+				resp, err := client.Favorites.Remove(&sonar.FavoritesRemoveOptions{
 					Component: "non-existent-component",
 				})
 				Expect(err).To(HaveOccurred())
@@ -183,12 +183,12 @@ var _ = Describe("Favorites Service", Ordered, func() {
 		Context("Not Favorited Component", func() {
 			It("should fail when removing a component that is not favorited", func() {
 				// Ensure it's not favorited first
-				_, _ = client.Favorites.Remove(&sonar.FavoritesRemoveOption{
+				_, _ = client.Favorites.Remove(&sonar.FavoritesRemoveOptions{
 					Component: projectKey,
 				})
 
 				// Try to remove again
-				resp, err := client.Favorites.Remove(&sonar.FavoritesRemoveOption{
+				resp, err := client.Favorites.Remove(&sonar.FavoritesRemoveOptions{
 					Component: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -205,7 +205,7 @@ var _ = Describe("Favorites Service", Ordered, func() {
 	Describe("Full Workflow", func() {
 		It("should add, verify, and remove a favorite", func() {
 			// Add favorite
-			resp, err := client.Favorites.Add(&sonar.FavoritesAddOption{
+			resp, err := client.Favorites.Add(&sonar.FavoritesAddOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -220,7 +220,7 @@ var _ = Describe("Favorites Service", Ordered, func() {
 			Expect(containsFavorite(searchResult.Favorites, projectKey)).To(BeTrue(), "Project should be in favorites")
 
 			// Remove favorite
-			resp, err = client.Favorites.Remove(&sonar.FavoritesRemoveOption{
+			resp, err = client.Favorites.Remove(&sonar.FavoritesRemoveOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/helpers/cleanup.go
+++ b/integration_testing/helpers/cleanup.go
@@ -117,7 +117,7 @@ func cleanupOrphanedTemplates(client *sonar.Client, _ time.Duration) error {
 
 	for _, t := range templates.PermissionTemplates {
 		if strings.HasPrefix(t.Name, E2EResourcePrefix) {
-			_, _ = client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+			_, _ = client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 				TemplateName: t.Name,
 			})
 		}
@@ -128,7 +128,7 @@ func cleanupOrphanedTemplates(client *sonar.Client, _ time.Duration) error {
 
 func cleanupOrphanedProjects(client *sonar.Client, _ time.Duration) error {
 	// Search for projects with e2e prefix
-	projects, _, err := client.Projects.Search(&sonar.ProjectsSearchOption{
+	projects, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
 		PaginationArgs:    sonar.PaginationArgs{Page: 0, PageSize: 0},
 		AnalyzedBefore:    "",
 		OnProvisionedOnly: false,
@@ -147,7 +147,7 @@ func cleanupOrphanedProjects(client *sonar.Client, _ time.Duration) error {
 
 	for _, p := range projects.Components {
 		if strings.HasPrefix(p.Key, E2EResourcePrefix) {
-			_, _ = client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, _ = client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: p.Key,
 			})
 		}
@@ -158,7 +158,7 @@ func cleanupOrphanedProjects(client *sonar.Client, _ time.Duration) error {
 
 func cleanupOrphanedUsers(client *sonar.Client, _ time.Duration) error {
 	//nolint:staticcheck // Using deprecated API until v2 API is implemented
-	users, _, err := client.Users.Search(&sonar.UsersSearchOption{
+	users, _, err := client.Users.Search(&sonar.UsersSearchOptions{
 		PaginationArgs:        sonar.PaginationArgs{Page: 0, PageSize: 0},
 		Deactivated:           false,
 		ExternalIdentity:      "",
@@ -180,7 +180,7 @@ func cleanupOrphanedUsers(client *sonar.Client, _ time.Duration) error {
 	for _, u := range users.Users {
 		if strings.HasPrefix(u.Login, E2EResourcePrefix) {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, _ = client.Users.Deactivate(&sonar.UsersDeactivateOption{
+			_, _, _ = client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 				Login:     u.Login,
 				Anonymize: false,
 			})
@@ -192,7 +192,7 @@ func cleanupOrphanedUsers(client *sonar.Client, _ time.Duration) error {
 
 func cleanupOrphanedGroups(client *sonar.Client, _ time.Duration) error {
 	//nolint:staticcheck // Using deprecated API until v2 API is implemented
-	groups, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOption{
+	groups, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
 		PaginationArgs: sonar.PaginationArgs{Page: 0, PageSize: 0},
 		Managed:        nil,
 		Fields:         nil,
@@ -209,7 +209,7 @@ func cleanupOrphanedGroups(client *sonar.Client, _ time.Duration) error {
 	for _, g := range groups.Groups {
 		if strings.HasPrefix(g.Name, E2EResourcePrefix) {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _ = client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+			_, _ = client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 				Name: g.Name,
 			})
 		}

--- a/integration_testing/hotspots_test.go
+++ b/integration_testing/hotspots_test.go
@@ -26,14 +26,14 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		// Create a test project for hotspots-related operations
 		projectKey = helpers.UniqueResourceName("hot")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    "Hotspots Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -61,7 +61,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without project or hotspots parameter", func() {
-				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOption{})
+				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
 				Expect(resp).To(BeNil())
@@ -70,7 +70,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should search hotspots for a project", func() {
-				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOption{
+				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -79,7 +79,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should search hotspots with pagination", func() {
-				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOption{
+				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOptions{
 					Project: projectKey,
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 10,
@@ -92,7 +92,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should search hotspots with status filter", func() {
-				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOption{
+				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOptions{
 					Project: projectKey,
 					Status:  "TO_REVIEW",
 				})
@@ -102,7 +102,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should search hotspots in new code period", func() {
-				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOption{
+				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOptions{
 					Project:         projectKey,
 					InNewCodePeriod: true,
 				})
@@ -114,7 +114,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOption{
+				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOptions{
 					Project: "non-existent-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -140,7 +140,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required project", func() {
-				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOption{})
+				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Project"))
 				Expect(result).To(BeNil())
@@ -150,7 +150,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should list hotspots for a project", func() {
-				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOption{
+				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -159,7 +159,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should list hotspots with pagination", func() {
-				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOption{
+				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOptions{
 					Project: projectKey,
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 10,
@@ -172,7 +172,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should list hotspots with status filter", func() {
-				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOption{
+				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOptions{
 					Project: projectKey,
 					Status:  "TO_REVIEW",
 				})
@@ -184,7 +184,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOption{
+				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOptions{
 					Project: "non-existent-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -210,7 +210,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required hotspot key", func() {
-				result, resp, err := client.Hotspots.Show(&sonar.HotspotsShowOption{})
+				result, resp, err := client.Hotspots.Show(&sonar.HotspotsShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Hotspot"))
 				Expect(result).To(BeNil())
@@ -220,7 +220,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Hotspot", func() {
 			It("should fail with non-existent hotspot key", func() {
-				result, resp, err := client.Hotspots.Show(&sonar.HotspotsShowOption{
+				result, resp, err := client.Hotspots.Show(&sonar.HotspotsShowOptions{
 					Hotspot: "AXxxxxxxxxxxxxxxxxxx",
 				})
 				Expect(err).To(HaveOccurred())
@@ -246,7 +246,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required project key", func() {
-				result, resp, err := client.Hotspots.Pull(&sonar.HotspotsPullOption{
+				result, resp, err := client.Hotspots.Pull(&sonar.HotspotsPullOptions{
 					BranchName: "main",
 				})
 				Expect(err).To(HaveOccurred())
@@ -256,7 +256,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required branch name", func() {
-				result, resp, err := client.Hotspots.Pull(&sonar.HotspotsPullOption{
+				result, resp, err := client.Hotspots.Pull(&sonar.HotspotsPullOptions{
 					ProjectKey: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -268,7 +268,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.Hotspots.Pull(&sonar.HotspotsPullOption{
+				result, resp, err := client.Hotspots.Pull(&sonar.HotspotsPullOptions{
 					ProjectKey: "non-existent-project",
 					BranchName: "main",
 				})
@@ -294,7 +294,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required hotspot key", func() {
-				resp, err := client.Hotspots.AddComment(&sonar.HotspotsAddCommentOption{
+				resp, err := client.Hotspots.AddComment(&sonar.HotspotsAddCommentOptions{
 					Comment: "Test comment",
 				})
 				Expect(err).To(HaveOccurred())
@@ -303,7 +303,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required comment", func() {
-				resp, err := client.Hotspots.AddComment(&sonar.HotspotsAddCommentOption{
+				resp, err := client.Hotspots.AddComment(&sonar.HotspotsAddCommentOptions{
 					Hotspot: "AXxxxxxxxxxxxxxxxxxx",
 				})
 				Expect(err).To(HaveOccurred())
@@ -314,7 +314,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Hotspot", func() {
 			It("should fail with non-existent hotspot key", func() {
-				resp, err := client.Hotspots.AddComment(&sonar.HotspotsAddCommentOption{
+				resp, err := client.Hotspots.AddComment(&sonar.HotspotsAddCommentOptions{
 					Hotspot: "AXxxxxxxxxxxxxxxxxxx",
 					Comment: "Test comment",
 				})
@@ -339,7 +339,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required hotspot key", func() {
-				resp, err := client.Hotspots.Assign(&sonar.HotspotsAssignOption{
+				resp, err := client.Hotspots.Assign(&sonar.HotspotsAssignOptions{
 					Assignee: "admin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -350,7 +350,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Hotspot", func() {
 			It("should fail with non-existent hotspot key", func() {
-				resp, err := client.Hotspots.Assign(&sonar.HotspotsAssignOption{
+				resp, err := client.Hotspots.Assign(&sonar.HotspotsAssignOptions{
 					Hotspot:  "AXxxxxxxxxxxxxxxxxxx",
 					Assignee: "admin",
 				})
@@ -375,7 +375,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required hotspot key", func() {
-				resp, err := client.Hotspots.ChangeStatus(&sonar.HotspotsChangeStatusOption{
+				resp, err := client.Hotspots.ChangeStatus(&sonar.HotspotsChangeStatusOptions{
 					Status: "REVIEWED",
 				})
 				Expect(err).To(HaveOccurred())
@@ -384,7 +384,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required status", func() {
-				resp, err := client.Hotspots.ChangeStatus(&sonar.HotspotsChangeStatusOption{
+				resp, err := client.Hotspots.ChangeStatus(&sonar.HotspotsChangeStatusOptions{
 					Hotspot: "AXxxxxxxxxxxxxxxxxxx",
 				})
 				Expect(err).To(HaveOccurred())
@@ -395,7 +395,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Hotspot", func() {
 			It("should fail with non-existent hotspot key", func() {
-				resp, err := client.Hotspots.ChangeStatus(&sonar.HotspotsChangeStatusOption{
+				resp, err := client.Hotspots.ChangeStatus(&sonar.HotspotsChangeStatusOptions{
 					Hotspot:    "AXxxxxxxxxxxxxxxxxxx",
 					Status:     "REVIEWED",
 					Resolution: "SAFE",
@@ -421,7 +421,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required comment key", func() {
-				resp, err := client.Hotspots.DeleteComment(&sonar.HotspotsDeleteCommentOption{})
+				resp, err := client.Hotspots.DeleteComment(&sonar.HotspotsDeleteCommentOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Comment"))
 				Expect(resp).To(BeNil())
@@ -430,7 +430,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Comment", func() {
 			It("should fail with non-existent comment key", func() {
-				resp, err := client.Hotspots.DeleteComment(&sonar.HotspotsDeleteCommentOption{
+				resp, err := client.Hotspots.DeleteComment(&sonar.HotspotsDeleteCommentOptions{
 					Comment: "AXxxxxxxxxxxxxxxxxxx",
 				})
 				Expect(err).To(HaveOccurred())
@@ -455,7 +455,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required comment key", func() {
-				result, resp, err := client.Hotspots.EditComment(&sonar.HotspotsEditCommentOption{
+				result, resp, err := client.Hotspots.EditComment(&sonar.HotspotsEditCommentOptions{
 					Text: "Updated comment",
 				})
 				Expect(err).To(HaveOccurred())
@@ -465,7 +465,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required text", func() {
-				result, resp, err := client.Hotspots.EditComment(&sonar.HotspotsEditCommentOption{
+				result, resp, err := client.Hotspots.EditComment(&sonar.HotspotsEditCommentOptions{
 					Comment: "AXxxxxxxxxxxxxxxxxxx",
 				})
 				Expect(err).To(HaveOccurred())
@@ -477,7 +477,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Comment", func() {
 			It("should fail with non-existent comment key", func() {
-				result, resp, err := client.Hotspots.EditComment(&sonar.HotspotsEditCommentOption{
+				result, resp, err := client.Hotspots.EditComment(&sonar.HotspotsEditCommentOptions{
 					Comment: "AXxxxxxxxxxxxxxxxxxx",
 					Text:    "Updated comment",
 				})

--- a/integration_testing/issues_test.go
+++ b/integration_testing/issues_test.go
@@ -31,14 +31,14 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		// Create a test project for issues-related operations
 		projectKey = helpers.UniqueResourceName("iss")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    "Issues Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -65,7 +65,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should search issues for a project", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOption{
+				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
 					Projects: []string{projectKey},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -74,7 +74,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should search issues with pagination", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOption{
+				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
 					Projects: []string{projectKey},
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 10,
@@ -87,7 +87,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should search issues with impact severities filter", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOption{
+				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
 					Projects:         []string{projectKey},
 					ImpactSeverities: []string{"HIGH", "MEDIUM"},
 				})
@@ -97,7 +97,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should search issues with issue statuses filter", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOption{
+				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
 					Projects:      []string{projectKey},
 					IssueStatuses: []string{"OPEN", "CONFIRMED"},
 				})
@@ -107,7 +107,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should search issues with clean code categories filter", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOption{
+				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
 					Projects:                     []string{projectKey},
 					CleanCodeAttributeCategories: []string{"INTENTIONAL", "CONSISTENT"},
 				})
@@ -117,7 +117,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should search issues with additional fields", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOption{
+				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
 					Projects:         []string{projectKey},
 					AdditionalFields: []string{"rules", "users"},
 				})
@@ -127,7 +127,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should search issues with facets", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOption{
+				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
 					Projects: []string{projectKey},
 					Facets:   []string{"impactSeverities", "issueStatuses"},
 				})
@@ -139,7 +139,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should return empty results for non-existent project", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOption{
+				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
 					Projects: []string{nonExistentProjectKey},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -164,7 +164,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without project or component", func() {
-				result, resp, err := client.Issues.List(&sonar.IssuesListOption{})
+				result, resp, err := client.Issues.List(&sonar.IssuesListOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
 				Expect(resp).To(BeNil())
@@ -173,7 +173,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should list issues for a project", func() {
-				result, resp, err := client.Issues.List(&sonar.IssuesListOption{
+				result, resp, err := client.Issues.List(&sonar.IssuesListOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -182,7 +182,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should list issues with pagination", func() {
-				result, resp, err := client.Issues.List(&sonar.IssuesListOption{
+				result, resp, err := client.Issues.List(&sonar.IssuesListOptions{
 					Project: projectKey,
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 10,
@@ -209,7 +209,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should list authors for a project", func() {
-				result, resp, err := client.Issues.Authors(&sonar.IssuesAuthorsOption{
+				result, resp, err := client.Issues.Authors(&sonar.IssuesAuthorsOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -218,7 +218,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should list authors with query filter", func() {
-				result, resp, err := client.Issues.Authors(&sonar.IssuesAuthorsOption{
+				result, resp, err := client.Issues.Authors(&sonar.IssuesAuthorsOptions{
 					Query: "admin",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -227,7 +227,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should list authors with pagination", func() {
-				result, resp, err := client.Issues.Authors(&sonar.IssuesAuthorsOption{
+				result, resp, err := client.Issues.Authors(&sonar.IssuesAuthorsOptions{
 					PageSize: 10,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -250,7 +250,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should list tags for a project", func() {
-				result, resp, err := client.Issues.Tags(&sonar.IssuesTagsOption{
+				result, resp, err := client.Issues.Tags(&sonar.IssuesTagsOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -259,7 +259,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should list tags with query filter", func() {
-				result, resp, err := client.Issues.Tags(&sonar.IssuesTagsOption{
+				result, resp, err := client.Issues.Tags(&sonar.IssuesTagsOptions{
 					Query: "security",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -283,7 +283,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Issues.AddComment(&sonar.IssuesAddCommentOption{
+				result, resp, err := client.Issues.AddComment(&sonar.IssuesAddCommentOptions{
 					Text: "Test comment",
 				})
 				Expect(err).To(HaveOccurred())
@@ -293,7 +293,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required text", func() {
-				result, resp, err := client.Issues.AddComment(&sonar.IssuesAddCommentOption{
+				result, resp, err := client.Issues.AddComment(&sonar.IssuesAddCommentOptions{
 					Issue: nonExistentIssueKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -305,7 +305,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Issues.AddComment(&sonar.IssuesAddCommentOption{
+				result, resp, err := client.Issues.AddComment(&sonar.IssuesAddCommentOptions{
 					Issue: nonExistentIssueKey,
 					Text:  "Test comment",
 				})
@@ -332,7 +332,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Issues.Assign(&sonar.IssuesAssignOption{
+				result, resp, err := client.Issues.Assign(&sonar.IssuesAssignOptions{
 					Assignee: "admin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -344,7 +344,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Issues.Assign(&sonar.IssuesAssignOption{
+				result, resp, err := client.Issues.Assign(&sonar.IssuesAssignOptions{
 					Issue:    nonExistentIssueKey,
 					Assignee: "admin",
 				})
@@ -371,7 +371,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Issues.Changelog(&sonar.IssuesChangelogOption{})
+				result, resp, err := client.Issues.Changelog(&sonar.IssuesChangelogOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Issue"))
 				Expect(result).To(BeNil())
@@ -381,7 +381,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Issues.Changelog(&sonar.IssuesChangelogOption{
+				result, resp, err := client.Issues.Changelog(&sonar.IssuesChangelogOptions{
 					Issue: nonExistentIssueKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -407,7 +407,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Issues.DoTransition(&sonar.IssuesDoTransitionOption{
+				result, resp, err := client.Issues.DoTransition(&sonar.IssuesDoTransitionOptions{
 					Transition: "confirm",
 				})
 				Expect(err).To(HaveOccurred())
@@ -417,7 +417,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required transition", func() {
-				result, resp, err := client.Issues.DoTransition(&sonar.IssuesDoTransitionOption{
+				result, resp, err := client.Issues.DoTransition(&sonar.IssuesDoTransitionOptions{
 					Issue: nonExistentIssueKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -429,7 +429,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Issues.DoTransition(&sonar.IssuesDoTransitionOption{
+				result, resp, err := client.Issues.DoTransition(&sonar.IssuesDoTransitionOptions{
 					Issue:      nonExistentIssueKey,
 					Transition: "confirm",
 				})
@@ -456,7 +456,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issues", func() {
-				result, resp, err := client.Issues.BulkChange(&sonar.IssuesBulkChangeOption{
+				result, resp, err := client.Issues.BulkChange(&sonar.IssuesBulkChangeOptions{
 					AddTags: []string{"test-tag"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -468,7 +468,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issues", func() {
 			It("should handle bulk change on non-existent issues", func() {
-				result, resp, err := client.Issues.BulkChange(&sonar.IssuesBulkChangeOption{
+				result, resp, err := client.Issues.BulkChange(&sonar.IssuesBulkChangeOptions{
 					Issues:  []string{nonExistentIssueKey},
 					AddTags: []string{"test-tag"},
 				})
@@ -497,7 +497,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Issues.SetSeverity(&sonar.IssuesSetSeverityOption{
+				result, resp, err := client.Issues.SetSeverity(&sonar.IssuesSetSeverityOptions{
 					Severity: "MAJOR",
 				})
 				Expect(err).To(HaveOccurred())
@@ -509,7 +509,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Issues.SetSeverity(&sonar.IssuesSetSeverityOption{
+				result, resp, err := client.Issues.SetSeverity(&sonar.IssuesSetSeverityOptions{
 					Issue:    nonExistentIssueKey,
 					Severity: "MAJOR",
 				})
@@ -536,7 +536,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Issues.SetTags(&sonar.IssuesSetTagsOption{
+				result, resp, err := client.Issues.SetTags(&sonar.IssuesSetTagsOptions{
 					Tags: []string{"test-tag"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -548,7 +548,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Issues.SetTags(&sonar.IssuesSetTagsOption{
+				result, resp, err := client.Issues.SetTags(&sonar.IssuesSetTagsOptions{
 					Issue: nonExistentIssueKey,
 					Tags:  []string{"test-tag"},
 				})
@@ -575,7 +575,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Issues.SetType(&sonar.IssuesSetTypeOption{
+				result, resp, err := client.Issues.SetType(&sonar.IssuesSetTypeOptions{
 					Type: "BUG",
 				})
 				Expect(err).To(HaveOccurred())
@@ -585,7 +585,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required type", func() {
-				result, resp, err := client.Issues.SetType(&sonar.IssuesSetTypeOption{
+				result, resp, err := client.Issues.SetType(&sonar.IssuesSetTypeOptions{
 					Issue: nonExistentIssueKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -597,7 +597,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Issues.SetType(&sonar.IssuesSetTypeOption{
+				result, resp, err := client.Issues.SetType(&sonar.IssuesSetTypeOptions{
 					Issue: nonExistentIssueKey,
 					Type:  "BUG",
 				})
@@ -624,7 +624,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required comment key", func() {
-				result, resp, err := client.Issues.DeleteComment(&sonar.IssuesDeleteCommentOption{})
+				result, resp, err := client.Issues.DeleteComment(&sonar.IssuesDeleteCommentOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Comment"))
 				Expect(result).To(BeNil())
@@ -634,7 +634,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Comment", func() {
 			It("should fail with non-existent comment key", func() {
-				result, resp, err := client.Issues.DeleteComment(&sonar.IssuesDeleteCommentOption{
+				result, resp, err := client.Issues.DeleteComment(&sonar.IssuesDeleteCommentOptions{
 					Comment: nonExistentIssueKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -660,7 +660,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required comment key", func() {
-				result, resp, err := client.Issues.EditComment(&sonar.IssuesEditCommentOption{
+				result, resp, err := client.Issues.EditComment(&sonar.IssuesEditCommentOptions{
 					Text: "Updated comment",
 				})
 				Expect(err).To(HaveOccurred())
@@ -670,7 +670,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required text", func() {
-				result, resp, err := client.Issues.EditComment(&sonar.IssuesEditCommentOption{
+				result, resp, err := client.Issues.EditComment(&sonar.IssuesEditCommentOptions{
 					Comment: nonExistentIssueKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -682,7 +682,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Comment", func() {
 			It("should fail with non-existent comment key", func() {
-				result, resp, err := client.Issues.EditComment(&sonar.IssuesEditCommentOption{
+				result, resp, err := client.Issues.EditComment(&sonar.IssuesEditCommentOptions{
 					Comment: nonExistentIssueKey,
 					Text:    "Updated comment",
 				})
@@ -708,7 +708,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required project key", func() {
-				resp, err := client.Issues.Reindex(&sonar.IssuesReindexOption{})
+				resp, err := client.Issues.Reindex(&sonar.IssuesReindexOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Project"))
 				Expect(resp).To(BeNil())
@@ -717,7 +717,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should trigger reindex for a project", func() {
-				resp, err := client.Issues.Reindex(&sonar.IssuesReindexOption{
+				resp, err := client.Issues.Reindex(&sonar.IssuesReindexOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -727,7 +727,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				resp, err := client.Issues.Reindex(&sonar.IssuesReindexOption{
+				resp, err := client.Issues.Reindex(&sonar.IssuesReindexOptions{
 					Project: nonExistentProjectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -752,7 +752,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required project key", func() {
-				result, resp, err := client.Issues.Pull(&sonar.IssuesPullOption{})
+				result, resp, err := client.Issues.Pull(&sonar.IssuesPullOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("ProjectKey"))
 				Expect(result).To(BeNil())
@@ -760,7 +760,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required branch name", func() {
-				result, resp, err := client.Issues.Pull(&sonar.IssuesPullOption{
+				result, resp, err := client.Issues.Pull(&sonar.IssuesPullOptions{
 					ProjectKey: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -774,7 +774,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.Issues.Pull(&sonar.IssuesPullOption{
+				result, resp, err := client.Issues.Pull(&sonar.IssuesPullOptions{
 					ProjectKey: nonExistentProjectKey,
 					BranchName: "main",
 				})
@@ -801,7 +801,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required project key", func() {
-				result, resp, err := client.Issues.PullTaint(&sonar.IssuesPullTaintOption{})
+				result, resp, err := client.Issues.PullTaint(&sonar.IssuesPullTaintOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("ProjectKey"))
 				Expect(result).To(BeNil())
@@ -809,7 +809,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required branch name", func() {
-				result, resp, err := client.Issues.PullTaint(&sonar.IssuesPullTaintOption{
+				result, resp, err := client.Issues.PullTaint(&sonar.IssuesPullTaintOptions{
 					ProjectKey: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -823,7 +823,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.Issues.PullTaint(&sonar.IssuesPullTaintOption{
+				result, resp, err := client.Issues.PullTaint(&sonar.IssuesPullTaintOptions{
 					ProjectKey: nonExistentProjectKey,
 					BranchName: "main",
 				})
@@ -850,7 +850,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required component UUID", func() {
-				result, resp, err := client.Issues.ComponentTags(&sonar.IssuesComponentTagsOption{})
+				result, resp, err := client.Issues.ComponentTags(&sonar.IssuesComponentTagsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("ComponentUuid"))
 				Expect(result).To(BeNil())
@@ -862,7 +862,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			It("should handle non-existent component UUID", func() {
 				// Use a properly formatted UUID that's guaranteed to not exist
 				// Format matches SonarQube's UUID format: 8-4-4-4-12 hexadecimal digits
-				result, resp, err := client.Issues.ComponentTags(&sonar.IssuesComponentTagsOption{
+				result, resp, err := client.Issues.ComponentTags(&sonar.IssuesComponentTagsOptions{
 					ComponentUuid: "00000000-0000-0000-0000-000000000000",
 				})
 

--- a/integration_testing/l10n_test.go
+++ b/integration_testing/l10n_test.go
@@ -71,7 +71,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 
 		Context("Specific Locale", func() {
 			It("should get localization messages for specific locale", func() {
-				result, resp, err := client.L10N.Index(&sonar.L10NIndexOption{
+				result, resp, err := client.L10N.Index(&sonar.L10NIndexOptions{
 					Locale: "en",
 				})
 				// Skip if API not available
@@ -93,7 +93,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 		Context("Compare Different Locales", func() {
 			It("should return different translations for different locales if available", func() {
 				// Get English locale
-				resultEN, respEN, err := client.L10N.Index(&sonar.L10NIndexOption{
+				resultEN, respEN, err := client.L10N.Index(&sonar.L10NIndexOptions{
 					Locale: "en",
 				})
 				// Skip if API not available
@@ -104,7 +104,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 				Expect(respEN.StatusCode).To(Equal(http.StatusOK))
 
 				// Try to get French locale
-				resultFR, respFR, err := client.L10N.Index(&sonar.L10NIndexOption{
+				resultFR, respFR, err := client.L10N.Index(&sonar.L10NIndexOptions{
 					Locale: "fr",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -130,7 +130,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 			It("should get localization messages with timestamp", func() {
 				// Use a recent timestamp (1 year ago)
 				oneYearAgo := time.Now().AddDate(-1, 0, 0).Format("2006-01-02T15:04:05-0700")
-				result, resp, err := client.L10N.Index(&sonar.L10NIndexOption{
+				result, resp, err := client.L10N.Index(&sonar.L10NIndexOptions{
 					Timestamp: oneYearAgo,
 				})
 				// Skip if API not available

--- a/integration_testing/languages_test.go
+++ b/integration_testing/languages_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Languages Service", Ordered, func() {
 			})
 
 			It("should succeed with empty options", func() {
-				result, resp, err := client.Languages.List(&sonar.LanguagesListOption{})
+				result, resp, err := client.Languages.List(&sonar.LanguagesListOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -91,7 +91,7 @@ var _ = Describe("Languages Service", Ordered, func() {
 			})
 
 			It("should filter languages with query", func() {
-				result, resp, err := client.Languages.List(&sonar.LanguagesListOption{
+				result, resp, err := client.Languages.List(&sonar.LanguagesListOptions{
 					Query: "java",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -112,7 +112,7 @@ var _ = Describe("Languages Service", Ordered, func() {
 				}
 			})
 			It("should limit results with page size", func() {
-				result, resp, err := client.Languages.List(&sonar.LanguagesListOption{
+				result, resp, err := client.Languages.List(&sonar.LanguagesListOptions{
 					PageSize: 2,
 				})
 				Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/measures_test.go
+++ b/integration_testing/measures_test.go
@@ -26,14 +26,14 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		// Create a test project for measures-related operations
 		projectKey = helpers.UniqueResourceName("msr")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    "Measures Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -61,7 +61,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required component parameter", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOption{
+				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
 					MetricKeys: []string{"ncloc"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -71,7 +71,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required metric keys", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOption{
+				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
 					Component: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -83,7 +83,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should get component measures for an existing project", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOption{
+				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc", "complexity", "coverage"},
 				})
@@ -94,7 +94,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get measures with single metric", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOption{
+				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"lines"},
 				})
@@ -105,7 +105,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get measures with additional fields", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOption{
+				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
 					Component:        projectKey,
 					MetricKeys:       []string{"ncloc"},
 					AdditionalFields: []string{"metrics"},
@@ -118,7 +118,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("Non-Existent Component", func() {
 			It("should fail with non-existent component", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOption{
+				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
 					Component:  "non-existent-project",
 					MetricKeys: []string{"ncloc"},
 				})
@@ -132,7 +132,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("With Branch", func() {
 			It("should fail for non-existent branch", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOption{
+				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
 					Branch:     "non-existent-branch",
@@ -147,7 +147,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("With Pull Request", func() {
 			It("should fail for non-existent pull request", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOption{
+				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
 					Component:   projectKey,
 					MetricKeys:  []string{"ncloc"},
 					PullRequest: "99999",
@@ -175,7 +175,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required component parameter", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOption{
+				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					MetricKeys: []string{"ncloc"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -185,7 +185,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required metric keys", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOption{
+				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -195,7 +195,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail with invalid metric sort filter", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOption{
+				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:        projectKey,
 					MetricKeys:       []string{"ncloc"},
 					MetricSortFilter: "invalid",
@@ -207,7 +207,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail with invalid strategy", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOption{
+				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
 					Strategy:   "invalid",
@@ -221,7 +221,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should get component tree measures for an existing project", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOption{
+				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc", "complexity"},
 				})
@@ -232,7 +232,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get component tree with children strategy", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOption{
+				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
 					Strategy:   "children",
@@ -243,7 +243,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get component tree with leaves strategy", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOption{
+				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
 					Strategy:   "leaves",
@@ -254,7 +254,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get component tree with all strategy", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOption{
+				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
 					Strategy:   "all",
@@ -265,7 +265,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get component tree with metric sort filter", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOption{
+				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:        projectKey,
 					MetricKeys:       []string{"ncloc"},
 					MetricSortFilter: "withMeasuresOnly",
@@ -278,7 +278,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get component tree with pagination", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOption{
+				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
 					PaginationArgs: sonar.PaginationArgs{
@@ -293,7 +293,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get component tree with qualifiers filter", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOption{
+				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
 					Qualifiers: []string{"FIL"},
@@ -304,7 +304,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get component tree with additional fields", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOption{
+				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:        projectKey,
 					MetricKeys:       []string{"ncloc"},
 					AdditionalFields: []string{"metrics"},
@@ -317,7 +317,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("Non-Existent Component", func() {
 			It("should fail with non-existent component", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOption{
+				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:  "non-existent-project",
 					MetricKeys: []string{"ncloc"},
 				})
@@ -344,7 +344,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required metric keys", func() {
-				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOption{
+				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOptions{
 					ProjectKeys: []string{projectKey},
 				})
 				Expect(err).To(HaveOccurred())
@@ -354,7 +354,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required project keys", func() {
-				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOption{
+				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOptions{
 					MetricKeys: []string{"ncloc"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -366,7 +366,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should search measures for an existing project", func() {
-				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOption{
+				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOptions{
 					MetricKeys:  []string{"ncloc"},
 					ProjectKeys: []string{projectKey},
 				})
@@ -376,7 +376,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should search measures with multiple metrics", func() {
-				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOption{
+				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOptions{
 					MetricKeys:  []string{"ncloc", "complexity", "coverage"},
 					ProjectKeys: []string{projectKey},
 				})
@@ -391,14 +391,14 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 			BeforeAll(func() {
 				secondProjectKey = helpers.UniqueResourceName("msr2")
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    "Second Measures Test Project",
 					Project: secondProjectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", secondProjectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: secondProjectKey,
 					})
 					return err
@@ -406,7 +406,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should search measures for multiple projects", func() {
-				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOption{
+				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOptions{
 					MetricKeys:  []string{"ncloc"},
 					ProjectKeys: []string{projectKey, secondProjectKey},
 				})
@@ -419,7 +419,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 		Context("Non-Existent Project", func() {
 			It("should return empty measures for non-existent project", func() {
 				// The API doesn't fail for non-existent projects, it just returns empty measures
-				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOption{
+				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOptions{
 					MetricKeys:  []string{"ncloc"},
 					ProjectKeys: []string{"non-existent-project"},
 				})
@@ -446,7 +446,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required component parameter", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOption{
+				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
 					Metrics: []string{"ncloc"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -456,7 +456,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required metrics", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOption{
+				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
 					Component: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -468,7 +468,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should get measure history for an existing project", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOption{
+				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
 					Component: projectKey,
 					Metrics:   []string{"ncloc"},
 				})
@@ -478,7 +478,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get history with multiple metrics", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOption{
+				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
 					Component: projectKey,
 					Metrics:   []string{"ncloc", "complexity", "coverage"},
 				})
@@ -488,7 +488,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get history with pagination", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOption{
+				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
 					Component: projectKey,
 					Metrics:   []string{"ncloc"},
 					PaginationArgs: sonar.PaginationArgs{
@@ -503,7 +503,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get history with date range", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOption{
+				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
 					Component: projectKey,
 					Metrics:   []string{"ncloc"},
 					From:      "2020-01-01",
@@ -517,7 +517,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("Non-Existent Component", func() {
 			It("should fail with non-existent component", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOption{
+				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
 					Component: "non-existent-project",
 					Metrics:   []string{"ncloc"},
 				})
@@ -531,7 +531,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("With Branch", func() {
 			It("should fail for non-existent branch", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOption{
+				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
 					Component: projectKey,
 					Metrics:   []string{"ncloc"},
 					Branch:    "non-existent-branch",
@@ -546,7 +546,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("With Pull Request", func() {
 			It("should fail for non-existent pull request", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOption{
+				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
 					Component:   projectKey,
 					Metrics:     []string{"ncloc"},
 					PullRequest: "99999",

--- a/integration_testing/metrics_test.go
+++ b/integration_testing/metrics_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Metrics Service", Ordered, func() {
 			})
 
 			It("should search metrics with empty options", func() {
-				result, resp, err := client.Metrics.Search(&sonar.MetricsSearchOption{})
+				result, resp, err := client.Metrics.Search(&sonar.MetricsSearchOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -80,7 +80,7 @@ var _ = Describe("Metrics Service", Ordered, func() {
 			})
 
 			It("should support pagination", func() {
-				result, resp, err := client.Metrics.Search(&sonar.MetricsSearchOption{
+				result, resp, err := client.Metrics.Search(&sonar.MetricsSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 5,
 					},

--- a/integration_testing/navigation_test.go
+++ b/integration_testing/navigation_test.go
@@ -26,14 +26,14 @@ var _ = Describe("Navigation Service", Ordered, func() {
 
 		// Create a test project for component navigation
 		projectKey = helpers.UniqueResourceName("nav")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    "Navigation Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -59,7 +59,7 @@ var _ = Describe("Navigation Service", Ordered, func() {
 			})
 
 			It("should fail with empty component key", func() {
-				resp, _, err := client.Navigation.Component(&sonar.NavigationComponentOption{
+				resp, _, err := client.Navigation.Component(&sonar.NavigationComponentOptions{
 					Component: "",
 				})
 				Expect(resp).To(BeNil())
@@ -69,7 +69,7 @@ var _ = Describe("Navigation Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should get component navigation with valid component key and breadcrumbs", func() {
-				result, resp, err := client.Navigation.Component(&sonar.NavigationComponentOption{
+				result, resp, err := client.Navigation.Component(&sonar.NavigationComponentOptions{
 					Component: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -82,7 +82,7 @@ var _ = Describe("Navigation Service", Ordered, func() {
 
 		Context("Error Cases", func() {
 			It("should fail with non-existent component key", func() {
-				_, resp, err := client.Navigation.Component(&sonar.NavigationComponentOption{
+				_, resp, err := client.Navigation.Component(&sonar.NavigationComponentOptions{
 					Component: "non-existent-component-key-12345",
 				})
 				Expect(err).To(HaveOccurred())

--- a/integration_testing/new_code_periods_test.go
+++ b/integration_testing/new_code_periods_test.go
@@ -62,20 +62,20 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should show project-level new code period definition", func() {
 			projectKey := helpers.UniqueResourceName("ncp-show-proj")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "NCP Show Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			result, resp, err := client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOption{
+			result, resp, err := client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -87,7 +87,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should show branch-level new code period definition", func() {
 			projectKey := helpers.UniqueResourceName("ncp-show-branch")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "NCP Branch Show Test Project",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -95,13 +95,13 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			result, resp, err := client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOption{
+			result, resp, err := client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOptions{
 				Project: projectKey,
 				Branch:  "main",
 			})
@@ -119,7 +119,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should list new code periods for project", func() {
 			projectKey := helpers.UniqueResourceName("ncp-list-proj")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "NCP List Test Project",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -127,13 +127,13 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			result, resp, err := client.NewCodePeriods.List(&sonar.NewCodePeriodsListOption{
+			result, resp, err := client.NewCodePeriods.List(&sonar.NewCodePeriodsListOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -151,7 +151,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				result, resp, err := client.NewCodePeriods.List(&sonar.NewCodePeriodsListOption{})
+				result, resp, err := client.NewCodePeriods.List(&sonar.NewCodePeriodsListOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -160,7 +160,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.NewCodePeriods.List(&sonar.NewCodePeriodsListOption{
+				result, resp, err := client.NewCodePeriods.List(&sonar.NewCodePeriodsListOptions{
 					Project: "non-existent-project-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -182,7 +182,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should set project-level new code period with PREVIOUS_VERSION", func() {
 			projectKey := helpers.UniqueResourceName("ncp-prevver")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "NCP Set PreviousVersion Test",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -190,13 +190,13 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Type:    "PREVIOUS_VERSION",
 			})
@@ -211,7 +211,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should set project-level new code period with NUMBER_OF_DAYS", func() {
 			projectKey := helpers.UniqueResourceName("ncp-numdays")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "NCP Set Days Test",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -219,13 +219,13 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Type:    "NUMBER_OF_DAYS",
 				Value:   "30",
@@ -241,7 +241,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should set project-level new code period with REFERENCE_BRANCH", func() {
 			projectKey := helpers.UniqueResourceName("ncp-refbranch")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "NCP Set RefBranch Test",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -249,13 +249,13 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Type:    "REFERENCE_BRANCH",
 				Value:   "main",
@@ -271,7 +271,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should set branch-level new code period", func() {
 			projectKey := helpers.UniqueResourceName("ncp-branchlvl")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "NCP Set Branch Test",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -279,13 +279,13 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Branch:  "main",
 				Type:    "NUMBER_OF_DAYS",
@@ -295,7 +295,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			// Verify the setting was applied
-			result, _, err := client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOption{
+			result, _, err := client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOptions{
 				Project: projectKey,
 				Branch:  "main",
 			})
@@ -312,7 +312,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with missing type", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -320,7 +320,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with invalid type", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 					Type:    "INVALID_TYPE",
 				})
@@ -329,7 +329,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with NUMBER_OF_DAYS and invalid value", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 					Type:    "NUMBER_OF_DAYS",
 					Value:   "invalid",
@@ -339,7 +339,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with NUMBER_OF_DAYS exceeding max value", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 					Type:    "NUMBER_OF_DAYS",
 					Value:   "100",
@@ -349,7 +349,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with NUMBER_OF_DAYS without value", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 					Type:    "NUMBER_OF_DAYS",
 					Value:   "",
@@ -359,7 +359,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with NUMBER_OF_DAYS with zero value", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 					Type:    "NUMBER_OF_DAYS",
 					Value:   "0",
@@ -369,7 +369,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with NUMBER_OF_DAYS with negative value", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 					Type:    "NUMBER_OF_DAYS",
 					Value:   "-5",
@@ -381,20 +381,20 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			It("should succeed with NUMBER_OF_DAYS minimum value", func() {
 				projectKey := helpers.UniqueResourceName("ncp-mindays")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    "NCP Min Days Test",
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: projectKey,
 					Type:    "NUMBER_OF_DAYS",
 					Value:   "1",
@@ -406,20 +406,20 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			It("should succeed with NUMBER_OF_DAYS maximum value", func() {
 				projectKey := helpers.UniqueResourceName("ncp-maxdays")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    "NCP Max Days Test",
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: projectKey,
 					Type:    "NUMBER_OF_DAYS",
 					Value:   "90",
@@ -429,7 +429,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with REFERENCE_BRANCH missing project", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Type:  "REFERENCE_BRANCH",
 					Value: "main",
 				})
@@ -438,7 +438,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with SPECIFIC_ANALYSIS missing branch", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 					Type:    "SPECIFIC_ANALYSIS",
 					Value:   "some-analysis-id",
@@ -456,28 +456,28 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should unset project-level new code period", func() {
 			projectKey := helpers.UniqueResourceName("ncp-unsetproj")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "NCP Unset Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// First, set a new code period
-			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Type:    "PREVIOUS_VERSION",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Unset it
-			resp, err := client.NewCodePeriods.Unset(&sonar.NewCodePeriodsUnsetOption{
+			resp, err := client.NewCodePeriods.Unset(&sonar.NewCodePeriodsUnsetOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -487,7 +487,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should unset branch-level new code period", func() {
 			projectKey := helpers.UniqueResourceName("ncp-unsetbranch")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "NCP Unset Branch Test Project",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -495,14 +495,14 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// First, set a branch-level new code period
-			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Branch:  "main",
 				Type:    "NUMBER_OF_DAYS",
@@ -511,7 +511,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Unset it
-			resp, err := client.NewCodePeriods.Unset(&sonar.NewCodePeriodsUnsetOption{
+			resp, err := client.NewCodePeriods.Unset(&sonar.NewCodePeriodsUnsetOptions{
 				Project: projectKey,
 				Branch:  "main",
 			})
@@ -535,7 +535,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			projectKey := helpers.UniqueResourceName("ncp-lifecycle")
 
 			// Step 1: Create project
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "NCP Lifecycle Test Project",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -543,21 +543,21 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// Step 2: Show project-level (inherits from global initially)
-			result, _, err := client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOption{
+			result, _, err := client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
 			// Step 3: Set project-level new code period
-			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Type:    "NUMBER_OF_DAYS",
 				Value:   "30",
@@ -565,7 +565,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 4: Set branch-level new code period
-			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOption{
+			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Branch:  "main",
 				Type:    "PREVIOUS_VERSION",
@@ -573,14 +573,14 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: List all new code periods for project
-			listResult, _, err := client.NewCodePeriods.List(&sonar.NewCodePeriodsListOption{
+			listResult, _, err := client.NewCodePeriods.List(&sonar.NewCodePeriodsListOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(listResult.NewCodePeriods).NotTo(BeNil())
 
 			// Step 6: Show branch-level
-			result, _, err = client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOption{
+			result, _, err = client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOptions{
 				Project: projectKey,
 				Branch:  "main",
 			})
@@ -588,14 +588,14 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(result.BranchKey).To(Equal("main"))
 
 			// Step 7: Unset branch-level
-			_, err = client.NewCodePeriods.Unset(&sonar.NewCodePeriodsUnsetOption{
+			_, err = client.NewCodePeriods.Unset(&sonar.NewCodePeriodsUnsetOptions{
 				Project: projectKey,
 				Branch:  "main",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 8: Unset project-level
-			_, err = client.NewCodePeriods.Unset(&sonar.NewCodePeriodsUnsetOption{
+			_, err = client.NewCodePeriods.Unset(&sonar.NewCodePeriodsUnsetOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/notifications_test.go
+++ b/integration_testing/notifications_test.go
@@ -26,14 +26,14 @@ var _ = Describe("Notifications Service", Ordered, func() {
 
 		// Create a test project for project-scoped notifications
 		projectKey = helpers.UniqueResourceName("notif")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    "Notifications Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -62,7 +62,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 			})
 
 			It("should list notifications with empty options", func() {
-				result, resp, err := client.Notifications.List(&sonar.NotificationsListOption{})
+				result, resp, err := client.Notifications.List(&sonar.NotificationsListOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -83,7 +83,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 			})
 
 			It("should fail without required type", func() {
-				resp, err := client.Notifications.Add(&sonar.NotificationsAddOption{})
+				resp, err := client.Notifications.Add(&sonar.NotificationsAddOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Type"))
 				Expect(resp).To(BeNil())
@@ -100,14 +100,14 @@ var _ = Describe("Notifications Service", Ordered, func() {
 
 				notificationType := listResult.GlobalTypes[0]
 
-				resp, err := client.Notifications.Add(&sonar.NotificationsAddOption{
+				resp, err := client.Notifications.Add(&sonar.NotificationsAddOptions{
 					Type: notificationType,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Clean up
-				_, err = client.Notifications.Remove(&sonar.NotificationsRemoveOption{
+				_, err = client.Notifications.Remove(&sonar.NotificationsRemoveOptions{
 					Type: notificationType,
 				})
 				if err != nil {
@@ -124,7 +124,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 
 				notificationType := listResult.PerProjectTypes[0]
 
-				resp, err := client.Notifications.Add(&sonar.NotificationsAddOption{
+				resp, err := client.Notifications.Add(&sonar.NotificationsAddOptions{
 					Type:    notificationType,
 					Project: projectKey,
 				})
@@ -132,7 +132,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Clean up
-				_, err = client.Notifications.Remove(&sonar.NotificationsRemoveOption{
+				_, err = client.Notifications.Remove(&sonar.NotificationsRemoveOptions{
 					Type:    notificationType,
 					Project: projectKey,
 				})
@@ -144,7 +144,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 
 		Context("Invalid Type", func() {
 			It("should fail for invalid notification type", func() {
-				resp, err := client.Notifications.Add(&sonar.NotificationsAddOption{
+				resp, err := client.Notifications.Add(&sonar.NotificationsAddOptions{
 					Type: "invalid-type",
 				})
 				Expect(err).To(HaveOccurred())
@@ -168,7 +168,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 			})
 
 			It("should fail without required type", func() {
-				resp, err := client.Notifications.Remove(&sonar.NotificationsRemoveOption{})
+				resp, err := client.Notifications.Remove(&sonar.NotificationsRemoveOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Type"))
 				Expect(resp).To(BeNil())
@@ -186,13 +186,13 @@ var _ = Describe("Notifications Service", Ordered, func() {
 				notificationType := listResult.GlobalTypes[0]
 
 				// Add the notification first
-				_, err = client.Notifications.Add(&sonar.NotificationsAddOption{
+				_, err = client.Notifications.Add(&sonar.NotificationsAddOptions{
 					Type: notificationType,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Now remove it
-				resp, err := client.Notifications.Remove(&sonar.NotificationsRemoveOption{
+				resp, err := client.Notifications.Remove(&sonar.NotificationsRemoveOptions{
 					Type: notificationType,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -225,7 +225,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 				}
 
 				if unsubscribedType != "" {
-					resp, err := client.Notifications.Remove(&sonar.NotificationsRemoveOption{
+					resp, err := client.Notifications.Remove(&sonar.NotificationsRemoveOptions{
 						Type: unsubscribedType,
 					})
 					Expect(err).To(HaveOccurred())
@@ -251,7 +251,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 			notificationType := listResult.GlobalTypes[0]
 
 			// Remove if already exists (clean state)
-			_, err = client.Notifications.Remove(&sonar.NotificationsRemoveOption{
+			_, err = client.Notifications.Remove(&sonar.NotificationsRemoveOptions{
 				Type: notificationType,
 			})
 			if err != nil {
@@ -259,7 +259,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 			}
 
 			// Add the notification
-			resp, err := client.Notifications.Add(&sonar.NotificationsAddOption{
+			resp, err := client.Notifications.Add(&sonar.NotificationsAddOptions{
 				Type: notificationType,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -280,7 +280,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 			Expect(found).To(BeTrue(), "Notification should be in the list")
 
 			// Remove the notification
-			resp, err = client.Notifications.Remove(&sonar.NotificationsRemoveOption{
+			resp, err = client.Notifications.Remove(&sonar.NotificationsRemoveOptions{
 				Type: notificationType,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/permissions_test.go
+++ b/integration_testing/permissions_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testUserLogin = helpers.UniqueResourceName("user-perm")
 
 			// Create private project (codeviewer/user permissions only work on private projects)
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Permission Test Project",
 				Project:    testProjectKey,
 				Visibility: "private",
@@ -53,7 +53,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -61,7 +61,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Permission Test User",
 				Password: "SecurePassword123!",
@@ -71,7 +71,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", testUserLogin, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 					Login:     testUserLogin,
 					Anonymize: true,
 				})
@@ -80,7 +80,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add user permission to project", func() {
-			resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOption{
+			resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
 				Login:      testUserLogin,
 				Permission: "codeviewer",
 				ProjectKey: testProjectKey,
@@ -89,7 +89,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify user has permission
-			result, _, err := client.Permissions.Users(&sonar.PermissionsUsersOption{
+			result, _, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
 				ProjectKey: testProjectKey,
 				Permission: "codeviewer",
 			})
@@ -105,7 +105,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add admin permission to project", func() {
-			resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOption{
+			resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
 				Login:      testUserLogin,
 				Permission: "admin",
 				ProjectKey: testProjectKey,
@@ -115,7 +115,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add issueadmin permission to project", func() {
-			resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOption{
+			resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
 				Login:      testUserLogin,
 				Permission: "issueadmin",
 				ProjectKey: testProjectKey,
@@ -132,7 +132,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing login", func() {
-				resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOption{
+				resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
 					Permission: "codeviewer",
 					ProjectKey: testProjectKey,
 				})
@@ -141,7 +141,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOption{
+				resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
 					Login:      testUserLogin,
 					ProjectKey: testProjectKey,
 				})
@@ -150,7 +150,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with invalid permission", func() {
-				resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOption{
+				resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
 					Login:      testUserLogin,
 					Permission: "invalid_permission",
 					ProjectKey: testProjectKey,
@@ -170,7 +170,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testUserLogin = helpers.UniqueResourceName("user-rmperm")
 
 			// Create private project (codeviewer permission only works on private projects)
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Remove User Permission Test",
 				Project:    testProjectKey,
 				Visibility: "private",
@@ -178,7 +178,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -186,7 +186,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Remove Permission Test User",
 				Password: "SecurePassword123!",
@@ -196,7 +196,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", testUserLogin, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 					Login:     testUserLogin,
 					Anonymize: true,
 				})
@@ -204,7 +204,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			// Add permission first
-			_, err = client.Permissions.AddUser(&sonar.PermissionsAddUserOption{
+			_, err = client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
 				Login:      testUserLogin,
 				Permission: "codeviewer",
 				ProjectKey: testProjectKey,
@@ -213,7 +213,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should remove user permission from project", func() {
-			resp, err := client.Permissions.RemoveUser(&sonar.PermissionsRemoveUserOption{
+			resp, err := client.Permissions.RemoveUser(&sonar.PermissionsRemoveUserOptions{
 				Login:      testUserLogin,
 				Permission: "codeviewer",
 				ProjectKey: testProjectKey,
@@ -222,7 +222,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify user no longer has permission
-			result, _, err := client.Permissions.Users(&sonar.PermissionsUsersOption{
+			result, _, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
 				ProjectKey: testProjectKey,
 				Permission: "codeviewer",
 			})
@@ -240,7 +240,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing login", func() {
-				resp, err := client.Permissions.RemoveUser(&sonar.PermissionsRemoveUserOption{
+				resp, err := client.Permissions.RemoveUser(&sonar.PermissionsRemoveUserOptions{
 					Permission: "codeviewer",
 					ProjectKey: testProjectKey,
 				})
@@ -249,7 +249,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.RemoveUser(&sonar.PermissionsRemoveUserOption{
+				resp, err := client.Permissions.RemoveUser(&sonar.PermissionsRemoveUserOptions{
 					Login:      testUserLogin,
 					ProjectKey: testProjectKey,
 				})
@@ -271,7 +271,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testGroupName = helpers.UniqueResourceName("grp-perm")
 
 			// Create private project (codeviewer permission only works on private projects)
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Group Permission Test Project",
 				Project:    testProjectKey,
 				Visibility: "private",
@@ -279,7 +279,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -287,7 +287,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 				Name:        testGroupName,
 				Description: "Permission Test Group",
 			})
@@ -295,7 +295,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("group", testGroupName, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 					Name: testGroupName,
 				})
 				return err
@@ -303,7 +303,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add group permission to project", func() {
-			resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOption{
+			resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOptions{
 				GroupName:  testGroupName,
 				Permission: "codeviewer",
 				ProjectKey: testProjectKey,
@@ -312,7 +312,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify group has permission
-			result, _, err := client.Permissions.Groups(&sonar.PermissionsGroupsOption{
+			result, _, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
 				ProjectKey: testProjectKey,
 				Permission: "codeviewer",
 			})
@@ -328,7 +328,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add admin permission to group", func() {
-			resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOption{
+			resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOptions{
 				GroupName:  testGroupName,
 				Permission: "admin",
 				ProjectKey: testProjectKey,
@@ -337,7 +337,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify group has admin permission
-			result, _, err := client.Permissions.Groups(&sonar.PermissionsGroupsOption{
+			result, _, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
 				ProjectKey: testProjectKey,
 				Permission: "admin",
 			})
@@ -360,7 +360,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing group name", func() {
-				resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOption{
+				resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOptions{
 					Permission: "codeviewer",
 					ProjectKey: testProjectKey,
 				})
@@ -369,7 +369,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOption{
+				resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOptions{
 					GroupName:  testGroupName,
 					ProjectKey: testProjectKey,
 				})
@@ -378,7 +378,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with invalid permission", func() {
-				resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOption{
+				resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOptions{
 					GroupName:  testGroupName,
 					Permission: "invalid_permission",
 					ProjectKey: testProjectKey,
@@ -398,7 +398,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testGroupName = helpers.UniqueResourceName("grp-rmperm")
 
 			// Create private project (codeviewer permission only works on private projects)
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Remove Group Permission Test",
 				Project:    testProjectKey,
 				Visibility: "private",
@@ -406,7 +406,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -414,7 +414,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 				Name:        testGroupName,
 				Description: "Remove Permission Test Group",
 			})
@@ -422,14 +422,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("group", testGroupName, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 					Name: testGroupName,
 				})
 				return err
 			})
 
 			// Add permission first
-			_, err = client.Permissions.AddGroup(&sonar.PermissionsAddGroupOption{
+			_, err = client.Permissions.AddGroup(&sonar.PermissionsAddGroupOptions{
 				GroupName:  testGroupName,
 				Permission: "codeviewer",
 				ProjectKey: testProjectKey,
@@ -438,7 +438,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should remove group permission from project", func() {
-			resp, err := client.Permissions.RemoveGroup(&sonar.PermissionsRemoveGroupOption{
+			resp, err := client.Permissions.RemoveGroup(&sonar.PermissionsRemoveGroupOptions{
 				GroupName:  testGroupName,
 				Permission: "codeviewer",
 				ProjectKey: testProjectKey,
@@ -447,7 +447,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify group no longer has permission
-			result, _, err := client.Permissions.Groups(&sonar.PermissionsGroupsOption{
+			result, _, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
 				ProjectKey: testProjectKey,
 				Permission: "codeviewer",
 			})
@@ -465,7 +465,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing group name", func() {
-				resp, err := client.Permissions.RemoveGroup(&sonar.PermissionsRemoveGroupOption{
+				resp, err := client.Permissions.RemoveGroup(&sonar.PermissionsRemoveGroupOptions{
 					Permission: "codeviewer",
 					ProjectKey: testProjectKey,
 				})
@@ -474,7 +474,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.RemoveGroup(&sonar.PermissionsRemoveGroupOption{
+				resp, err := client.Permissions.RemoveGroup(&sonar.PermissionsRemoveGroupOptions{
 					GroupName:  testGroupName,
 					ProjectKey: testProjectKey,
 				})
@@ -498,7 +498,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should list users with specific permission", func() {
-			result, resp, err := client.Permissions.Users(&sonar.PermissionsUsersOption{
+			result, resp, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
 				Permission: "admin",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -512,14 +512,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			BeforeEach(func() {
 				testProjectKey = helpers.UniqueResourceName("proj-listuser")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    "List Users Test",
 					Project: testProjectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", testProjectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: testProjectKey,
 					})
 					return err
@@ -527,7 +527,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should list users with project permissions", func() {
-				result, resp, err := client.Permissions.Users(&sonar.PermissionsUsersOption{
+				result, resp, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
 					ProjectKey: testProjectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -538,7 +538,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with query too short", func() {
-				_, resp, err := client.Permissions.Users(&sonar.PermissionsUsersOption{
+				_, resp, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
 					Query: "ab", // min 3 chars
 				})
 				Expect(err).To(HaveOccurred())
@@ -546,7 +546,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with invalid permission", func() {
-				_, resp, err := client.Permissions.Users(&sonar.PermissionsUsersOption{
+				_, resp, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
 					Permission: "invalid_permission",
 				})
 				Expect(err).To(HaveOccurred())
@@ -574,7 +574,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should list groups with specific permission", func() {
-			result, resp, err := client.Permissions.Groups(&sonar.PermissionsGroupsOption{
+			result, resp, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
 				Permission: "admin",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -588,14 +588,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			BeforeEach(func() {
 				testProjectKey = helpers.UniqueResourceName("proj-listgrp")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    "List Groups Test",
 					Project: testProjectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", testProjectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: testProjectKey,
 					})
 					return err
@@ -603,7 +603,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should list groups with project permissions", func() {
-				result, resp, err := client.Permissions.Groups(&sonar.PermissionsGroupsOption{
+				result, resp, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
 					ProjectKey: testProjectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -614,7 +614,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with query too short", func() {
-				_, resp, err := client.Permissions.Groups(&sonar.PermissionsGroupsOption{
+				_, resp, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
 					Query: "ab", // min 3 chars
 				})
 				Expect(err).To(HaveOccurred())
@@ -622,7 +622,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with invalid permission", func() {
-				_, resp, err := client.Permissions.Groups(&sonar.PermissionsGroupsOption{
+				_, resp, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
 					Permission: "invalid_permission",
 				})
 				Expect(err).To(HaveOccurred())
@@ -638,7 +638,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		It("should create a permission template", func() {
 			templateName := helpers.UniqueResourceName("tpl")
 
-			result, resp, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			result, resp, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name:        templateName,
 				Description: "E2E Test Template",
 			})
@@ -647,7 +647,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Register cleanup
 			cleanup.RegisterCleanup("template", templateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: templateName,
 				})
 				return err
@@ -661,7 +661,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		It("should create a template with project key pattern", func() {
 			templateName := helpers.UniqueResourceName("tpl-pattern")
 
-			result, resp, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			result, resp, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name:              templateName,
 				Description:       "Template with pattern",
 				ProjectKeyPattern: "e2e-tpl-pattern-.*",
@@ -670,7 +670,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", templateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: templateName,
 				})
 				return err
@@ -689,7 +689,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing name", func() {
-				_, resp, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+				_, resp, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 					Description: "Test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -704,14 +704,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		BeforeEach(func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-search")
 
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name:        testTemplateName,
 				Description: "Search Test Template",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -727,7 +727,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should search templates by query", func() {
-			result, resp, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOption{
+			result, resp, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOptions{
 				Query: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -757,19 +757,19 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		It("should delete a template", func() {
 			templateName := helpers.UniqueResourceName("tpl-del")
 
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name: templateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			resp, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+			resp, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 				TemplateName: templateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify template is deleted
-			result, _, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOption{
+			result, _, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOptions{
 				Query: templateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -786,7 +786,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{})
+				resp, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -800,14 +800,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		BeforeEach(func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-update")
 
-			result, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			result, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name:        testTemplateName,
 				Description: "Original description",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Get template ID from search
-			searchResult, _, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOption{
+			searchResult, _, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOptions{
 				Query: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -820,7 +820,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(templateID).NotTo(BeEmpty(), "Template ID not found for: %s, result: %+v", testTemplateName, result)
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -828,7 +828,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should update template description", func() {
-			result, resp, err := client.Permissions.UpdateTemplate(&sonar.PermissionsUpdateTemplateOption{
+			result, resp, err := client.Permissions.UpdateTemplate(&sonar.PermissionsUpdateTemplateOptions{
 				ID:          templateID,
 				Description: "Updated description",
 			})
@@ -841,7 +841,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		It("should update template name", func() {
 			newName := helpers.UniqueResourceName("tpl-renamed")
 
-			result, resp, err := client.Permissions.UpdateTemplate(&sonar.PermissionsUpdateTemplateOption{
+			result, resp, err := client.Permissions.UpdateTemplate(&sonar.PermissionsUpdateTemplateOptions{
 				ID:   templateID,
 				Name: newName,
 			})
@@ -852,7 +852,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Update cleanup to use new name
 			cleanup.RegisterCleanup("template", newName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: newName,
 				})
 				return err
@@ -867,7 +867,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing ID", func() {
-				_, resp, err := client.Permissions.UpdateTemplate(&sonar.PermissionsUpdateTemplateOption{
+				_, resp, err := client.Permissions.UpdateTemplate(&sonar.PermissionsUpdateTemplateOptions{
 					Description: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -888,13 +888,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testUserLogin = helpers.UniqueResourceName("user-tpl")
 
 			// Create template
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -902,7 +902,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Template User Test",
 				Password: "SecurePassword123!",
@@ -912,7 +912,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", testUserLogin, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 					Login:     testUserLogin,
 					Anonymize: true,
 				})
@@ -921,7 +921,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add user to template", func() {
-			resp, err := client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOption{
+			resp, err := client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOptions{
 				Login:        testUserLogin,
 				Permission:   "codeviewer",
 				TemplateName: testTemplateName,
@@ -930,7 +930,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify user is in template
-			result, _, err := client.Permissions.TemplateUsers(&sonar.PermissionsTemplateUsersOption{
+			result, _, err := client.Permissions.TemplateUsers(&sonar.PermissionsTemplateUsersOptions{
 				TemplateName: testTemplateName,
 				Permission:   "codeviewer",
 			})
@@ -953,7 +953,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing login", func() {
-				resp, err := client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOption{
+				resp, err := client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOptions{
 					Permission:   "codeviewer",
 					TemplateName: testTemplateName,
 				})
@@ -962,7 +962,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOption{
+				resp, err := client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOptions{
 					Login:        testUserLogin,
 					TemplateName: testTemplateName,
 				})
@@ -971,7 +971,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOption{
+				resp, err := client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOptions{
 					Login:      testUserLogin,
 					Permission: "codeviewer",
 				})
@@ -990,13 +990,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testUserLogin = helpers.UniqueResourceName("user-tplrm")
 
 			// Create template
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1004,7 +1004,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Remove Template User Test",
 				Password: "SecurePassword123!",
@@ -1014,7 +1014,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", testUserLogin, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 					Login:     testUserLogin,
 					Anonymize: true,
 				})
@@ -1022,7 +1022,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			// Add user to template
-			_, err = client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOption{
+			_, err = client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOptions{
 				Login:        testUserLogin,
 				Permission:   "codeviewer",
 				TemplateName: testTemplateName,
@@ -1031,7 +1031,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should remove user from template", func() {
-			resp, err := client.Permissions.RemoveUserFromTemplate(&sonar.PermissionsRemoveUserFromTemplateOption{
+			resp, err := client.Permissions.RemoveUserFromTemplate(&sonar.PermissionsRemoveUserFromTemplateOptions{
 				Login:        testUserLogin,
 				Permission:   "codeviewer",
 				TemplateName: testTemplateName,
@@ -1040,7 +1040,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify user is removed from template
-			result, _, err := client.Permissions.TemplateUsers(&sonar.PermissionsTemplateUsersOption{
+			result, _, err := client.Permissions.TemplateUsers(&sonar.PermissionsTemplateUsersOptions{
 				TemplateName: testTemplateName,
 				Permission:   "codeviewer",
 			})
@@ -1060,13 +1060,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testGroupName = helpers.UniqueResourceName("grp-tpl")
 
 			// Create template
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1074,7 +1074,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 				Name:        testGroupName,
 				Description: "Template Group Test",
 			})
@@ -1082,7 +1082,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("group", testGroupName, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 					Name: testGroupName,
 				})
 				return err
@@ -1090,7 +1090,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add group to template", func() {
-			resp, err := client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOption{
+			resp, err := client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOptions{
 				GroupName:    testGroupName,
 				Permission:   "codeviewer",
 				TemplateName: testTemplateName,
@@ -1099,7 +1099,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify group is in template
-			result, _, err := client.Permissions.TemplateGroups(&sonar.PermissionsTemplateGroupsOption{
+			result, _, err := client.Permissions.TemplateGroups(&sonar.PermissionsTemplateGroupsOptions{
 				TemplateName: testTemplateName,
 				Permission:   "codeviewer",
 			})
@@ -1122,7 +1122,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing group name", func() {
-				resp, err := client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOption{
+				resp, err := client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOptions{
 					Permission:   "codeviewer",
 					TemplateName: testTemplateName,
 				})
@@ -1131,7 +1131,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOption{
+				resp, err := client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOptions{
 					GroupName:    testGroupName,
 					TemplateName: testTemplateName,
 				})
@@ -1140,7 +1140,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOption{
+				resp, err := client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOptions{
 					GroupName:  testGroupName,
 					Permission: "codeviewer",
 				})
@@ -1159,13 +1159,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testGroupName = helpers.UniqueResourceName("grp-tplrm")
 
 			// Create template
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1173,7 +1173,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 				Name:        testGroupName,
 				Description: "Remove Template Group Test",
 			})
@@ -1181,14 +1181,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("group", testGroupName, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 					Name: testGroupName,
 				})
 				return err
 			})
 
 			// Add group to template
-			_, err = client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOption{
+			_, err = client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOptions{
 				GroupName:    testGroupName,
 				Permission:   "codeviewer",
 				TemplateName: testTemplateName,
@@ -1197,7 +1197,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should remove group from template", func() {
-			resp, err := client.Permissions.RemoveGroupFromTemplate(&sonar.PermissionsRemoveGroupFromTemplateOption{
+			resp, err := client.Permissions.RemoveGroupFromTemplate(&sonar.PermissionsRemoveGroupFromTemplateOptions{
 				GroupName:    testGroupName,
 				Permission:   "codeviewer",
 				TemplateName: testTemplateName,
@@ -1206,7 +1206,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify group is removed from template
-			result, _, err := client.Permissions.TemplateGroups(&sonar.PermissionsTemplateGroupsOption{
+			result, _, err := client.Permissions.TemplateGroups(&sonar.PermissionsTemplateGroupsOptions{
 				TemplateName: testTemplateName,
 				Permission:   "codeviewer",
 			})
@@ -1223,13 +1223,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		BeforeEach(func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-usrlist")
 
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1237,7 +1237,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should list template users", func() {
-			result, resp, err := client.Permissions.TemplateUsers(&sonar.PermissionsTemplateUsersOption{
+			result, resp, err := client.Permissions.TemplateUsers(&sonar.PermissionsTemplateUsersOptions{
 				TemplateName: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1253,7 +1253,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				_, resp, err := client.Permissions.TemplateUsers(&sonar.PermissionsTemplateUsersOption{})
+				_, resp, err := client.Permissions.TemplateUsers(&sonar.PermissionsTemplateUsersOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -1266,13 +1266,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		BeforeEach(func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-grplist")
 
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1280,7 +1280,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should list template groups", func() {
-			result, resp, err := client.Permissions.TemplateGroups(&sonar.PermissionsTemplateGroupsOption{
+			result, resp, err := client.Permissions.TemplateGroups(&sonar.PermissionsTemplateGroupsOptions{
 				TemplateName: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1296,7 +1296,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				_, resp, err := client.Permissions.TemplateGroups(&sonar.PermissionsTemplateGroupsOption{})
+				_, resp, err := client.Permissions.TemplateGroups(&sonar.PermissionsTemplateGroupsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -1312,13 +1312,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		BeforeEach(func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-creator")
 
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1326,7 +1326,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add project creator to template", func() {
-			resp, err := client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOption{
+			resp, err := client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOptions{
 				Permission:   "admin",
 				TemplateName: testTemplateName,
 			})
@@ -1334,7 +1334,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify by searching templates
-			result, _, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOption{
+			result, _, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOptions{
 				Query: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1361,7 +1361,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOption{
+				resp, err := client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				Expect(err).To(HaveOccurred())
@@ -1369,7 +1369,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOption{
+				resp, err := client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOptions{
 					Permission: "admin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1384,20 +1384,20 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		BeforeEach(func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-rmcreator")
 
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
 			})
 
 			// Add project creator first
-			_, err = client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOption{
+			_, err = client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOptions{
 				Permission:   "admin",
 				TemplateName: testTemplateName,
 			})
@@ -1405,7 +1405,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should remove project creator from template", func() {
-			resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(&sonar.PermissionsRemoveProjectCreatorFromTemplateOption{
+			resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(&sonar.PermissionsRemoveProjectCreatorFromTemplateOptions{
 				Permission:   "admin",
 				TemplateName: testTemplateName,
 			})
@@ -1413,7 +1413,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify by searching templates
-			result, _, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOption{
+			result, _, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOptions{
 				Query: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1437,7 +1437,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(&sonar.PermissionsRemoveProjectCreatorFromTemplateOption{
+				resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(&sonar.PermissionsRemoveProjectCreatorFromTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				Expect(err).To(HaveOccurred())
@@ -1445,7 +1445,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(&sonar.PermissionsRemoveProjectCreatorFromTemplateOption{
+				resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(&sonar.PermissionsRemoveProjectCreatorFromTemplateOptions{
 					Permission: "admin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1468,7 +1468,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testUserLogin = helpers.UniqueResourceName("user-apply")
 
 			// Create private project (codeviewer permission only works on private projects)
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Apply Template Test",
 				Project:    testProjectKey,
 				Visibility: "private",
@@ -1476,20 +1476,20 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
 			})
 
 			// Create template
-			_, _, err = client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			_, _, err = client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1497,7 +1497,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create user and add to template
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Apply Template User",
 				Password: "SecurePassword123!",
@@ -1507,7 +1507,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", testUserLogin, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 					Login:     testUserLogin,
 					Anonymize: true,
 				})
@@ -1515,7 +1515,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			// Add user to template
-			_, err = client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOption{
+			_, err = client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOptions{
 				Login:        testUserLogin,
 				Permission:   "codeviewer",
 				TemplateName: testTemplateName,
@@ -1524,7 +1524,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should apply template to project", func() {
-			resp, err := client.Permissions.ApplyTemplate(&sonar.PermissionsApplyTemplateOption{
+			resp, err := client.Permissions.ApplyTemplate(&sonar.PermissionsApplyTemplateOptions{
 				ProjectKey:   testProjectKey,
 				TemplateName: testTemplateName,
 			})
@@ -1532,7 +1532,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify user has permission on project
-			result, _, err := client.Permissions.Users(&sonar.PermissionsUsersOption{
+			result, _, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
 				ProjectKey: testProjectKey,
 				Permission: "codeviewer",
 			})
@@ -1555,7 +1555,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing project identifier", func() {
-				resp, err := client.Permissions.ApplyTemplate(&sonar.PermissionsApplyTemplateOption{
+				resp, err := client.Permissions.ApplyTemplate(&sonar.PermissionsApplyTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				Expect(err).To(HaveOccurred())
@@ -1563,7 +1563,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.ApplyTemplate(&sonar.PermissionsApplyTemplateOption{
+				resp, err := client.Permissions.ApplyTemplate(&sonar.PermissionsApplyTemplateOptions{
 					ProjectKey: testProjectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -1583,40 +1583,40 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-bulk")
 
 			// Create projects
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Bulk Apply Test 1",
 				Project: testProjectKey1,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey1, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: testProjectKey1,
 				})
 				return err
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Bulk Apply Test 2",
 				Project: testProjectKey2,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey2, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: testProjectKey2,
 				})
 				return err
 			})
 
 			// Create template
-			_, _, err = client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			_, _, err = client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1624,7 +1624,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should bulk apply template to projects", func() {
-			resp, err := client.Permissions.BulkApplyTemplate(&sonar.PermissionsBulkApplyTemplateOption{
+			resp, err := client.Permissions.BulkApplyTemplate(&sonar.PermissionsBulkApplyTemplateOptions{
 				TemplateName: testTemplateName,
 				Projects:     []string{testProjectKey1, testProjectKey2},
 			})
@@ -1637,7 +1637,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			queryPrefix := strings.TrimPrefix(testProjectKey1, helpers.E2EResourcePrefix)
 			queryPrefix = helpers.E2EResourcePrefix + queryPrefix[:10] // Take first part
 
-			resp, err := client.Permissions.BulkApplyTemplate(&sonar.PermissionsBulkApplyTemplateOption{
+			resp, err := client.Permissions.BulkApplyTemplate(&sonar.PermissionsBulkApplyTemplateOptions{
 				TemplateName: testTemplateName,
 				Query:        queryPrefix,
 			})
@@ -1653,7 +1653,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.BulkApplyTemplate(&sonar.PermissionsBulkApplyTemplateOption{
+				resp, err := client.Permissions.BulkApplyTemplate(&sonar.PermissionsBulkApplyTemplateOptions{
 					Projects: []string{testProjectKey1},
 				})
 				Expect(err).To(HaveOccurred())
@@ -1661,7 +1661,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with invalid qualifier", func() {
-				resp, err := client.Permissions.BulkApplyTemplate(&sonar.PermissionsBulkApplyTemplateOption{
+				resp, err := client.Permissions.BulkApplyTemplate(&sonar.PermissionsBulkApplyTemplateOptions{
 					TemplateName: testTemplateName,
 					Qualifiers:   "INVALID",
 				})
@@ -1677,13 +1677,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		BeforeEach(func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-default")
 
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1704,7 +1704,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			}
 
 			// Set our template as default
-			resp, err := client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOption{
+			resp, err := client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOptions{
 				TemplateName: testTemplateName,
 				Qualifier:    "TRK",
 			})
@@ -1730,7 +1730,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Restore original default
 			if originalDefaultID != "" {
-				_, _ = client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOption{
+				_, _ = client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOptions{
 					TemplateID: originalDefaultID,
 					Qualifier:  "TRK",
 				})
@@ -1745,7 +1745,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOption{
+				resp, err := client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOptions{
 					Qualifier: "TRK",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1753,7 +1753,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with invalid qualifier", func() {
-				resp, err := client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOption{
+				resp, err := client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOptions{
 					TemplateName: testTemplateName,
 					Qualifier:    "INVALID",
 				})
@@ -1772,7 +1772,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			userLogin := helpers.UniqueResourceName("user-lifecycle")
 
 			// Step 1: Create private project (codeviewer permission only works on private projects)
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Lifecycle Test Project",
 				Project:    projectKey,
 				Visibility: "private",
@@ -1781,7 +1781,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Step 2: Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    userLogin,
 				Name:     "Lifecycle Test User",
 				Password: "SecurePassword123!",
@@ -1790,7 +1790,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 3: Add permission
-			_, err = client.Permissions.AddUser(&sonar.PermissionsAddUserOption{
+			_, err = client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
 				Login:      userLogin,
 				Permission: "codeviewer",
 				ProjectKey: projectKey,
@@ -1798,7 +1798,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 4: Verify permission
-			result, _, err := client.Permissions.Users(&sonar.PermissionsUsersOption{
+			result, _, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
 				ProjectKey: projectKey,
 				Permission: "codeviewer",
 			})
@@ -1813,7 +1813,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(found).To(BeTrue())
 
 			// Step 5: Remove permission
-			_, err = client.Permissions.RemoveUser(&sonar.PermissionsRemoveUserOption{
+			_, err = client.Permissions.RemoveUser(&sonar.PermissionsRemoveUserOptions{
 				Login:      userLogin,
 				Permission: "codeviewer",
 				ProjectKey: projectKey,
@@ -1821,7 +1821,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 6: Verify permission removed
-			result, _, err = client.Permissions.Users(&sonar.PermissionsUsersOption{
+			result, _, err = client.Permissions.Users(&sonar.PermissionsUsersOptions{
 				ProjectKey: projectKey,
 				Permission: "codeviewer",
 			})
@@ -1832,11 +1832,11 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Cleanup
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, _ = client.Users.Deactivate(&sonar.UsersDeactivateOption{
+			_, _, _ = client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 				Login:     userLogin,
 				Anonymize: true,
 			})
-			_, _ = client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, _ = client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 		})
@@ -1847,7 +1847,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			projectKey := helpers.UniqueResourceName("proj-tpllife")
 
 			// Step 1: Create template
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOption{
+			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
 				Name:        templateName,
 				Description: "Lifecycle test template",
 			})
@@ -1855,13 +1855,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Step 2: Create group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 				Name: groupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 3: Add group to template
-			_, err = client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOption{
+			_, err = client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOptions{
 				GroupName:    groupName,
 				Permission:   "codeviewer",
 				TemplateName: templateName,
@@ -1869,14 +1869,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 4: Add project creator to template
-			_, err = client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOption{
+			_, err = client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOptions{
 				Permission:   "admin",
 				TemplateName: templateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: Create private project (codeviewer permission only works on private projects)
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Template Lifecycle Project",
 				Project:    projectKey,
 				Visibility: "private",
@@ -1884,14 +1884,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 6: Apply template to project
-			_, err = client.Permissions.ApplyTemplate(&sonar.PermissionsApplyTemplateOption{
+			_, err = client.Permissions.ApplyTemplate(&sonar.PermissionsApplyTemplateOptions{
 				ProjectKey:   projectKey,
 				TemplateName: templateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 7: Verify group has permission on project
-			result, _, err := client.Permissions.Groups(&sonar.PermissionsGroupsOption{
+			result, _, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
 				ProjectKey: projectKey,
 				Permission: "codeviewer",
 			})
@@ -1906,14 +1906,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(found).To(BeTrue())
 
 			// Cleanup
-			_, _ = client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, _ = client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _ = client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+			_, _ = client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 				Name: groupName,
 			})
-			_, _ = client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOption{
+			_, _ = client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
 				TemplateName: templateName,
 			})
 		})

--- a/integration_testing/plugins_test.go
+++ b/integration_testing/plugins_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 	Describe("Download", func() {
 		Context("Functional Tests", func() {
 			It("should attempt to download a plugin", func() {
-				_, resp, err := client.Plugins.Download(&sonar.PluginsDownloadOption{
+				_, resp, err := client.Plugins.Download(&sonar.PluginsDownloadOptions{
 					Plugin: "java",
 				})
 				// Skip if API not available - this is internal API
@@ -76,7 +76,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing plugin key", func() {
-				result, resp, err := client.Plugins.Download(&sonar.PluginsDownloadOption{})
+				result, resp, err := client.Plugins.Download(&sonar.PluginsDownloadOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -97,7 +97,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 	Describe("Install", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing key", func() {
-				resp, err := client.Plugins.Install(&sonar.PluginsInstallOption{})
+				resp, err := client.Plugins.Install(&sonar.PluginsInstallOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -109,7 +109,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent plugin key", func() {
-				resp, err := client.Plugins.Install(&sonar.PluginsInstallOption{
+				resp, err := client.Plugins.Install(&sonar.PluginsInstallOptions{
 					Key: "non-existent-plugin-12345",
 				})
 				// Skip if API not available
@@ -142,7 +142,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 			})
 
 			It("should list installed plugins with category field", func() {
-				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOption{
+				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOptions{
 					Fields: []string{"category"},
 				})
 				// Skip if API not available
@@ -155,7 +155,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 			})
 
 			It("should list bundled plugins only", func() {
-				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOption{
+				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOptions{
 					Type: "BUNDLED",
 				})
 				// Skip if API not available
@@ -168,7 +168,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 			})
 
 			It("should list external plugins only", func() {
-				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOption{
+				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOptions{
 					Type: "EXTERNAL",
 				})
 				// Skip if API not available
@@ -183,7 +183,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with invalid type", func() {
-				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOption{
+				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOptions{
 					Type: "INVALID",
 				})
 				Expect(err).To(HaveOccurred())
@@ -192,7 +192,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 			})
 
 			It("should fail with invalid field", func() {
-				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOption{
+				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOptions{
 					Fields: []string{"invalid_field"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -226,7 +226,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 	Describe("Uninstall", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing key", func() {
-				resp, err := client.Plugins.Uninstall(&sonar.PluginsUninstallOption{})
+				resp, err := client.Plugins.Uninstall(&sonar.PluginsUninstallOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -238,7 +238,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent plugin key", func() {
-				resp, err := client.Plugins.Uninstall(&sonar.PluginsUninstallOption{
+				resp, err := client.Plugins.Uninstall(&sonar.PluginsUninstallOptions{
 					Key: "non-existent-plugin-12345",
 				})
 				// Skip if API not available
@@ -259,7 +259,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 	Describe("Update", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing key", func() {
-				resp, err := client.Plugins.Update(&sonar.PluginsUpdateOption{})
+				resp, err := client.Plugins.Update(&sonar.PluginsUpdateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -271,7 +271,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent plugin key", func() {
-				resp, err := client.Plugins.Update(&sonar.PluginsUpdateOption{
+				resp, err := client.Plugins.Update(&sonar.PluginsUpdateOptions{
 					Key: "non-existent-plugin-12345",
 				})
 				// Skip if API not available

--- a/integration_testing/project_analyses_test.go
+++ b/integration_testing/project_analyses_test.go
@@ -27,13 +27,13 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 
 		// Create a test project for project analyses operations
 		projectKey := helpers.UniqueResourceName("proj-analyses")
-		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    projectKey,
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		cleanupManager.RegisterCleanup("project", testProject.Project.Key, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: testProject.Project.Key,
 			})
 			return err
@@ -53,7 +53,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 	Describe("Search", func() {
 		Context("Functional Tests", func() {
 			It("should search project analyses", func() {
-				result, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOption{
+				result, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{
 					Project: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -63,7 +63,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should search project analyses with pagination", func() {
-				result, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOption{
+				result, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{
 					Project: testProject.Project.Key,
 					PaginationArgs: sonar.PaginationArgs{
 						Page:     1,
@@ -76,7 +76,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should search project analyses with category filter", func() {
-				result, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOption{
+				result, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{
 					Project:  testProject.Project.Key,
 					Category: "VERSION",
 				})
@@ -86,7 +86,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should search project analyses with date range", func() {
-				result, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOption{
+				result, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{
 					Project: testProject.Project.Key,
 					From:    "2020-01-01",
 					To:      "2030-12-31",
@@ -99,7 +99,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing project", func() {
-				_, _, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOption{})
+				_, _, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -109,7 +109,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should fail with invalid category", func() {
-				_, _, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOption{
+				_, _, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{
 					Project:  testProject.Project.Key,
 					Category: "INVALID_CATEGORY",
 				})
@@ -117,7 +117,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should fail with invalid date format", func() {
-				_, _, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOption{
+				_, _, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{
 					Project: testProject.Project.Key,
 					From:    "invalid-date",
 				})
@@ -125,7 +125,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent project", func() {
-				_, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOption{
+				_, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{
 					Project: "non-existent-project-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -141,7 +141,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 	Describe("SearchAll", func() {
 		Context("Functional Tests", func() {
 			It("should search all project analyses", func() {
-				result, resp, err := client.ProjectAnalyses.SearchAll(&sonar.ProjectAnalysesSearchOption{
+				result, resp, err := client.ProjectAnalyses.SearchAll(&sonar.ProjectAnalysesSearchOptions{
 					Project: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -153,7 +153,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing project", func() {
-				_, _, err := client.ProjectAnalyses.SearchAll(&sonar.ProjectAnalysesSearchOption{})
+				_, _, err := client.ProjectAnalyses.SearchAll(&sonar.ProjectAnalysesSearchOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -170,14 +170,14 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 	Describe("CreateEvent", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing analysis", func() {
-				_, _, err := client.ProjectAnalyses.CreateEvent(&sonar.ProjectAnalysesCreateEventOption{
+				_, _, err := client.ProjectAnalyses.CreateEvent(&sonar.ProjectAnalysesCreateEventOptions{
 					Name: "test-event",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing name", func() {
-				_, _, err := client.ProjectAnalyses.CreateEvent(&sonar.ProjectAnalysesCreateEventOption{
+				_, _, err := client.ProjectAnalyses.CreateEvent(&sonar.ProjectAnalysesCreateEventOptions{
 					Analysis: "some-analysis-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -189,7 +189,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should fail with invalid category", func() {
-				_, _, err := client.ProjectAnalyses.CreateEvent(&sonar.ProjectAnalysesCreateEventOption{
+				_, _, err := client.ProjectAnalyses.CreateEvent(&sonar.ProjectAnalysesCreateEventOptions{
 					Analysis: "some-analysis-key",
 					Name:     "test-event",
 					Category: "INVALID_CATEGORY",
@@ -198,7 +198,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent analysis", func() {
-				_, resp, err := client.ProjectAnalyses.CreateEvent(&sonar.ProjectAnalysesCreateEventOption{
+				_, resp, err := client.ProjectAnalyses.CreateEvent(&sonar.ProjectAnalysesCreateEventOptions{
 					Analysis: "non-existent-analysis-12345",
 					Name:     "test-event",
 					Category: "VERSION",
@@ -216,14 +216,14 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 	Describe("UpdateEvent", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing event", func() {
-				_, _, err := client.ProjectAnalyses.UpdateEvent(&sonar.ProjectAnalysesUpdateEventOption{
+				_, _, err := client.ProjectAnalyses.UpdateEvent(&sonar.ProjectAnalysesUpdateEventOptions{
 					Name: "updated-name",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing name", func() {
-				_, _, err := client.ProjectAnalyses.UpdateEvent(&sonar.ProjectAnalysesUpdateEventOption{
+				_, _, err := client.ProjectAnalyses.UpdateEvent(&sonar.ProjectAnalysesUpdateEventOptions{
 					Event: "some-event-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -235,7 +235,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent event", func() {
-				_, resp, err := client.ProjectAnalyses.UpdateEvent(&sonar.ProjectAnalysesUpdateEventOption{
+				_, resp, err := client.ProjectAnalyses.UpdateEvent(&sonar.ProjectAnalysesUpdateEventOptions{
 					Event: "non-existent-event-12345",
 					Name:  "updated-name",
 				})
@@ -252,7 +252,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 	Describe("DeleteEvent", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing event", func() {
-				_, err := client.ProjectAnalyses.DeleteEvent(&sonar.ProjectAnalysesDeleteEventOption{})
+				_, err := client.ProjectAnalyses.DeleteEvent(&sonar.ProjectAnalysesDeleteEventOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -262,7 +262,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent event", func() {
-				resp, err := client.ProjectAnalyses.DeleteEvent(&sonar.ProjectAnalysesDeleteEventOption{
+				resp, err := client.ProjectAnalyses.DeleteEvent(&sonar.ProjectAnalysesDeleteEventOptions{
 					Event: "non-existent-event-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -278,7 +278,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 	Describe("Delete", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing analysis", func() {
-				_, err := client.ProjectAnalyses.Delete(&sonar.ProjectAnalysesDeleteOption{})
+				_, err := client.ProjectAnalyses.Delete(&sonar.ProjectAnalysesDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -288,7 +288,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent analysis", func() {
-				resp, err := client.ProjectAnalyses.Delete(&sonar.ProjectAnalysesDeleteOption{
+				resp, err := client.ProjectAnalyses.Delete(&sonar.ProjectAnalysesDeleteOptions{
 					Analysis: "non-existent-analysis-12345",
 				})
 				Expect(err).To(HaveOccurred())

--- a/integration_testing/project_badges_test.go
+++ b/integration_testing/project_badges_test.go
@@ -27,14 +27,14 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		// Create a test project for badge operations
 		projectKey = helpers.UniqueResourceName("badge")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    "ProjectBadges Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -62,7 +62,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should fail without required project", func() {
-				result, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOption{})
+				result, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Project"))
 				Expect(result).To(BeNil())
@@ -72,7 +72,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should get token for a project", func() {
-				result, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOption{
+				result, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -84,7 +84,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOption{
+				result, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOptions{
 					Project: "non-existent-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -109,7 +109,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should fail without required project", func() {
-				resp, err := client.ProjectBadges.RenewToken(&sonar.ProjectBadgesRenewTokenOption{})
+				resp, err := client.ProjectBadges.RenewToken(&sonar.ProjectBadgesRenewTokenOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Project"))
 				Expect(resp).To(BeNil())
@@ -119,20 +119,20 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 		Context("Valid Requests", func() {
 			It("should renew token for a project", func() {
 				// Get current token
-				tokenBefore, _, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOption{
+				tokenBefore, _, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Renew token
-				resp, err := client.ProjectBadges.RenewToken(&sonar.ProjectBadgesRenewTokenOption{
+				resp, err := client.ProjectBadges.RenewToken(&sonar.ProjectBadgesRenewTokenOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Get new token
-				tokenAfter, _, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOption{
+				tokenAfter, _, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -142,7 +142,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				resp, err := client.ProjectBadges.RenewToken(&sonar.ProjectBadgesRenewTokenOption{
+				resp, err := client.ProjectBadges.RenewToken(&sonar.ProjectBadgesRenewTokenOptions{
 					Project: "non-existent-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -167,7 +167,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should fail without required project", func() {
-				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOption{
+				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
 					Metric: "coverage",
 				})
 				Expect(err).To(HaveOccurred())
@@ -177,7 +177,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should fail without required metric", func() {
-				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOption{
+				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
 					Project: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -187,7 +187,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should fail with invalid metric", func() {
-				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOption{
+				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
 					Project: projectKey,
 					Metric:  "invalid_metric",
 				})
@@ -200,7 +200,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should get coverage badge", func() {
-				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOption{
+				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
 					Project: projectKey,
 					Metric:  "coverage",
 				})
@@ -212,7 +212,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should get ncloc badge", func() {
-				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOption{
+				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
 					Project: projectKey,
 					Metric:  "ncloc",
 				})
@@ -222,7 +222,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should get alert_status badge", func() {
-				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOption{
+				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
 					Project: projectKey,
 					Metric:  "alert_status",
 				})
@@ -234,7 +234,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should return an error badge for non-existent project", func() {
-				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOption{
+				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
 					Project: "non-existent-project",
 					Metric:  "coverage",
 				})
@@ -265,7 +265,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should fail without required project", func() {
-				result, resp, err := client.ProjectBadges.QualityGate(&sonar.ProjectBadgesQualityGateOption{})
+				result, resp, err := client.ProjectBadges.QualityGate(&sonar.ProjectBadgesQualityGateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Project"))
 				Expect(result).To(BeNil())
@@ -275,7 +275,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should get quality gate badge", func() {
-				result, resp, err := client.ProjectBadges.QualityGate(&sonar.ProjectBadgesQualityGateOption{
+				result, resp, err := client.ProjectBadges.QualityGate(&sonar.ProjectBadgesQualityGateOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -288,7 +288,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should return an error badge for non-existent project", func() {
-				result, resp, err := client.ProjectBadges.QualityGate(&sonar.ProjectBadgesQualityGateOption{
+				result, resp, err := client.ProjectBadges.QualityGate(&sonar.ProjectBadgesQualityGateOptions{
 					Project: "non-existent-project",
 				})
 				// Badge API may return 200 with an error badge instead of an error
@@ -310,7 +310,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 	Describe("Full Workflow", func() {
 		It("should get token, renew it, and use it for badge access", func() {
 			// Get token
-			tokenResult, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOption{
+			tokenResult, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -318,7 +318,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			Expect(tokenResult.Token).NotTo(BeEmpty())
 
 			// Use token to get badge
-			result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOption{
+			result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
 				Project: projectKey,
 				Metric:  "coverage",
 				Token:   tokenResult.Token,
@@ -328,14 +328,14 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			Expect(result).NotTo(BeNil())
 
 			// Renew token
-			resp, err = client.ProjectBadges.RenewToken(&sonar.ProjectBadgesRenewTokenOption{
+			resp, err = client.ProjectBadges.RenewToken(&sonar.ProjectBadgesRenewTokenOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Get new token
-			newTokenResult, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOption{
+			newTokenResult, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/project_branches_test.go
+++ b/integration_testing/project_branches_test.go
@@ -41,14 +41,14 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 		BeforeEach(func() {
 			testProjectKey = helpers.UniqueResourceName("proj-branch")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Branch Test Project",
 				Project: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -56,7 +56,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 		})
 
 		It("should list branches of a project", func() {
-			result, resp, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOption{
+			result, resp, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOptions{
 				Project: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -86,7 +86,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				_, resp, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOption{})
+				_, resp, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -94,7 +94,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				_, resp, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOption{
+				_, resp, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOptions{
 					Project: "non-existent-project-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -113,7 +113,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 		BeforeEach(func() {
 			testProjectKey = helpers.UniqueResourceName("proj-rename")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Rename Branch Test Project",
 				Project:    testProjectKey,
 				MainBranch: "main",
@@ -121,7 +121,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -129,7 +129,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 		})
 
 		It("should rename the main branch", func() {
-			resp, err := client.ProjectBranches.Rename(&sonar.ProjectBranchesRenameOption{
+			resp, err := client.ProjectBranches.Rename(&sonar.ProjectBranchesRenameOptions{
 				Project: testProjectKey,
 				Name:    "master",
 			})
@@ -137,7 +137,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify the branch was renamed
-			result, _, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOption{
+			result, _, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOptions{
 				Project: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -161,7 +161,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.ProjectBranches.Rename(&sonar.ProjectBranchesRenameOption{
+				resp, err := client.ProjectBranches.Rename(&sonar.ProjectBranchesRenameOptions{
 					Name: "new-main",
 				})
 				Expect(err).To(HaveOccurred())
@@ -169,7 +169,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 
 			It("should fail with missing name", func() {
-				resp, err := client.ProjectBranches.Rename(&sonar.ProjectBranchesRenameOption{
+				resp, err := client.ProjectBranches.Rename(&sonar.ProjectBranchesRenameOptions{
 					Project: helpers.UniqueResourceName("proj"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -190,7 +190,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOption{
+				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOptions{
 					Branch: "feature-branch",
 				})
 				Expect(err).To(HaveOccurred())
@@ -198,7 +198,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 
 			It("should fail with missing branch name", func() {
-				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOption{
+				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOptions{
 					Project: helpers.UniqueResourceName("proj"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -208,7 +208,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOption{
+				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOptions{
 					Project: "non-existent-project-12345",
 					Branch:  "feature-branch",
 				})
@@ -220,7 +220,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			It("should fail when trying to delete main branch", func() {
 				projectKey := helpers.UniqueResourceName("proj-del-main")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:       "Delete Main Branch Test",
 					Project:    projectKey,
 					MainBranch: "main",
@@ -228,13 +228,13 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
-				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOption{
+				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOptions{
 					Project: projectKey,
 					Branch:  "main",
 				})
@@ -246,20 +246,20 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			It("should fail for non-existent branch", func() {
 				projectKey := helpers.UniqueResourceName("proj-del-noexist")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    "Delete Non-existent Branch Test",
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
-				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOption{
+				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOptions{
 					Project: projectKey,
 					Branch:  "non-existent-branch",
 				})
@@ -279,7 +279,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 		BeforeEach(func() {
 			testProjectKey = helpers.UniqueResourceName("proj-protect")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Protection Test Project",
 				Project:    testProjectKey,
 				MainBranch: "main",
@@ -287,7 +287,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -296,7 +296,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 
 		It("should set automatic deletion protection on main branch", func() {
 			// Main branch should already be protected, but we can still call the API
-			resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(&sonar.ProjectBranchesSetAutomaticDeletionProtectionOption{
+			resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(&sonar.ProjectBranchesSetAutomaticDeletionProtectionOptions{
 				Project: testProjectKey,
 				Branch:  "main",
 				Value:   true,
@@ -305,7 +305,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify protection is set
-			result, _, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOption{
+			result, _, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOptions{
 				Project: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -329,7 +329,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(&sonar.ProjectBranchesSetAutomaticDeletionProtectionOption{
+				resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(&sonar.ProjectBranchesSetAutomaticDeletionProtectionOptions{
 					Branch: "main",
 					Value:  true,
 				})
@@ -338,7 +338,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 
 			It("should fail with missing branch name", func() {
-				resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(&sonar.ProjectBranchesSetAutomaticDeletionProtectionOption{
+				resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(&sonar.ProjectBranchesSetAutomaticDeletionProtectionOptions{
 					Project: helpers.UniqueResourceName("proj"),
 					Value:   true,
 				})
@@ -349,7 +349,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(&sonar.ProjectBranchesSetAutomaticDeletionProtectionOption{
+				resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(&sonar.ProjectBranchesSetAutomaticDeletionProtectionOptions{
 					Project: "non-existent-project-12345",
 					Branch:  "main",
 					Value:   true,
@@ -373,7 +373,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.ProjectBranches.SetMain(&sonar.ProjectBranchesSetMainOption{
+				resp, err := client.ProjectBranches.SetMain(&sonar.ProjectBranchesSetMainOptions{
 					Branch: "new-main",
 				})
 				Expect(err).To(HaveOccurred())
@@ -381,7 +381,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 
 			It("should fail with missing branch name", func() {
-				resp, err := client.ProjectBranches.SetMain(&sonar.ProjectBranchesSetMainOption{
+				resp, err := client.ProjectBranches.SetMain(&sonar.ProjectBranchesSetMainOptions{
 					Project: helpers.UniqueResourceName("proj"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -391,7 +391,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				resp, err := client.ProjectBranches.SetMain(&sonar.ProjectBranchesSetMainOption{
+				resp, err := client.ProjectBranches.SetMain(&sonar.ProjectBranchesSetMainOptions{
 					Project: "non-existent-project-12345",
 					Branch:  "develop",
 				})
@@ -403,20 +403,20 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			It("should fail for non-existent branch", func() {
 				projectKey := helpers.UniqueResourceName("proj-setmain")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    "Set Main Test Project",
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
-				resp, err := client.ProjectBranches.SetMain(&sonar.ProjectBranchesSetMainOption{
+				resp, err := client.ProjectBranches.SetMain(&sonar.ProjectBranchesSetMainOptions{
 					Project: projectKey,
 					Branch:  "non-existent-branch",
 				})
@@ -435,7 +435,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			projectKey := helpers.UniqueResourceName("proj-lifecycle")
 
 			// Step 1: Create project with specific main branch name
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Lifecycle Test Project",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -443,14 +443,14 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// Step 2: List branches
-			result, _, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOption{
+			result, _, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -467,14 +467,14 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			Expect(mainBranch.Name).To(Equal("main"))
 
 			// Step 3: Rename main branch
-			_, err = client.ProjectBranches.Rename(&sonar.ProjectBranchesRenameOption{
+			_, err = client.ProjectBranches.Rename(&sonar.ProjectBranchesRenameOptions{
 				Project: projectKey,
 				Name:    "master",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 4: Verify rename
-			result, _, err = client.ProjectBranches.List(&sonar.ProjectBranchesListOption{
+			result, _, err = client.ProjectBranches.List(&sonar.ProjectBranchesListOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/project_dump_test.go
+++ b/integration_testing/project_dump_test.go
@@ -42,7 +42,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				result, resp, err := client.ProjectDump.Export(&sonar.ProjectDumpExportOption{})
+				result, resp, err := client.ProjectDump.Export(&sonar.ProjectDumpExportOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(resp).To(BeNil())
@@ -52,7 +52,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 
 		Context("Functional Tests", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.ProjectDump.Export(&sonar.ProjectDumpExportOption{
+				result, resp, err := client.ProjectDump.Export(&sonar.ProjectDumpExportOptions{
 					Key: "non-existent-project-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -64,7 +64,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 			It("should successfully trigger export for existing project", func() {
 				// Create a project for testing
 				projectKey := helpers.UniqueResourceName("dump-export")
-				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    projectKey,
 					Project: projectKey,
 				})
@@ -72,12 +72,12 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{Project: projectKey})
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{Project: projectKey})
 					return err
 				})
 
 				// Trigger export
-				result, resp, err := client.ProjectDump.Export(&sonar.ProjectDumpExportOption{
+				result, resp, err := client.ProjectDump.Export(&sonar.ProjectDumpExportOptions{
 					Key: projectKey,
 				})
 
@@ -109,7 +109,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 			})
 
 			It("should fail without id or key", func() {
-				result, resp, err := client.ProjectDump.Status(&sonar.ProjectDumpStatusOption{})
+				result, resp, err := client.ProjectDump.Status(&sonar.ProjectDumpStatusOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("ID or Key"))
 				Expect(resp).To(BeNil())
@@ -119,7 +119,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 
 		Context("Functional Tests", func() {
 			It("should fail for non-existent project by key", func() {
-				result, resp, err := client.ProjectDump.Status(&sonar.ProjectDumpStatusOption{
+				result, resp, err := client.ProjectDump.Status(&sonar.ProjectDumpStatusOptions{
 					Key: "non-existent-project-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -131,7 +131,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 			It("should get status for existing project by key", func() {
 				// Create a project for testing
 				projectKey := helpers.UniqueResourceName("dump-status")
-				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    projectKey,
 					Project: projectKey,
 				})
@@ -139,12 +139,12 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{Project: projectKey})
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{Project: projectKey})
 					return err
 				})
 
 				// Get status
-				result, resp, err := client.ProjectDump.Status(&sonar.ProjectDumpStatusOption{
+				result, resp, err := client.ProjectDump.Status(&sonar.ProjectDumpStatusOptions{
 					Key: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -163,7 +163,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 			It("should handle project dump status workflow", func() {
 				// Create a project
 				projectKey := helpers.UniqueResourceName("dump-workflow")
-				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    projectKey,
 					Project: projectKey,
 				})
@@ -171,12 +171,12 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{Project: projectKey})
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{Project: projectKey})
 					return err
 				})
 
 				// Check initial status
-				status, resp, err := client.ProjectDump.Status(&sonar.ProjectDumpStatusOption{
+				status, resp, err := client.ProjectDump.Status(&sonar.ProjectDumpStatusOptions{
 					Key: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -185,7 +185,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 
 				// If export is available, try to trigger it
 				if status.CanBeExported {
-					result, resp, err := client.ProjectDump.Export(&sonar.ProjectDumpExportOption{
+					result, resp, err := client.ProjectDump.Export(&sonar.ProjectDumpExportOptions{
 						Key: projectKey,
 					})
 					if err == nil {

--- a/integration_testing/project_links_test.go
+++ b/integration_testing/project_links_test.go
@@ -40,14 +40,14 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		BeforeEach(func() {
 			testProjectKey = helpers.UniqueResourceName("proj-link")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Link Test Project",
 				Project: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -55,7 +55,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		})
 
 		It("should create a project link", func() {
-			result, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOption{
+			result, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
 				ProjectKey: testProjectKey,
 				Name:       "Homepage",
 				URL:        "https://example.com",
@@ -69,7 +69,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 			linkID := result.Link.ID
 			cleanup.RegisterCleanup("project-link", linkID, func() error {
-				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOption{
+				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
 					ID: linkID,
 				})
 				return err
@@ -77,7 +77,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		})
 
 		It("should create multiple links for same project", func() {
-			result1, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOption{
+			result1, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
 				ProjectKey: testProjectKey,
 				Name:       "Homepage",
 				URL:        "https://example.com",
@@ -86,13 +86,13 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			Expect(result1.Link.ID).NotTo(BeEmpty())
 
 			cleanup.RegisterCleanup("project-link", result1.Link.ID, func() error {
-				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOption{
+				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
 					ID: result1.Link.ID,
 				})
 				return err
 			})
 
-			result2, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOption{
+			result2, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
 				ProjectKey: testProjectKey,
 				Name:       "CI",
 				URL:        "https://ci.example.com",
@@ -102,13 +102,13 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			Expect(result2.Link.ID).NotTo(Equal(result1.Link.ID))
 
 			cleanup.RegisterCleanup("project-link", result2.Link.ID, func() error {
-				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOption{
+				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
 					ID: result2.Link.ID,
 				})
 				return err
 			})
 
-			searchResult, _, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOption{
+			searchResult, _, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
 				ProjectKey: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -117,7 +117,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 		It("should create links with different types", func() {
 			// Create a generic custom link (won't match predefined type patterns)
-			customResult, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOption{
+			customResult, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
 				ProjectKey: testProjectKey,
 				Name:       "Documentation",
 				URL:        "https://docs.example.com",
@@ -127,7 +127,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			Expect(customResult.Link.Name).To(Equal("Documentation"))
 
 			cleanup.RegisterCleanup("project-link", customResult.Link.ID, func() error {
-				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOption{
+				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
 					ID: customResult.Link.ID,
 				})
 				return err
@@ -137,7 +137,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			// Types can be: homepage, issue, scm, ci, custom, etc.
 			// Note: Links with certain inferred types (homepage, issue, scm, ci) may be
 			// provided by SonarQube and cannot be deleted
-			searchResult, _, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOption{
+			searchResult, _, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
 				ProjectKey: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -161,7 +161,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			})
 
 			It("should fail with missing name", func() {
-				_, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOption{
+				_, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
 					ProjectKey: testProjectKey,
 					URL:        "https://example.com",
 				})
@@ -170,7 +170,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			})
 
 			It("should fail with missing URL", func() {
-				_, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOption{
+				_, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
 					ProjectKey: testProjectKey,
 					Name:       "Homepage",
 				})
@@ -179,7 +179,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			})
 
 			It("should fail with missing project identifier", func() {
-				_, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOption{
+				_, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
 					Name: "Homepage",
 					URL:  "https://example.com",
 				})
@@ -190,7 +190,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				_, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOption{
+				_, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
 					ProjectKey: "non-existent-project-12345",
 					Name:       "Homepage",
 					URL:        "https://example.com",
@@ -216,20 +216,20 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		BeforeEach(func() {
 			testProjectKey = helpers.UniqueResourceName("proj-search-link")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Search Link Test Project",
 				Project: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
 			})
 
-			result, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOption{
+			result, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
 				ProjectKey: testProjectKey,
 				Name:       "Test Link",
 				URL:        "https://test.example.com",
@@ -238,7 +238,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			testLinkID = result.Link.ID
 
 			cleanup.RegisterCleanup("project-link", testLinkID, func() error {
-				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOption{
+				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
 					ID: testLinkID,
 				})
 				return err
@@ -246,7 +246,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		})
 
 		It("should search links by project key", func() {
-			result, resp, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOption{
+			result, resp, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
 				ProjectKey: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -269,20 +269,20 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		It("should return empty list for project without links", func() {
 			newProjectKey := helpers.UniqueResourceName("proj-no-links")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "No Links Project",
 				Project: newProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", newProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: newProjectKey,
 				})
 				return err
 			})
 
-			result, resp, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOption{
+			result, resp, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
 				ProjectKey: newProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -299,7 +299,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			})
 
 			It("should fail with missing project identifier", func() {
-				_, resp, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOption{})
+				_, resp, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -307,7 +307,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				_, resp, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOption{
+				_, resp, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
 					ProjectKey: "non-existent-project-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -324,20 +324,20 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		It("should delete a project link", func() {
 			projectKey := helpers.UniqueResourceName("proj-del-link")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Delete Link Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			result, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOption{
+			result, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
 				ProjectKey: projectKey,
 				Name:       "To Delete",
 				URL:        "https://delete.example.com",
@@ -347,19 +347,19 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 			// Register cleanup in case deletion fails
 			cleanup.RegisterCleanup("project-link", linkID, func() error {
-				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOption{
+				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
 					ID: linkID,
 				})
 				return err
 			})
 
-			resp, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOption{
+			resp, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
 				ID: linkID,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
-			searchResult, _, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOption{
+			searchResult, _, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -376,7 +376,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			})
 
 			It("should fail with missing ID", func() {
-				resp, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOption{})
+				resp, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -384,7 +384,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent link", func() {
-				resp, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOption{
+				resp, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
 					ID: "99999999",
 				})
 				Expect(err).To(HaveOccurred())
@@ -401,20 +401,20 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		It("should complete full link lifecycle", func() {
 			projectKey := helpers.UniqueResourceName("proj-link-lifecycle")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Link Lifecycle Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			createResult, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOption{
+			createResult, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
 				ProjectKey: projectKey,
 				Name:       "Lifecycle Link",
 				URL:        "https://lifecycle.example.com",
@@ -425,13 +425,13 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 			// Register cleanup in case test fails before deletion
 			cleanup.RegisterCleanup("project-link", linkID, func() error {
-				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOption{
+				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
 					ID: linkID,
 				})
 				return err
 			})
 
-			searchResult, _, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOption{
+			searchResult, _, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -446,12 +446,12 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			}
 			Expect(found).To(BeTrue())
 
-			_, err = client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOption{
+			_, err = client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
 				ID: linkID,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			searchResult, _, err = client.ProjectLinks.Search(&sonar.ProjectLinksSearchOption{
+			searchResult, _, err = client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/project_tags_test.go
+++ b/integration_testing/project_tags_test.go
@@ -47,14 +47,14 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 			// First set a tag on a project
 			projectKey := helpers.UniqueResourceName("proj-tag-search")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Tag Search Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -62,14 +62,14 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 
 			// Set a unique tag
 			tagName := "e2e-test-tag"
-			_, err = client.ProjectTags.Set(&sonar.ProjectTagsSetOption{
+			_, err = client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
 				Project: projectKey,
 				Tags:    []string{tagName},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Search for the tag
-			result, resp, err := client.ProjectTags.Search(&sonar.ProjectTagsSearchOption{
+			result, resp, err := client.ProjectTags.Search(&sonar.ProjectTagsSearchOptions{
 				Query: tagName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -79,7 +79,7 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 		})
 
 		It("should search tags with pagination", func() {
-			result, resp, err := client.ProjectTags.Search(&sonar.ProjectTagsSearchOption{
+			result, resp, err := client.ProjectTags.Search(&sonar.ProjectTagsSearchOptions{
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 5,
 					Page:     1,
@@ -100,14 +100,14 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 		BeforeEach(func() {
 			testProjectKey = helpers.UniqueResourceName("proj-tag")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Tag Test Project",
 				Project: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -115,7 +115,7 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 		})
 
 		It("should set a single tag on a project", func() {
-			resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOption{
+			resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
 				Project: testProjectKey,
 				Tags:    []string{"backend"},
 			})
@@ -124,7 +124,7 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 		})
 
 		It("should set multiple tags on a project", func() {
-			resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOption{
+			resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
 				Project: testProjectKey,
 				Tags:    []string{"backend", "api", "golang"},
 			})
@@ -134,14 +134,14 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 
 		It("should replace existing tags", func() {
 			// Set initial tags
-			_, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOption{
+			_, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
 				Project: testProjectKey,
 				Tags:    []string{"old-tag"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Replace with new tags
-			resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOption{
+			resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
 				Project: testProjectKey,
 				Tags:    []string{"new-tag"},
 			})
@@ -151,14 +151,14 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 
 		It("should clear all tags with empty array", func() {
 			// Set initial tags
-			_, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOption{
+			_, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
 				Project: testProjectKey,
 				Tags:    []string{"tag1", "tag2", "tag3"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Clear all tags by passing an empty array
-			resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOption{
+			resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
 				Project: testProjectKey,
 				Tags:    []string{},
 			})
@@ -166,7 +166,7 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify tags were cleared by setting them again
-			_, err = client.ProjectTags.Set(&sonar.ProjectTagsSetOption{
+			_, err = client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
 				Project: testProjectKey,
 				Tags:    []string{"verified"},
 			})
@@ -181,7 +181,7 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOption{
+				resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
 					Tags: []string{"tag1"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -191,7 +191,7 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOption{
+				resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
 					Project: "non-existent-project-12345",
 					Tags:    []string{"tag1"},
 				})
@@ -210,42 +210,42 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 			projectKey := helpers.UniqueResourceName("proj-tag-lifecycle")
 
 			// Step 1: Create project
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Tag Lifecycle Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// Step 2: Set initial tags
-			_, err = client.ProjectTags.Set(&sonar.ProjectTagsSetOption{
+			_, err = client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
 				Project: projectKey,
 				Tags:    []string{"initial-tag", "e2e-lifecycle"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 3: Search for the tag
-			result, _, err := client.ProjectTags.Search(&sonar.ProjectTagsSearchOption{
+			result, _, err := client.ProjectTags.Search(&sonar.ProjectTagsSearchOptions{
 				Query: "e2e-lifecycle",
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Tags).To(ContainElement("e2e-lifecycle"))
 
 			// Step 4: Update tags (replaces all previous tags)
-			_, err = client.ProjectTags.Set(&sonar.ProjectTagsSetOption{
+			_, err = client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
 				Project: projectKey,
 				Tags:    []string{"updated-tag"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: Verify update by searching
-			result, _, err = client.ProjectTags.Search(&sonar.ProjectTagsSearchOption{
+			result, _, err = client.ProjectTags.Search(&sonar.ProjectTagsSearchOptions{
 				Query: "updated-tag",
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/projects_test.go
+++ b/integration_testing/projects_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		It("should create a project with minimal parameters", func() {
 			projectKey := helpers.UniqueResourceName("proj-min")
 
-			result, resp, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			result, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Minimal Project",
 				Project: projectKey,
 			})
@@ -46,7 +46,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup immediately after successful Create to avoid orphaned resources
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -61,7 +61,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		It("should create a project with full configuration", func() {
 			projectKey := helpers.UniqueResourceName("proj-full")
 
-			result, resp, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			result, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Full Config Project",
 				Project:    projectKey,
 				Visibility: "private",
@@ -71,7 +71,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup immediately after successful Create to avoid orphaned resources
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -86,7 +86,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		It("should create a public project", func() {
 			projectKey := helpers.UniqueResourceName("proj-pub")
 
-			result, resp, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			result, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Public Project",
 				Project:    projectKey,
 				Visibility: "public",
@@ -95,7 +95,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup immediately after successful Create to avoid orphaned resources
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -114,7 +114,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with missing name", func() {
-				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Project: helpers.UniqueResourceName("proj-noname"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -122,7 +122,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name: "No Key Project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -130,7 +130,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with invalid visibility", func() {
-				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:       "Invalid Visibility",
 					Project:    helpers.UniqueResourceName("proj-badvis"),
 					Visibility: "invalid",
@@ -145,21 +145,21 @@ var _ = Describe("Projects Service", Ordered, func() {
 				projectKey := helpers.UniqueResourceName("proj-dup")
 
 				// Create first project
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    "Original Project",
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
 				// Try to create duplicate
-				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    "Duplicate Project",
 					Project: projectKey,
 				})
@@ -180,7 +180,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		BeforeEach(func() {
 			testProjectKey = helpers.UniqueResourceName("proj-search")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Search Test Project",
 				Project:    testProjectKey,
 				Visibility: "private",
@@ -188,7 +188,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -196,7 +196,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should search all projects", func() {
-			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOption{})
+			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -204,7 +204,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should search projects by query", func() {
-			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOption{
+			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
 				Query: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -221,7 +221,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should search projects with pagination", func() {
-			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOption{
+			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 5,
 					Page:     1,
@@ -234,7 +234,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should search projects by visibility", func() {
-			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOption{
+			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
 				Visibility: "private",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -246,7 +246,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should search projects by qualifier", func() {
-			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOption{
+			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
 				Qualifiers: []string{"TRK"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -265,7 +265,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with invalid visibility", func() {
-				_, resp, err := client.Projects.Search(&sonar.ProjectsSearchOption{
+				_, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
 					Visibility: "invalid",
 				})
 				Expect(err).To(HaveOccurred())
@@ -273,7 +273,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with invalid qualifier", func() {
-				_, resp, err := client.Projects.Search(&sonar.ProjectsSearchOption{
+				_, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
 					Qualifiers: []string{"INVALID"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -289,7 +289,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		It("should delete a project", func() {
 			projectKey := helpers.UniqueResourceName("proj-del")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Delete Test Project",
 				Project: projectKey,
 			})
@@ -298,21 +298,21 @@ var _ = Describe("Projects Service", Ordered, func() {
 			// Register cleanup to handle orphaned resources if delete or assertions fail
 			// The cleanup will gracefully handle "not found" errors if the project was already deleted
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				// Ignore not found errors since the test may have already deleted it
 				return helpers.IgnoreNotFoundError(err)
 			})
 
-			resp, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			resp, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify project is deleted
-			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOption{
+			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
 				Query: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -329,7 +329,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{})
+				resp, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -337,7 +337,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail to delete non-existent project", func() {
-				resp, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				resp, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: "non-existent-project-key-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -356,7 +356,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			oldKey := helpers.UniqueResourceName("proj-oldkey")
 			newKey := helpers.UniqueResourceName("proj-newkey")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Update Key Project",
 				Project: oldKey,
 			})
@@ -364,13 +364,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup with old key first in case UpdateKey fails
 			cleanup.RegisterCleanup("project", oldKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: oldKey,
 				})
 				return helpers.IgnoreNotFoundError(err)
 			})
 
-			resp, err := client.Projects.UpdateKey(&sonar.ProjectsUpdateKeyOption{
+			resp, err := client.Projects.UpdateKey(&sonar.ProjectsUpdateKeyOptions{
 				From: oldKey,
 				To:   newKey,
 			})
@@ -379,14 +379,14 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup with new key
 			cleanup.RegisterCleanup("project", newKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: newKey,
 				})
 				return err
 			})
 
 			// Verify old key no longer exists
-			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOption{
+			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
 				Query: oldKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -395,7 +395,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			}
 
 			// Verify new key exists
-			result, _, err = client.Projects.Search(&sonar.ProjectsSearchOption{
+			result, _, err = client.Projects.Search(&sonar.ProjectsSearchOptions{
 				Query: newKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -417,7 +417,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with missing from key", func() {
-				resp, err := client.Projects.UpdateKey(&sonar.ProjectsUpdateKeyOption{
+				resp, err := client.Projects.UpdateKey(&sonar.ProjectsUpdateKeyOptions{
 					To: helpers.UniqueResourceName("proj-to"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -425,7 +425,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with missing to key", func() {
-				resp, err := client.Projects.UpdateKey(&sonar.ProjectsUpdateKeyOption{
+				resp, err := client.Projects.UpdateKey(&sonar.ProjectsUpdateKeyOptions{
 					From: helpers.UniqueResourceName("proj-from"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -441,7 +441,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		It("should update project visibility from public to private", func() {
 			projectKey := helpers.UniqueResourceName("proj-vis")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Visibility Test Project",
 				Project:    projectKey,
 				Visibility: "public",
@@ -449,13 +449,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOption{
+			resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
 				Project:    projectKey,
 				Visibility: "private",
 			})
@@ -463,7 +463,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify visibility changed
-			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOption{
+			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
 				Query: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -481,7 +481,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		It("should update project visibility from private to public", func() {
 			projectKey := helpers.UniqueResourceName("proj-vis2")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Visibility Test Project 2",
 				Project:    projectKey,
 				Visibility: "private",
@@ -489,13 +489,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOption{
+			resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
 				Project:    projectKey,
 				Visibility: "public",
 			})
@@ -503,7 +503,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify visibility changed
-			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOption{
+			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
 				Query: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -526,7 +526,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOption{
+				resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
 					Visibility: "private",
 				})
 				Expect(err).To(HaveOccurred())
@@ -534,7 +534,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with missing visibility", func() {
-				resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOption{
+				resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
 					Project: helpers.UniqueResourceName("proj"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -542,7 +542,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with invalid visibility", func() {
-				resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOption{
+				resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
 					Project:    helpers.UniqueResourceName("proj"),
 					Visibility: "invalid",
 				})
@@ -560,7 +560,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			projectKey1 := helpers.UniqueResourceName("proj-bulk1")
 			projectKey2 := helpers.UniqueResourceName("proj-bulk2")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Bulk Delete 1",
 				Project: projectKey1,
 			})
@@ -568,13 +568,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup immediately after successful Create (ignores 404 if bulk delete succeeds)
 			cleanup.RegisterCleanup("project", projectKey1, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey1,
 				})
 				return helpers.IgnoreNotFoundError(err)
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Bulk Delete 2",
 				Project: projectKey2,
 			})
@@ -582,20 +582,20 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup immediately after successful Create (ignores 404 if bulk delete succeeds)
 			cleanup.RegisterCleanup("project", projectKey2, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey2,
 				})
 				return helpers.IgnoreNotFoundError(err)
 			})
 
-			resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOption{
+			resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOptions{
 				Projects: []string{projectKey1, projectKey2},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify projectKey1 is deleted
-			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOption{
+			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
 				Query: projectKey1,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -604,7 +604,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			}
 
 			// Verify projectKey2 is deleted
-			result, _, err = client.Projects.Search(&sonar.ProjectsSearchOption{
+			result, _, err = client.Projects.Search(&sonar.ProjectsSearchOptions{
 				Query: projectKey2,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -618,7 +618,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			projectKey1 := uniquePrefix + "-a"
 			projectKey2 := uniquePrefix + "-b"
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Bulk Query Delete 1",
 				Project: projectKey1,
 			})
@@ -626,13 +626,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup immediately after successful Create (ignores 404 if bulk delete succeeds)
 			cleanup.RegisterCleanup("project", projectKey1, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey1,
 				})
 				return helpers.IgnoreNotFoundError(err)
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Bulk Query Delete 2",
 				Project: projectKey2,
 			})
@@ -640,13 +640,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup immediately after successful Create (ignores 404 if bulk delete succeeds)
 			cleanup.RegisterCleanup("project", projectKey2, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey2,
 				})
 				return helpers.IgnoreNotFoundError(err)
 			})
 
-			resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOption{
+			resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOptions{
 				Query: uniquePrefix,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -661,13 +661,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with no filter", func() {
-				resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOption{})
+				resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid visibility", func() {
-				resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOption{
+				resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOptions{
 					Query:      "test",
 					Visibility: "invalid",
 				})
@@ -676,7 +676,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with invalid qualifier", func() {
-				resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOption{
+				resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOptions{
 					Query:      "test",
 					Qualifiers: []string{"INVALID"},
 				})
@@ -691,7 +691,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 	// =========================================================================
 	Describe("SearchMyProjects", func() {
 		It("should search my projects", func() {
-			result, resp, err := client.Projects.SearchMyProjects(&sonar.ProjectsSearchMyProjectsOption{})
+			result, resp, err := client.Projects.SearchMyProjects(&sonar.ProjectsSearchMyProjectsOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -699,7 +699,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should search my projects with pagination", func() {
-			result, resp, err := client.Projects.SearchMyProjects(&sonar.ProjectsSearchMyProjectsOption{
+			result, resp, err := client.Projects.SearchMyProjects(&sonar.ProjectsSearchMyProjectsOptions{
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 5,
 					Page:     1,
@@ -731,7 +731,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should search my scannable projects with query", func() {
-			result, resp, err := client.Projects.SearchMyScannableProjects(&sonar.ProjectsSearchMyScannableProjectsOption{
+			result, resp, err := client.Projects.SearchMyScannableProjects(&sonar.ProjectsSearchMyScannableProjectsOptions{
 				Query: helpers.E2EResourcePrefix,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -757,7 +757,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		AfterAll(func() {
 			// Restore original default visibility
-			_, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOption{
+			_, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOptions{
 				ProjectVisibility: originalVisibility,
 			})
 			if err != nil {
@@ -766,7 +766,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should update default visibility to private", func() {
-			resp, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOption{
+			resp, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOptions{
 				ProjectVisibility: "private",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -774,7 +774,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should update default visibility to public", func() {
-			resp, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOption{
+			resp, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOptions{
 				ProjectVisibility: "public",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -789,13 +789,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with missing visibility", func() {
-				resp, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOption{})
+				resp, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid visibility", func() {
-				resp, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOption{
+				resp, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOptions{
 					ProjectVisibility: "invalid",
 				})
 				Expect(err).To(HaveOccurred())
@@ -813,7 +813,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			newProjectKey := helpers.UniqueResourceName("proj-lifecycle-new")
 
 			// Step 1: Create project
-			result, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			result, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Lifecycle Test",
 				Project:    projectKey,
 				Visibility: "public",
@@ -822,13 +822,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup for both possible project keys to handle orphans
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return helpers.IgnoreNotFoundError(err)
 			})
 			cleanup.RegisterCleanup("project", newProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: newProjectKey,
 				})
 				return helpers.IgnoreNotFoundError(err)
@@ -838,7 +838,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(result.Project.Visibility).To(Equal("public"))
 
 			// Step 2: Search for project
-			searchResult, _, err := client.Projects.Search(&sonar.ProjectsSearchOption{
+			searchResult, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
 				Query: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -852,21 +852,21 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(found).To(BeTrue())
 
 			// Step 3: Update visibility
-			_, err = client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOption{
+			_, err = client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
 				Project:    projectKey,
 				Visibility: "private",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 4: Update key
-			_, err = client.Projects.UpdateKey(&sonar.ProjectsUpdateKeyOption{
+			_, err = client.Projects.UpdateKey(&sonar.ProjectsUpdateKeyOptions{
 				From: projectKey,
 				To:   newProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: Verify changes
-			searchResult, _, err = client.Projects.Search(&sonar.ProjectsSearchOption{
+			searchResult, _, err = client.Projects.Search(&sonar.ProjectsSearchOptions{
 				Query: newProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -881,13 +881,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(found).To(BeTrue())
 
 			// Step 6: Delete project
-			_, err = client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err = client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: newProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 7: Verify deletion
-			searchResult, _, err = client.Projects.Search(&sonar.ProjectsSearchOption{
+			searchResult, _, err = client.Projects.Search(&sonar.ProjectsSearchOptions{
 				Query: newProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/push_test.go
+++ b/integration_testing/push_test.go
@@ -27,13 +27,13 @@ var _ = Describe("Push Service", Ordered, func() {
 
 		// Create a test project for push events
 		projectKey := helpers.UniqueResourceName("push")
-		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    projectKey,
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		cleanupManager.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: testProject.Project.Key,
 			})
 			return err
@@ -53,7 +53,7 @@ var _ = Describe("Push Service", Ordered, func() {
 	Describe("SonarlintEvents", func() {
 		Context("Functional Tests", func() {
 			It("should connect to sonarlint events stream with valid parameters", func() {
-				resp, err := client.Push.SonarlintEvents(&sonar.PushSonarlintEventsOption{
+				resp, err := client.Push.SonarlintEvents(&sonar.PushSonarlintEventsOptions{
 					Languages:   []string{"java"},
 					ProjectKeys: []string{testProject.Project.Key},
 				})
@@ -72,7 +72,7 @@ var _ = Describe("Push Service", Ordered, func() {
 			})
 
 			It("should connect with multiple languages", func() {
-				resp, err := client.Push.SonarlintEvents(&sonar.PushSonarlintEventsOption{
+				resp, err := client.Push.SonarlintEvents(&sonar.PushSonarlintEventsOptions{
 					Languages:   []string{"java", "js", "py"},
 					ProjectKeys: []string{testProject.Project.Key},
 				})
@@ -91,14 +91,14 @@ var _ = Describe("Push Service", Ordered, func() {
 
 		Context("Error Handling", func() {
 			It("should fail with missing languages", func() {
-				_, err := client.Push.SonarlintEvents(&sonar.PushSonarlintEventsOption{
+				_, err := client.Push.SonarlintEvents(&sonar.PushSonarlintEventsOptions{
 					ProjectKeys: []string{testProject.Project.Key},
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing project keys", func() {
-				_, err := client.Push.SonarlintEvents(&sonar.PushSonarlintEventsOption{
+				_, err := client.Push.SonarlintEvents(&sonar.PushSonarlintEventsOptions{
 					Languages: []string{"java"},
 				})
 				Expect(err).To(HaveOccurred())

--- a/integration_testing/qualitygates_test.go
+++ b/integration_testing/qualitygates_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should create a new quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg")
 
-			result, resp, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			result, resp, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -76,7 +76,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(result.Name).To(Equal(gateName))
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
@@ -92,7 +92,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with empty name", func() {
-				result, resp, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{})
+				result, resp, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -103,20 +103,20 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			It("should fail with duplicate name", func() {
 				gateName := helpers.UniqueResourceName("qg-dup")
 
-				_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+				_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 					Name: gateName,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-					_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+					_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 						Name: gateName,
 					})
 					return err
 				})
 
 				// Try to create with same name
-				result, resp, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+				result, resp, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 					Name: gateName,
 				})
 				Expect(err).To(HaveOccurred())
@@ -133,19 +133,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should show quality gate details", func() {
 			gateName := helpers.UniqueResourceName("qg-show")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualitygates.Show(&sonar.QualitygatesShowOption{
+			result, resp, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -164,7 +164,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with empty name", func() {
-				result, resp, err := client.Qualitygates.Show(&sonar.QualitygatesShowOption{})
+				result, resp, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -173,7 +173,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent quality gate", func() {
-				result, resp, err := client.Qualitygates.Show(&sonar.QualitygatesShowOption{
+				result, resp, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
 					Name: "non-existent-gate-xyz",
 				})
 				Expect(err).To(HaveOccurred())
@@ -192,19 +192,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			originalName := helpers.UniqueResourceName("qg-rename")
 			newName := helpers.UniqueResourceName("qg-renamed")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: originalName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", newName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: newName,
 				})
 				return err
 			})
 
-			resp, err := client.Qualitygates.Rename(&sonar.QualitygatesRenameOption{
+			resp, err := client.Qualitygates.Rename(&sonar.QualitygatesRenameOptions{
 				CurrentName: originalName,
 				Name:        newName,
 			})
@@ -212,7 +212,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			// Verify rename succeeded
-			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOption{
+			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
 				Name: newName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -227,7 +227,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with empty current name", func() {
-				resp, err := client.Qualitygates.Rename(&sonar.QualitygatesRenameOption{
+				resp, err := client.Qualitygates.Rename(&sonar.QualitygatesRenameOptions{
 					Name: "new-name",
 				})
 				Expect(err).To(HaveOccurred())
@@ -235,7 +235,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with empty new name", func() {
-				resp, err := client.Qualitygates.Rename(&sonar.QualitygatesRenameOption{
+				resp, err := client.Qualitygates.Rename(&sonar.QualitygatesRenameOptions{
 					CurrentName: "current-name",
 				})
 				Expect(err).To(HaveOccurred())
@@ -252,19 +252,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			sourceName := helpers.UniqueResourceName("qg-source")
 			copyName := helpers.UniqueResourceName("qg-copy")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: sourceName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", sourceName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: sourceName,
 				})
 				return err
 			})
 
-			resp, err := client.Qualitygates.Copy(&sonar.QualitygatesCopyOption{
+			resp, err := client.Qualitygates.Copy(&sonar.QualitygatesCopyOptions{
 				SourceName: sourceName,
 				Name:       copyName,
 			})
@@ -272,14 +272,14 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			cleanup.RegisterCleanup("qualitygate", copyName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: copyName,
 				})
 				return err
 			})
 
 			// Verify copy exists
-			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOption{
+			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
 				Name: copyName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -294,7 +294,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with empty source name", func() {
-				resp, err := client.Qualitygates.Copy(&sonar.QualitygatesCopyOption{
+				resp, err := client.Qualitygates.Copy(&sonar.QualitygatesCopyOptions{
 					Name: "new-copy",
 				})
 				Expect(err).To(HaveOccurred())
@@ -302,7 +302,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with empty target name", func() {
-				resp, err := client.Qualitygates.Copy(&sonar.QualitygatesCopyOption{
+				resp, err := client.Qualitygates.Copy(&sonar.QualitygatesCopyOptions{
 					SourceName: "source",
 				})
 				Expect(err).To(HaveOccurred())
@@ -318,19 +318,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should delete a quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-destroy")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			resp, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+			resp, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify deletion
-			_, _, err = client.Qualitygates.Show(&sonar.QualitygatesShowOption{
+			_, _, err = client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
 				Name: gateName,
 			})
 			Expect(err).To(HaveOccurred())
@@ -344,7 +344,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with empty name", func() {
-				resp, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{})
+				resp, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -352,7 +352,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent quality gate", func() {
-				resp, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				resp, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: "non-existent-gate-xyz",
 				})
 				Expect(err).To(HaveOccurred())
@@ -369,26 +369,26 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should set a quality gate as default", func() {
 			gateName := helpers.UniqueResourceName("qg-default")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			resp, err := client.Qualitygates.SetAsDefault(&sonar.QualitygatesSetAsDefaultOption{
+			resp, err := client.Qualitygates.SetAsDefault(&sonar.QualitygatesSetAsDefaultOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify it's now default
-			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOption{
+			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -398,7 +398,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			listResult, _, _ := client.Qualitygates.List()
 			for _, gate := range listResult.Qualitygates {
 				if gate.IsBuiltIn {
-					_, _ = client.Qualitygates.SetAsDefault(&sonar.QualitygatesSetAsDefaultOption{
+					_, _ = client.Qualitygates.SetAsDefault(&sonar.QualitygatesSetAsDefaultOptions{
 						Name: gate.Name,
 					})
 					break
@@ -414,7 +414,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with empty name", func() {
-				resp, err := client.Qualitygates.SetAsDefault(&sonar.QualitygatesSetAsDefaultOption{})
+				resp, err := client.Qualitygates.SetAsDefault(&sonar.QualitygatesSetAsDefaultOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -428,19 +428,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should create a condition for a quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-cond")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOption{
+			result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
 				GateName: gateName,
 				Metric:   "coverage",
 				Op:       "LT",
@@ -457,19 +457,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should create condition with GT operator", func() {
 			gateName := helpers.UniqueResourceName("qg-condgt")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOption{
+			result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
 				GateName: gateName,
 				Metric:   "duplicated_lines_density",
 				Op:       "GT",
@@ -489,7 +489,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing gate name", func() {
-				result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOption{
+				result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
 					Metric: "coverage",
 					Error:  "80",
 				})
@@ -499,7 +499,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing metric", func() {
-				result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOption{
+				result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
 					GateName: "some-gate",
 					Error:    "80",
 				})
@@ -509,7 +509,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing error threshold", func() {
-				result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOption{
+				result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
 					GateName: "some-gate",
 					Metric:   "coverage",
 				})
@@ -527,20 +527,20 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should update a condition", func() {
 			gateName := helpers.UniqueResourceName("qg-upd")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
 			// Create a condition first
-			condResult, _, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOption{
+			condResult, _, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
 				GateName: gateName,
 				Metric:   "coverage",
 				Op:       "LT",
@@ -549,7 +549,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Update it
-			resp, err := client.Qualitygates.UpdateCondition(&sonar.QualitygatesUpdateConditionOption{
+			resp, err := client.Qualitygates.UpdateCondition(&sonar.QualitygatesUpdateConditionOptions{
 				ID:     condResult.ID,
 				Metric: "coverage",
 				Op:     "LT",
@@ -559,7 +559,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			// Verify update - find the condition with our ID
-			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOption{
+			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -583,7 +583,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing ID", func() {
-				resp, err := client.Qualitygates.UpdateCondition(&sonar.QualitygatesUpdateConditionOption{
+				resp, err := client.Qualitygates.UpdateCondition(&sonar.QualitygatesUpdateConditionOptions{
 					Metric: "coverage",
 					Error:  "80",
 				})
@@ -600,20 +600,20 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should delete a condition", func() {
 			gateName := helpers.UniqueResourceName("qg-delcond")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
 			// Create a condition first
-			condResult, _, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOption{
+			condResult, _, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
 				GateName: gateName,
 				Metric:   "coverage",
 				Op:       "LT",
@@ -622,14 +622,14 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Delete it
-			resp, err := client.Qualitygates.DeleteCondition(&sonar.QualitygatesDeleteConditionOption{
+			resp, err := client.Qualitygates.DeleteCondition(&sonar.QualitygatesDeleteConditionOptions{
 				ID: condResult.ID,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify deletion - the specific condition should no longer exist
-			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOption{
+			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -646,7 +646,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing ID", func() {
-				resp, err := client.Qualitygates.DeleteCondition(&sonar.QualitygatesDeleteConditionOption{})
+				resp, err := client.Qualitygates.DeleteCondition(&sonar.QualitygatesDeleteConditionOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -661,32 +661,32 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			gateName := helpers.UniqueResourceName("qg-sel")
 			projectKey := helpers.UniqueResourceName("proj-qg")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "QualityGate Select Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.Qualitygates.Select(&sonar.QualitygatesSelectOption{
+			resp, err := client.Qualitygates.Select(&sonar.QualitygatesSelectOptions{
 				GateName:   gateName,
 				ProjectKey: projectKey,
 			})
@@ -694,7 +694,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify association
-			result, _, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOption{
+			result, _, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -709,7 +709,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing gate name", func() {
-				resp, err := client.Qualitygates.Select(&sonar.QualitygatesSelectOption{
+				resp, err := client.Qualitygates.Select(&sonar.QualitygatesSelectOptions{
 					ProjectKey: "some-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -717,7 +717,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.Qualitygates.Select(&sonar.QualitygatesSelectOption{
+				resp, err := client.Qualitygates.Select(&sonar.QualitygatesSelectOptions{
 					GateName: "some-gate",
 				})
 				Expect(err).To(HaveOccurred())
@@ -731,47 +731,47 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			gateName := helpers.UniqueResourceName("qg-desel")
 			projectKey := helpers.UniqueResourceName("proj-qgde")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "QualityGate Deselect Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// Associate first
-			_, err = client.Qualitygates.Select(&sonar.QualitygatesSelectOption{
+			_, err = client.Qualitygates.Select(&sonar.QualitygatesSelectOptions{
 				GateName:   gateName,
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Deselect
-			resp, err := client.Qualitygates.Deselect(&sonar.QualitygatesDeselectOption{
+			resp, err := client.Qualitygates.Deselect(&sonar.QualitygatesDeselectOptions{
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify - project should now use default gate
-			result, _, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOption{
+			result, _, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -786,7 +786,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.Qualitygates.Deselect(&sonar.QualitygatesDeselectOption{})
+				resp, err := client.Qualitygates.Deselect(&sonar.QualitygatesDeselectOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -800,20 +800,20 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should get quality gate for a project", func() {
 			projectKey := helpers.UniqueResourceName("proj-getqg")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "GetByProject Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOption{
+			result, resp, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -832,7 +832,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with empty project", func() {
-				result, resp, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOption{})
+				result, resp, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -841,7 +841,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOption{
+				result, resp, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOptions{
 					Project: "non-existent-project-xyz",
 				})
 				Expect(err).To(HaveOccurred())
@@ -859,19 +859,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should search projects for a quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-search")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualitygates.Search(&sonar.QualitygatesSearchOption{
+			result, resp, err := client.Qualitygates.Search(&sonar.QualitygatesSearchOptions{
 				GateName: gateName,
 				Selected: "all",
 			})
@@ -884,40 +884,40 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			gateName := helpers.UniqueResourceName("qg-searchq")
 			projectKey := helpers.UniqueResourceName("proj-searchq")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Search Query Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// Associate project with gate
-			_, err = client.Qualitygates.Select(&sonar.QualitygatesSelectOption{
+			_, err = client.Qualitygates.Select(&sonar.QualitygatesSelectOptions{
 				GateName:   gateName,
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Search
-			result, resp, err := client.Qualitygates.Search(&sonar.QualitygatesSearchOption{
+			result, resp, err := client.Qualitygates.Search(&sonar.QualitygatesSearchOptions{
 				GateName: gateName,
 				Query:    projectKey,
 			})
@@ -936,7 +936,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing gate name", func() {
-				result, resp, err := client.Qualitygates.Search(&sonar.QualitygatesSearchOption{})
+				result, resp, err := client.Qualitygates.Search(&sonar.QualitygatesSearchOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -951,19 +951,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should add group permission to quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-grp")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			resp, err := client.Qualitygates.AddGroup(&sonar.QualitygatesAddGroupOption{
+			resp, err := client.Qualitygates.AddGroup(&sonar.QualitygatesAddGroupOptions{
 				GateName:  gateName,
 				GroupName: "sonar-users",
 			})
@@ -971,7 +971,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify the group was actually added
-			groupsResult, _, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOption{
+			groupsResult, _, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOptions{
 				GateName: gateName,
 				Selected: "selected",
 			})
@@ -994,7 +994,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing gate name", func() {
-				resp, err := client.Qualitygates.AddGroup(&sonar.QualitygatesAddGroupOption{
+				resp, err := client.Qualitygates.AddGroup(&sonar.QualitygatesAddGroupOptions{
 					GroupName: "sonar-users",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1002,7 +1002,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing group name", func() {
-				resp, err := client.Qualitygates.AddGroup(&sonar.QualitygatesAddGroupOption{
+				resp, err := client.Qualitygates.AddGroup(&sonar.QualitygatesAddGroupOptions{
 					GateName: "some-gate",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1015,19 +1015,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should search groups for a quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-sgrp")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOption{
+			result, resp, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOptions{
 				GateName: gateName,
 				Selected: "all",
 			})
@@ -1045,7 +1045,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing gate name", func() {
-				result, resp, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOption{})
+				result, resp, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -1057,27 +1057,27 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should remove group permission from quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-rmgrp")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
 			// Add group first
-			_, err = client.Qualitygates.AddGroup(&sonar.QualitygatesAddGroupOption{
+			_, err = client.Qualitygates.AddGroup(&sonar.QualitygatesAddGroupOptions{
 				GateName:  gateName,
 				GroupName: "sonar-users",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Remove group
-			resp, err := client.Qualitygates.RemoveGroup(&sonar.QualitygatesRemoveGroupOption{
+			resp, err := client.Qualitygates.RemoveGroup(&sonar.QualitygatesRemoveGroupOptions{
 				GateName:  gateName,
 				GroupName: "sonar-users",
 			})
@@ -1085,7 +1085,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify the group was actually removed
-			groupsResult, _, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOption{
+			groupsResult, _, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOptions{
 				GateName: gateName,
 				Selected: "selected",
 			})
@@ -1103,7 +1103,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing gate name", func() {
-				resp, err := client.Qualitygates.RemoveGroup(&sonar.QualitygatesRemoveGroupOption{
+				resp, err := client.Qualitygates.RemoveGroup(&sonar.QualitygatesRemoveGroupOptions{
 					GroupName: "sonar-users",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1111,7 +1111,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing group name", func() {
-				resp, err := client.Qualitygates.RemoveGroup(&sonar.QualitygatesRemoveGroupOption{
+				resp, err := client.Qualitygates.RemoveGroup(&sonar.QualitygatesRemoveGroupOptions{
 					GateName: "some-gate",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1127,19 +1127,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should add user permission to quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-usr")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			resp, err := client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOption{
+			resp, err := client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOptions{
 				GateName: gateName,
 				Login:    "admin",
 			})
@@ -1155,7 +1155,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing gate name", func() {
-				resp, err := client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOption{
+				resp, err := client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOptions{
 					Login: "admin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1163,7 +1163,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing login", func() {
-				resp, err := client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOption{
+				resp, err := client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOptions{
 					GateName: "some-gate",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1176,19 +1176,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should search users for a quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-susr")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualitygates.SearchUsers(&sonar.QualitygatesSearchUsersOption{
+			result, resp, err := client.Qualitygates.SearchUsers(&sonar.QualitygatesSearchUsersOptions{
 				GateName: gateName,
 				Selected: "all",
 			})
@@ -1206,7 +1206,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing gate name", func() {
-				result, resp, err := client.Qualitygates.SearchUsers(&sonar.QualitygatesSearchUsersOption{})
+				result, resp, err := client.Qualitygates.SearchUsers(&sonar.QualitygatesSearchUsersOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -1218,27 +1218,27 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should remove user permission from quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-rmusr")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
 			// Add user first
-			_, err = client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOption{
+			_, err = client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOptions{
 				GateName: gateName,
 				Login:    "admin",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Remove user
-			resp, err := client.Qualitygates.RemoveUser(&sonar.QualitygatesRemoveUserOption{
+			resp, err := client.Qualitygates.RemoveUser(&sonar.QualitygatesRemoveUserOptions{
 				GateName: gateName,
 				Login:    "admin",
 			})
@@ -1254,7 +1254,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing gate name", func() {
-				resp, err := client.Qualitygates.RemoveUser(&sonar.QualitygatesRemoveUserOption{
+				resp, err := client.Qualitygates.RemoveUser(&sonar.QualitygatesRemoveUserOptions{
 					Login: "admin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1262,7 +1262,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing login", func() {
-				resp, err := client.Qualitygates.RemoveUser(&sonar.QualitygatesRemoveUserOption{
+				resp, err := client.Qualitygates.RemoveUser(&sonar.QualitygatesRemoveUserOptions{
 					GateName: "some-gate",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1280,28 +1280,28 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			projectKey := helpers.UniqueResourceName("proj-lifecycle")
 
 			// Step 1: Create quality gate
-			createResult, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOption{
+			createResult, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(createResult.Name).To(Equal(gateName))
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOption{
+				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
 			// Step 2: Show the quality gate
-			showResult, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOption{
+			showResult, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(showResult).NotTo(BeNil())
 
 			// Step 3: Create condition
-			condResult, _, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOption{
+			condResult, _, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
 				GateName: gateName,
 				Metric:   "coverage",
 				Op:       "LT",
@@ -1311,7 +1311,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			conditionID := condResult.ID
 
 			// Step 4: Update condition
-			_, err = client.Qualitygates.UpdateCondition(&sonar.QualitygatesUpdateConditionOption{
+			_, err = client.Qualitygates.UpdateCondition(&sonar.QualitygatesUpdateConditionOptions{
 				ID:     conditionID,
 				Metric: "coverage",
 				Op:     "LT",
@@ -1320,27 +1320,27 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: Create project and associate
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Lifecycle Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			_, err = client.Qualitygates.Select(&sonar.QualitygatesSelectOption{
+			_, err = client.Qualitygates.Select(&sonar.QualitygatesSelectOptions{
 				GateName:   gateName,
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5.5: Get project status for the quality gate
-			projectStatusResult, _, err := client.Qualitygates.ProjectStatus(&sonar.QualitygatesProjectStatusOption{
+			projectStatusResult, _, err := client.Qualitygates.ProjectStatus(&sonar.QualitygatesProjectStatusOptions{
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1348,14 +1348,14 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(projectStatusResult.ProjectStatus).NotTo(BeNil())
 
 			// Step 6: Add user permission
-			_, err = client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOption{
+			_, err = client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOptions{
 				GateName: gateName,
 				Login:    "admin",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 7: Search users
-			usersResult, _, err := client.Qualitygates.SearchUsers(&sonar.QualitygatesSearchUsersOption{
+			usersResult, _, err := client.Qualitygates.SearchUsers(&sonar.QualitygatesSearchUsersOptions{
 				GateName: gateName,
 				Selected: "selected",
 			})
@@ -1363,26 +1363,26 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(usersResult.Users).To(HaveLen(1))
 
 			// Step 8: Remove user permission
-			_, err = client.Qualitygates.RemoveUser(&sonar.QualitygatesRemoveUserOption{
+			_, err = client.Qualitygates.RemoveUser(&sonar.QualitygatesRemoveUserOptions{
 				GateName: gateName,
 				Login:    "admin",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 9: Deselect project
-			_, err = client.Qualitygates.Deselect(&sonar.QualitygatesDeselectOption{
+			_, err = client.Qualitygates.Deselect(&sonar.QualitygatesDeselectOptions{
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 10: Delete condition
-			_, err = client.Qualitygates.DeleteCondition(&sonar.QualitygatesDeleteConditionOption{
+			_, err = client.Qualitygates.DeleteCondition(&sonar.QualitygatesDeleteConditionOptions{
 				ID: conditionID,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 11: Verify condition was deleted
-			showResult, _, err = client.Qualitygates.Show(&sonar.QualitygatesShowOption{
+			showResult, _, err = client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/qualityprofiles_test.go
+++ b/integration_testing/qualityprofiles_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 	// =========================================================================
 	Describe("Search", func() {
 		It("should list all quality profiles", func() {
-			result, resp, err := client.Qualityprofiles.Search(&sonar.QualityprofilesSearchOption{})
+			result, resp, err := client.Qualityprofiles.Search(&sonar.QualityprofilesSearchOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -44,7 +44,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		})
 
 		It("should filter by language", func() {
-			result, resp, err := client.Qualityprofiles.Search(&sonar.QualityprofilesSearchOption{
+			result, resp, err := client.Qualityprofiles.Search(&sonar.QualityprofilesSearchOptions{
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -55,7 +55,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		})
 
 		It("should include defaults", func() {
-			result, resp, err := client.Qualityprofiles.Search(&sonar.QualityprofilesSearchOption{
+			result, resp, err := client.Qualityprofiles.Search(&sonar.QualityprofilesSearchOptions{
 				Defaults: true,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -73,7 +73,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should create a new quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp")
 
-			result, resp, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			result, resp, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
@@ -83,7 +83,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(result.Profile.Name).To(Equal(profileName))
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -100,7 +100,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing name", func() {
-				result, resp, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+				result, resp, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -109,7 +109,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				result, resp, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+				result, resp, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 					Name: "test-profile",
 				})
 				Expect(err).To(HaveOccurred())
@@ -126,21 +126,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should show quality profile details", func() {
 			profileName := helpers.UniqueResourceName("qp-show")
 
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOption{
+			result, resp, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOptions{
 				Key: createResult.Profile.Key,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -158,7 +158,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with empty key", func() {
-				result, resp, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOption{})
+				result, resp, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -174,7 +174,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			originalName := helpers.UniqueResourceName("qp-rename")
 			newName := helpers.UniqueResourceName("qp-renamed")
 
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     originalName,
 				Language: "java",
 			})
@@ -183,7 +183,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			// Register cleanup that tries both names in case rename fails
 			cleanup.RegisterCleanup("qualityprofile", originalName+"-or-"+newName, func() error {
 				// Try deleting by new name first (expected case)
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: newName,
 					Language:       "java",
 				})
@@ -191,14 +191,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 					return nil
 				}
 				// If that fails, try deleting by original name (rename failed)
-				_, err = client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err = client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: originalName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			resp, err := client.Qualityprofiles.Rename(&sonar.QualityprofilesRenameOption{
+			resp, err := client.Qualityprofiles.Rename(&sonar.QualityprofilesRenameOptions{
 				Key:  createResult.Profile.Key,
 				Name: newName,
 			})
@@ -206,7 +206,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify rename
-			result, _, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOption{
+			result, _, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOptions{
 				Key: createResult.Profile.Key,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -221,7 +221,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing key", func() {
-				resp, err := client.Qualityprofiles.Rename(&sonar.QualityprofilesRenameOption{
+				resp, err := client.Qualityprofiles.Rename(&sonar.QualityprofilesRenameOptions{
 					Name: "new-name",
 				})
 				Expect(err).To(HaveOccurred())
@@ -229,7 +229,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing name", func() {
-				resp, err := client.Qualityprofiles.Rename(&sonar.QualityprofilesRenameOption{
+				resp, err := client.Qualityprofiles.Rename(&sonar.QualityprofilesRenameOptions{
 					Key: "some-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -246,21 +246,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			sourceName := helpers.UniqueResourceName("qp-source")
 			copyName := helpers.UniqueResourceName("qp-copy")
 
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     sourceName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", sourceName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: sourceName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.Copy(&sonar.QualityprofilesCopyOption{
+			result, resp, err := client.Qualityprofiles.Copy(&sonar.QualityprofilesCopyOptions{
 				FromKey: createResult.Profile.Key,
 				ToName:  copyName,
 			})
@@ -270,7 +270,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(result.Name).To(Equal(copyName))
 
 			cleanup.RegisterCleanup("qualityprofile", copyName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: copyName,
 					Language:       "java",
 				})
@@ -287,7 +287,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing from key", func() {
-				result, resp, err := client.Qualityprofiles.Copy(&sonar.QualityprofilesCopyOption{
+				result, resp, err := client.Qualityprofiles.Copy(&sonar.QualityprofilesCopyOptions{
 					ToName: "new-copy",
 				})
 				Expect(err).To(HaveOccurred())
@@ -296,7 +296,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing to name", func() {
-				result, resp, err := client.Qualityprofiles.Copy(&sonar.QualityprofilesCopyOption{
+				result, resp, err := client.Qualityprofiles.Copy(&sonar.QualityprofilesCopyOptions{
 					FromKey: "some-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -313,13 +313,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should delete a quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-delete")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			resp, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+			resp, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 			})
@@ -335,7 +335,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				resp, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -343,7 +343,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				resp, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				resp, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -360,7 +360,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName := helpers.UniqueResourceName("qp-default")
 
 			// Capture the current default profile for this language FIRST
-			searchResult, _, err := client.Qualityprofiles.Search(&sonar.QualityprofilesSearchOption{
+			searchResult, _, err := client.Qualityprofiles.Search(&sonar.QualityprofilesSearchOptions{
 				Language: "java",
 				Defaults: true,
 			})
@@ -374,7 +374,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			}
 			Expect(originalDefaultName).NotTo(BeEmpty(), "Should find original default Java profile")
 
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
@@ -383,7 +383,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			// Use DeferCleanup to ensure restoration happens even if test fails
 			DeferCleanup(func() {
 				// Restore the original default profile
-				_, restoreErr := client.Qualityprofiles.SetDefault(&sonar.QualityprofilesSetDefaultOption{
+				_, restoreErr := client.Qualityprofiles.SetDefault(&sonar.QualityprofilesSetDefaultOptions{
 					QualityProfile: originalDefaultName,
 					Language:       "java",
 				})
@@ -391,13 +391,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 					GinkgoWriter.Printf("Failed to restore default profile %s: %v\n", originalDefaultName, restoreErr)
 				}
 				// Delete the test profile
-				_, _ = client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, _ = client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 			})
 
-			resp, err := client.Qualityprofiles.SetDefault(&sonar.QualityprofilesSetDefaultOption{
+			resp, err := client.Qualityprofiles.SetDefault(&sonar.QualityprofilesSetDefaultOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 			})
@@ -405,7 +405,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify it's now default
-			result, _, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOption{
+			result, _, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOptions{
 				Key: createResult.Profile.Key,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -420,7 +420,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.SetDefault(&sonar.QualityprofilesSetDefaultOption{
+				resp, err := client.Qualityprofiles.SetDefault(&sonar.QualityprofilesSetDefaultOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -428,7 +428,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				resp, err := client.Qualityprofiles.SetDefault(&sonar.QualityprofilesSetDefaultOption{
+				resp, err := client.Qualityprofiles.SetDefault(&sonar.QualityprofilesSetDefaultOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -445,34 +445,34 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName := helpers.UniqueResourceName("qp-proj")
 			projectKey := helpers.UniqueResourceName("proj-qp")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "QualityProfile AddProject Test",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOption{
+			resp, err := client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Project:        projectKey,
@@ -489,7 +489,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOption{
+				resp, err := client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOptions{
 					Language: "java",
 					Project:  "some-project",
 				})
@@ -498,7 +498,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing project", func() {
-				resp, err := client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOption{
+				resp, err := client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOptions{
 					QualityProfile: "test",
 					Language:       "java",
 				})
@@ -513,35 +513,35 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName := helpers.UniqueResourceName("qp-rmproj")
 			projectKey := helpers.UniqueResourceName("proj-rmqp")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "QualityProfile RemoveProject Test",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// Add first
-			_, err = client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOption{
+			_, err = client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Project:        projectKey,
@@ -549,7 +549,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Remove
-			resp, err := client.Qualityprofiles.RemoveProject(&sonar.QualityprofilesRemoveProjectOption{
+			resp, err := client.Qualityprofiles.RemoveProject(&sonar.QualityprofilesRemoveProjectOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Project:        projectKey,
@@ -566,7 +566,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.RemoveProject(&sonar.QualityprofilesRemoveProjectOption{
+				resp, err := client.Qualityprofiles.RemoveProject(&sonar.QualityprofilesRemoveProjectOptions{
 					Language: "java",
 					Project:  "some-project",
 				})
@@ -583,21 +583,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should list projects for a quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-projects")
 
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.Projects(&sonar.QualityprofilesProjectsOption{
+			result, resp, err := client.Qualityprofiles.Projects(&sonar.QualityprofilesProjectsOptions{
 				Key: createResult.Profile.Key,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -614,7 +614,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing key", func() {
-				result, resp, err := client.Qualityprofiles.Projects(&sonar.QualityprofilesProjectsOption{})
+				result, resp, err := client.Qualityprofiles.Projects(&sonar.QualityprofilesProjectsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -629,21 +629,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should show profile inheritance", func() {
 			profileName := helpers.UniqueResourceName("qp-inh")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.Inheritance(&sonar.QualityprofilesInheritanceOption{
+			result, resp, err := client.Qualityprofiles.Inheritance(&sonar.QualityprofilesInheritanceOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 			})
@@ -662,7 +662,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing profile name", func() {
-				result, resp, err := client.Qualityprofiles.Inheritance(&sonar.QualityprofilesInheritanceOption{
+				result, resp, err := client.Qualityprofiles.Inheritance(&sonar.QualityprofilesInheritanceOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -671,7 +671,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				result, resp, err := client.Qualityprofiles.Inheritance(&sonar.QualityprofilesInheritanceOption{
+				result, resp, err := client.Qualityprofiles.Inheritance(&sonar.QualityprofilesInheritanceOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -689,21 +689,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			parentName := helpers.UniqueResourceName("qp-parent")
 			childName := helpers.UniqueResourceName("qp-child")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     parentName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", parentName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: parentName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			_, _, err = client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			_, _, err = client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     childName,
 				Language: "java",
 			})
@@ -711,18 +711,18 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("qualityprofile", childName, func() error {
 				// Remove parent first
-				_, _ = client.Qualityprofiles.ChangeParent(&sonar.QualityprofilesChangeParentOption{
+				_, _ = client.Qualityprofiles.ChangeParent(&sonar.QualityprofilesChangeParentOptions{
 					QualityProfile: childName,
 					Language:       "java",
 				})
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: childName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			resp, err := client.Qualityprofiles.ChangeParent(&sonar.QualityprofilesChangeParentOption{
+			resp, err := client.Qualityprofiles.ChangeParent(&sonar.QualityprofilesChangeParentOptions{
 				QualityProfile:       childName,
 				Language:             "java",
 				ParentQualityProfile: parentName,
@@ -731,7 +731,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify parent was set by checking ancestors
-			result, _, err := client.Qualityprofiles.Inheritance(&sonar.QualityprofilesInheritanceOption{
+			result, _, err := client.Qualityprofiles.Inheritance(&sonar.QualityprofilesInheritanceOptions{
 				QualityProfile: childName,
 				Language:       "java",
 			})
@@ -748,7 +748,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.ChangeParent(&sonar.QualityprofilesChangeParentOption{
+				resp, err := client.Qualityprofiles.ChangeParent(&sonar.QualityprofilesChangeParentOptions{
 					Language:             "java",
 					ParentQualityProfile: "some-parent",
 				})
@@ -757,7 +757,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				resp, err := client.Qualityprofiles.ChangeParent(&sonar.QualityprofilesChangeParentOption{
+				resp, err := client.Qualityprofiles.ChangeParent(&sonar.QualityprofilesChangeParentOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -774,35 +774,35 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName1 := helpers.UniqueResourceName("qp-cmp1")
 			profileName2 := helpers.UniqueResourceName("qp-cmp2")
 
-			result1, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			result1, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName1,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName1, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName1,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result2, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			result2, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName2,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName2, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName2,
 					Language:       "java",
 				})
 				return err
 			})
 
-			compareResult, resp, err := client.Qualityprofiles.Compare(&sonar.QualityprofilesCompareOption{
+			compareResult, resp, err := client.Qualityprofiles.Compare(&sonar.QualityprofilesCompareOptions{
 				LeftKey:  result1.Profile.Key,
 				RightKey: result2.Profile.Key,
 			})
@@ -820,7 +820,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing left key", func() {
-				result, resp, err := client.Qualityprofiles.Compare(&sonar.QualityprofilesCompareOption{
+				result, resp, err := client.Qualityprofiles.Compare(&sonar.QualityprofilesCompareOptions{
 					RightKey: "some-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -829,7 +829,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing right key", func() {
-				result, resp, err := client.Qualityprofiles.Compare(&sonar.QualityprofilesCompareOption{
+				result, resp, err := client.Qualityprofiles.Compare(&sonar.QualityprofilesCompareOptions{
 					LeftKey: "some-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -846,21 +846,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should show quality profile changelog", func() {
 			profileName := helpers.UniqueResourceName("qp-chlog")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.Changelog(&sonar.QualityprofilesChangelogOption{
+			result, resp, err := client.Qualityprofiles.Changelog(&sonar.QualityprofilesChangelogOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 			})
@@ -878,7 +878,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing profile name", func() {
-				result, resp, err := client.Qualityprofiles.Changelog(&sonar.QualityprofilesChangelogOption{
+				result, resp, err := client.Qualityprofiles.Changelog(&sonar.QualityprofilesChangelogOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -887,7 +887,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				result, resp, err := client.Qualityprofiles.Changelog(&sonar.QualityprofilesChangelogOption{
+				result, resp, err := client.Qualityprofiles.Changelog(&sonar.QualityprofilesChangelogOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -904,21 +904,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should backup a quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-backup")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.Backup(&sonar.QualityprofilesBackupOption{
+			result, resp, err := client.Qualityprofiles.Backup(&sonar.QualityprofilesBackupOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 			})
@@ -937,7 +937,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing profile name", func() {
-				result, resp, err := client.Qualityprofiles.Backup(&sonar.QualityprofilesBackupOption{
+				result, resp, err := client.Qualityprofiles.Backup(&sonar.QualityprofilesBackupOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -946,7 +946,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				result, resp, err := client.Qualityprofiles.Backup(&sonar.QualityprofilesBackupOption{
+				result, resp, err := client.Qualityprofiles.Backup(&sonar.QualityprofilesBackupOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -977,7 +977,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with empty backup", func() {
-				resp, err := client.Qualityprofiles.Restore(&sonar.QualityprofilesRestoreOption{})
+				resp, err := client.Qualityprofiles.Restore(&sonar.QualityprofilesRestoreOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -992,7 +992,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName := helpers.UniqueResourceName("qp-activate")
 
 			// Create a profile
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
@@ -1000,7 +1000,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileKey := createResult.Profile.Key
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -1008,7 +1008,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			// Find an available Java rule to activate
-			rulesResult, _, err := client.Rules.Search(&sonar.RulesSearchOption{
+			rulesResult, _, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				Languages: []string{"java"},
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 1,
@@ -1019,7 +1019,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			ruleKey := rulesResult.Rules[0].Key
 
 			// Activate the rule
-			resp, err := client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOption{
+			resp, err := client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOptions{
 				Key:  profileKey,
 				Rule: ruleKey,
 			})
@@ -1035,7 +1035,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing key", func() {
-				resp, err := client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOption{
+				resp, err := client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOptions{
 					Rule: "java:S1234",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1043,7 +1043,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing rule", func() {
-				resp, err := client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOption{
+				resp, err := client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOptions{
 					Key: "some-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1057,7 +1057,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName := helpers.UniqueResourceName("qp-deactivate")
 
 			// Create a profile
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
@@ -1065,7 +1065,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileKey := createResult.Profile.Key
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -1073,7 +1073,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			// Find an available Java rule to activate then deactivate
-			rulesResult, _, err := client.Rules.Search(&sonar.RulesSearchOption{
+			rulesResult, _, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				Languages: []string{"java"},
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 1,
@@ -1084,14 +1084,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			ruleKey := rulesResult.Rules[0].Key
 
 			// First activate the rule
-			_, err = client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOption{
+			_, err = client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOptions{
 				Key:  profileKey,
 				Rule: ruleKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Now deactivate it
-			resp, err := client.Qualityprofiles.DeactivateRule(&sonar.QualityprofilesDeactivateRuleOption{
+			resp, err := client.Qualityprofiles.DeactivateRule(&sonar.QualityprofilesDeactivateRuleOptions{
 				Key:  profileKey,
 				Rule: ruleKey,
 			})
@@ -1107,7 +1107,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing key", func() {
-				resp, err := client.Qualityprofiles.DeactivateRule(&sonar.QualityprofilesDeactivateRuleOption{
+				resp, err := client.Qualityprofiles.DeactivateRule(&sonar.QualityprofilesDeactivateRuleOptions{
 					Rule: "java:S1234",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1115,7 +1115,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing rule", func() {
-				resp, err := client.Qualityprofiles.DeactivateRule(&sonar.QualityprofilesDeactivateRuleOption{
+				resp, err := client.Qualityprofiles.DeactivateRule(&sonar.QualityprofilesDeactivateRuleOptions{
 					Key: "some-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1132,7 +1132,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName := helpers.UniqueResourceName("qp-bulk-activate")
 
 			// Create a profile
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
@@ -1140,7 +1140,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileKey := createResult.Profile.Key
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -1148,7 +1148,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			// Bulk activate rules by language
-			resp, err := client.Qualityprofiles.ActivateRules(&sonar.QualityprofilesActivateRulesOption{
+			resp, err := client.Qualityprofiles.ActivateRules(&sonar.QualityprofilesActivateRulesOptions{
 				TargetKey: profileKey,
 				Languages: []string{"java"},
 			})
@@ -1164,7 +1164,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing target key", func() {
-				resp, err := client.Qualityprofiles.ActivateRules(&sonar.QualityprofilesActivateRulesOption{
+				resp, err := client.Qualityprofiles.ActivateRules(&sonar.QualityprofilesActivateRulesOptions{
 					Languages: []string{"java"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -1178,7 +1178,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName := helpers.UniqueResourceName("qp-bulk-deactivate")
 
 			// Create a profile
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
@@ -1186,7 +1186,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileKey := createResult.Profile.Key
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -1194,7 +1194,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			// Find an available Java rule and activate it first
-			rulesResult, _, err := client.Rules.Search(&sonar.RulesSearchOption{
+			rulesResult, _, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				Languages: []string{"java"},
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 1,
@@ -1205,14 +1205,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			ruleKey := rulesResult.Rules[0].Key
 
 			// Activate a rule first
-			_, err = client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOption{
+			_, err = client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOptions{
 				Key:  profileKey,
 				Rule: ruleKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Bulk deactivate rules
-			resp, err := client.Qualityprofiles.DeactivateRules(&sonar.QualityprofilesDeactivateRulesOption{
+			resp, err := client.Qualityprofiles.DeactivateRules(&sonar.QualityprofilesDeactivateRulesOptions{
 				TargetKey: profileKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1227,7 +1227,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing target key", func() {
-				resp, err := client.Qualityprofiles.DeactivateRules(&sonar.QualityprofilesDeactivateRulesOption{})
+				resp, err := client.Qualityprofiles.DeactivateRules(&sonar.QualityprofilesDeactivateRulesOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -1262,21 +1262,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should add group permission to quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-grp")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			resp, err := client.Qualityprofiles.AddGroup(&sonar.QualityprofilesAddGroupOption{
+			resp, err := client.Qualityprofiles.AddGroup(&sonar.QualityprofilesAddGroupOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Group:          "sonar-users",
@@ -1293,7 +1293,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.AddGroup(&sonar.QualityprofilesAddGroupOption{
+				resp, err := client.Qualityprofiles.AddGroup(&sonar.QualityprofilesAddGroupOptions{
 					Language: "java",
 					Group:    "sonar-users",
 				})
@@ -1302,7 +1302,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing group", func() {
-				resp, err := client.Qualityprofiles.AddGroup(&sonar.QualityprofilesAddGroupOption{
+				resp, err := client.Qualityprofiles.AddGroup(&sonar.QualityprofilesAddGroupOptions{
 					QualityProfile: "test",
 					Language:       "java",
 				})
@@ -1316,21 +1316,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should search groups for a quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-sgrp")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.SearchGroups(&sonar.QualityprofilesSearchGroupsOption{
+			result, resp, err := client.Qualityprofiles.SearchGroups(&sonar.QualityprofilesSearchGroupsOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Selected:       "all",
@@ -1349,7 +1349,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing profile name", func() {
-				result, resp, err := client.Qualityprofiles.SearchGroups(&sonar.QualityprofilesSearchGroupsOption{
+				result, resp, err := client.Qualityprofiles.SearchGroups(&sonar.QualityprofilesSearchGroupsOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1358,7 +1358,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				result, resp, err := client.Qualityprofiles.SearchGroups(&sonar.QualityprofilesSearchGroupsOption{
+				result, resp, err := client.Qualityprofiles.SearchGroups(&sonar.QualityprofilesSearchGroupsOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1372,14 +1372,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should remove group permission from quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-rmgrp")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -1387,7 +1387,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			// Add group first
-			_, err = client.Qualityprofiles.AddGroup(&sonar.QualityprofilesAddGroupOption{
+			_, err = client.Qualityprofiles.AddGroup(&sonar.QualityprofilesAddGroupOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Group:          "sonar-users",
@@ -1395,7 +1395,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Remove group
-			resp, err := client.Qualityprofiles.RemoveGroup(&sonar.QualityprofilesRemoveGroupOption{
+			resp, err := client.Qualityprofiles.RemoveGroup(&sonar.QualityprofilesRemoveGroupOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Group:          "sonar-users",
@@ -1412,7 +1412,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.RemoveGroup(&sonar.QualityprofilesRemoveGroupOption{
+				resp, err := client.Qualityprofiles.RemoveGroup(&sonar.QualityprofilesRemoveGroupOptions{
 					Language: "java",
 					Group:    "sonar-users",
 				})
@@ -1421,7 +1421,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing group", func() {
-				resp, err := client.Qualityprofiles.RemoveGroup(&sonar.QualityprofilesRemoveGroupOption{
+				resp, err := client.Qualityprofiles.RemoveGroup(&sonar.QualityprofilesRemoveGroupOptions{
 					QualityProfile: "test",
 					Language:       "java",
 				})
@@ -1438,21 +1438,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should add user permission to quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-usr")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			resp, err := client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOption{
+			resp, err := client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Login:          "admin",
@@ -1469,7 +1469,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOption{
+				resp, err := client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOptions{
 					Language: "java",
 					Login:    "admin",
 				})
@@ -1478,7 +1478,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing login", func() {
-				resp, err := client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOption{
+				resp, err := client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOptions{
 					QualityProfile: "test",
 					Language:       "java",
 				})
@@ -1492,21 +1492,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should search users for a quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-susr")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.SearchUsers(&sonar.QualityprofilesSearchUsersOption{
+			result, resp, err := client.Qualityprofiles.SearchUsers(&sonar.QualityprofilesSearchUsersOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Selected:       "all",
@@ -1525,7 +1525,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing profile name", func() {
-				result, resp, err := client.Qualityprofiles.SearchUsers(&sonar.QualityprofilesSearchUsersOption{
+				result, resp, err := client.Qualityprofiles.SearchUsers(&sonar.QualityprofilesSearchUsersOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1534,7 +1534,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				result, resp, err := client.Qualityprofiles.SearchUsers(&sonar.QualityprofilesSearchUsersOption{
+				result, resp, err := client.Qualityprofiles.SearchUsers(&sonar.QualityprofilesSearchUsersOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1548,14 +1548,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should remove user permission from quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-rmusr")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -1563,7 +1563,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			// Add user first
-			_, err = client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOption{
+			_, err = client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Login:          "admin",
@@ -1571,7 +1571,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Remove user
-			resp, err := client.Qualityprofiles.RemoveUser(&sonar.QualityprofilesRemoveUserOption{
+			resp, err := client.Qualityprofiles.RemoveUser(&sonar.QualityprofilesRemoveUserOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Login:          "admin",
@@ -1588,7 +1588,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.RemoveUser(&sonar.QualityprofilesRemoveUserOption{
+				resp, err := client.Qualityprofiles.RemoveUser(&sonar.QualityprofilesRemoveUserOptions{
 					Language: "java",
 					Login:    "admin",
 				})
@@ -1597,7 +1597,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing login", func() {
-				resp, err := client.Qualityprofiles.RemoveUser(&sonar.QualityprofilesRemoveUserOption{
+				resp, err := client.Qualityprofiles.RemoveUser(&sonar.QualityprofilesRemoveUserOptions{
 					QualityProfile: "test",
 					Language:       "java",
 				})
@@ -1616,7 +1616,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			projectKey := helpers.UniqueResourceName("proj-qplc")
 
 			// Step 1: Create quality profile
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOption{
+			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
@@ -1624,7 +1624,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileKey := createResult.Profile.Key
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOption{
+				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -1632,34 +1632,34 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			// Step 2: Show the profile
-			showResult, _, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOption{
+			showResult, _, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOptions{
 				Key: profileKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(showResult.Profile.Name).To(Equal(profileName))
 
 			// Step 3: View changelog
-			_, _, err = client.Qualityprofiles.Changelog(&sonar.QualityprofilesChangelogOption{
+			_, _, err = client.Qualityprofiles.Changelog(&sonar.QualityprofilesChangelogOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 4: Create project and associate
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "Lifecycle Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			_, err = client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOption{
+			_, err = client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Project:        projectKey,
@@ -1667,7 +1667,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: List projects and verify our project is associated
-			projectsResult, _, err := client.Qualityprofiles.Projects(&sonar.QualityprofilesProjectsOption{
+			projectsResult, _, err := client.Qualityprofiles.Projects(&sonar.QualityprofilesProjectsOptions{
 				Key: profileKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1681,7 +1681,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(foundProject).To(BeTrue(), "Project %s should be associated with the quality profile", projectKey)
 
 			// Step 6: Add user permission
-			_, err = client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOption{
+			_, err = client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Login:          "admin",
@@ -1689,7 +1689,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 7: Search users and verify admin is selected
-			usersResult, _, err := client.Qualityprofiles.SearchUsers(&sonar.QualityprofilesSearchUsersOption{
+			usersResult, _, err := client.Qualityprofiles.SearchUsers(&sonar.QualityprofilesSearchUsersOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Selected:       "selected",
@@ -1705,7 +1705,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(foundAdmin).To(BeTrue(), "Admin user should have permission on quality profile")
 
 			// Step 8: Remove user permission
-			_, err = client.Qualityprofiles.RemoveUser(&sonar.QualityprofilesRemoveUserOption{
+			_, err = client.Qualityprofiles.RemoveUser(&sonar.QualityprofilesRemoveUserOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Login:          "admin",
@@ -1713,7 +1713,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 9: Remove project association
-			_, err = client.Qualityprofiles.RemoveProject(&sonar.QualityprofilesRemoveProjectOption{
+			_, err = client.Qualityprofiles.RemoveProject(&sonar.QualityprofilesRemoveProjectOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Project:        projectKey,
@@ -1721,7 +1721,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 10: Backup profile
-			backupResult, _, err := client.Qualityprofiles.Backup(&sonar.QualityprofilesBackupOption{
+			backupResult, _, err := client.Qualityprofiles.Backup(&sonar.QualityprofilesBackupOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 			})

--- a/integration_testing/rules_test.go
+++ b/integration_testing/rules_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 	// =========================================================================
 	Describe("Repositories", func() {
 		It("should list all rule repositories", func() {
-			result, resp, err := client.Rules.Repositories(&sonar.RulesRepositoriesOption{})
+			result, resp, err := client.Rules.Repositories(&sonar.RulesRepositoriesOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -68,7 +68,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter by language", func() {
-			result, resp, err := client.Rules.Repositories(&sonar.RulesRepositoriesOption{
+			result, resp, err := client.Rules.Repositories(&sonar.RulesRepositoriesOptions{
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -79,7 +79,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter by query", func() {
-			result, resp, err := client.Rules.Repositories(&sonar.RulesRepositoriesOption{
+			result, resp, err := client.Rules.Repositories(&sonar.RulesRepositoriesOptions{
 				Query: "sonar",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -103,7 +103,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 	// =========================================================================
 	Describe("Tags", func() {
 		It("should list all rule tags", func() {
-			result, resp, err := client.Rules.Tags(&sonar.RulesTagsOption{})
+			result, resp, err := client.Rules.Tags(&sonar.RulesTagsOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -111,7 +111,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should limit by page size", func() {
-			result, resp, err := client.Rules.Tags(&sonar.RulesTagsOption{
+			result, resp, err := client.Rules.Tags(&sonar.RulesTagsOptions{
 				PageSize: 5,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -120,7 +120,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter by query", func() {
-			result, resp, err := client.Rules.Tags(&sonar.RulesTagsOption{
+			result, resp, err := client.Rules.Tags(&sonar.RulesTagsOptions{
 				Query: "sec",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -140,7 +140,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with invalid page size (negative)", func() {
-				_, resp, err := client.Rules.Tags(&sonar.RulesTagsOption{
+				_, resp, err := client.Rules.Tags(&sonar.RulesTagsOptions{
 					PageSize: -1,
 				})
 				Expect(err).To(HaveOccurred())
@@ -148,7 +148,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 			})
 
 			It("should fail with page size exceeding max", func() {
-				_, resp, err := client.Rules.Tags(&sonar.RulesTagsOption{
+				_, resp, err := client.Rules.Tags(&sonar.RulesTagsOptions{
 					PageSize: 501,
 				})
 				Expect(err).To(HaveOccurred())
@@ -162,7 +162,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 	// =========================================================================
 	Describe("Search", func() {
 		It("should search for all rules", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOption{})
+			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -171,7 +171,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter by language", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOption{
+			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				Languages: []string{"java"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -183,7 +183,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 		It("should filter by repository", func() {
 			// First get available repositories
-			repos, _, err := client.Rules.Repositories(&sonar.RulesRepositoriesOption{
+			repos, _, err := client.Rules.Repositories(&sonar.RulesRepositoriesOptions{
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -191,7 +191,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 			repoKey := repos.Repositories[0].Key
 
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOption{
+			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				Repositories: []string{repoKey},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -202,7 +202,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter by severity", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOption{
+			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				Severities: []string{"CRITICAL"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -213,7 +213,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter by type", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOption{
+			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				Types: []string{"BUG"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -224,7 +224,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter by status", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOption{
+			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				Statuses: []string{"READY"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -236,13 +236,13 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 		It("should filter by tags", func() {
 			// First get available tags
-			tags, _, err := client.Rules.Tags(&sonar.RulesTagsOption{
+			tags, _, err := client.Rules.Tags(&sonar.RulesTagsOptions{
 				PageSize: 1,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			if len(tags.Tags) > 0 {
 				targetTag := tags.Tags[0]
-				result, resp, err := client.Rules.Search(&sonar.RulesSearchOption{
+				result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
 					Tags: []string{targetTag},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -273,7 +273,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter template rules", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOption{
+			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				IsTemplate: true,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -284,7 +284,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should paginate results", func() {
-			result1, resp, err := client.Rules.Search(&sonar.RulesSearchOption{
+			result1, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				PaginationArgs: sonar.PaginationArgs{
 					Page:     1,
 					PageSize: 5,
@@ -295,7 +295,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 			Expect(len(result1.Rules)).To(BeNumerically("<=", 5))
 
 			if result1.Paging.Total > 5 {
-				result2, resp, err := client.Rules.Search(&sonar.RulesSearchOption{
+				result2, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{
 						Page:     2,
 						PageSize: 5,
@@ -311,7 +311,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should include facets", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOption{
+			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				Facets: []string{"languages", "repositories", "tags"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -320,7 +320,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should search by query", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOption{
+			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				Query: "null",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -329,7 +329,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should include external rules", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOption{
+			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				IncludeExternal: true,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -346,7 +346,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with search query too short", func() {
-				_, resp, err := client.Rules.Search(&sonar.RulesSearchOption{
+				_, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
 					Query: "a",
 				})
 				Expect(err).To(HaveOccurred())
@@ -363,7 +363,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 		BeforeAll(func() {
 			// Get an existing rule key for show tests
-			result, _, err := client.Rules.Search(&sonar.RulesSearchOption{
+			result, _, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 1,
 				},
@@ -374,7 +374,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should show rule details", func() {
-			result, resp, err := client.Rules.Show(&sonar.RulesShowOption{
+			result, resp, err := client.Rules.Show(&sonar.RulesShowOptions{
 				Key: existingRuleKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -385,7 +385,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should include actives when requested", func() {
-			result, resp, err := client.Rules.Show(&sonar.RulesShowOption{
+			result, resp, err := client.Rules.Show(&sonar.RulesShowOptions{
 				Key:     existingRuleKey,
 				Actives: true,
 			})
@@ -403,13 +403,13 @@ var _ = Describe("Rules Service", Ordered, func() {
 			})
 
 			It("should fail with missing key", func() {
-				_, resp, err := client.Rules.Show(&sonar.RulesShowOption{})
+				_, resp, err := client.Rules.Show(&sonar.RulesShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with non-existent rule", func() {
-				_, resp, err := client.Rules.Show(&sonar.RulesShowOption{
+				_, resp, err := client.Rules.Show(&sonar.RulesShowOptions{
 					Key: "nonexistent:rule-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -426,7 +426,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 		BeforeAll(func() {
 			// Find a template rule to use for creating custom rules
-			result, _, err := client.Rules.Search(&sonar.RulesSearchOption{
+			result, _, err := client.Rules.Search(&sonar.RulesSearchOptions{
 				IsTemplate: true,
 				Languages:  []string{"java"},
 				PaginationArgs: sonar.PaginationArgs{
@@ -445,7 +445,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 			It("should create a custom rule from template", func() {
 				customKey := helpers.UniqueResourceName("rule")
 
-				result, resp, err := client.Rules.Create(&sonar.RulesCreateOption{
+				result, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "E2E Test Rule " + customKey,
 					MarkdownDescription: "This is a test rule created by e2e tests",
@@ -459,7 +459,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 				// Register cleanup
 				cleanup.RegisterCleanup("rule", result.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOption{
+					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
 						Key: result.Rule.Key,
 					})
 					return err
@@ -469,7 +469,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 			It("should create a custom rule with severity", func() {
 				customKey := helpers.UniqueResourceName("rule")
 
-				result, resp, err := client.Rules.Create(&sonar.RulesCreateOption{
+				result, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "E2E Severity Rule " + customKey,
 					MarkdownDescription: "Rule with custom severity",
@@ -481,7 +481,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(result.Rule.Severity).To(Equal("CRITICAL"))
 
 				cleanup.RegisterCleanup("rule", result.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOption{
+					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
 						Key: result.Rule.Key,
 					})
 					return err
@@ -491,7 +491,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 			It("should create a custom rule with status", func() {
 				customKey := helpers.UniqueResourceName("rule")
 
-				result, resp, err := client.Rules.Create(&sonar.RulesCreateOption{
+				result, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "E2E Status Rule " + customKey,
 					MarkdownDescription: "Rule with custom status",
@@ -503,7 +503,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(result.Rule.Status).To(Equal("BETA"))
 
 				cleanup.RegisterCleanup("rule", result.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOption{
+					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
 						Key: result.Rule.Key,
 					})
 					return err
@@ -518,7 +518,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				})
 
 				It("should fail with missing custom key", func() {
-					_, resp, err := client.Rules.Create(&sonar.RulesCreateOption{
+					_, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
 						Name:                "Test Rule",
 						MarkdownDescription: "Description",
 						TemplateKey:         templateRule.Key,
@@ -528,7 +528,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				})
 
 				It("should fail with missing name", func() {
-					_, resp, err := client.Rules.Create(&sonar.RulesCreateOption{
+					_, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
 						CustomKey:           "test-rule",
 						MarkdownDescription: "Description",
 						TemplateKey:         templateRule.Key,
@@ -538,7 +538,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				})
 
 				It("should fail with missing markdown description", func() {
-					_, resp, err := client.Rules.Create(&sonar.RulesCreateOption{
+					_, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
 						CustomKey:   "test-rule",
 						Name:        "Test Rule",
 						TemplateKey: templateRule.Key,
@@ -548,7 +548,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				})
 
 				It("should fail with missing template key", func() {
-					_, resp, err := client.Rules.Create(&sonar.RulesCreateOption{
+					_, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
 						CustomKey:           "test-rule",
 						Name:                "Test Rule",
 						MarkdownDescription: "Description",
@@ -559,7 +559,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 				It("should fail with custom key too long", func() {
 					longKey := strings.Repeat("a", 201)
-					_, resp, err := client.Rules.Create(&sonar.RulesCreateOption{
+					_, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
 						CustomKey:           longKey,
 						Name:                "Test Rule",
 						MarkdownDescription: "Description",
@@ -571,7 +571,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 				It("should fail with name too long", func() {
 					longName := strings.Repeat("a", 201)
-					_, resp, err := client.Rules.Create(&sonar.RulesCreateOption{
+					_, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
 						CustomKey:           "test-rule",
 						Name:                longName,
 						MarkdownDescription: "Description",
@@ -591,7 +591,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				customKey := helpers.UniqueResourceName("rule")
 
 				// Create rule
-				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOption{
+				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "Original Name",
 					MarkdownDescription: "Original description",
@@ -600,7 +600,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("rule", createResult.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOption{
+					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
 						Key: createResult.Rule.Key,
 					})
 					return err
@@ -608,7 +608,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 				// Update rule
 				updatedName := "Updated Name " + customKey
-				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOption{
+				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
 					Key:                 createResult.Rule.Key,
 					Name:                updatedName,
 					MarkdownDescription: "Updated description",
@@ -621,7 +621,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 			It("should update a custom rule severity", func() {
 				customKey := helpers.UniqueResourceName("rule")
 
-				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOption{
+				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "Severity Update Rule",
 					MarkdownDescription: "Testing severity update",
@@ -631,13 +631,13 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("rule", createResult.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOption{
+					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
 						Key: createResult.Rule.Key,
 					})
 					return err
 				})
 
-				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOption{
+				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
 					Key:      createResult.Rule.Key,
 					Severity: "BLOCKER",
 				})
@@ -649,7 +649,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 			It("should update a custom rule status", func() {
 				customKey := helpers.UniqueResourceName("rule")
 
-				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOption{
+				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "Status Update Rule",
 					MarkdownDescription: "Testing status update",
@@ -659,13 +659,13 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("rule", createResult.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOption{
+					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
 						Key: createResult.Rule.Key,
 					})
 					return err
 				})
 
-				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOption{
+				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
 					Key:    createResult.Rule.Key,
 					Status: "DEPRECATED",
 				})
@@ -678,7 +678,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				customKey := helpers.UniqueResourceName("rule")
 
 				// Create a custom rule for testing tag updates
-				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOption{
+				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "Tag Update Test Rule",
 					MarkdownDescription: "Testing tag updates",
@@ -687,14 +687,14 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("rule", createResult.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOption{
+					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
 						Key: createResult.Rule.Key,
 					})
 					return err
 				})
 
 				// Add a custom tag
-				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOption{
+				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
 					Key:  createResult.Rule.Key,
 					Tags: []string{"e2e-test-tag"},
 				})
@@ -703,7 +703,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(updateResult.Rule.Tags).To(ContainElement("e2e-test-tag"))
 
 				// Clear tags
-				clearResult, _, err := client.Rules.Update(&sonar.RulesUpdateOption{
+				clearResult, _, err := client.Rules.Update(&sonar.RulesUpdateOptions{
 					Key:  createResult.Rule.Key,
 					Tags: []string{},
 				})
@@ -715,7 +715,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				customKey := helpers.UniqueResourceName("rule")
 
 				// Create a custom rule for testing note updates
-				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOption{
+				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "Note Update Test Rule",
 					MarkdownDescription: "Testing note updates",
@@ -724,14 +724,14 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("rule", createResult.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOption{
+					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
 						Key: createResult.Rule.Key,
 					})
 					return err
 				})
 
 				// Add a note
-				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOption{
+				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
 					Key:          createResult.Rule.Key,
 					MarkdownNote: "E2E test note: This is a test note added during e2e testing",
 				})
@@ -740,7 +740,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(updateResult.Rule.MdNote).To(ContainSubstring("E2E test note"))
 
 				// Update the note with different content
-				updateResult2, _, err := client.Rules.Update(&sonar.RulesUpdateOption{
+				updateResult2, _, err := client.Rules.Update(&sonar.RulesUpdateOptions{
 					Key:          createResult.Rule.Key,
 					MarkdownNote: "Updated note content",
 				})
@@ -757,7 +757,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				})
 
 				It("should fail with missing key", func() {
-					_, resp, err := client.Rules.Update(&sonar.RulesUpdateOption{
+					_, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
 						Name: "Updated Name",
 					})
 					Expect(err).To(HaveOccurred())
@@ -766,7 +766,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 				It("should fail with key too long", func() {
 					longKey := strings.Repeat("a", 201)
-					_, resp, err := client.Rules.Update(&sonar.RulesUpdateOption{
+					_, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
 						Key:  longKey,
 						Name: "Updated Name",
 					})
@@ -784,7 +784,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				customKey := helpers.UniqueResourceName("rule")
 
 				// Create rule
-				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOption{
+				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "Rule To Delete",
 					MarkdownDescription: "This rule will be deleted",
@@ -793,14 +793,14 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Delete rule
-				resp, err := client.Rules.Delete(&sonar.RulesDeleteOption{
+				resp, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
 					Key: createResult.Rule.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 				// Verify deletion - rule is marked as REMOVED
-				showResult, _, err := client.Rules.Show(&sonar.RulesShowOption{
+				showResult, _, err := client.Rules.Show(&sonar.RulesShowOptions{
 					Key: createResult.Rule.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -815,7 +815,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				})
 
 				It("should fail with missing key", func() {
-					resp, err := client.Rules.Delete(&sonar.RulesDeleteOption{})
+					resp, err := client.Rules.Delete(&sonar.RulesDeleteOptions{})
 					Expect(err).To(HaveOccurred())
 					Expect(resp).To(BeNil())
 				})
@@ -828,7 +828,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 	// =========================================================================
 	Describe("List", func() {
 		It("should list rules", func() {
-			result, resp, err := client.Rules.List(&sonar.RulesListOption{})
+			result, resp, err := client.Rules.List(&sonar.RulesListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -836,7 +836,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should paginate results", func() {
-			result, resp, err := client.Rules.List(&sonar.RulesListOption{
+			result, resp, err := client.Rules.List(&sonar.RulesListOptions{
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 10,
 				},

--- a/integration_testing/settings_test.go
+++ b/integration_testing/settings_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 	// =========================================================================
 	Describe("ListDefinitions", func() {
 		It("should list all setting definitions", func() {
-			result, resp, err := client.Settings.ListDefinitions(&sonar.SettingsListDefinitionsOption{})
+			result, resp, err := client.Settings.ListDefinitions(&sonar.SettingsListDefinitionsOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -44,7 +44,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 		})
 
 		It("should return definitions with proper structure", func() {
-			result, resp, err := client.Settings.ListDefinitions(&sonar.SettingsListDefinitionsOption{})
+			result, resp, err := client.Settings.ListDefinitions(&sonar.SettingsListDefinitionsOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			// Each definition should have at least a key
@@ -56,21 +56,21 @@ var _ = Describe("Settings Service", Ordered, func() {
 		It("should list definitions for a specific project", func() {
 			// First create a project
 			projectKey := helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// List definitions for the project
-			result, resp, err := client.Settings.ListDefinitions(&sonar.SettingsListDefinitionsOption{
+			result, resp, err := client.Settings.ListDefinitions(&sonar.SettingsListDefinitionsOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -92,7 +92,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 	// =========================================================================
 	Describe("Values", func() {
 		It("should list all setting values", func() {
-			result, resp, err := client.Settings.Values(&sonar.SettingsValuesOption{})
+			result, resp, err := client.Settings.Values(&sonar.SettingsValuesOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -100,7 +100,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 		})
 
 		It("should filter by specific keys", func() {
-			result, resp, err := client.Settings.Values(&sonar.SettingsValuesOption{
+			result, resp, err := client.Settings.Values(&sonar.SettingsValuesOptions{
 				Keys: []string{"sonar.core.id", "sonar.core.startTime"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -115,21 +115,21 @@ var _ = Describe("Settings Service", Ordered, func() {
 		It("should get values for a specific project", func() {
 			// First create a project
 			projectKey := helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// Get values for the project
-			result, resp, err := client.Settings.Values(&sonar.SettingsValuesOption{
+			result, resp, err := client.Settings.Values(&sonar.SettingsValuesOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -153,7 +153,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 		Describe("Set", func() {
 			It("should set a global setting value", func() {
 				// Set a simple string setting
-				resp, err := client.Settings.Set(&sonar.SettingsSetOption{
+				resp, err := client.Settings.Set(&sonar.SettingsSetOptions{
 					Key:   "sonar.login.message",
 					Value: "E2E Test Login Message",
 				})
@@ -161,7 +161,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Verify the value was set
-				values, _, err := client.Settings.Values(&sonar.SettingsValuesOption{
+				values, _, err := client.Settings.Values(&sonar.SettingsValuesOptions{
 					Keys: []string{"sonar.login.message"},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -169,7 +169,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 				Expect(values.Settings[0].Value).To(Equal("E2E Test Login Message"))
 
 				// Clean up - reset the setting
-				_, _ = client.Settings.Reset(&sonar.SettingsResetOption{
+				_, _ = client.Settings.Reset(&sonar.SettingsResetOptions{
 					Keys: []string{"sonar.login.message"},
 				})
 			})
@@ -177,21 +177,21 @@ var _ = Describe("Settings Service", Ordered, func() {
 			It("should set a project-level setting", func() {
 				// Create a project
 				projectKey := helpers.UniqueResourceName("proj")
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    projectKey,
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
 				// Set a project-level setting (sonar.exclusions is a multi-value setting)
-				resp, err := client.Settings.Set(&sonar.SettingsSetOption{
+				resp, err := client.Settings.Set(&sonar.SettingsSetOptions{
 					Key:       "sonar.exclusions",
 					Values:    []string{"**/test/**"},
 					Component: projectKey,
@@ -200,7 +200,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Verify the value was set
-				values, _, err := client.Settings.Values(&sonar.SettingsValuesOption{
+				values, _, err := client.Settings.Values(&sonar.SettingsValuesOptions{
 					Component: projectKey,
 					Keys:      []string{"sonar.exclusions"},
 				})
@@ -211,21 +211,21 @@ var _ = Describe("Settings Service", Ordered, func() {
 			It("should set a multi-value setting", func() {
 				// Create a project for testing
 				projectKey := helpers.UniqueResourceName("proj")
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    projectKey,
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
 				// Set a multi-value setting on the project
-				resp, err := client.Settings.Set(&sonar.SettingsSetOption{
+				resp, err := client.Settings.Set(&sonar.SettingsSetOptions{
 					Key:       "sonar.exclusions",
 					Values:    []string{"**/test/**", "**/vendor/**"},
 					Component: projectKey,
@@ -242,7 +242,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 				})
 
 				It("should fail with missing key", func() {
-					resp, err := client.Settings.Set(&sonar.SettingsSetOption{
+					resp, err := client.Settings.Set(&sonar.SettingsSetOptions{
 						Value: "some value",
 					})
 					Expect(err).To(HaveOccurred())
@@ -250,7 +250,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 				})
 
 				It("should fail with missing value/values/fieldValues", func() {
-					resp, err := client.Settings.Set(&sonar.SettingsSetOption{
+					resp, err := client.Settings.Set(&sonar.SettingsSetOptions{
 						Key: "some.key",
 					})
 					Expect(err).To(HaveOccurred())
@@ -262,21 +262,21 @@ var _ = Describe("Settings Service", Ordered, func() {
 		Describe("Reset", func() {
 			It("should reset a global setting value", func() {
 				// First set a value
-				_, err := client.Settings.Set(&sonar.SettingsSetOption{
+				_, err := client.Settings.Set(&sonar.SettingsSetOptions{
 					Key:   "sonar.login.message",
 					Value: "Message to be reset",
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Reset the setting
-				resp, err := client.Settings.Reset(&sonar.SettingsResetOption{
+				resp, err := client.Settings.Reset(&sonar.SettingsResetOptions{
 					Keys: []string{"sonar.login.message"},
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Verify the value was reset (should not be found or have default value)
-				values, _, err := client.Settings.Values(&sonar.SettingsValuesOption{
+				values, _, err := client.Settings.Values(&sonar.SettingsValuesOptions{
 					Keys: []string{"sonar.login.message"},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -289,21 +289,21 @@ var _ = Describe("Settings Service", Ordered, func() {
 			It("should reset a project-level setting", func() {
 				// Create a project
 				projectKey := helpers.UniqueResourceName("proj")
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    projectKey,
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
 				// Set a project-level setting (sonar.exclusions is a multi-value setting)
-				_, err = client.Settings.Set(&sonar.SettingsSetOption{
+				_, err = client.Settings.Set(&sonar.SettingsSetOptions{
 					Key:       "sonar.exclusions",
 					Values:    []string{"**/test/**"},
 					Component: projectKey,
@@ -311,7 +311,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Reset the project-level setting
-				resp, err := client.Settings.Reset(&sonar.SettingsResetOption{
+				resp, err := client.Settings.Reset(&sonar.SettingsResetOptions{
 					Keys:      []string{"sonar.exclusions"},
 					Component: projectKey,
 				})
@@ -322,28 +322,28 @@ var _ = Describe("Settings Service", Ordered, func() {
 			It("should reset multiple settings at once", func() {
 				// Create a project
 				projectKey := helpers.UniqueResourceName("proj")
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    projectKey,
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
 				// Set multiple settings (sonar.exclusions and sonar.inclusions are multi-value)
-				_, err = client.Settings.Set(&sonar.SettingsSetOption{
+				_, err = client.Settings.Set(&sonar.SettingsSetOptions{
 					Key:       "sonar.exclusions",
 					Values:    []string{"**/test/**"},
 					Component: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				_, err = client.Settings.Set(&sonar.SettingsSetOption{
+				_, err = client.Settings.Set(&sonar.SettingsSetOptions{
 					Key:       "sonar.inclusions",
 					Values:    []string{"**/src/**"},
 					Component: projectKey,
@@ -351,7 +351,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Reset multiple settings
-				resp, err := client.Settings.Reset(&sonar.SettingsResetOption{
+				resp, err := client.Settings.Reset(&sonar.SettingsResetOptions{
 					Keys:      []string{"sonar.exclusions", "sonar.inclusions"},
 					Component: projectKey,
 				})
@@ -367,13 +367,13 @@ var _ = Describe("Settings Service", Ordered, func() {
 				})
 
 				It("should fail with missing keys", func() {
-					resp, err := client.Settings.Reset(&sonar.SettingsResetOption{})
+					resp, err := client.Settings.Reset(&sonar.SettingsResetOptions{})
 					Expect(err).To(HaveOccurred())
 					Expect(resp).To(BeNil())
 				})
 
 				It("should fail with empty keys array", func() {
-					resp, err := client.Settings.Reset(&sonar.SettingsResetOption{
+					resp, err := client.Settings.Reset(&sonar.SettingsResetOptions{
 						Keys: []string{},
 					})
 					Expect(err).To(HaveOccurred())
@@ -397,14 +397,14 @@ var _ = Describe("Settings Service", Ordered, func() {
 
 		It("should return the set login message", func() {
 			// Set a login message
-			_, err := client.Settings.Set(&sonar.SettingsSetOption{
+			_, err := client.Settings.Set(&sonar.SettingsSetOptions{
 				Key:   "sonar.login.message",
 				Value: "Welcome to E2E Testing!",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify the value was set using Values endpoint
-			values, _, err := client.Settings.Values(&sonar.SettingsValuesOption{
+			values, _, err := client.Settings.Values(&sonar.SettingsValuesOptions{
 				Keys: []string{"sonar.login.message"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -419,7 +419,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 			Expect(result).NotTo(BeNil())
 
 			// Clean up
-			_, _ = client.Settings.Reset(&sonar.SettingsResetOption{
+			_, _ = client.Settings.Reset(&sonar.SettingsResetOptions{
 				Keys: []string{"sonar.login.message"},
 			})
 		})
@@ -465,7 +465,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 				Skip("Secret key not available, skipping encryption test")
 			}
 
-			result, resp, err := client.Settings.Encrypt(&sonar.SettingsEncryptOption{
+			result, resp, err := client.Settings.Encrypt(&sonar.SettingsEncryptOptions{
 				Value: "my-secret-value",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -484,7 +484,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 			})
 
 			It("should fail with missing value", func() {
-				_, resp, err := client.Settings.Encrypt(&sonar.SettingsEncryptOption{})
+				_, resp, err := client.Settings.Encrypt(&sonar.SettingsEncryptOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})

--- a/integration_testing/sources_test.go
+++ b/integration_testing/sources_test.go
@@ -24,14 +24,14 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		// Create a test project for source-related operations
 		projectKey = helpers.UniqueResourceName("src")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    "Sources Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -59,7 +59,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 			})
 
 			It("should fail without required resource parameter", func() {
-				result, resp, err := client.Sources.Index(&sonar.SourcesIndexOption{})
+				result, resp, err := client.Sources.Index(&sonar.SourcesIndexOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Resource"))
 				Expect(result).To(BeNil())
@@ -69,7 +69,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("Non-Existent Resource", func() {
 			It("should fail with non-existent file key", func() {
-				result, resp, err := client.Sources.Index(&sonar.SourcesIndexOption{
+				result, resp, err := client.Sources.Index(&sonar.SourcesIndexOptions{
 					Resource: "non-existent:src/main.go",
 				})
 				// API should return an error for non-existent resource
@@ -84,7 +84,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 		Context("With Valid Project (No Analysis)", func() {
 			It("should fail for project without analyzed files", func() {
 				// Projects without analysis have no source files indexed
-				result, resp, err := client.Sources.Index(&sonar.SourcesIndexOption{
+				result, resp, err := client.Sources.Index(&sonar.SourcesIndexOptions{
 					Resource: projectKey + ":src/main.go",
 				})
 				// Should fail because there's no analyzed source
@@ -98,7 +98,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Line Range", func() {
 			It("should fail for non-existent file with line range", func() {
-				result, resp, err := client.Sources.Index(&sonar.SourcesIndexOption{
+				result, resp, err := client.Sources.Index(&sonar.SourcesIndexOptions{
 					Resource: "non-existent:src/main.go",
 					From:     1,
 					To:       10,
@@ -126,7 +126,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Sources.IssueSnippets(&sonar.SourcesIssueSnippetsOption{})
+				result, resp, err := client.Sources.IssueSnippets(&sonar.SourcesIssueSnippetsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("IssueKey"))
 				Expect(result).To(BeNil())
@@ -136,7 +136,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Sources.IssueSnippets(&sonar.SourcesIssueSnippetsOption{
+				result, resp, err := client.Sources.IssueSnippets(&sonar.SourcesIssueSnippetsOptions{
 					IssueKey: "AXxxxxxxxxxxxxxxxxxx",
 				})
 				// API should return an error for non-existent issue
@@ -163,7 +163,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 			})
 
 			It("should fail without required key parameter", func() {
-				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOption{})
+				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(result).To(BeNil())
@@ -173,7 +173,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("Non-Existent File", func() {
 			It("should fail with non-existent file key", func() {
-				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOption{
+				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOptions{
 					Key: "non-existent:src/main.go",
 				})
 				// API should return an error for non-existent file
@@ -187,7 +187,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Valid Project (No Analysis)", func() {
 			It("should fail for project without analyzed files", func() {
-				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOption{
+				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOptions{
 					Key: projectKey + ":src/main.go",
 				})
 				// Should fail because there's no analyzed source
@@ -201,7 +201,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Line Range", func() {
 			It("should fail for non-existent file with line range", func() {
-				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOption{
+				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOptions{
 					Key:  "non-existent:src/main.go",
 					From: 1,
 					To:   10,
@@ -216,7 +216,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Branch", func() {
 			It("should fail for non-existent branch", func() {
-				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOption{
+				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOptions{
 					Key:    projectKey + ":src/main.go",
 					Branch: "non-existent-branch",
 				})
@@ -230,7 +230,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Pull Request", func() {
 			It("should fail for non-existent pull request", func() {
-				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOption{
+				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOptions{
 					Key:         projectKey + ":src/main.go",
 					PullRequest: "99999",
 				})
@@ -257,7 +257,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 			})
 
 			It("should fail without required key parameter", func() {
-				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOption{})
+				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(result).To(BeEmpty())
@@ -267,7 +267,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("Non-Existent File", func() {
 			It("should fail with non-existent file key", func() {
-				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOption{
+				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOptions{
 					Key: "non-existent:src/main.go",
 				})
 				// API should return an error for non-existent file
@@ -281,7 +281,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Valid Project (No Analysis)", func() {
 			It("should fail for project without analyzed files", func() {
-				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOption{
+				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOptions{
 					Key: projectKey + ":src/main.go",
 				})
 				// Should fail because there's no analyzed source
@@ -295,7 +295,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Branch", func() {
 			It("should fail for non-existent branch", func() {
-				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOption{
+				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOptions{
 					Key:    projectKey + ":src/main.go",
 					Branch: "non-existent-branch",
 				})
@@ -309,7 +309,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Pull Request", func() {
 			It("should fail for non-existent pull request", func() {
-				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOption{
+				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOptions{
 					Key:         projectKey + ":src/main.go",
 					PullRequest: "99999",
 				})
@@ -336,7 +336,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 			})
 
 			It("should fail without required key parameter", func() {
-				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOption{})
+				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(result).To(BeNil())
@@ -346,7 +346,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("Non-Existent File", func() {
 			It("should fail with non-existent file key", func() {
-				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOption{
+				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOptions{
 					Key: "non-existent:src/main.go",
 				})
 				// API should return an error for non-existent file
@@ -360,7 +360,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Valid Project (No Analysis)", func() {
 			It("should fail for project without analyzed files", func() {
-				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOption{
+				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOptions{
 					Key: projectKey + ":src/main.go",
 				})
 				// Should fail because there's no analyzed source
@@ -374,7 +374,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Line Range", func() {
 			It("should fail for non-existent file with line range", func() {
-				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOption{
+				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOptions{
 					Key:  "non-existent:src/main.go",
 					From: 1,
 					To:   10,
@@ -389,7 +389,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With CommitsByLine Option", func() {
 			It("should fail for non-existent file with commits_by_line", func() {
-				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOption{
+				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOptions{
 					Key:           "non-existent:src/main.go",
 					CommitsByLine: true,
 				})
@@ -416,7 +416,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 			})
 
 			It("should fail without required key parameter", func() {
-				result, resp, err := client.Sources.Show(&sonar.SourcesShowOption{})
+				result, resp, err := client.Sources.Show(&sonar.SourcesShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(result).To(BeNil())
@@ -426,7 +426,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("Non-Existent File", func() {
 			It("should fail with non-existent file key", func() {
-				result, resp, err := client.Sources.Show(&sonar.SourcesShowOption{
+				result, resp, err := client.Sources.Show(&sonar.SourcesShowOptions{
 					Key: "non-existent:src/main.go",
 				})
 				// API should return an error for non-existent file
@@ -440,7 +440,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Valid Project (No Analysis)", func() {
 			It("should fail for project without analyzed files", func() {
-				result, resp, err := client.Sources.Show(&sonar.SourcesShowOption{
+				result, resp, err := client.Sources.Show(&sonar.SourcesShowOptions{
 					Key: projectKey + ":src/main.go",
 				})
 				// Should fail because there's no analyzed source
@@ -454,7 +454,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Line Range", func() {
 			It("should fail for non-existent file with line range", func() {
-				result, resp, err := client.Sources.Show(&sonar.SourcesShowOption{
+				result, resp, err := client.Sources.Show(&sonar.SourcesShowOptions{
 					Key:  "non-existent:src/main.go",
 					From: 1,
 					To:   10,

--- a/integration_testing/system_test.go
+++ b/integration_testing/system_test.go
@@ -162,14 +162,14 @@ var _ = Describe("System Service", Ordered, func() {
 
 			AfterEach(func() {
 				// Restore original log level
-				_, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOption{
+				_, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOptions{
 					Level: originalLevel,
 				})
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should change log level to DEBUG", func() {
-				resp, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOption{
+				resp, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOptions{
 					Level: "DEBUG",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -177,7 +177,7 @@ var _ = Describe("System Service", Ordered, func() {
 			})
 
 			It("should change log level to TRACE", func() {
-				resp, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOption{
+				resp, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOptions{
 					Level: "TRACE",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -185,7 +185,7 @@ var _ = Describe("System Service", Ordered, func() {
 			})
 
 			It("should change log level to INFO", func() {
-				resp, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOption{
+				resp, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOptions{
 					Level: "INFO",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -193,7 +193,7 @@ var _ = Describe("System Service", Ordered, func() {
 			})
 
 			It("should reject invalid log levels", func() {
-				resp, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOption{
+				resp, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOptions{
 					Level: "INVALID_LEVEL",
 				})
 				// This should fail with validation error
@@ -204,7 +204,7 @@ var _ = Describe("System Service", Ordered, func() {
 
 		Describe("Logs", func() {
 			It("should retrieve app logs", func() {
-				logs, resp, err := client.System.Logs(&sonar.SystemLogsOption{
+				logs, resp, err := client.System.Logs(&sonar.SystemLogsOptions{
 					Name: "app",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -214,7 +214,7 @@ var _ = Describe("System Service", Ordered, func() {
 			})
 
 			It("should retrieve web logs", func() {
-				logs, resp, err := client.System.Logs(&sonar.SystemLogsOption{
+				logs, resp, err := client.System.Logs(&sonar.SystemLogsOptions{
 					Name: "web",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -223,7 +223,7 @@ var _ = Describe("System Service", Ordered, func() {
 			})
 
 			It("should retrieve ce logs", func() {
-				logs, resp, err := client.System.Logs(&sonar.SystemLogsOption{
+				logs, resp, err := client.System.Logs(&sonar.SystemLogsOptions{
 					Name: "ce",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -232,7 +232,7 @@ var _ = Describe("System Service", Ordered, func() {
 			})
 
 			It("should reject invalid log names", func() {
-				_, resp, err := client.System.Logs(&sonar.SystemLogsOption{
+				_, resp, err := client.System.Logs(&sonar.SystemLogsOptions{
 					Name: "invalid_log_name",
 				})
 				// This should fail with validation error

--- a/integration_testing/user_groups_test.go
+++ b/integration_testing/user_groups_test.go
@@ -37,7 +37,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("with default options", func() {
 			It("should return list of groups", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOption{})
+				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -49,7 +49,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("with query filter", func() {
 			It("should filter groups by query", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOption{
+				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
 					Query: "admin",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -68,7 +68,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should return empty list for non-matching query", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOption{
+				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
 					Query: "nonexistentgroupxyz123",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -81,7 +81,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("with pagination", func() {
 			It("should support page size", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOption{
+				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 1,
 					},
@@ -96,7 +96,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("with fields selection", func() {
 			It("should return specified fields", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOption{
+				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
 					Fields: []string{"name", "description", "membersCount"},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -120,7 +120,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with invalid page size", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOption{
+				_, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 1000, // Too large
 					},
@@ -130,7 +130,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with invalid field", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOption{
+				_, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
 					Fields: []string{"invalid_field"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -145,7 +145,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 				groupName := helpers.UniqueResourceName("group")
 
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+				result, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 					Name: groupName,
 				})
 
@@ -154,7 +154,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 				// Register cleanup
 				cleanup.RegisterCleanup("group", groupName, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+					_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 						Name: groupName,
 					})
 					return err
@@ -172,7 +172,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 				groupName := helpers.UniqueResourceName("group-desc")
 
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+				result, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 					Name:        groupName,
 					Description: "E2E test group with description",
 				})
@@ -182,7 +182,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 				// Register cleanup
 				cleanup.RegisterCleanup("group", groupName, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+					_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 						Name: groupName,
 					})
 					return err
@@ -201,7 +201,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 				// Create first group
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+				_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 					Name: groupName,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -209,7 +209,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 				// Register cleanup
 				cleanup.RegisterCleanup("group", groupName, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+					_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 						Name: groupName,
 					})
 					return err
@@ -217,7 +217,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 				// Try to create duplicate
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+				_, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 					Name: groupName,
 				})
 				Expect(err).To(HaveOccurred())
@@ -237,7 +237,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with missing name", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+				_, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 					Description: "Test description",
 				})
 				Expect(err).To(HaveOccurred())
@@ -246,7 +246,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with name too long", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+				_, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 					Name: strings.Repeat("a", sonar.MaxGroupNameLength+1),
 				})
 				Expect(err).To(HaveOccurred())
@@ -255,7 +255,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with description too long", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+				_, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 					Name:        "validname",
 					Description: strings.Repeat("a", sonar.MaxGroupDescriptionLength+1),
 				})
@@ -274,7 +274,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 			nameToCleanup := testGroupName
 
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 				Name:        testGroupName,
 				Description: "Original description",
 			})
@@ -282,7 +282,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("group", nameToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 					Name: nameToCleanup,
 				})
 				return err
@@ -291,7 +291,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should update group description", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOption{
+			resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOptions{
 				CurrentName: testGroupName,
 				Description: "Updated description",
 			})
@@ -302,7 +302,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Verify update
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOption{
+			result, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
 				Query:  testGroupName,
 				Fields: []string{"name", "description"},
 			})
@@ -322,7 +322,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 			newName := helpers.UniqueResourceName("group-renamed")
 
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOption{
+			resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOptions{
 				CurrentName: testGroupName,
 				Name:        newName,
 			})
@@ -336,7 +336,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Verify update
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOption{
+			result, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
 				Query: newName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -360,7 +360,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with missing current name", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOption{
+				resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOptions{
 					Name: "newname",
 				})
 				Expect(err).To(HaveOccurred())
@@ -369,7 +369,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with name too long", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOption{
+				resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOptions{
 					CurrentName: testGroupName,
 					Name:        strings.Repeat("a", sonar.MaxGroupNameLength+1),
 				})
@@ -379,7 +379,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with description too long", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOption{
+				resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOptions{
 					CurrentName: testGroupName,
 					Description: strings.Repeat("a", sonar.MaxGroupDescriptionLength+1),
 				})
@@ -389,7 +389,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail for non-existent group", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOption{
+				_, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOptions{
 					CurrentName: "nonexistentgroup12345",
 					Description: "New description",
 				})
@@ -404,14 +404,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Create group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 				Name: groupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Delete group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+			resp, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 				Name: groupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -419,7 +419,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Verify deletion
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOption{
+			result, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
 				Query: groupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -438,14 +438,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with missing name", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{})
+				resp, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail for non-existent group", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 					Name: "nonexistentgroup12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -467,14 +467,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Create group first
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 				Name: testGroupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("group", groupToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 					Name: groupToCleanup,
 				})
 				return err
@@ -482,7 +482,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Test User for Group",
 				Password: "SecurePassword123!",
@@ -492,7 +492,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", userToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 					Login:     userToCleanup,
 					Anonymize: true,
 				})
@@ -502,7 +502,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should add user to group", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOption{
+			resp, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
 				Name:  testGroupName,
 				Login: testUserLogin,
 			})
@@ -511,7 +511,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Verify user is in group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOption{
+			result, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
 				Selected: "selected",
 			})
@@ -529,7 +529,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should add user to group by login only", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOption{
+			resp, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
 				Name:  testGroupName,
 				Login: testUserLogin,
 			})
@@ -547,7 +547,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with missing group name", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOption{
+				resp, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
 					Login: testUserLogin,
 				})
 				Expect(err).To(HaveOccurred())
@@ -556,7 +556,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail for non-existent group", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOption{
+				_, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
 					Name:  "nonexistentgroup12345",
 					Login: testUserLogin,
 				})
@@ -565,7 +565,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail for non-existent user", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOption{
+				_, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
 					Name:  testGroupName,
 					Login: "nonexistentuser12345",
 				})
@@ -588,14 +588,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Create group first
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 				Name: testGroupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("group", groupToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 					Name: groupToCleanup,
 				})
 				return err
@@ -603,7 +603,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Test User for Remove",
 				Password: "SecurePassword123!",
@@ -613,7 +613,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", userToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 					Login:     userToCleanup,
 					Anonymize: true,
 				})
@@ -622,7 +622,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Add user to group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, err = client.UserGroups.AddUser(&sonar.UserGroupsAddUserOption{
+			_, err = client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
 				Name:  testGroupName,
 				Login: testUserLogin,
 			})
@@ -631,7 +631,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should remove user from group", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.UserGroups.RemoveUser(&sonar.UserGroupsRemoveUserOption{
+			resp, err := client.UserGroups.RemoveUser(&sonar.UserGroupsRemoveUserOptions{
 				Name:  testGroupName,
 				Login: testUserLogin,
 			})
@@ -640,7 +640,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Verify user is not in group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOption{
+			result, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
 				Selected: "selected",
 			})
@@ -660,7 +660,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with missing group name", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.RemoveUser(&sonar.UserGroupsRemoveUserOption{
+				resp, err := client.UserGroups.RemoveUser(&sonar.UserGroupsRemoveUserOptions{
 					Login: testUserLogin,
 				})
 				Expect(err).To(HaveOccurred())
@@ -669,7 +669,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail for non-existent group", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.RemoveUser(&sonar.UserGroupsRemoveUserOption{
+				_, err := client.UserGroups.RemoveUser(&sonar.UserGroupsRemoveUserOptions{
 					Name:  "nonexistentgroup12345",
 					Login: testUserLogin,
 				})
@@ -692,14 +692,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Create group first
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 				Name: testGroupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("group", groupToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 					Name: groupToCleanup,
 				})
 				return err
@@ -707,7 +707,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Test User in Group",
 				Password: "SecurePassword123!",
@@ -717,7 +717,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", userToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 					Login:     userToCleanup,
 					Anonymize: true,
 				})
@@ -726,7 +726,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Add user to group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, err = client.UserGroups.AddUser(&sonar.UserGroupsAddUserOption{
+			_, err = client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
 				Name:  testGroupName,
 				Login: testUserLogin,
 			})
@@ -735,7 +735,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should list selected users in group", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOption{
+			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
 				Selected: "selected",
 			})
@@ -758,7 +758,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should list all users with membership info", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOption{
+			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
 				Selected: "all",
 			})
@@ -771,7 +771,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should list deselected users", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOption{
+			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
 				Selected: "deselected",
 			})
@@ -786,7 +786,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should filter users by query", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOption{
+			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
 				Query:    testUserLogin,
 				Selected: "all",
@@ -808,7 +808,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("with pagination", func() {
 			It("should support page size", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOption{
+				result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 					Name: testGroupName,
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 1,
@@ -831,14 +831,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with missing name", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOption{})
+				_, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid selected value", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOption{
+				_, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 					Name:     testGroupName,
 					Selected: "invalid",
 				})
@@ -848,7 +848,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail for non-existent group", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOption{
+				_, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 					Name: "nonexistentgroup12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -863,7 +863,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 1: Create group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			createResult, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOption{
+			createResult, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
 				Name:        groupName,
 				Description: "Lifecycle test group",
 			})
@@ -874,7 +874,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 2: Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    userLogin,
 				Name:     "Lifecycle Test User",
 				Password: "SecurePassword123!",
@@ -884,7 +884,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 3: Add user to group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, err = client.UserGroups.AddUser(&sonar.UserGroupsAddUserOption{
+			_, err = client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
 				Name:  groupName,
 				Login: userLogin,
 			})
@@ -892,7 +892,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 4: Verify user in group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			usersResult, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOption{
+			usersResult, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     groupName,
 				Selected: "selected",
 			})
@@ -908,7 +908,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 5: Update group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, err = client.UserGroups.Update(&sonar.UserGroupsUpdateOption{
+			_, err = client.UserGroups.Update(&sonar.UserGroupsUpdateOptions{
 				CurrentName: groupName,
 				Description: "Updated lifecycle description",
 			})
@@ -916,7 +916,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 6: Remove user from group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, err = client.UserGroups.RemoveUser(&sonar.UserGroupsRemoveUserOption{
+			_, err = client.UserGroups.RemoveUser(&sonar.UserGroupsRemoveUserOptions{
 				Name:  groupName,
 				Login: userLogin,
 			})
@@ -924,7 +924,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 7: Verify user removed
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			usersResult, _, err = client.UserGroups.Users(&sonar.UserGroupsUsersOption{
+			usersResult, _, err = client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     groupName,
 				Selected: "selected",
 			})
@@ -935,7 +935,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 8: Cleanup - deactivate user first
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Deactivate(&sonar.UsersDeactivateOption{
+			_, _, err = client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 				Login:     userLogin,
 				Anonymize: true,
 			})
@@ -943,14 +943,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 9: Delete group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, err = client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+			_, err = client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 				Name: groupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify group deleted
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			searchResult, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOption{
+			searchResult, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
 				Query: groupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -963,7 +963,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 	Describe("Default Groups", func() {
 		It("should find sonar-users group", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOption{
+			result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
 				Query: "sonar-users",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -981,7 +981,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should find sonar-administrators group", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOption{
+			result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
 				Query: "sonar-administrators",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1000,7 +1000,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		It("should not delete default groups", func() {
 			// Try to delete sonar-users (default group) - should fail
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOption{
+			_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
 				Name: "sonar-users",
 			})
 			// Default groups cannot be deleted

--- a/integration_testing/user_tokens_test.go
+++ b/integration_testing/user_tokens_test.go
@@ -38,7 +38,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			It("should generate a user token", func() {
 				tokenName := helpers.UniqueResourceName("token")
 
-				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 					Name: tokenName,
 				})
 
@@ -46,7 +46,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				// Register cleanup
 				cleanup.RegisterCleanup("token", tokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 						Name: tokenName,
 					})
 					return err
@@ -63,7 +63,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			It("should generate a token with explicit USER_TOKEN type", func() {
 				tokenName := helpers.UniqueResourceName("token-user")
 
-				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 					Name: tokenName,
 					Type: "USER_TOKEN",
 				})
@@ -72,7 +72,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				// Register cleanup
 				cleanup.RegisterCleanup("token", tokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 						Name: tokenName,
 					})
 					return err
@@ -90,7 +90,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			It("should generate a global analysis token", func() {
 				tokenName := helpers.UniqueResourceName("token-global")
 
-				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 					Name: tokenName,
 					Type: "GLOBAL_ANALYSIS_TOKEN",
 				})
@@ -99,7 +99,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				// Register cleanup
 				cleanup.RegisterCleanup("token", tokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 						Name: tokenName,
 					})
 					return err
@@ -120,14 +120,14 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				// Create a project for the token
 				testProjectKey = helpers.UniqueResourceName("proj-token")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 					Name:    "Token Test Project",
 					Project: testProjectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", testProjectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: testProjectKey,
 					})
 					return err
@@ -137,7 +137,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			It("should generate a project analysis token", func() {
 				tokenName := helpers.UniqueResourceName("token-proj")
 
-				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 					Name:       tokenName,
 					Type:       "PROJECT_ANALYSIS_TOKEN",
 					ProjectKey: testProjectKey,
@@ -147,7 +147,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				// Register cleanup
 				cleanup.RegisterCleanup("token", tokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 						Name: tokenName,
 					})
 					return err
@@ -167,7 +167,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				// Set expiration date to 30 days from now
 				expirationDate := "2027-01-01"
 
-				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 					Name:           tokenName,
 					ExpirationDate: expirationDate,
 				})
@@ -176,7 +176,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				// Register cleanup
 				cleanup.RegisterCleanup("token", tokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 						Name: tokenName,
 					})
 					return err
@@ -196,7 +196,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				testUserLogin = helpers.UniqueResourceName("user-token")
 
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Create(&sonar.UsersCreateOption{
+				_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
 					Login:    testUserLogin,
 					Name:     "Token Test User",
 					Password: "SecurePassword123!",
@@ -206,7 +206,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				cleanup.RegisterCleanup("user", testUserLogin, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 						Login:     testUserLogin,
 						Anonymize: true,
 					})
@@ -217,7 +217,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			It("should generate a token for another user", func() {
 				tokenName := helpers.UniqueResourceName("token-other")
 
-				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 					Name:  tokenName,
 					Login: testUserLogin,
 				})
@@ -226,7 +226,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				// Register cleanup
 				cleanup.RegisterCleanup("token", tokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 						Name:  tokenName,
 						Login: testUserLogin,
 					})
@@ -245,21 +245,21 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				tokenName := helpers.UniqueResourceName("token-dup")
 
 				// Generate first token
-				_, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+				_, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 					Name: tokenName,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Register cleanup
 				cleanup.RegisterCleanup("token", tokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 						Name: tokenName,
 					})
 					return err
 				})
 
 				// Try to generate duplicate
-				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 					Name: tokenName,
 				})
 				Expect(err).To(HaveOccurred())
@@ -277,13 +277,13 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			})
 
 			It("should fail with missing name", func() {
-				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{})
+				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid type", func() {
-				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 					Name: "test-token",
 					Type: "INVALID_TYPE",
 				})
@@ -292,7 +292,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			})
 
 			It("should fail with PROJECT_ANALYSIS_TOKEN without project key", func() {
-				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 					Name: "test-token",
 					Type: "PROJECT_ANALYSIS_TOKEN",
 				})
@@ -302,7 +302,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 			It("should fail with name too long", func() {
 				longName := strings.Repeat("a", sonar.MaxTokenNameLength+1)
-				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 					Name: longName,
 				})
 				Expect(err).To(HaveOccurred())
@@ -317,13 +317,13 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 		BeforeEach(func() {
 			tokenName = helpers.UniqueResourceName("token-search")
 
-			_, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+			_, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 				Name: tokenName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("token", tokenName, func() error {
-				_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+				_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 					Name: tokenName,
 				})
 				return err
@@ -351,7 +351,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 		})
 
 		It("should search tokens with empty options", func() {
-			result, resp, err := client.UserTokens.Search(&sonar.UserTokensSearchOption{})
+			result, resp, err := client.UserTokens.Search(&sonar.UserTokensSearchOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -367,7 +367,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				userTokenName = helpers.UniqueResourceName("token-usrsrch")
 
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Create(&sonar.UsersCreateOption{
+				_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
 					Login:    testUserLogin,
 					Name:     "Search Test User",
 					Password: "SecurePassword123!",
@@ -377,7 +377,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				cleanup.RegisterCleanup("user", testUserLogin, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 						Login:     testUserLogin,
 						Anonymize: true,
 					})
@@ -385,14 +385,14 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				})
 
 				// Generate a token for the test user
-				_, _, err = client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+				_, _, err = client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 					Name:  userTokenName,
 					Login: testUserLogin,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("token", userTokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 						Name:  userTokenName,
 						Login: testUserLogin,
 					})
@@ -401,7 +401,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			})
 
 			It("should search tokens for specific user", func() {
-				result, resp, err := client.UserTokens.Search(&sonar.UserTokensSearchOption{
+				result, resp, err := client.UserTokens.Search(&sonar.UserTokensSearchOptions{
 					Login: testUserLogin,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -445,13 +445,13 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			tokenName := helpers.UniqueResourceName("token-revoke")
 
 			// Generate a token first
-			_, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+			_, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 				Name: tokenName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Revoke the token
-			resp, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+			resp, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 				Name: tokenName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -474,7 +474,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				userTokenName = helpers.UniqueResourceName("token-usrrev")
 
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Create(&sonar.UsersCreateOption{
+				_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
 					Login:    testUserLogin,
 					Name:     "Revoke Test User",
 					Password: "SecurePassword123!",
@@ -484,7 +484,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				cleanup.RegisterCleanup("user", testUserLogin, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 						Login:     testUserLogin,
 						Anonymize: true,
 					})
@@ -492,7 +492,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				})
 
 				// Generate a token for the test user
-				_, _, err = client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+				_, _, err = client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 					Name:  userTokenName,
 					Login: testUserLogin,
 				})
@@ -500,7 +500,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			})
 
 			It("should revoke a token for another user", func() {
-				resp, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+				resp, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 					Name:  userTokenName,
 					Login: testUserLogin,
 				})
@@ -508,7 +508,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Verify token is revoked
-				result, _, err := client.UserTokens.Search(&sonar.UserTokensSearchOption{
+				result, _, err := client.UserTokens.Search(&sonar.UserTokensSearchOptions{
 					Login: testUserLogin,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -526,14 +526,14 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			})
 
 			It("should fail with missing name", func() {
-				resp, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{})
+				resp, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should handle revoking non-existent token gracefully", func() {
 				// SonarQube API is idempotent - revoking a non-existent token succeeds silently
-				resp, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+				resp, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 					Name: "nonexistent-token-xyz12345",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -547,7 +547,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			tokenName := helpers.UniqueResourceName("token-lifecycle")
 
 			// Step 1: Generate token
-			generateResult, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+			generateResult, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 				Name: tokenName,
 				Type: "USER_TOKEN",
 			})
@@ -584,7 +584,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			Expect(authResult.Valid).To(BeTrue())
 
 			// Step 4: Revoke token
-			_, err = client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+			_, err = client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 				Name: tokenName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -605,38 +605,38 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			token3Name := helpers.UniqueResourceName("token-multi3")
 
 			// Generate multiple tokens
-			_, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+			_, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 				Name: token1Name,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("token", token1Name, func() error {
-				_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+				_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 					Name: token1Name,
 				})
 				return err
 			})
 
-			_, _, err = client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+			_, _, err = client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 				Name: token2Name,
 				Type: "GLOBAL_ANALYSIS_TOKEN",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("token", token2Name, func() error {
-				_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+				_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 					Name: token2Name,
 				})
 				return err
 			})
 
-			_, _, err = client.UserTokens.Generate(&sonar.UserTokensGenerateOption{
+			_, _, err = client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
 				Name: token3Name,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("token", token3Name, func() error {
-				_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOption{
+				_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
 					Name: token3Name,
 				})
 				return err

--- a/integration_testing/users_test.go
+++ b/integration_testing/users_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("with query filter", func() {
 			It("should filter users by query", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.Users.Search(&sonar.UsersSearchOption{
+				result, resp, err := client.Users.Search(&sonar.UsersSearchOptions{
 					Query: "admin",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -100,7 +100,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should return empty list for non-matching query", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.Users.Search(&sonar.UsersSearchOption{
+				result, resp, err := client.Users.Search(&sonar.UsersSearchOptions{
 					Query: "nonexistentuserxyz123",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -113,7 +113,7 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("with pagination", func() {
 			It("should support page size", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.Users.Search(&sonar.UsersSearchOption{
+				result, resp, err := client.Users.Search(&sonar.UsersSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 1,
 					},
@@ -128,7 +128,7 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should reject invalid page size", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Search(&sonar.UsersSearchOption{
+				_, _, err := client.Users.Search(&sonar.UsersSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 1000, // Too large
 					},
@@ -144,7 +144,7 @@ var _ = Describe("Users Service", Ordered, func() {
 				login := helpers.UniqueResourceName("user")
 
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.Users.Create(&sonar.UsersCreateOption{
+				result, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
 					Login:    login,
 					Name:     "E2E Test User",
 					Password: "SecurePassword123!",
@@ -156,7 +156,7 @@ var _ = Describe("Users Service", Ordered, func() {
 				// Register cleanup
 				cleanup.RegisterCleanup("user", login, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 						Login:     login,
 						Anonymize: true,
 					})
@@ -178,7 +178,7 @@ var _ = Describe("Users Service", Ordered, func() {
 				scmAccount2 := fmt.Sprintf("gitlab:%s", login)
 
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.Users.Create(&sonar.UsersCreateOption{
+				result, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
 					Login:       login,
 					Name:        "E2E Full User",
 					Email:       "e2e-test@example.com",
@@ -192,7 +192,7 @@ var _ = Describe("Users Service", Ordered, func() {
 				// Register cleanup
 				cleanup.RegisterCleanup("user", login, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 						Login:     login,
 						Anonymize: true,
 					})
@@ -212,7 +212,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 				// Create first user
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Create(&sonar.UsersCreateOption{
+				_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
 					Login:    login,
 					Name:     "First User",
 					Password: "SecurePassword123!",
@@ -223,7 +223,7 @@ var _ = Describe("Users Service", Ordered, func() {
 				// Register cleanup
 				cleanup.RegisterCleanup("user", login, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 						Login:     login,
 						Anonymize: true,
 					})
@@ -232,7 +232,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 				// Try to create duplicate
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Create(&sonar.UsersCreateOption{
+				_, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
 					Login:    login,
 					Name:     "Duplicate User",
 					Password: "AnotherPassword123!",
@@ -255,7 +255,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Create(&sonar.UsersCreateOption{
+				_, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
 					Name:     "Test User",
 					Password: "SecurePassword123!",
 				})
@@ -265,7 +265,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing name", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Create(&sonar.UsersCreateOption{
+				_, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
 					Login:    "testuser",
 					Password: "SecurePassword123!",
 				})
@@ -275,7 +275,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with login too short", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Create(&sonar.UsersCreateOption{
+				_, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
 					Login:    "x",
 					Name:     "Test User",
 					Password: "SecurePassword123!",
@@ -286,7 +286,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing password for local user", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Create(&sonar.UsersCreateOption{
+				_, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
 					Login: "testuser",
 					Name:  "Test User",
 					Local: true,
@@ -297,7 +297,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with password too short", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Create(&sonar.UsersCreateOption{
+				_, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
 					Login:    "testuser",
 					Name:     "Test User",
 					Password: "short",
@@ -318,7 +318,7 @@ var _ = Describe("Users Service", Ordered, func() {
 			loginToCleanup := testUserLogin
 
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Original Name",
 				Email:    "original@example.com",
@@ -329,7 +329,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", loginToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 					Login:     loginToCleanup,
 					Anonymize: true,
 				})
@@ -339,7 +339,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 		It("should update user name", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.Update(&sonar.UsersUpdateOption{
+			result, resp, err := client.Users.Update(&sonar.UsersUpdateOptions{
 				Login: testUserLogin,
 				Name:  "Updated Name",
 			})
@@ -351,7 +351,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 		It("should update user email", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.Update(&sonar.UsersUpdateOption{
+			result, resp, err := client.Users.Update(&sonar.UsersUpdateOptions{
 				Login: testUserLogin,
 				Email: "updated@example.com",
 			})
@@ -367,7 +367,7 @@ var _ = Describe("Users Service", Ordered, func() {
 			scmAccount2 := fmt.Sprintf("bitbucket:%s", testUserLogin)
 
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.Update(&sonar.UsersUpdateOption{
+			result, resp, err := client.Users.Update(&sonar.UsersUpdateOptions{
 				Login:       testUserLogin,
 				ScmAccounts: []string{scmAccount1, scmAccount2},
 			})
@@ -387,7 +387,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Update(&sonar.UsersUpdateOption{
+				_, resp, err := client.Users.Update(&sonar.UsersUpdateOptions{
 					Name: "Some Name",
 				})
 				Expect(err).To(HaveOccurred())
@@ -396,7 +396,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail for non-existent user", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Update(&sonar.UsersUpdateOption{
+				_, resp, err := client.Users.Update(&sonar.UsersUpdateOptions{
 					Login: "nonexistentuser12345",
 					Name:  "New Name",
 				})
@@ -417,7 +417,7 @@ var _ = Describe("Users Service", Ordered, func() {
 			loginToCleanup := testUserLogin
 
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Password Test User",
 				Password: "OldPassword123!",
@@ -427,7 +427,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", loginToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 					Login:     loginToCleanup,
 					Anonymize: true,
 				})
@@ -437,7 +437,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 		It("should change user password", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.Users.ChangePassword(&sonar.UsersChangePasswordOption{
+			resp, err := client.Users.ChangePassword(&sonar.UsersChangePasswordOptions{
 				Login:    testUserLogin,
 				Password: "NewPassword456!",
 			})
@@ -468,7 +468,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.ChangePassword(&sonar.UsersChangePasswordOption{
+				resp, err := client.Users.ChangePassword(&sonar.UsersChangePasswordOptions{
 					Password: "NewPassword123!",
 				})
 				Expect(err).To(HaveOccurred())
@@ -477,7 +477,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing password", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.ChangePassword(&sonar.UsersChangePasswordOption{
+				resp, err := client.Users.ChangePassword(&sonar.UsersChangePasswordOptions{
 					Login: testUserLogin,
 				})
 				Expect(err).To(HaveOccurred())
@@ -486,7 +486,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with password too short", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.ChangePassword(&sonar.UsersChangePasswordOption{
+				resp, err := client.Users.ChangePassword(&sonar.UsersChangePasswordOptions{
 					Login:    testUserLogin,
 					Password: "short",
 				})
@@ -503,7 +503,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    oldLogin,
 				Name:     "Login Update User",
 				Password: "SecurePassword123!",
@@ -513,7 +513,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Update login
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.Users.UpdateLogin(&sonar.UsersUpdateLoginOption{
+			resp, err := client.Users.UpdateLogin(&sonar.UsersUpdateLoginOptions{
 				Login:    oldLogin,
 				NewLogin: newLogin,
 			})
@@ -523,7 +523,7 @@ var _ = Describe("Users Service", Ordered, func() {
 			// Register cleanup with new login
 			cleanup.RegisterCleanup("user", newLogin, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 					Login:     newLogin,
 					Anonymize: true,
 				})
@@ -532,7 +532,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Verify new login exists
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, _, err := client.Users.Search(&sonar.UsersSearchOption{
+			result, _, err := client.Users.Search(&sonar.UsersSearchOptions{
 				Query: newLogin,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -556,7 +556,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.UpdateLogin(&sonar.UsersUpdateLoginOption{
+				resp, err := client.Users.UpdateLogin(&sonar.UsersUpdateLoginOptions{
 					NewLogin: "newlogin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -565,7 +565,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing new login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.UpdateLogin(&sonar.UsersUpdateLoginOption{
+				resp, err := client.Users.UpdateLogin(&sonar.UsersUpdateLoginOptions{
 					Login: "oldlogin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -574,7 +574,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with new login too short", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.UpdateLogin(&sonar.UsersUpdateLoginOption{
+				resp, err := client.Users.UpdateLogin(&sonar.UsersUpdateLoginOptions{
 					Login:    "someuser",
 					NewLogin: "x",
 				})
@@ -587,7 +587,7 @@ var _ = Describe("Users Service", Ordered, func() {
 	Describe("Groups", func() {
 		It("should return groups for a user", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.Groups(&sonar.UsersGroupsOption{
+			result, resp, err := client.Users.Groups(&sonar.UsersGroupsOptions{
 				Login: "admin",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -599,7 +599,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 		It("should filter groups with query", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.Groups(&sonar.UsersGroupsOption{
+			result, resp, err := client.Users.Groups(&sonar.UsersGroupsOptions{
 				Login: "admin",
 				Query: "sonar",
 			})
@@ -618,7 +618,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Groups(&sonar.UsersGroupsOption{})
+				_, resp, err := client.Users.Groups(&sonar.UsersGroupsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -652,7 +652,7 @@ var _ = Describe("Users Service", Ordered, func() {
 	Describe("SetHomepage", func() {
 		It("should set homepage to PROJECTS", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.Users.SetHomepage(&sonar.UsersSetHomepageOption{
+			resp, err := client.Users.SetHomepage(&sonar.UsersSetHomepageOptions{
 				Type: "PROJECTS",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -661,7 +661,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 		It("should set homepage to ISSUES", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.Users.SetHomepage(&sonar.UsersSetHomepageOption{
+			resp, err := client.Users.SetHomepage(&sonar.UsersSetHomepageOptions{
 				Type: "ISSUES",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -678,14 +678,14 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing type", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.SetHomepage(&sonar.UsersSetHomepageOption{})
+				resp, err := client.Users.SetHomepage(&sonar.UsersSetHomepageOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid type", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.SetHomepage(&sonar.UsersSetHomepageOption{
+				resp, err := client.Users.SetHomepage(&sonar.UsersSetHomepageOptions{
 					Type: "INVALID_TYPE",
 				})
 				Expect(err).To(HaveOccurred())
@@ -697,7 +697,7 @@ var _ = Describe("Users Service", Ordered, func() {
 	Describe("DismissNotice", func() {
 		It("should dismiss a notice", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.Users.DismissNotice(&sonar.UsersDismissNoticeOption{
+			resp, err := client.Users.DismissNotice(&sonar.UsersDismissNoticeOptions{
 				Notice: "educationPrinciples",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -707,7 +707,7 @@ var _ = Describe("Users Service", Ordered, func() {
 		It("should handle already dismissed notice gracefully", func() {
 			// Dismiss the same notice twice - should succeed silently
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.Users.DismissNotice(&sonar.UsersDismissNoticeOption{
+			resp, err := client.Users.DismissNotice(&sonar.UsersDismissNoticeOptions{
 				Notice: "sonarlintAd",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -715,7 +715,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Dismiss again
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err = client.Users.DismissNotice(&sonar.UsersDismissNoticeOption{
+			resp, err = client.Users.DismissNotice(&sonar.UsersDismissNoticeOptions{
 				Notice: "sonarlintAd",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -732,14 +732,14 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing notice", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.DismissNotice(&sonar.UsersDismissNoticeOption{})
+				resp, err := client.Users.DismissNotice(&sonar.UsersDismissNoticeOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid notice type", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.DismissNotice(&sonar.UsersDismissNoticeOption{
+				resp, err := client.Users.DismissNotice(&sonar.UsersDismissNoticeOptions{
 					Notice: "invalidNoticeType",
 				})
 				Expect(err).To(HaveOccurred())
@@ -754,7 +754,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    login,
 				Name:     "Deactivate Test User",
 				Password: "SecurePassword123!",
@@ -764,7 +764,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Deactivate user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+			result, resp, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 				Login: login,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -775,7 +775,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Verify user is deactivated
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			searchResult, _, err := client.Users.Search(&sonar.UsersSearchOption{
+			searchResult, _, err := client.Users.Search(&sonar.UsersSearchOptions{
 				Query:       login,
 				Deactivated: true,
 			})
@@ -796,7 +796,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    login,
 				Name:     "Anonymize Test User",
 				Email:    "anon@example.com",
@@ -807,7 +807,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Deactivate with anonymize
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+			result, resp, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 				Login:     login,
 				Anonymize: true,
 			})
@@ -827,14 +827,14 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{})
+				_, resp, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail for non-existent user", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+				_, resp, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 					Login: "nonexistentuser12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -851,7 +851,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.Users.Create(&sonar.UsersCreateOption{
+			_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    login,
 				Name:     "Anonymize Test User 2",
 				Email:    "anon2@example.com",
@@ -862,14 +862,14 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Deactivate first (required before anonymize)
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Deactivate(&sonar.UsersDeactivateOption{
+			_, _, err = client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 				Login: login,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Anonymize
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.Users.Anonymize(&sonar.UsersAnonymizeOption{
+			resp, err := client.Users.Anonymize(&sonar.UsersAnonymizeOptions{
 				Login: login,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -886,7 +886,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.Anonymize(&sonar.UsersAnonymizeOption{})
+				resp, err := client.Users.Anonymize(&sonar.UsersAnonymizeOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -904,7 +904,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.UpdateIdentityProvider(&sonar.UsersUpdateIdentityProviderOption{
+				resp, err := client.Users.UpdateIdentityProvider(&sonar.UsersUpdateIdentityProviderOptions{
 					NewExternalProvider: "sonarqube",
 				})
 				Expect(err).To(HaveOccurred())
@@ -913,7 +913,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing new external provider", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.UpdateIdentityProvider(&sonar.UsersUpdateIdentityProviderOption{
+				resp, err := client.Users.UpdateIdentityProvider(&sonar.UsersUpdateIdentityProviderOptions{
 					Login: "someuser",
 				})
 				Expect(err).To(HaveOccurred())
@@ -929,7 +929,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Step 1: Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			createResult, _, err := client.Users.Create(&sonar.UsersCreateOption{
+			createResult, _, err := client.Users.Create(&sonar.UsersCreateOptions{
 				Login:    login,
 				Name:     "Lifecycle User " + timestamp,
 				Email:    "lifecycle" + timestamp + "@example.com",
@@ -942,7 +942,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Step 2: Search and verify
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			searchResult, _, err := client.Users.Search(&sonar.UsersSearchOption{
+			searchResult, _, err := client.Users.Search(&sonar.UsersSearchOptions{
 				Query: login,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -957,7 +957,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Step 3: Update user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			updateResult, _, err := client.Users.Update(&sonar.UsersUpdateOption{
+			updateResult, _, err := client.Users.Update(&sonar.UsersUpdateOptions{
 				Login: login,
 				Name:  "Updated Lifecycle User",
 			})
@@ -966,14 +966,14 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Step 4: Get user groups
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Groups(&sonar.UsersGroupsOption{
+			_, _, err = client.Users.Groups(&sonar.UsersGroupsOptions{
 				Login: login,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: Deactivate and anonymize
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			deactivateResult, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOption{
+			deactivateResult, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
 				Login:     login,
 				Anonymize: true,
 			})

--- a/integration_testing/v2_analysis_test.go
+++ b/integration_testing/v2_analysis_test.go
@@ -197,7 +197,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 
 		BeforeAll(func() {
 			projectKey = helpers.UniqueResourceName("v2arproj")
-			_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOption{
+			_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:    "V2 Active Rules Test",
 				Project: projectKey,
 			})
@@ -205,7 +205,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, cleanupErr := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+				_, cleanupErr := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return helpers.IgnoreNotFoundError(cleanupErr)

--- a/integration_testing/v2_clean_code_policy_test.go
+++ b/integration_testing/v2_clean_code_policy_test.go
@@ -137,7 +137,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 
 			BeforeAll(func() {
 				// Find a template rule to use for creating custom rules.
-				result, _, err := client.Rules.Search(&sonar.RulesSearchOption{
+				result, _, err := client.Rules.Search(&sonar.RulesSearchOptions{
 					IsTemplate: true,
 					Languages:  []string{"java"},
 					PaginationArgs: sonar.PaginationArgs{
@@ -173,7 +173,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 
 				// Register cleanup using V1 Rules.Delete.
 				cleanup.RegisterCleanup("rule", ruleKey, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOption{
+					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
 						Key: ruleKey,
 					})
 					return err

--- a/integration_testing/v2_dop_translation_test.go
+++ b/integration_testing/v2_dop_translation_test.go
@@ -130,7 +130,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 				Expect(result.NewProjectCreated).To(BeTrue())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return helpers.IgnoreNotFoundError(err)
@@ -200,7 +200,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 				Expect(result.NewProjectCreated).To(BeTrue())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return helpers.IgnoreNotFoundError(err)
@@ -222,7 +222,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 				Expect(createResult.NewProjectCreated).To(BeTrue())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return helpers.IgnoreNotFoundError(err)

--- a/integration_testing/webhooks_test.go
+++ b/integration_testing/webhooks_test.go
@@ -26,14 +26,14 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 		// Create a test project for project-scoped webhooks
 		projectKey = helpers.UniqueResourceName("webhook")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOption{
+		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 			Name:    "Webhooks Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOption{
+			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -63,14 +63,14 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should list global webhooks", func() {
-				result, resp, err := client.Webhooks.List(&sonar.WebhooksListOption{})
+				result, resp, err := client.Webhooks.List(&sonar.WebhooksListOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
 			})
 
 			It("should list project webhooks", func() {
-				result, resp, err := client.Webhooks.List(&sonar.WebhooksListOption{
+				result, resp, err := client.Webhooks.List(&sonar.WebhooksListOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -94,7 +94,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should fail without required name", func() {
-				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOption{
+				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
 					URL: "https://example.com/webhook",
 				})
 				Expect(err).To(HaveOccurred())
@@ -104,7 +104,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should fail without required URL", func() {
-				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOption{
+				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
 					Name: "Test Webhook",
 				})
 				Expect(err).To(HaveOccurred())
@@ -114,7 +114,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should fail with secret too short", func() {
-				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOption{
+				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
 					Name:   "Test Webhook",
 					URL:    "https://example.com/webhook",
 					Secret: "short",
@@ -129,7 +129,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 		Context("Valid Requests", func() {
 			It("should create a global webhook", func() {
 				webhookName := helpers.UniqueResourceName("wh")
-				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOption{
+				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
 					Name: webhookName,
 					URL:  "https://example.com/webhook",
 				})
@@ -140,14 +140,14 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 				Expect(result.Webhook.Name).To(Equal(webhookName))
 
 				// Clean up
-				_, _ = client.Webhooks.Delete(&sonar.WebhooksDeleteOption{
+				_, _ = client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{
 					Webhook: result.Webhook.Key,
 				})
 			})
 
 			It("should create a project webhook", func() {
 				webhookName := helpers.UniqueResourceName("wh")
-				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOption{
+				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
 					Name:    webhookName,
 					URL:     "https://example.com/webhook",
 					Project: projectKey,
@@ -158,14 +158,14 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 				Expect(result.Webhook.Key).NotTo(BeEmpty())
 
 				// Clean up
-				_, _ = client.Webhooks.Delete(&sonar.WebhooksDeleteOption{
+				_, _ = client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{
 					Webhook: result.Webhook.Key,
 				})
 			})
 
 			It("should create a webhook with secret", func() {
 				webhookName := helpers.UniqueResourceName("wh")
-				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOption{
+				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
 					Name:   webhookName,
 					URL:    "https://example.com/webhook",
 					Secret: "super-secret-key-16chars",
@@ -176,7 +176,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 				Expect(result.Webhook.HasSecret).To(BeTrue())
 
 				// Clean up
-				_, _ = client.Webhooks.Delete(&sonar.WebhooksDeleteOption{
+				_, _ = client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{
 					Webhook: result.Webhook.Key,
 				})
 			})
@@ -196,7 +196,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should fail without required webhook key", func() {
-				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOption{
+				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOptions{
 					Name: "Updated Name",
 					URL:  "https://example.com/updated",
 				})
@@ -206,7 +206,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should fail without required name", func() {
-				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOption{
+				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOptions{
 					Webhook: "some-key",
 					URL:     "https://example.com/updated",
 				})
@@ -216,7 +216,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should fail without required URL", func() {
-				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOption{
+				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOptions{
 					Webhook: "some-key",
 					Name:    "Updated Name",
 				})
@@ -230,7 +230,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			It("should update a webhook", func() {
 				// Create a webhook first
 				webhookName := helpers.UniqueResourceName("wh")
-				createResult, _, err := client.Webhooks.Create(&sonar.WebhooksCreateOption{
+				createResult, _, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
 					Name: webhookName,
 					URL:  "https://example.com/webhook",
 				})
@@ -238,7 +238,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 				// Update it
 				updatedName := webhookName + "-updated"
-				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOption{
+				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOptions{
 					Webhook: createResult.Webhook.Key,
 					Name:    updatedName,
 					URL:     "https://example.com/updated",
@@ -247,7 +247,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Clean up
-				_, _ = client.Webhooks.Delete(&sonar.WebhooksDeleteOption{
+				_, _ = client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{
 					Webhook: createResult.Webhook.Key,
 				})
 			})
@@ -255,7 +255,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 		Context("Non-Existent Webhook", func() {
 			It("should fail for non-existent webhook", func() {
-				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOption{
+				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOptions{
 					Webhook: "non-existent-webhook-key",
 					Name:    "Updated Name",
 					URL:     "https://example.com/updated",
@@ -281,7 +281,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should fail without required webhook key", func() {
-				resp, err := client.Webhooks.Delete(&sonar.WebhooksDeleteOption{})
+				resp, err := client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Webhook"))
 				Expect(resp).To(BeNil())
@@ -292,14 +292,14 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			It("should delete a webhook", func() {
 				// Create a webhook first
 				webhookName := helpers.UniqueResourceName("wh")
-				createResult, _, err := client.Webhooks.Create(&sonar.WebhooksCreateOption{
+				createResult, _, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
 					Name: webhookName,
 					URL:  "https://example.com/webhook",
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Delete it
-				resp, err := client.Webhooks.Delete(&sonar.WebhooksDeleteOption{
+				resp, err := client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{
 					Webhook: createResult.Webhook.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -309,7 +309,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 		Context("Non-Existent Webhook", func() {
 			It("should fail for non-existent webhook", func() {
-				resp, err := client.Webhooks.Delete(&sonar.WebhooksDeleteOption{
+				resp, err := client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{
 					Webhook: "non-existent-webhook-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -336,7 +336,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should list deliveries for a project", func() {
-				result, resp, err := client.Webhooks.Deliveries(&sonar.WebhooksDeliveriesOption{
+				result, resp, err := client.Webhooks.Deliveries(&sonar.WebhooksDeliveriesOptions{
 					ComponentKey: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -345,7 +345,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should list deliveries with pagination", func() {
-				result, resp, err := client.Webhooks.Deliveries(&sonar.WebhooksDeliveriesOption{
+				result, resp, err := client.Webhooks.Deliveries(&sonar.WebhooksDeliveriesOptions{
 					ComponentKey: projectKey,
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 10,
@@ -373,7 +373,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should fail without required DeliveryID", func() {
-				result, resp, err := client.Webhooks.Delivery(&sonar.WebhooksDeliveryOption{})
+				result, resp, err := client.Webhooks.Delivery(&sonar.WebhooksDeliveryOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("DeliveryID"))
 				Expect(result).To(BeNil())
@@ -383,7 +383,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 		Context("Non-Existent Delivery", func() {
 			It("should fail for non-existent delivery", func() {
-				result, resp, err := client.Webhooks.Delivery(&sonar.WebhooksDeliveryOption{
+				result, resp, err := client.Webhooks.Delivery(&sonar.WebhooksDeliveryOptions{
 					DeliveryID: "non-existent-delivery-id",
 				})
 				Expect(err).To(HaveOccurred())
@@ -402,7 +402,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 		It("should create, list, update, and delete a webhook", func() {
 			// Create a webhook
 			webhookName := helpers.UniqueResourceName("wh")
-			createResult, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOption{
+			createResult, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
 				Name: webhookName,
 				URL:  "https://example.com/webhook",
 			})
@@ -412,7 +412,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			webhookKey := createResult.Webhook.Key
 
 			// List and verify it's there
-			listResult, resp, err := client.Webhooks.List(&sonar.WebhooksListOption{})
+			listResult, resp, err := client.Webhooks.List(&sonar.WebhooksListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -428,7 +428,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 			// Update the webhook
 			updatedName := webhookName + "-updated"
-			resp, err = client.Webhooks.Update(&sonar.WebhooksUpdateOption{
+			resp, err = client.Webhooks.Update(&sonar.WebhooksUpdateOptions{
 				Webhook: webhookKey,
 				Name:    updatedName,
 				URL:     "https://example.com/updated",
@@ -437,7 +437,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify update
-			listResult, _, err = client.Webhooks.List(&sonar.WebhooksListOption{})
+			listResult, _, err = client.Webhooks.List(&sonar.WebhooksListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, w := range listResult.Webhooks {
@@ -449,14 +449,14 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			}
 
 			// Delete the webhook
-			resp, err = client.Webhooks.Delete(&sonar.WebhooksDeleteOption{
+			resp, err = client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{
 				Webhook: webhookKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify it's gone
-			listResult, _, err = client.Webhooks.List(&sonar.WebhooksListOption{})
+			listResult, _, err = client.Webhooks.List(&sonar.WebhooksListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			found = false

--- a/integration_testing/webservices_test.go
+++ b/integration_testing/webservices_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Webservices Service", Ordered, func() {
 			})
 
 			It("should list webservices with empty options", func() {
-				result, resp, err := client.Webservices.List(&sonar.WebservicesListOption{})
+				result, resp, err := client.Webservices.List(&sonar.WebservicesListOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -97,12 +97,12 @@ var _ = Describe("Webservices Service", Ordered, func() {
 			})
 
 			It("should include internals when requested", func() {
-				withoutInternals, _, err := client.Webservices.List(&sonar.WebservicesListOption{
+				withoutInternals, _, err := client.Webservices.List(&sonar.WebservicesListOptions{
 					IncludeInternals: false,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				withInternals, _, err := client.Webservices.List(&sonar.WebservicesListOption{
+				withInternals, _, err := client.Webservices.List(&sonar.WebservicesListOptions{
 					IncludeInternals: true,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -130,7 +130,7 @@ var _ = Describe("Webservices Service", Ordered, func() {
 		Context("Functional Tests", func() {
 			It("should get response example for an action with example", func() {
 				// First find an action with a response example
-				list, _, err := client.Webservices.List(&sonar.WebservicesListOption{
+				list, _, err := client.Webservices.List(&sonar.WebservicesListOptions{
 					IncludeInternals: true,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -154,7 +154,7 @@ var _ = Describe("Webservices Service", Ordered, func() {
 					Skip("No action with response example found in this SonarQube version")
 				}
 
-				result, resp, err := client.Webservices.ResponseExample(&sonar.WebservicesResponseExampleOption{
+				result, resp, err := client.Webservices.ResponseExample(&sonar.WebservicesResponseExampleOptions{
 					Controller: controller,
 					Action:     action,
 				})
@@ -173,14 +173,14 @@ var _ = Describe("Webservices Service", Ordered, func() {
 			})
 
 			It("should fail with empty options", func() {
-				_, resp, err := client.Webservices.ResponseExample(&sonar.WebservicesResponseExampleOption{})
+				_, resp, err := client.Webservices.ResponseExample(&sonar.WebservicesResponseExampleOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(err.Error()).To(ContainSubstring("Action"))
 			})
 
 			It("should fail with missing action", func() {
-				_, resp, err := client.Webservices.ResponseExample(&sonar.WebservicesResponseExampleOption{
+				_, resp, err := client.Webservices.ResponseExample(&sonar.WebservicesResponseExampleOptions{
 					Controller: "api/system",
 				})
 				Expect(err).To(HaveOccurred())
@@ -189,7 +189,7 @@ var _ = Describe("Webservices Service", Ordered, func() {
 			})
 
 			It("should fail with missing controller", func() {
-				_, resp, err := client.Webservices.ResponseExample(&sonar.WebservicesResponseExampleOption{
+				_, resp, err := client.Webservices.ResponseExample(&sonar.WebservicesResponseExampleOptions{
 					Action: "status",
 				})
 				Expect(err).To(HaveOccurred())

--- a/internal/cli/pagination_test.go
+++ b/internal/cli/pagination_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// paginatedOption is a test option struct with pagination support.
-type paginatedOption struct {
+// paginatedOptions is a test option struct with pagination support.
+type paginatedOptions struct {
 	PaginationArgs
 	Query string `url:"q,omitempty"`
 }
@@ -33,8 +33,8 @@ type testPaging struct {
 	Total     int64
 }
 
-// nonPaginatedOption is a test option struct without pagination.
-type nonPaginatedOption struct {
+// nonPaginatedOptions is a test option struct without pagination.
+type nonPaginatedOptions struct {
 	Query string `url:"q,omitempty"`
 }
 
@@ -47,12 +47,12 @@ func TestHasPagination(t *testing.T) {
 	}{
 		{
 			name: "with pagination",
-			typ:  reflect.TypeOf(paginatedOption{}),
+			typ:  reflect.TypeOf(paginatedOptions{}),
 			want: true,
 		},
 		{
 			name: "without pagination",
-			typ:  reflect.TypeOf(nonPaginatedOption{}),
+			typ:  reflect.TypeOf(nonPaginatedOptions{}),
 			want: false,
 		},
 	}
@@ -141,7 +141,7 @@ type paginatedService struct {
 }
 
 // Search simulates a paginated method that returns pages of results.
-func (s *paginatedService) Search(opt *paginatedOption) (*paginatedResponse, *http.Response, error) {
+func (s *paginatedService) Search(opt *paginatedOptions) (*paginatedResponse, *http.Response, error) {
 	s.callCount++
 
 	// Return different data based on page.
@@ -167,7 +167,7 @@ func (s *paginatedService) Search(opt *paginatedOption) (*paginatedResponse, *ht
 // TestPaginateAll tests multi-page result collection.
 func TestPaginateAll(t *testing.T) {
 	svc := &paginatedService{}
-	opt := &paginatedOption{Query: "test"}
+	opt := &paginatedOptions{Query: "test"}
 	optValue := reflect.New(reflect.TypeOf(*opt))
 	optValue.Elem().Set(reflect.ValueOf(*opt))
 	svcValue := reflect.ValueOf(svc)
@@ -190,7 +190,7 @@ func TestPaginateAll(t *testing.T) {
 
 // TestSetPageField tests setting pagination fields on option structs.
 func TestSetPageField(t *testing.T) {
-	opt := &paginatedOption{}
+	opt := &paginatedOptions{}
 	optVal := reflect.ValueOf(opt).Elem()
 
 	setPageField(optVal, "Page", 5)

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -115,7 +115,7 @@ func buildMethodCommand(serviceName string, _ reflect.Type, method reflect.Metho
 	)
 
 	if hasOpt {
-		optType = methodType.In(1) // The option parameter type (should be *SomeOption)
+		optType = methodType.In(1) // The option parameter type (should be *SomeOptions)
 		if optType.Kind() == reflect.Ptr {
 			optType = optType.Elem()
 		}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -114,7 +114,7 @@ func initClient(cmd *cobra.Command, args []string, globalFlags *globalFlags) err
 		return nil
 	}
 
-	opts := &sonar.ClientCreateOption{} //nolint:exhaustruct // fields set conditionally below
+	opts := &sonar.ClientCreateOptions{} //nolint:exhaustruct // fields set conditionally below
 
 	if globalFlags.url == "" {
 		err := errors.New("server URL must be provided via --url flag or SONAR_CLI_URL env var")
@@ -174,7 +174,7 @@ func isCompletionDirective(args []string) bool {
 }
 
 // setClientOptionalFields sets optional authentication fields on the client options.
-func setClientOptionalFields(opts *sonar.ClientCreateOption, globalFlags *globalFlags) {
+func setClientOptionalFields(opts *sonar.ClientCreateOptions, globalFlags *globalFlags) {
 	if globalFlags.token != "" {
 		opts.Token = &globalFlags.token
 	}

--- a/sonar/alm_integrations_service.go
+++ b/sonar/alm_integrations_service.go
@@ -230,24 +230,24 @@ type GitlabRepository struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// AlmIntegrationsCheckPatOption contains options for checking a Personal Access Token.
-type AlmIntegrationsCheckPatOption struct {
+// AlmIntegrationsCheckPatOptions contains options for checking a Personal Access Token.
+type AlmIntegrationsCheckPatOptions struct {
 	// AlmSetting is the DevOps Platform setting key (required).
 	// Maximum length: 200 characters
 	AlmSetting string `url:"almSetting,omitempty"`
 }
 
-// AlmIntegrationsGetGithubClientIdOption contains options for getting a GitHub client ID.
-type AlmIntegrationsGetGithubClientIdOption struct {
+// AlmIntegrationsGetGithubClientIdOptions contains options for getting a GitHub client ID.
+type AlmIntegrationsGetGithubClientIdOptions struct {
 	// AlmSetting is the DevOps Platform setting key (required).
 	// Maximum length: 200 characters
 	AlmSetting string `url:"almSetting,omitempty"`
 }
 
-// AlmIntegrationsImportAzureProjectOption contains options for importing an Azure DevOps project.
+// AlmIntegrationsImportAzureProjectOptions contains options for importing an Azure DevOps project.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-type AlmIntegrationsImportAzureProjectOption struct {
+type AlmIntegrationsImportAzureProjectOptions struct {
 	// AlmSetting is the DevOps Platform configuration key.
 	// This parameter is optional if you have only one Azure integration.
 	// Maximum length: 200 characters
@@ -267,10 +267,10 @@ type AlmIntegrationsImportAzureProjectOption struct {
 	NewCodeDefinitionValue int64 `url:"newCodeDefinitionValue,omitempty"`
 }
 
-// AlmIntegrationsImportBitbucketCloudRepoOption contains options for importing a Bitbucket Cloud repository.
+// AlmIntegrationsImportBitbucketCloudRepoOptions contains options for importing a Bitbucket Cloud repository.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-type AlmIntegrationsImportBitbucketCloudRepoOption struct {
+type AlmIntegrationsImportBitbucketCloudRepoOptions struct {
 	// AlmSetting is the DevOps Platform configuration key.
 	// This parameter is optional if you have only one Bitbucket Cloud integration.
 	// Maximum length: 200 characters
@@ -287,10 +287,10 @@ type AlmIntegrationsImportBitbucketCloudRepoOption struct {
 	NewCodeDefinitionValue int64 `url:"newCodeDefinitionValue,omitempty"`
 }
 
-// AlmIntegrationsImportBitbucketServerProjectOption contains options for importing a Bitbucket Server project.
+// AlmIntegrationsImportBitbucketServerProjectOptions contains options for importing a Bitbucket Server project.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-type AlmIntegrationsImportBitbucketServerProjectOption struct {
+type AlmIntegrationsImportBitbucketServerProjectOptions struct {
 	// AlmSetting is the DevOps Platform configuration key.
 	// This parameter is optional if you have only one Bitbucket Server integration.
 	// Maximum length: 200 characters
@@ -310,10 +310,10 @@ type AlmIntegrationsImportBitbucketServerProjectOption struct {
 	NewCodeDefinitionValue int64 `url:"newCodeDefinitionValue,omitempty"`
 }
 
-// AlmIntegrationsImportGithubProjectOption contains options for importing a GitHub project.
+// AlmIntegrationsImportGithubProjectOptions contains options for importing a GitHub project.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-type AlmIntegrationsImportGithubProjectOption struct {
+type AlmIntegrationsImportGithubProjectOptions struct {
 	// AlmSetting is the DevOps Platform configuration key.
 	// This parameter is optional if you have only one GitHub integration.
 	// Maximum length: 200 characters
@@ -330,10 +330,10 @@ type AlmIntegrationsImportGithubProjectOption struct {
 	NewCodeDefinitionValue int64 `url:"newCodeDefinitionValue,omitempty"`
 }
 
-// AlmIntegrationsImportGitlabProjectOption contains options for importing a GitLab project.
+// AlmIntegrationsImportGitlabProjectOptions contains options for importing a GitLab project.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-type AlmIntegrationsImportGitlabProjectOption struct {
+type AlmIntegrationsImportGitlabProjectOptions struct {
 	// AlmSetting is the DevOps Platform configuration key.
 	// This parameter is optional if you have only one GitLab integration.
 	AlmSetting string `url:"almSetting,omitempty"`
@@ -348,15 +348,15 @@ type AlmIntegrationsImportGitlabProjectOption struct {
 	NewCodeDefinitionValue int64 `url:"newCodeDefinitionValue,omitempty"`
 }
 
-// AlmIntegrationsListAzureProjectsOption contains options for listing Azure projects.
-type AlmIntegrationsListAzureProjectsOption struct {
+// AlmIntegrationsListAzureProjectsOptions contains options for listing Azure projects.
+type AlmIntegrationsListAzureProjectsOptions struct {
 	// AlmSetting is the DevOps Platform setting key (required).
 	// Maximum length: 200 characters
 	AlmSetting string `url:"almSetting,omitempty"`
 }
 
-// AlmIntegrationsListBitbucketServerProjectsOption contains options for listing Bitbucket Server projects.
-type AlmIntegrationsListBitbucketServerProjectsOption struct {
+// AlmIntegrationsListBitbucketServerProjectsOptions contains options for listing Bitbucket Server projects.
+type AlmIntegrationsListBitbucketServerProjectsOptions struct {
 	// AlmSetting is the DevOps Platform setting key (required).
 	// Maximum length: 200 characters
 	AlmSetting string `url:"almSetting,omitempty"`
@@ -367,10 +367,10 @@ type AlmIntegrationsListBitbucketServerProjectsOption struct {
 	Start int64 `url:"start,omitempty"`
 }
 
-// AlmIntegrationsListGithubOrganizationsOption contains options for listing GitHub organizations.
+// AlmIntegrationsListGithubOrganizationsOptions contains options for listing GitHub organizations.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type AlmIntegrationsListGithubOrganizationsOption struct {
+type AlmIntegrationsListGithubOrganizationsOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -382,10 +382,10 @@ type AlmIntegrationsListGithubOrganizationsOption struct {
 	Token string `url:"token,omitempty"`
 }
 
-// AlmIntegrationsListGithubRepositoriesOption contains options for listing GitHub repositories.
+// AlmIntegrationsListGithubRepositoriesOptions contains options for listing GitHub repositories.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type AlmIntegrationsListGithubRepositoriesOption struct {
+type AlmIntegrationsListGithubRepositoriesOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -399,8 +399,8 @@ type AlmIntegrationsListGithubRepositoriesOption struct {
 	Query string `url:"q,omitempty"`
 }
 
-// AlmIntegrationsSearchAzureReposOption contains options for searching Azure repositories.
-type AlmIntegrationsSearchAzureReposOption struct {
+// AlmIntegrationsSearchAzureReposOptions contains options for searching Azure repositories.
+type AlmIntegrationsSearchAzureReposOptions struct {
 	// AlmSetting is the DevOps Platform setting key (required).
 	// Maximum length: 200 characters
 	AlmSetting string `url:"almSetting,omitempty"`
@@ -412,10 +412,10 @@ type AlmIntegrationsSearchAzureReposOption struct {
 	SearchQuery string `url:"searchQuery,omitempty"`
 }
 
-// AlmIntegrationsSearchBitbucketCloudReposOption contains options for searching Bitbucket Cloud repositories.
+// AlmIntegrationsSearchBitbucketCloudReposOptions contains options for searching Bitbucket Cloud repositories.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type AlmIntegrationsSearchBitbucketCloudReposOption struct {
+type AlmIntegrationsSearchBitbucketCloudReposOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -427,10 +427,10 @@ type AlmIntegrationsSearchBitbucketCloudReposOption struct {
 	RepositoryName string `url:"repositoryName,omitempty"`
 }
 
-// AlmIntegrationsSearchBitbucketServerReposOption contains options for searching Bitbucket Server repositories.
+// AlmIntegrationsSearchBitbucketServerReposOptions contains options for searching Bitbucket Server repositories.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type AlmIntegrationsSearchBitbucketServerReposOption struct {
+type AlmIntegrationsSearchBitbucketServerReposOptions struct {
 	// AlmSetting is the DevOps Platform setting key (required).
 	// Maximum length: 200 characters
 	AlmSetting string `url:"almSetting,omitempty"`
@@ -447,10 +447,10 @@ type AlmIntegrationsSearchBitbucketServerReposOption struct {
 	Start int64 `url:"start,omitempty"`
 }
 
-// AlmIntegrationsSearchGitlabReposOption contains options for searching GitLab repositories.
+// AlmIntegrationsSearchGitlabReposOptions contains options for searching GitLab repositories.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type AlmIntegrationsSearchGitlabReposOption struct {
+type AlmIntegrationsSearchGitlabReposOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -462,8 +462,8 @@ type AlmIntegrationsSearchGitlabReposOption struct {
 	ProjectName string `url:"projectName,omitempty"`
 }
 
-// AlmIntegrationsSetPatOption contains options for setting a Personal Access Token.
-type AlmIntegrationsSetPatOption struct {
+// AlmIntegrationsSetPatOptions contains options for setting a Personal Access Token.
+type AlmIntegrationsSetPatOptions struct {
 	// AlmSetting is the DevOps Platform configuration key.
 	// This parameter is optional if you have only one single DevOps Platform integration.
 	AlmSetting string `url:"almSetting,omitempty"`
@@ -481,7 +481,7 @@ type AlmIntegrationsSetPatOption struct {
 
 // CheckPat checks the validity of a Personal Access Token for the given DevOps Platform setting.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) CheckPat(opt *AlmIntegrationsCheckPatOption) (v *AlmIntegrationsCheckPat, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) CheckPat(opt *AlmIntegrationsCheckPatOptions) (v *AlmIntegrationsCheckPat, resp *http.Response, err error) {
 	err = s.ValidateCheckPatOpt(opt)
 	if err != nil {
 		return
@@ -504,7 +504,7 @@ func (s *AlmIntegrationsService) CheckPat(opt *AlmIntegrationsCheckPatOption) (v
 
 // GetGithubClientId gets the client ID of a GitHub Integration.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) GetGithubClientId(opt *AlmIntegrationsGetGithubClientIdOption) (v *AlmIntegrationsGetGithubClientId, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) GetGithubClientId(opt *AlmIntegrationsGetGithubClientIdOptions) (v *AlmIntegrationsGetGithubClientId, resp *http.Response, err error) {
 	err = s.ValidateGetGithubClientIdOpt(opt)
 	if err != nil {
 		return
@@ -530,7 +530,7 @@ func (s *AlmIntegrationsService) GetGithubClientId(opt *AlmIntegrationsGetGithub
 // Requires the 'Create Projects' permission.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-func (s *AlmIntegrationsService) ImportAzureProject(opt *AlmIntegrationsImportAzureProjectOption) (resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ImportAzureProject(opt *AlmIntegrationsImportAzureProjectOptions) (resp *http.Response, err error) {
 	err = s.ValidateImportAzureProjectOpt(opt)
 	if err != nil {
 		return
@@ -554,7 +554,7 @@ func (s *AlmIntegrationsService) ImportAzureProject(opt *AlmIntegrationsImportAz
 // Requires the 'Create Projects' permission.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-func (s *AlmIntegrationsService) ImportBitbucketCloudRepo(opt *AlmIntegrationsImportBitbucketCloudRepoOption) (resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ImportBitbucketCloudRepo(opt *AlmIntegrationsImportBitbucketCloudRepoOptions) (resp *http.Response, err error) {
 	err = s.ValidateImportBitbucketCloudRepoOpt(opt)
 	if err != nil {
 		return
@@ -578,7 +578,7 @@ func (s *AlmIntegrationsService) ImportBitbucketCloudRepo(opt *AlmIntegrationsIm
 // Requires the 'Create Projects' permission.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-func (s *AlmIntegrationsService) ImportBitbucketServerProject(opt *AlmIntegrationsImportBitbucketServerProjectOption) (resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ImportBitbucketServerProject(opt *AlmIntegrationsImportBitbucketServerProjectOptions) (resp *http.Response, err error) {
 	err = s.ValidateImportBitbucketServerProjectOpt(opt)
 	if err != nil {
 		return
@@ -603,7 +603,7 @@ func (s *AlmIntegrationsService) ImportBitbucketServerProject(opt *AlmIntegratio
 // Requires the 'Create Projects' permission.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-func (s *AlmIntegrationsService) ImportGithubProject(opt *AlmIntegrationsImportGithubProjectOption) (resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ImportGithubProject(opt *AlmIntegrationsImportGithubProjectOptions) (resp *http.Response, err error) {
 	err = s.ValidateImportGithubProjectOpt(opt)
 	if err != nil {
 		return
@@ -626,7 +626,7 @@ func (s *AlmIntegrationsService) ImportGithubProject(opt *AlmIntegrationsImportG
 // Requires the 'Create Projects' permission.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-func (s *AlmIntegrationsService) ImportGitlabProject(opt *AlmIntegrationsImportGitlabProjectOption) (resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ImportGitlabProject(opt *AlmIntegrationsImportGitlabProjectOptions) (resp *http.Response, err error) {
 	err = s.ValidateImportGitlabProjectOpt(opt)
 	if err != nil {
 		return
@@ -647,7 +647,7 @@ func (s *AlmIntegrationsService) ImportGitlabProject(opt *AlmIntegrationsImportG
 
 // ListAzureProjects lists Azure projects.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) ListAzureProjects(opt *AlmIntegrationsListAzureProjectsOption) (v *AlmIntegrationsListAzureProjects, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ListAzureProjects(opt *AlmIntegrationsListAzureProjectsOptions) (v *AlmIntegrationsListAzureProjects, resp *http.Response, err error) {
 	err = s.ValidateListAzureProjectsOpt(opt)
 	if err != nil {
 		return
@@ -670,7 +670,7 @@ func (s *AlmIntegrationsService) ListAzureProjects(opt *AlmIntegrationsListAzure
 
 // ListBitbucketServerProjects lists the Bitbucket Server projects.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) ListBitbucketServerProjects(opt *AlmIntegrationsListBitbucketServerProjectsOption) (v *AlmIntegrationsListBitbucketServerProjects, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ListBitbucketServerProjects(opt *AlmIntegrationsListBitbucketServerProjectsOptions) (v *AlmIntegrationsListBitbucketServerProjects, resp *http.Response, err error) {
 	err = s.ValidateListBitbucketServerProjectsOpt(opt)
 	if err != nil {
 		return
@@ -693,7 +693,7 @@ func (s *AlmIntegrationsService) ListBitbucketServerProjects(opt *AlmIntegration
 
 // ListGithubOrganizations lists GitHub organizations.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) ListGithubOrganizations(opt *AlmIntegrationsListGithubOrganizationsOption) (v *AlmIntegrationsListGithubOrganizations, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ListGithubOrganizations(opt *AlmIntegrationsListGithubOrganizationsOptions) (v *AlmIntegrationsListGithubOrganizations, resp *http.Response, err error) {
 	err = s.ValidateListGithubOrganizationsOpt(opt)
 	if err != nil {
 		return
@@ -716,7 +716,7 @@ func (s *AlmIntegrationsService) ListGithubOrganizations(opt *AlmIntegrationsLis
 
 // ListGithubRepositories lists the GitHub repositories for an organization.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) ListGithubRepositories(opt *AlmIntegrationsListGithubRepositoriesOption) (v *AlmIntegrationsListGithubRepositories, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ListGithubRepositories(opt *AlmIntegrationsListGithubRepositoriesOptions) (v *AlmIntegrationsListGithubRepositories, resp *http.Response, err error) {
 	err = s.ValidateListGithubRepositoriesOpt(opt)
 	if err != nil {
 		return
@@ -739,7 +739,7 @@ func (s *AlmIntegrationsService) ListGithubRepositories(opt *AlmIntegrationsList
 
 // SearchAzureRepos searches the Azure repositories.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) SearchAzureRepos(opt *AlmIntegrationsSearchAzureReposOption) (v *AlmIntegrationsSearchAzureRepos, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) SearchAzureRepos(opt *AlmIntegrationsSearchAzureReposOptions) (v *AlmIntegrationsSearchAzureRepos, resp *http.Response, err error) {
 	err = s.ValidateSearchAzureReposOpt(opt)
 	if err != nil {
 		return
@@ -762,7 +762,7 @@ func (s *AlmIntegrationsService) SearchAzureRepos(opt *AlmIntegrationsSearchAzur
 
 // SearchBitbucketCloudRepos searches the Bitbucket Cloud repositories.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) SearchBitbucketCloudRepos(opt *AlmIntegrationsSearchBitbucketCloudReposOption) (v *AlmIntegrationsSearchBitbucketCloudRepos, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) SearchBitbucketCloudRepos(opt *AlmIntegrationsSearchBitbucketCloudReposOptions) (v *AlmIntegrationsSearchBitbucketCloudRepos, resp *http.Response, err error) {
 	err = s.ValidateSearchBitbucketCloudReposOpt(opt)
 	if err != nil {
 		return
@@ -785,7 +785,7 @@ func (s *AlmIntegrationsService) SearchBitbucketCloudRepos(opt *AlmIntegrationsS
 
 // SearchBitbucketServerRepos searches the Bitbucket Server repositories with REPO_ADMIN access.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) SearchBitbucketServerRepos(opt *AlmIntegrationsSearchBitbucketServerReposOption) (v *AlmIntegrationsSearchBitbucketServerRepos, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) SearchBitbucketServerRepos(opt *AlmIntegrationsSearchBitbucketServerReposOptions) (v *AlmIntegrationsSearchBitbucketServerRepos, resp *http.Response, err error) {
 	err = s.ValidateSearchBitbucketServerReposOpt(opt)
 	if err != nil {
 		return
@@ -808,7 +808,7 @@ func (s *AlmIntegrationsService) SearchBitbucketServerRepos(opt *AlmIntegrations
 
 // SearchGitlabRepos searches the GitLab projects.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) SearchGitlabRepos(opt *AlmIntegrationsSearchGitlabReposOption) (v *AlmIntegrationsSearchGitlabRepos, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) SearchGitlabRepos(opt *AlmIntegrationsSearchGitlabReposOptions) (v *AlmIntegrationsSearchGitlabRepos, resp *http.Response, err error) {
 	err = s.ValidateSearchGitlabReposOpt(opt)
 	if err != nil {
 		return
@@ -831,7 +831,7 @@ func (s *AlmIntegrationsService) SearchGitlabRepos(opt *AlmIntegrationsSearchGit
 
 // SetPat sets a Personal Access Token for the given DevOps Platform setting.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) SetPat(opt *AlmIntegrationsSetPatOption) (resp *http.Response, err error) {
+func (s *AlmIntegrationsService) SetPat(opt *AlmIntegrationsSetPatOptions) (resp *http.Response, err error) {
 	err = s.ValidateSetPatOpt(opt)
 	if err != nil {
 		return
@@ -855,7 +855,7 @@ func (s *AlmIntegrationsService) SetPat(opt *AlmIntegrationsSetPatOption) (resp 
 // -----------------------------------------------------------------------------
 
 // ValidateCheckPatOpt validates the options for checking a Personal Access Token.
-func (s *AlmIntegrationsService) ValidateCheckPatOpt(opt *AlmIntegrationsCheckPatOption) error {
+func (s *AlmIntegrationsService) ValidateCheckPatOpt(opt *AlmIntegrationsCheckPatOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsCheckPatOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -874,7 +874,7 @@ func (s *AlmIntegrationsService) ValidateCheckPatOpt(opt *AlmIntegrationsCheckPa
 }
 
 // ValidateGetGithubClientIdOpt validates the options for getting a GitHub client ID.
-func (s *AlmIntegrationsService) ValidateGetGithubClientIdOpt(opt *AlmIntegrationsGetGithubClientIdOption) error {
+func (s *AlmIntegrationsService) ValidateGetGithubClientIdOpt(opt *AlmIntegrationsGetGithubClientIdOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsGetGithubClientIdOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -893,7 +893,7 @@ func (s *AlmIntegrationsService) ValidateGetGithubClientIdOpt(opt *AlmIntegratio
 }
 
 // ValidateImportAzureProjectOpt validates the options for importing an Azure DevOps project.
-func (s *AlmIntegrationsService) ValidateImportAzureProjectOpt(opt *AlmIntegrationsImportAzureProjectOption) error {
+func (s *AlmIntegrationsService) ValidateImportAzureProjectOpt(opt *AlmIntegrationsImportAzureProjectOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsImportAzureProjectOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -936,7 +936,7 @@ func (s *AlmIntegrationsService) ValidateImportAzureProjectOpt(opt *AlmIntegrati
 }
 
 // ValidateImportBitbucketCloudRepoOpt validates the options for importing a Bitbucket Cloud repository.
-func (s *AlmIntegrationsService) ValidateImportBitbucketCloudRepoOpt(opt *AlmIntegrationsImportBitbucketCloudRepoOption) error {
+func (s *AlmIntegrationsService) ValidateImportBitbucketCloudRepoOpt(opt *AlmIntegrationsImportBitbucketCloudRepoOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsImportBitbucketCloudRepoOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -969,7 +969,7 @@ func (s *AlmIntegrationsService) ValidateImportBitbucketCloudRepoOpt(opt *AlmInt
 }
 
 // ValidateImportBitbucketServerProjectOpt validates the options for importing a Bitbucket Server project.
-func (s *AlmIntegrationsService) ValidateImportBitbucketServerProjectOpt(opt *AlmIntegrationsImportBitbucketServerProjectOption) error {
+func (s *AlmIntegrationsService) ValidateImportBitbucketServerProjectOpt(opt *AlmIntegrationsImportBitbucketServerProjectOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsImportBitbucketServerProjectOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1012,7 +1012,7 @@ func (s *AlmIntegrationsService) ValidateImportBitbucketServerProjectOpt(opt *Al
 }
 
 // ValidateImportGithubProjectOpt validates the options for importing a GitHub project.
-func (s *AlmIntegrationsService) ValidateImportGithubProjectOpt(opt *AlmIntegrationsImportGithubProjectOption) error {
+func (s *AlmIntegrationsService) ValidateImportGithubProjectOpt(opt *AlmIntegrationsImportGithubProjectOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsImportGithubProjectOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1045,7 +1045,7 @@ func (s *AlmIntegrationsService) ValidateImportGithubProjectOpt(opt *AlmIntegrat
 }
 
 // ValidateImportGitlabProjectOpt validates the options for importing a GitLab project.
-func (s *AlmIntegrationsService) ValidateImportGitlabProjectOpt(opt *AlmIntegrationsImportGitlabProjectOption) error {
+func (s *AlmIntegrationsService) ValidateImportGitlabProjectOpt(opt *AlmIntegrationsImportGitlabProjectOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsImportGitlabProjectOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1073,7 +1073,7 @@ func (s *AlmIntegrationsService) ValidateImportGitlabProjectOpt(opt *AlmIntegrat
 }
 
 // ValidateListAzureProjectsOpt validates the options for listing Azure projects.
-func (s *AlmIntegrationsService) ValidateListAzureProjectsOpt(opt *AlmIntegrationsListAzureProjectsOption) error {
+func (s *AlmIntegrationsService) ValidateListAzureProjectsOpt(opt *AlmIntegrationsListAzureProjectsOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsListAzureProjectsOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1092,7 +1092,7 @@ func (s *AlmIntegrationsService) ValidateListAzureProjectsOpt(opt *AlmIntegratio
 }
 
 // ValidateListBitbucketServerProjectsOpt validates the options for listing Bitbucket Server projects.
-func (s *AlmIntegrationsService) ValidateListBitbucketServerProjectsOpt(opt *AlmIntegrationsListBitbucketServerProjectsOption) error {
+func (s *AlmIntegrationsService) ValidateListBitbucketServerProjectsOpt(opt *AlmIntegrationsListBitbucketServerProjectsOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsListBitbucketServerProjectsOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1118,7 +1118,7 @@ func (s *AlmIntegrationsService) ValidateListBitbucketServerProjectsOpt(opt *Alm
 }
 
 // ValidateListGithubOrganizationsOpt validates the options for listing GitHub organizations.
-func (s *AlmIntegrationsService) ValidateListGithubOrganizationsOpt(opt *AlmIntegrationsListGithubOrganizationsOption) error {
+func (s *AlmIntegrationsService) ValidateListGithubOrganizationsOpt(opt *AlmIntegrationsListGithubOrganizationsOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsListGithubOrganizationsOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1144,7 +1144,7 @@ func (s *AlmIntegrationsService) ValidateListGithubOrganizationsOpt(opt *AlmInte
 }
 
 // ValidateListGithubRepositoriesOpt validates the options for listing GitHub repositories.
-func (s *AlmIntegrationsService) ValidateListGithubRepositoriesOpt(opt *AlmIntegrationsListGithubRepositoriesOption) error {
+func (s *AlmIntegrationsService) ValidateListGithubRepositoriesOpt(opt *AlmIntegrationsListGithubRepositoriesOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsListGithubRepositoriesOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1173,7 +1173,7 @@ func (s *AlmIntegrationsService) ValidateListGithubRepositoriesOpt(opt *AlmInteg
 }
 
 // ValidateSearchAzureReposOpt validates the options for searching Azure repositories.
-func (s *AlmIntegrationsService) ValidateSearchAzureReposOpt(opt *AlmIntegrationsSearchAzureReposOption) error {
+func (s *AlmIntegrationsService) ValidateSearchAzureReposOpt(opt *AlmIntegrationsSearchAzureReposOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsSearchAzureReposOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1206,7 +1206,7 @@ func (s *AlmIntegrationsService) ValidateSearchAzureReposOpt(opt *AlmIntegration
 }
 
 // ValidateSearchBitbucketCloudReposOpt validates the options for searching Bitbucket Cloud repositories.
-func (s *AlmIntegrationsService) ValidateSearchBitbucketCloudReposOpt(opt *AlmIntegrationsSearchBitbucketCloudReposOption) error {
+func (s *AlmIntegrationsService) ValidateSearchBitbucketCloudReposOpt(opt *AlmIntegrationsSearchBitbucketCloudReposOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsSearchBitbucketCloudReposOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1239,7 +1239,7 @@ func (s *AlmIntegrationsService) ValidateSearchBitbucketCloudReposOpt(opt *AlmIn
 }
 
 // ValidateSearchBitbucketServerReposOpt validates the options for searching Bitbucket Server repositories.
-func (s *AlmIntegrationsService) ValidateSearchBitbucketServerReposOpt(opt *AlmIntegrationsSearchBitbucketServerReposOption) error {
+func (s *AlmIntegrationsService) ValidateSearchBitbucketServerReposOpt(opt *AlmIntegrationsSearchBitbucketServerReposOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsSearchBitbucketServerReposOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1279,7 +1279,7 @@ func (s *AlmIntegrationsService) ValidateSearchBitbucketServerReposOpt(opt *AlmI
 }
 
 // ValidateSearchGitlabReposOpt validates the options for searching GitLab repositories.
-func (s *AlmIntegrationsService) ValidateSearchGitlabReposOpt(opt *AlmIntegrationsSearchGitlabReposOption) error {
+func (s *AlmIntegrationsService) ValidateSearchGitlabReposOpt(opt *AlmIntegrationsSearchGitlabReposOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsSearchGitlabReposOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1312,7 +1312,7 @@ func (s *AlmIntegrationsService) ValidateSearchGitlabReposOpt(opt *AlmIntegratio
 }
 
 // ValidateSetPatOpt validates the options for setting a Personal Access Token.
-func (s *AlmIntegrationsService) ValidateSetPatOpt(opt *AlmIntegrationsSetPatOption) error {
+func (s *AlmIntegrationsService) ValidateSetPatOpt(opt *AlmIntegrationsSetPatOptions) error {
 	if opt == nil {
 		return NewValidationError("AlmIntegrationsSetPatOption", "cannot be nil", ErrMissingRequired)
 	}

--- a/sonar/alm_integrations_service_test.go
+++ b/sonar/alm_integrations_service_test.go
@@ -18,7 +18,7 @@ func TestAlmIntegrations_CheckPat(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsCheckPatOption{
+	opt := &AlmIntegrationsCheckPatOptions{
 		AlmSetting: "my-azure-setting",
 	}
 
@@ -35,11 +35,11 @@ func TestAlmIntegrations_CheckPat_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.CheckPat(&AlmIntegrationsCheckPatOption{})
+	_, _, err = client.AlmIntegrations.CheckPat(&AlmIntegrationsCheckPatOptions{})
 	assert.Error(t, err)
 
 	// Test AlmSetting too long
-	_, _, err = client.AlmIntegrations.CheckPat(&AlmIntegrationsCheckPatOption{
+	_, _, err = client.AlmIntegrations.CheckPat(&AlmIntegrationsCheckPatOptions{
 		AlmSetting: strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
 	assert.Error(t, err)
@@ -54,7 +54,7 @@ func TestAlmIntegrations_GetGithubClientId(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsGetGithubClientIdOption{
+	opt := &AlmIntegrationsGetGithubClientIdOptions{
 		AlmSetting: "my-github-setting",
 	}
 
@@ -73,7 +73,7 @@ func TestAlmIntegrations_GetGithubClientId_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.GetGithubClientId(&AlmIntegrationsGetGithubClientIdOption{})
+	_, _, err = client.AlmIntegrations.GetGithubClientId(&AlmIntegrationsGetGithubClientIdOptions{})
 	assert.Error(t, err)
 }
 
@@ -86,7 +86,7 @@ func TestAlmIntegrations_ImportAzureProject(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsImportAzureProjectOption{
+	opt := &AlmIntegrationsImportAzureProjectOptions{
 		ProjectName:    "my-azure-project",
 		RepositoryName: "my-azure-repo",
 	}
@@ -104,19 +104,19 @@ func TestAlmIntegrations_ImportAzureProject_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing ProjectName
-	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOption{
+	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOptions{
 		RepositoryName: "repo",
 	})
 	assert.Error(t, err)
 
 	// Test missing RepositoryName
-	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOption{
+	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOptions{
 		ProjectName: "project",
 	})
 	assert.Error(t, err)
 
 	// Test invalid NewCodeDefinitionType
-	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOption{
+	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOptions{
 		ProjectName:           "project",
 		RepositoryName:        "repo",
 		NewCodeDefinitionType: "INVALID_TYPE",
@@ -124,7 +124,7 @@ func TestAlmIntegrations_ImportAzureProject_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test NUMBER_OF_DAYS without value
-	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOption{
+	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOptions{
 		ProjectName:           "project",
 		RepositoryName:        "repo",
 		NewCodeDefinitionType: "NUMBER_OF_DAYS",
@@ -132,7 +132,7 @@ func TestAlmIntegrations_ImportAzureProject_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test PREVIOUS_VERSION with value
-	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOption{
+	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOptions{
 		ProjectName:            "project",
 		RepositoryName:         "repo",
 		NewCodeDefinitionType:  "PREVIOUS_VERSION",
@@ -147,7 +147,7 @@ func TestAlmIntegrations_ImportAzureProject_WithNewCodeDefinition(t *testing.T) 
 	client := newTestClient(t, server.url())
 
 	// Test with PREVIOUS_VERSION
-	opt := &AlmIntegrationsImportAzureProjectOption{
+	opt := &AlmIntegrationsImportAzureProjectOptions{
 		ProjectName:           "project",
 		RepositoryName:        "repo",
 		NewCodeDefinitionType: "PREVIOUS_VERSION",
@@ -158,7 +158,7 @@ func TestAlmIntegrations_ImportAzureProject_WithNewCodeDefinition(t *testing.T) 
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 
 	// Test with NUMBER_OF_DAYS
-	opt = &AlmIntegrationsImportAzureProjectOption{
+	opt = &AlmIntegrationsImportAzureProjectOptions{
 		ProjectName:            "project",
 		RepositoryName:         "repo",
 		NewCodeDefinitionType:  "NUMBER_OF_DAYS",
@@ -179,7 +179,7 @@ func TestAlmIntegrations_ImportBitbucketCloudRepo(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsImportBitbucketCloudRepoOption{
+	opt := &AlmIntegrationsImportBitbucketCloudRepoOptions{
 		RepositorySlug: "my-repo",
 	}
 
@@ -196,7 +196,7 @@ func TestAlmIntegrations_ImportBitbucketCloudRepo_ValidationError(t *testing.T) 
 	assert.Error(t, err)
 
 	// Test missing RepositorySlug
-	_, err = client.AlmIntegrations.ImportBitbucketCloudRepo(&AlmIntegrationsImportBitbucketCloudRepoOption{})
+	_, err = client.AlmIntegrations.ImportBitbucketCloudRepo(&AlmIntegrationsImportBitbucketCloudRepoOptions{})
 	assert.Error(t, err)
 }
 
@@ -209,7 +209,7 @@ func TestAlmIntegrations_ImportBitbucketServerProject(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsImportBitbucketServerProjectOption{
+	opt := &AlmIntegrationsImportBitbucketServerProjectOptions{
 		ProjectKey:     "PRJ",
 		RepositorySlug: "my-repo",
 	}
@@ -227,13 +227,13 @@ func TestAlmIntegrations_ImportBitbucketServerProject_ValidationError(t *testing
 	assert.Error(t, err)
 
 	// Test missing ProjectKey
-	_, err = client.AlmIntegrations.ImportBitbucketServerProject(&AlmIntegrationsImportBitbucketServerProjectOption{
+	_, err = client.AlmIntegrations.ImportBitbucketServerProject(&AlmIntegrationsImportBitbucketServerProjectOptions{
 		RepositorySlug: "repo",
 	})
 	assert.Error(t, err)
 
 	// Test missing RepositorySlug
-	_, err = client.AlmIntegrations.ImportBitbucketServerProject(&AlmIntegrationsImportBitbucketServerProjectOption{
+	_, err = client.AlmIntegrations.ImportBitbucketServerProject(&AlmIntegrationsImportBitbucketServerProjectOptions{
 		ProjectKey: "PRJ",
 	})
 	assert.Error(t, err)
@@ -248,7 +248,7 @@ func TestAlmIntegrations_ImportGithubProject(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsImportGithubProjectOption{
+	opt := &AlmIntegrationsImportGithubProjectOptions{
 		RepositoryKey: "octocat/hello-world",
 	}
 
@@ -265,11 +265,11 @@ func TestAlmIntegrations_ImportGithubProject_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing RepositoryKey
-	_, err = client.AlmIntegrations.ImportGithubProject(&AlmIntegrationsImportGithubProjectOption{})
+	_, err = client.AlmIntegrations.ImportGithubProject(&AlmIntegrationsImportGithubProjectOptions{})
 	assert.Error(t, err)
 
 	// Test RepositoryKey too long
-	_, err = client.AlmIntegrations.ImportGithubProject(&AlmIntegrationsImportGithubProjectOption{
+	_, err = client.AlmIntegrations.ImportGithubProject(&AlmIntegrationsImportGithubProjectOptions{
 		RepositoryKey: strings.Repeat("a", MaxGitHubRepoKeyLength+1),
 	})
 	assert.Error(t, err)
@@ -284,7 +284,7 @@ func TestAlmIntegrations_ImportGitlabProject(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsImportGitlabProjectOption{
+	opt := &AlmIntegrationsImportGitlabProjectOptions{
 		GitlabProjectId: "12345",
 	}
 
@@ -301,7 +301,7 @@ func TestAlmIntegrations_ImportGitlabProject_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing GitlabProjectId
-	_, err = client.AlmIntegrations.ImportGitlabProject(&AlmIntegrationsImportGitlabProjectOption{})
+	_, err = client.AlmIntegrations.ImportGitlabProject(&AlmIntegrationsImportGitlabProjectOptions{})
 	assert.Error(t, err)
 }
 
@@ -314,7 +314,7 @@ func TestAlmIntegrations_ListAzureProjects(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsListAzureProjectsOption{
+	opt := &AlmIntegrationsListAzureProjectsOptions{
 		AlmSetting: "my-azure-setting",
 	}
 
@@ -333,7 +333,7 @@ func TestAlmIntegrations_ListAzureProjects_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.ListAzureProjects(&AlmIntegrationsListAzureProjectsOption{})
+	_, _, err = client.AlmIntegrations.ListAzureProjects(&AlmIntegrationsListAzureProjectsOptions{})
 	assert.Error(t, err)
 }
 
@@ -346,7 +346,7 @@ func TestAlmIntegrations_ListBitbucketServerProjects(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsListBitbucketServerProjectsOption{
+	opt := &AlmIntegrationsListBitbucketServerProjectsOptions{
 		AlmSetting: "my-bitbucket-setting",
 		PageSize:   25,
 	}
@@ -366,11 +366,11 @@ func TestAlmIntegrations_ListBitbucketServerProjects_ValidationError(t *testing.
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.ListBitbucketServerProjects(&AlmIntegrationsListBitbucketServerProjectsOption{})
+	_, _, err = client.AlmIntegrations.ListBitbucketServerProjects(&AlmIntegrationsListBitbucketServerProjectsOptions{})
 	assert.Error(t, err)
 
 	// Test PageSize out of range
-	_, _, err = client.AlmIntegrations.ListBitbucketServerProjects(&AlmIntegrationsListBitbucketServerProjectsOption{
+	_, _, err = client.AlmIntegrations.ListBitbucketServerProjects(&AlmIntegrationsListBitbucketServerProjectsOptions{
 		AlmSetting: "setting",
 		PageSize:   MaxPageSizeAlmIntegrations + 1,
 	})
@@ -386,7 +386,7 @@ func TestAlmIntegrations_ListGithubOrganizations(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsListGithubOrganizationsOption{
+	opt := &AlmIntegrationsListGithubOrganizationsOptions{
 		AlmSetting: "my-github-setting",
 	}
 
@@ -405,11 +405,11 @@ func TestAlmIntegrations_ListGithubOrganizations_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.ListGithubOrganizations(&AlmIntegrationsListGithubOrganizationsOption{})
+	_, _, err = client.AlmIntegrations.ListGithubOrganizations(&AlmIntegrationsListGithubOrganizationsOptions{})
 	assert.Error(t, err)
 
 	// Test Token too long
-	_, _, err = client.AlmIntegrations.ListGithubOrganizations(&AlmIntegrationsListGithubOrganizationsOption{
+	_, _, err = client.AlmIntegrations.ListGithubOrganizations(&AlmIntegrationsListGithubOrganizationsOptions{
 		AlmSetting: "setting",
 		Token:      strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
@@ -425,7 +425,7 @@ func TestAlmIntegrations_ListGithubRepositories(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsListGithubRepositoriesOption{
+	opt := &AlmIntegrationsListGithubRepositoriesOptions{
 		AlmSetting:   "my-github-setting",
 		Organization: "octocat",
 	}
@@ -445,13 +445,13 @@ func TestAlmIntegrations_ListGithubRepositories_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.ListGithubRepositories(&AlmIntegrationsListGithubRepositoriesOption{
+	_, _, err = client.AlmIntegrations.ListGithubRepositories(&AlmIntegrationsListGithubRepositoriesOptions{
 		Organization: "octocat",
 	})
 	assert.Error(t, err)
 
 	// Test missing Organization
-	_, _, err = client.AlmIntegrations.ListGithubRepositories(&AlmIntegrationsListGithubRepositoriesOption{
+	_, _, err = client.AlmIntegrations.ListGithubRepositories(&AlmIntegrationsListGithubRepositoriesOptions{
 		AlmSetting: "setting",
 	})
 	assert.Error(t, err)
@@ -466,7 +466,7 @@ func TestAlmIntegrations_SearchAzureRepos(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsSearchAzureReposOption{
+	opt := &AlmIntegrationsSearchAzureReposOptions{
 		AlmSetting: "my-azure-setting",
 	}
 
@@ -485,18 +485,18 @@ func TestAlmIntegrations_SearchAzureRepos_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.SearchAzureRepos(&AlmIntegrationsSearchAzureReposOption{})
+	_, _, err = client.AlmIntegrations.SearchAzureRepos(&AlmIntegrationsSearchAzureReposOptions{})
 	assert.Error(t, err)
 
 	// Test ProjectName too long
-	_, _, err = client.AlmIntegrations.SearchAzureRepos(&AlmIntegrationsSearchAzureReposOption{
+	_, _, err = client.AlmIntegrations.SearchAzureRepos(&AlmIntegrationsSearchAzureReposOptions{
 		AlmSetting:  "setting",
 		ProjectName: strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
 	assert.Error(t, err)
 
 	// Test SearchQuery too long
-	_, _, err = client.AlmIntegrations.SearchAzureRepos(&AlmIntegrationsSearchAzureReposOption{
+	_, _, err = client.AlmIntegrations.SearchAzureRepos(&AlmIntegrationsSearchAzureReposOptions{
 		AlmSetting:  "setting",
 		SearchQuery: strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
@@ -512,7 +512,7 @@ func TestAlmIntegrations_SearchBitbucketCloudRepos(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsSearchBitbucketCloudReposOption{
+	opt := &AlmIntegrationsSearchBitbucketCloudReposOptions{
 		AlmSetting: "my-bitbucket-setting",
 	}
 
@@ -532,11 +532,11 @@ func TestAlmIntegrations_SearchBitbucketCloudRepos_ValidationError(t *testing.T)
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.SearchBitbucketCloudRepos(&AlmIntegrationsSearchBitbucketCloudReposOption{})
+	_, _, err = client.AlmIntegrations.SearchBitbucketCloudRepos(&AlmIntegrationsSearchBitbucketCloudReposOptions{})
 	assert.Error(t, err)
 
 	// Test PageSize out of range
-	_, _, err = client.AlmIntegrations.SearchBitbucketCloudRepos(&AlmIntegrationsSearchBitbucketCloudReposOption{
+	_, _, err = client.AlmIntegrations.SearchBitbucketCloudRepos(&AlmIntegrationsSearchBitbucketCloudReposOptions{
 		AlmSetting: "setting",
 		PaginationArgs: PaginationArgs{
 			PageSize: MaxPageSizeAlmIntegrations + 1,
@@ -545,7 +545,7 @@ func TestAlmIntegrations_SearchBitbucketCloudRepos_ValidationError(t *testing.T)
 	assert.Error(t, err)
 
 	// Test RepositoryName too long
-	_, _, err = client.AlmIntegrations.SearchBitbucketCloudRepos(&AlmIntegrationsSearchBitbucketCloudReposOption{
+	_, _, err = client.AlmIntegrations.SearchBitbucketCloudRepos(&AlmIntegrationsSearchBitbucketCloudReposOptions{
 		AlmSetting:     "setting",
 		RepositoryName: strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
@@ -561,7 +561,7 @@ func TestAlmIntegrations_SearchBitbucketServerRepos(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsSearchBitbucketServerReposOption{
+	opt := &AlmIntegrationsSearchBitbucketServerReposOptions{
 		AlmSetting: "my-bitbucket-setting",
 	}
 
@@ -580,25 +580,25 @@ func TestAlmIntegrations_SearchBitbucketServerRepos_ValidationError(t *testing.T
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(&AlmIntegrationsSearchBitbucketServerReposOption{})
+	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(&AlmIntegrationsSearchBitbucketServerReposOptions{})
 	assert.Error(t, err)
 
 	// Test PageSize out of range
-	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(&AlmIntegrationsSearchBitbucketServerReposOption{
+	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(&AlmIntegrationsSearchBitbucketServerReposOptions{
 		AlmSetting: "setting",
 		PageSize:   MaxPageSizeAlmIntegrations + 1,
 	})
 	assert.Error(t, err)
 
 	// Test ProjectName too long
-	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(&AlmIntegrationsSearchBitbucketServerReposOption{
+	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(&AlmIntegrationsSearchBitbucketServerReposOptions{
 		AlmSetting:  "setting",
 		ProjectName: strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
 	assert.Error(t, err)
 
 	// Test RepositoryName too long
-	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(&AlmIntegrationsSearchBitbucketServerReposOption{
+	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(&AlmIntegrationsSearchBitbucketServerReposOptions{
 		AlmSetting:     "setting",
 		RepositoryName: strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
@@ -614,7 +614,7 @@ func TestAlmIntegrations_SearchGitlabRepos(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsSearchGitlabReposOption{
+	opt := &AlmIntegrationsSearchGitlabReposOptions{
 		AlmSetting: "my-gitlab-setting",
 	}
 
@@ -633,11 +633,11 @@ func TestAlmIntegrations_SearchGitlabRepos_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.SearchGitlabRepos(&AlmIntegrationsSearchGitlabReposOption{})
+	_, _, err = client.AlmIntegrations.SearchGitlabRepos(&AlmIntegrationsSearchGitlabReposOptions{})
 	assert.Error(t, err)
 
 	// Test PageSize out of range
-	_, _, err = client.AlmIntegrations.SearchGitlabRepos(&AlmIntegrationsSearchGitlabReposOption{
+	_, _, err = client.AlmIntegrations.SearchGitlabRepos(&AlmIntegrationsSearchGitlabReposOptions{
 		AlmSetting: "setting",
 		PaginationArgs: PaginationArgs{
 			PageSize: MaxPageSizeAlmIntegrations + 1,
@@ -646,7 +646,7 @@ func TestAlmIntegrations_SearchGitlabRepos_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test ProjectName too long
-	_, _, err = client.AlmIntegrations.SearchGitlabRepos(&AlmIntegrationsSearchGitlabReposOption{
+	_, _, err = client.AlmIntegrations.SearchGitlabRepos(&AlmIntegrationsSearchGitlabReposOptions{
 		AlmSetting:  "setting",
 		ProjectName: strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
@@ -662,7 +662,7 @@ func TestAlmIntegrations_SetPat(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsSetPatOption{
+	opt := &AlmIntegrationsSetPatOptions{
 		AlmSetting: "my-setting",
 		Pat:        "my-personal-access-token",
 	}
@@ -678,7 +678,7 @@ func TestAlmIntegrations_SetPat_WithUsername(t *testing.T) {
 	client := newTestClient(t, server.url())
 
 	// Test with username (for Bitbucket Cloud)
-	opt := &AlmIntegrationsSetPatOption{
+	opt := &AlmIntegrationsSetPatOptions{
 		AlmSetting: "my-bitbucket-cloud-setting",
 		Pat:        "my-app-password",
 		Username:   "my-username",
@@ -697,19 +697,19 @@ func TestAlmIntegrations_SetPat_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Pat
-	_, err = client.AlmIntegrations.SetPat(&AlmIntegrationsSetPatOption{
+	_, err = client.AlmIntegrations.SetPat(&AlmIntegrationsSetPatOptions{
 		AlmSetting: "setting",
 	})
 	assert.Error(t, err)
 
 	// Test Pat too long
-	_, err = client.AlmIntegrations.SetPat(&AlmIntegrationsSetPatOption{
+	_, err = client.AlmIntegrations.SetPat(&AlmIntegrationsSetPatOptions{
 		Pat: strings.Repeat("a", MaxPatLength+1),
 	})
 	assert.Error(t, err)
 
 	// Test Username too long
-	_, err = client.AlmIntegrations.SetPat(&AlmIntegrationsSetPatOption{
+	_, err = client.AlmIntegrations.SetPat(&AlmIntegrationsSetPatOptions{
 		Pat:      "token",
 		Username: strings.Repeat("a", MaxUsernameLength+1),
 	})

--- a/sonar/alm_settings_service.go
+++ b/sonar/alm_settings_service.go
@@ -168,15 +168,15 @@ type AlmValidationError struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// AlmSettingsCountBindingOption contains parameters for the CountBinding method.
-type AlmSettingsCountBindingOption struct {
+// AlmSettingsCountBindingOptions contains parameters for the CountBinding method.
+type AlmSettingsCountBindingOptions struct {
 	// AlmSetting is the DevOps Platform setting key.
 	// This field is required.
 	AlmSetting string `url:"almSetting"`
 }
 
-// AlmSettingsCreateAzureOption contains parameters for the CreateAzure method.
-type AlmSettingsCreateAzureOption struct {
+// AlmSettingsCreateAzureOptions contains parameters for the CreateAzure method.
+type AlmSettingsCreateAzureOptions struct {
 	// Key is the unique key of the Azure DevOps instance setting.
 	// This field is required. Maximum length: 200 characters.
 	Key string `url:"key"`
@@ -188,8 +188,8 @@ type AlmSettingsCreateAzureOption struct {
 	URL string `url:"url"`
 }
 
-// AlmSettingsCreateBitbucketOption contains parameters for the CreateBitbucket method.
-type AlmSettingsCreateBitbucketOption struct {
+// AlmSettingsCreateBitbucketOptions contains parameters for the CreateBitbucket method.
+type AlmSettingsCreateBitbucketOptions struct {
 	// Key is the unique key of the Bitbucket instance setting.
 	// This field is required. Maximum length: 200 characters.
 	Key string `url:"key"`
@@ -201,8 +201,8 @@ type AlmSettingsCreateBitbucketOption struct {
 	URL string `url:"url"`
 }
 
-// AlmSettingsCreateBitbucketCloudOption contains parameters for the CreateBitbucketCloud method.
-type AlmSettingsCreateBitbucketCloudOption struct {
+// AlmSettingsCreateBitbucketCloudOptions contains parameters for the CreateBitbucketCloud method.
+type AlmSettingsCreateBitbucketCloudOptions struct {
 	// ClientID is the Bitbucket Cloud Client ID.
 	// This field is required. Maximum length: 2000 characters.
 	ClientID string `url:"clientId"`
@@ -217,8 +217,8 @@ type AlmSettingsCreateBitbucketCloudOption struct {
 	Workspace string `url:"workspace"`
 }
 
-// AlmSettingsCreateGithubOption contains parameters for the CreateGithub method.
-type AlmSettingsCreateGithubOption struct {
+// AlmSettingsCreateGithubOptions contains parameters for the CreateGithub method.
+type AlmSettingsCreateGithubOptions struct {
 	// AppID is the GitHub App ID.
 	// This field is required. Maximum length: 80 characters.
 	AppID string `url:"appId"`
@@ -242,8 +242,8 @@ type AlmSettingsCreateGithubOption struct {
 	WebhookSecret string `url:"webhookSecret,omitempty"`
 }
 
-// AlmSettingsCreateGitlabOption contains parameters for the CreateGitlab method.
-type AlmSettingsCreateGitlabOption struct {
+// AlmSettingsCreateGitlabOptions contains parameters for the CreateGitlab method.
+type AlmSettingsCreateGitlabOptions struct {
 	// Key is the unique key of the GitLab instance setting.
 	// This field is required. Maximum length: 200 characters.
 	Key string `url:"key"`
@@ -255,29 +255,29 @@ type AlmSettingsCreateGitlabOption struct {
 	URL string `url:"url"`
 }
 
-// AlmSettingsDeleteOption contains parameters for the Delete method.
-type AlmSettingsDeleteOption struct {
+// AlmSettingsDeleteOptions contains parameters for the Delete method.
+type AlmSettingsDeleteOptions struct {
 	// Key is the DevOps Platform Setting key.
 	// This field is required.
 	Key string `url:"key"`
 }
 
-// AlmSettingsGetBindingOption contains parameters for the GetBinding method.
-type AlmSettingsGetBindingOption struct {
+// AlmSettingsGetBindingOptions contains parameters for the GetBinding method.
+type AlmSettingsGetBindingOptions struct {
 	// Project is the project key.
 	// This field is required.
 	Project string `url:"project"`
 }
 
-// AlmSettingsListOption contains parameters for the List method.
-type AlmSettingsListOption struct {
+// AlmSettingsListOptions contains parameters for the List method.
+type AlmSettingsListOptions struct {
 	// Project is the project key.
 	// This field is optional.
 	Project string `url:"project,omitempty"`
 }
 
-// AlmSettingsUpdateAzureOption contains parameters for the UpdateAzure method.
-type AlmSettingsUpdateAzureOption struct {
+// AlmSettingsUpdateAzureOptions contains parameters for the UpdateAzure method.
+type AlmSettingsUpdateAzureOptions struct {
 	// Key is the unique key of the Azure instance setting.
 	// This field is required. Maximum length: 200 characters.
 	Key string `url:"key"`
@@ -292,8 +292,8 @@ type AlmSettingsUpdateAzureOption struct {
 	URL string `url:"url"`
 }
 
-// AlmSettingsUpdateBitbucketOption contains parameters for the UpdateBitbucket method.
-type AlmSettingsUpdateBitbucketOption struct {
+// AlmSettingsUpdateBitbucketOptions contains parameters for the UpdateBitbucket method.
+type AlmSettingsUpdateBitbucketOptions struct {
 	// Key is the unique key of the Bitbucket instance setting.
 	// This field is required. Maximum length: 200 characters.
 	Key string `url:"key"`
@@ -308,8 +308,8 @@ type AlmSettingsUpdateBitbucketOption struct {
 	URL string `url:"url"`
 }
 
-// AlmSettingsUpdateBitbucketCloudOption contains parameters for the UpdateBitbucketCloud method.
-type AlmSettingsUpdateBitbucketCloudOption struct {
+// AlmSettingsUpdateBitbucketCloudOptions contains parameters for the UpdateBitbucketCloud method.
+type AlmSettingsUpdateBitbucketCloudOptions struct {
 	// ClientID is the Bitbucket Cloud Client ID.
 	// This field is required. Maximum length: 80 characters.
 	ClientID string `url:"clientId"`
@@ -327,8 +327,8 @@ type AlmSettingsUpdateBitbucketCloudOption struct {
 	Workspace string `url:"workspace"`
 }
 
-// AlmSettingsUpdateGithubOption contains parameters for the UpdateGithub method.
-type AlmSettingsUpdateGithubOption struct {
+// AlmSettingsUpdateGithubOptions contains parameters for the UpdateGithub method.
+type AlmSettingsUpdateGithubOptions struct {
 	// AppID is the GitHub API ID.
 	// This field is required. Maximum length: 80 characters.
 	AppID string `url:"appId"`
@@ -355,8 +355,8 @@ type AlmSettingsUpdateGithubOption struct {
 	WebhookSecret string `url:"webhookSecret,omitempty"`
 }
 
-// AlmSettingsUpdateGitlabOption contains parameters for the UpdateGitlab method.
-type AlmSettingsUpdateGitlabOption struct {
+// AlmSettingsUpdateGitlabOptions contains parameters for the UpdateGitlab method.
+type AlmSettingsUpdateGitlabOptions struct {
 	// Key is the unique key of the GitLab instance setting.
 	// This field is required. Maximum length: 200 characters.
 	Key string `url:"key"`
@@ -371,8 +371,8 @@ type AlmSettingsUpdateGitlabOption struct {
 	URL string `url:"url"`
 }
 
-// AlmSettingsValidateOption contains parameters for the Validate method.
-type AlmSettingsValidateOption struct {
+// AlmSettingsValidateOptions contains parameters for the Validate method.
+type AlmSettingsValidateOptions struct {
 	// Key is the unique key of the DevOps Platform settings.
 	// This field is required. Maximum length: 200 characters.
 	Key string `url:"key"`
@@ -383,7 +383,7 @@ type AlmSettingsValidateOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateCountBindingOpt validates the options for the CountBinding method.
-func (s *AlmSettingsService) ValidateCountBindingOpt(opt *AlmSettingsCountBindingOption) error {
+func (s *AlmSettingsService) ValidateCountBindingOpt(opt *AlmSettingsCountBindingOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -397,7 +397,7 @@ func (s *AlmSettingsService) ValidateCountBindingOpt(opt *AlmSettingsCountBindin
 }
 
 // ValidateCreateAzureOpt validates the options for the CreateAzure method.
-func (s *AlmSettingsService) ValidateCreateAzureOpt(opt *AlmSettingsCreateAzureOption) error {
+func (s *AlmSettingsService) ValidateCreateAzureOpt(opt *AlmSettingsCreateAzureOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -436,7 +436,7 @@ func (s *AlmSettingsService) ValidateCreateAzureOpt(opt *AlmSettingsCreateAzureO
 }
 
 // ValidateCreateBitbucketOpt validates the options for the CreateBitbucket method.
-func (s *AlmSettingsService) ValidateCreateBitbucketOpt(opt *AlmSettingsCreateBitbucketOption) error {
+func (s *AlmSettingsService) ValidateCreateBitbucketOpt(opt *AlmSettingsCreateBitbucketOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -475,7 +475,7 @@ func (s *AlmSettingsService) ValidateCreateBitbucketOpt(opt *AlmSettingsCreateBi
 }
 
 // ValidateCreateBitbucketCloudOpt validates the options for the CreateBitbucketCloud method.
-func (s *AlmSettingsService) ValidateCreateBitbucketCloudOpt(opt *AlmSettingsCreateBitbucketCloudOption) error {
+func (s *AlmSettingsService) ValidateCreateBitbucketCloudOpt(opt *AlmSettingsCreateBitbucketCloudOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -521,7 +521,7 @@ func (s *AlmSettingsService) ValidateCreateBitbucketCloudOpt(opt *AlmSettingsCre
 // ValidateCreateGithubOpt validates the options for the CreateGithub method.
 //
 //nolint:cyclop,funlen // Validation functions are naturally complex due to multiple checks
-func (s *AlmSettingsService) ValidateCreateGithubOpt(opt *AlmSettingsCreateGithubOption) error {
+func (s *AlmSettingsService) ValidateCreateGithubOpt(opt *AlmSettingsCreateGithubOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -597,7 +597,7 @@ func (s *AlmSettingsService) ValidateCreateGithubOpt(opt *AlmSettingsCreateGithu
 }
 
 // ValidateCreateGitlabOpt validates the options for the CreateGitlab method.
-func (s *AlmSettingsService) ValidateCreateGitlabOpt(opt *AlmSettingsCreateGitlabOption) error {
+func (s *AlmSettingsService) ValidateCreateGitlabOpt(opt *AlmSettingsCreateGitlabOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -636,7 +636,7 @@ func (s *AlmSettingsService) ValidateCreateGitlabOpt(opt *AlmSettingsCreateGitla
 }
 
 // ValidateDeleteOpt validates the options for the Delete method.
-func (s *AlmSettingsService) ValidateDeleteOpt(opt *AlmSettingsDeleteOption) error {
+func (s *AlmSettingsService) ValidateDeleteOpt(opt *AlmSettingsDeleteOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -650,7 +650,7 @@ func (s *AlmSettingsService) ValidateDeleteOpt(opt *AlmSettingsDeleteOption) err
 }
 
 // ValidateGetBindingOpt validates the options for the GetBinding method.
-func (s *AlmSettingsService) ValidateGetBindingOpt(opt *AlmSettingsGetBindingOption) error {
+func (s *AlmSettingsService) ValidateGetBindingOpt(opt *AlmSettingsGetBindingOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -664,13 +664,13 @@ func (s *AlmSettingsService) ValidateGetBindingOpt(opt *AlmSettingsGetBindingOpt
 }
 
 // ValidateListOpt validates the options for the List method.
-func (s *AlmSettingsService) ValidateListOpt(opt *AlmSettingsListOption) error {
+func (s *AlmSettingsService) ValidateListOpt(opt *AlmSettingsListOptions) error {
 	// Options are optional; nothing to validate.
 	return nil
 }
 
 // ValidateUpdateAzureOpt validates the options for the UpdateAzure method.
-func (s *AlmSettingsService) ValidateUpdateAzureOpt(opt *AlmSettingsUpdateAzureOption) error {
+func (s *AlmSettingsService) ValidateUpdateAzureOpt(opt *AlmSettingsUpdateAzureOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -713,7 +713,7 @@ func (s *AlmSettingsService) ValidateUpdateAzureOpt(opt *AlmSettingsUpdateAzureO
 }
 
 // ValidateUpdateBitbucketOpt validates the options for the UpdateBitbucket method.
-func (s *AlmSettingsService) ValidateUpdateBitbucketOpt(opt *AlmSettingsUpdateBitbucketOption) error {
+func (s *AlmSettingsService) ValidateUpdateBitbucketOpt(opt *AlmSettingsUpdateBitbucketOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -758,7 +758,7 @@ func (s *AlmSettingsService) ValidateUpdateBitbucketOpt(opt *AlmSettingsUpdateBi
 // ValidateUpdateBitbucketCloudOpt validates the options for the UpdateBitbucketCloud method.
 //
 //nolint:cyclop // Validation functions are naturally complex due to multiple checks
-func (s *AlmSettingsService) ValidateUpdateBitbucketCloudOpt(opt *AlmSettingsUpdateBitbucketCloudOption) error {
+func (s *AlmSettingsService) ValidateUpdateBitbucketCloudOpt(opt *AlmSettingsUpdateBitbucketCloudOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -813,7 +813,7 @@ func (s *AlmSettingsService) ValidateUpdateBitbucketCloudOpt(opt *AlmSettingsUpd
 // ValidateUpdateGithubOpt validates the options for the UpdateGithub method.
 //
 //nolint:cyclop,funlen // Validation functions are naturally complex due to multiple checks
-func (s *AlmSettingsService) ValidateUpdateGithubOpt(opt *AlmSettingsUpdateGithubOption) error {
+func (s *AlmSettingsService) ValidateUpdateGithubOpt(opt *AlmSettingsUpdateGithubOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -890,7 +890,7 @@ func (s *AlmSettingsService) ValidateUpdateGithubOpt(opt *AlmSettingsUpdateGithu
 }
 
 // ValidateUpdateGitlabOpt validates the options for the UpdateGitlab method.
-func (s *AlmSettingsService) ValidateUpdateGitlabOpt(opt *AlmSettingsUpdateGitlabOption) error {
+func (s *AlmSettingsService) ValidateUpdateGitlabOpt(opt *AlmSettingsUpdateGitlabOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -933,7 +933,7 @@ func (s *AlmSettingsService) ValidateUpdateGitlabOpt(opt *AlmSettingsUpdateGitla
 }
 
 // ValidateValidateOpt validates the options for the Validate method.
-func (s *AlmSettingsService) ValidateValidateOpt(opt *AlmSettingsValidateOption) error {
+func (s *AlmSettingsService) ValidateValidateOpt(opt *AlmSettingsValidateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -960,7 +960,7 @@ func (s *AlmSettingsService) ValidateValidateOpt(opt *AlmSettingsValidateOption)
 //
 // API endpoint: GET /api/alm_settings/count_binding.
 // Since: 8.1.
-func (s *AlmSettingsService) CountBinding(opt *AlmSettingsCountBindingOption) (*AlmSettingsCountBinding, *http.Response, error) {
+func (s *AlmSettingsService) CountBinding(opt *AlmSettingsCountBindingOptions) (*AlmSettingsCountBinding, *http.Response, error) {
 	err := s.ValidateCountBindingOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -986,7 +986,7 @@ func (s *AlmSettingsService) CountBinding(opt *AlmSettingsCountBindingOption) (*
 //
 // API endpoint: POST /api/alm_settings/create_azure.
 // Since: 8.1.
-func (s *AlmSettingsService) CreateAzure(opt *AlmSettingsCreateAzureOption) (*http.Response, error) {
+func (s *AlmSettingsService) CreateAzure(opt *AlmSettingsCreateAzureOptions) (*http.Response, error) {
 	err := s.ValidateCreateAzureOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1010,7 +1010,7 @@ func (s *AlmSettingsService) CreateAzure(opt *AlmSettingsCreateAzureOption) (*ht
 //
 // API endpoint: POST /api/alm_settings/create_bitbucket.
 // Since: 8.1.
-func (s *AlmSettingsService) CreateBitbucket(opt *AlmSettingsCreateBitbucketOption) (*http.Response, error) {
+func (s *AlmSettingsService) CreateBitbucket(opt *AlmSettingsCreateBitbucketOptions) (*http.Response, error) {
 	err := s.ValidateCreateBitbucketOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1034,7 +1034,7 @@ func (s *AlmSettingsService) CreateBitbucket(opt *AlmSettingsCreateBitbucketOpti
 //
 // API endpoint: POST /api/alm_settings/create_bitbucketcloud.
 // Since: 8.7.
-func (s *AlmSettingsService) CreateBitbucketCloud(opt *AlmSettingsCreateBitbucketCloudOption) (*http.Response, error) {
+func (s *AlmSettingsService) CreateBitbucketCloud(opt *AlmSettingsCreateBitbucketCloudOptions) (*http.Response, error) {
 	err := s.ValidateCreateBitbucketCloudOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1058,7 +1058,7 @@ func (s *AlmSettingsService) CreateBitbucketCloud(opt *AlmSettingsCreateBitbucke
 //
 // API endpoint: POST /api/alm_settings/create_github.
 // Since: 8.1.
-func (s *AlmSettingsService) CreateGithub(opt *AlmSettingsCreateGithubOption) (*http.Response, error) {
+func (s *AlmSettingsService) CreateGithub(opt *AlmSettingsCreateGithubOptions) (*http.Response, error) {
 	err := s.ValidateCreateGithubOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1082,7 +1082,7 @@ func (s *AlmSettingsService) CreateGithub(opt *AlmSettingsCreateGithubOption) (*
 //
 // API endpoint: POST /api/alm_settings/create_gitlab.
 // Since: 8.1.
-func (s *AlmSettingsService) CreateGitlab(opt *AlmSettingsCreateGitlabOption) (*http.Response, error) {
+func (s *AlmSettingsService) CreateGitlab(opt *AlmSettingsCreateGitlabOptions) (*http.Response, error) {
 	err := s.ValidateCreateGitlabOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1106,7 +1106,7 @@ func (s *AlmSettingsService) CreateGitlab(opt *AlmSettingsCreateGitlabOption) (*
 //
 // API endpoint: POST /api/alm_settings/delete.
 // Since: 8.1.
-func (s *AlmSettingsService) Delete(opt *AlmSettingsDeleteOption) (*http.Response, error) {
+func (s *AlmSettingsService) Delete(opt *AlmSettingsDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1130,7 +1130,7 @@ func (s *AlmSettingsService) Delete(opt *AlmSettingsDeleteOption) (*http.Respons
 //
 // API endpoint: GET /api/alm_settings/get_binding.
 // Since: 8.1.
-func (s *AlmSettingsService) GetBinding(opt *AlmSettingsGetBindingOption) (*AlmSettingsGetBinding, *http.Response, error) {
+func (s *AlmSettingsService) GetBinding(opt *AlmSettingsGetBindingOptions) (*AlmSettingsGetBinding, *http.Response, error) {
 	err := s.ValidateGetBindingOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -1157,7 +1157,7 @@ func (s *AlmSettingsService) GetBinding(opt *AlmSettingsGetBindingOption) (*AlmS
 //
 // API endpoint: GET /api/alm_settings/list.
 // Since: 8.1.
-func (s *AlmSettingsService) List(opt *AlmSettingsListOption) (*AlmSettingsList, *http.Response, error) {
+func (s *AlmSettingsService) List(opt *AlmSettingsListOptions) (*AlmSettingsList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -1204,7 +1204,7 @@ func (s *AlmSettingsService) ListDefinitions() (*AlmSettingsListDefinitions, *ht
 //
 // API endpoint: POST /api/alm_settings/update_azure.
 // Since: 8.1.
-func (s *AlmSettingsService) UpdateAzure(opt *AlmSettingsUpdateAzureOption) (*http.Response, error) {
+func (s *AlmSettingsService) UpdateAzure(opt *AlmSettingsUpdateAzureOptions) (*http.Response, error) {
 	err := s.ValidateUpdateAzureOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1228,7 +1228,7 @@ func (s *AlmSettingsService) UpdateAzure(opt *AlmSettingsUpdateAzureOption) (*ht
 //
 // API endpoint: POST /api/alm_settings/update_bitbucket.
 // Since: 8.1.
-func (s *AlmSettingsService) UpdateBitbucket(opt *AlmSettingsUpdateBitbucketOption) (*http.Response, error) {
+func (s *AlmSettingsService) UpdateBitbucket(opt *AlmSettingsUpdateBitbucketOptions) (*http.Response, error) {
 	err := s.ValidateUpdateBitbucketOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1252,7 +1252,7 @@ func (s *AlmSettingsService) UpdateBitbucket(opt *AlmSettingsUpdateBitbucketOpti
 //
 // API endpoint: POST /api/alm_settings/update_bitbucketcloud.
 // Since: 8.7.
-func (s *AlmSettingsService) UpdateBitbucketCloud(opt *AlmSettingsUpdateBitbucketCloudOption) (*http.Response, error) {
+func (s *AlmSettingsService) UpdateBitbucketCloud(opt *AlmSettingsUpdateBitbucketCloudOptions) (*http.Response, error) {
 	err := s.ValidateUpdateBitbucketCloudOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1276,7 +1276,7 @@ func (s *AlmSettingsService) UpdateBitbucketCloud(opt *AlmSettingsUpdateBitbucke
 //
 // API endpoint: POST /api/alm_settings/update_github.
 // Since: 8.1.
-func (s *AlmSettingsService) UpdateGithub(opt *AlmSettingsUpdateGithubOption) (*http.Response, error) {
+func (s *AlmSettingsService) UpdateGithub(opt *AlmSettingsUpdateGithubOptions) (*http.Response, error) {
 	err := s.ValidateUpdateGithubOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1300,7 +1300,7 @@ func (s *AlmSettingsService) UpdateGithub(opt *AlmSettingsUpdateGithubOption) (*
 //
 // API endpoint: POST /api/alm_settings/update_gitlab.
 // Since: 8.1.
-func (s *AlmSettingsService) UpdateGitlab(opt *AlmSettingsUpdateGitlabOption) (*http.Response, error) {
+func (s *AlmSettingsService) UpdateGitlab(opt *AlmSettingsUpdateGitlabOptions) (*http.Response, error) {
 	err := s.ValidateUpdateGitlabOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1324,7 +1324,7 @@ func (s *AlmSettingsService) UpdateGitlab(opt *AlmSettingsUpdateGitlabOption) (*
 //
 // API endpoint: GET /api/alm_settings/validate.
 // Since: 8.6.
-func (s *AlmSettingsService) Validate(opt *AlmSettingsValidateOption) (*AlmSettingsValidation, *http.Response, error) {
+func (s *AlmSettingsService) Validate(opt *AlmSettingsValidateOptions) (*AlmSettingsValidation, *http.Response, error) {
 	err := s.ValidateValidateOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/alm_settings_service_test.go
+++ b/sonar/alm_settings_service_test.go
@@ -21,7 +21,7 @@ func TestAlmSettings_CountBinding(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/alm_settings/count_binding", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsCountBindingOption{
+	opt := &AlmSettingsCountBindingOptions{
 		AlmSetting: "my-alm-setting",
 	}
 
@@ -41,7 +41,7 @@ func TestAlmSettings_CountBinding_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmSettings.CountBinding(&AlmSettingsCountBindingOption{})
+	_, _, err = client.AlmSettings.CountBinding(&AlmSettingsCountBindingOptions{})
 	assert.Error(t, err)
 }
 
@@ -53,7 +53,7 @@ func TestAlmSettings_CreateAzure(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/alm_settings/create_azure", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsCreateAzureOption{
+	opt := &AlmSettingsCreateAzureOptions{
 		Key:                 "my-azure-setting",
 		PersonalAccessToken: "my-pat",
 		URL:                 "https://dev.azure.com/myorg",
@@ -72,14 +72,14 @@ func TestAlmSettings_CreateAzure_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOption{
+	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOptions{
 		PersonalAccessToken: "pat",
 		URL:                 "https://dev.azure.com",
 	})
 	assert.Error(t, err)
 
 	// Test Key too long
-	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOption{
+	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOptions{
 		Key:                 strings.Repeat("a", MaxAlmKeyLength+1),
 		PersonalAccessToken: "pat",
 		URL:                 "https://dev.azure.com",
@@ -87,14 +87,14 @@ func TestAlmSettings_CreateAzure_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing PersonalAccessToken
-	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOption{
+	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOptions{
 		Key: "my-key",
 		URL: "https://dev.azure.com",
 	})
 	assert.Error(t, err)
 
 	// Test PersonalAccessToken too long
-	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOption{
+	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOptions{
 		Key:                 "my-key",
 		PersonalAccessToken: strings.Repeat("a", MaxPersonalAccessTokenLength+1),
 		URL:                 "https://dev.azure.com",
@@ -102,14 +102,14 @@ func TestAlmSettings_CreateAzure_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOption{
+	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOptions{
 		Key:                 "my-key",
 		PersonalAccessToken: "pat",
 	})
 	assert.Error(t, err)
 
 	// Test URL too long
-	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOption{
+	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOptions{
 		Key:                 "my-key",
 		PersonalAccessToken: "pat",
 		URL:                 strings.Repeat("a", MaxAlmURLLength+1),
@@ -125,7 +125,7 @@ func TestAlmSettings_CreateBitbucket(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/alm_settings/create_bitbucket", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsCreateBitbucketOption{
+	opt := &AlmSettingsCreateBitbucketOptions{
 		Key:                 "my-bitbucket-setting",
 		PersonalAccessToken: "my-pat",
 		URL:                 "https://bitbucket.example.com",
@@ -144,14 +144,14 @@ func TestAlmSettings_CreateBitbucket_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.CreateBitbucket(&AlmSettingsCreateBitbucketOption{
+	_, err = client.AlmSettings.CreateBitbucket(&AlmSettingsCreateBitbucketOptions{
 		PersonalAccessToken: "pat",
 		URL:                 "https://bitbucket.example.com",
 	})
 	assert.Error(t, err)
 
 	// Test Key too long
-	_, err = client.AlmSettings.CreateBitbucket(&AlmSettingsCreateBitbucketOption{
+	_, err = client.AlmSettings.CreateBitbucket(&AlmSettingsCreateBitbucketOptions{
 		Key:                 strings.Repeat("a", MaxAlmKeyLength+1),
 		PersonalAccessToken: "pat",
 		URL:                 "https://bitbucket.example.com",
@@ -159,14 +159,14 @@ func TestAlmSettings_CreateBitbucket_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing PersonalAccessToken
-	_, err = client.AlmSettings.CreateBitbucket(&AlmSettingsCreateBitbucketOption{
+	_, err = client.AlmSettings.CreateBitbucket(&AlmSettingsCreateBitbucketOptions{
 		Key: "my-key",
 		URL: "https://bitbucket.example.com",
 	})
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.CreateBitbucket(&AlmSettingsCreateBitbucketOption{
+	_, err = client.AlmSettings.CreateBitbucket(&AlmSettingsCreateBitbucketOptions{
 		Key:                 "my-key",
 		PersonalAccessToken: "pat",
 	})
@@ -181,7 +181,7 @@ func TestAlmSettings_CreateBitbucketCloud(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/alm_settings/create_bitbucketcloud", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsCreateBitbucketCloudOption{
+	opt := &AlmSettingsCreateBitbucketCloudOptions{
 		ClientID:     "my-client-id",
 		ClientSecret: "my-client-secret",
 		Key:          "my-bitbucket-cloud-setting",
@@ -201,7 +201,7 @@ func TestAlmSettings_CreateBitbucketCloud_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing ClientID
-	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOption{
+	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOptions{
 		ClientSecret: "secret",
 		Key:          "my-key",
 		Workspace:    "workspace",
@@ -209,7 +209,7 @@ func TestAlmSettings_CreateBitbucketCloud_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test ClientID too long
-	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOption{
+	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOptions{
 		ClientID:     strings.Repeat("a", MaxBitbucketCloudClientIDLength+1),
 		ClientSecret: "secret",
 		Key:          "my-key",
@@ -218,7 +218,7 @@ func TestAlmSettings_CreateBitbucketCloud_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing ClientSecret
-	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOption{
+	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOptions{
 		ClientID:  "client-id",
 		Key:       "my-key",
 		Workspace: "workspace",
@@ -226,7 +226,7 @@ func TestAlmSettings_CreateBitbucketCloud_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOption{
+	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOptions{
 		ClientID:     "client-id",
 		ClientSecret: "secret",
 		Workspace:    "workspace",
@@ -234,7 +234,7 @@ func TestAlmSettings_CreateBitbucketCloud_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Workspace
-	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOption{
+	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOptions{
 		ClientID:     "client-id",
 		ClientSecret: "secret",
 		Key:          "my-key",
@@ -250,7 +250,7 @@ func TestAlmSettings_CreateGithub(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/alm_settings/create_github", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsCreateGithubOption{
+	opt := &AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientID:     "my-client-id",
 		ClientSecret: "my-client-secret",
@@ -268,7 +268,7 @@ func TestAlmSettings_CreateGithub_WithOptionalWebhookSecret(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/alm_settings/create_github", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsCreateGithubOption{
+	opt := &AlmSettingsCreateGithubOptions{
 		AppID:         "12345",
 		ClientID:      "my-client-id",
 		ClientSecret:  "my-client-secret",
@@ -291,7 +291,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing AppID
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOption{
+	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
 		ClientID:     "client-id",
 		ClientSecret: "secret",
 		Key:          "my-key",
@@ -301,7 +301,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test AppID too long
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOption{
+	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
 		AppID:        strings.Repeat("a", MaxGitHubAppIDLength+1),
 		ClientID:     "client-id",
 		ClientSecret: "secret",
@@ -312,7 +312,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing ClientID
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOption{
+	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientSecret: "secret",
 		Key:          "my-key",
@@ -322,7 +322,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test ClientID too long
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOption{
+	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientID:     strings.Repeat("a", MaxGitHubClientIDLength+1),
 		ClientSecret: "secret",
@@ -333,7 +333,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing ClientSecret
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOption{
+	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
 		AppID:      "12345",
 		ClientID:   "client-id",
 		Key:        "my-key",
@@ -343,7 +343,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test ClientSecret too long
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOption{
+	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientID:     "client-id",
 		ClientSecret: strings.Repeat("a", MaxGitHubClientSecretLength+1),
@@ -354,7 +354,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOption{
+	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientID:     "client-id",
 		ClientSecret: "secret",
@@ -364,7 +364,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing PrivateKey
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOption{
+	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientID:     "client-id",
 		ClientSecret: "secret",
@@ -374,7 +374,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test PrivateKey too long
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOption{
+	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientID:     "client-id",
 		ClientSecret: "secret",
@@ -385,7 +385,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOption{
+	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientID:     "client-id",
 		ClientSecret: "secret",
@@ -395,7 +395,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test WebhookSecret too long
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOption{
+	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
 		AppID:         "12345",
 		ClientID:      "client-id",
 		ClientSecret:  "secret",
@@ -415,7 +415,7 @@ func TestAlmSettings_CreateGitlab(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/alm_settings/create_gitlab", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsCreateGitlabOption{
+	opt := &AlmSettingsCreateGitlabOptions{
 		Key:                 "my-gitlab-setting",
 		PersonalAccessToken: "my-pat",
 		URL:                 "https://gitlab.example.com",
@@ -434,21 +434,21 @@ func TestAlmSettings_CreateGitlab_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.CreateGitlab(&AlmSettingsCreateGitlabOption{
+	_, err = client.AlmSettings.CreateGitlab(&AlmSettingsCreateGitlabOptions{
 		PersonalAccessToken: "pat",
 		URL:                 "https://gitlab.example.com",
 	})
 	assert.Error(t, err)
 
 	// Test missing PersonalAccessToken
-	_, err = client.AlmSettings.CreateGitlab(&AlmSettingsCreateGitlabOption{
+	_, err = client.AlmSettings.CreateGitlab(&AlmSettingsCreateGitlabOptions{
 		Key: "my-key",
 		URL: "https://gitlab.example.com",
 	})
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.CreateGitlab(&AlmSettingsCreateGitlabOption{
+	_, err = client.AlmSettings.CreateGitlab(&AlmSettingsCreateGitlabOptions{
 		Key:                 "my-key",
 		PersonalAccessToken: "pat",
 	})
@@ -463,7 +463,7 @@ func TestAlmSettings_Delete(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/alm_settings/delete", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsDeleteOption{
+	opt := &AlmSettingsDeleteOptions{
 		Key: "my-alm-setting",
 	}
 
@@ -480,7 +480,7 @@ func TestAlmSettings_Delete_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.Delete(&AlmSettingsDeleteOption{})
+	_, err = client.AlmSettings.Delete(&AlmSettingsDeleteOptions{})
 	assert.Error(t, err)
 }
 
@@ -500,7 +500,7 @@ func TestAlmSettings_GetBinding(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/alm_settings/get_binding", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsGetBindingOption{
+	opt := &AlmSettingsGetBindingOptions{
 		Project: "my-project",
 	}
 
@@ -521,7 +521,7 @@ func TestAlmSettings_GetBinding_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Project
-	_, _, err = client.AlmSettings.GetBinding(&AlmSettingsGetBindingOption{})
+	_, _, err = client.AlmSettings.GetBinding(&AlmSettingsGetBindingOptions{})
 	assert.Error(t, err)
 }
 
@@ -539,7 +539,7 @@ func TestAlmSettings_List(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/alm_settings/list", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.AlmSettings.List(&AlmSettingsListOption{})
+	result, resp, err := client.AlmSettings.List(&AlmSettingsListOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -557,7 +557,7 @@ func TestAlmSettings_List_WithProject(t *testing.T) {
 	})
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsListOption{
+	opt := &AlmSettingsListOptions{
 		Project: "my-project",
 	}
 
@@ -607,7 +607,7 @@ func TestAlmSettings_UpdateAzure(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/alm_settings/update_azure", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsUpdateAzureOption{
+	opt := &AlmSettingsUpdateAzureOptions{
 		Key: "my-azure-setting",
 		URL: "https://dev.azure.com",
 	}
@@ -621,7 +621,7 @@ func TestAlmSettings_UpdateAzure_WithOptionalFields(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/alm_settings/update_azure", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsUpdateAzureOption{
+	opt := &AlmSettingsUpdateAzureOptions{
 		Key:                 "my-azure-setting",
 		NewKey:              "new-azure-setting",
 		PersonalAccessToken: "new-pat",
@@ -641,20 +641,20 @@ func TestAlmSettings_UpdateAzure_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOption{
+	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOptions{
 		URL: "https://dev.azure.com",
 	})
 	assert.Error(t, err)
 
 	// Test Key too long
-	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOption{
+	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOptions{
 		Key: strings.Repeat("a", MaxAlmKeyLength+1),
 		URL: "https://dev.azure.com",
 	})
 	assert.Error(t, err)
 
 	// Test NewKey too long
-	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOption{
+	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOptions{
 		Key:    "my-key",
 		NewKey: strings.Repeat("a", MaxAlmKeyLength+1),
 		URL:    "https://dev.azure.com",
@@ -662,7 +662,7 @@ func TestAlmSettings_UpdateAzure_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test PersonalAccessToken too long
-	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOption{
+	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOptions{
 		Key:                 "my-key",
 		PersonalAccessToken: strings.Repeat("a", MaxPersonalAccessTokenLength+1),
 		URL:                 "https://dev.azure.com",
@@ -670,13 +670,13 @@ func TestAlmSettings_UpdateAzure_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOption{
+	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOptions{
 		Key: "my-key",
 	})
 	assert.Error(t, err)
 
 	// Test URL too long
-	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOption{
+	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOptions{
 		Key: "my-key",
 		URL: strings.Repeat("a", MaxAlmURLLength+1),
 	})
@@ -691,7 +691,7 @@ func TestAlmSettings_UpdateBitbucket(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/alm_settings/update_bitbucket", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsUpdateBitbucketOption{
+	opt := &AlmSettingsUpdateBitbucketOptions{
 		Key: "my-bitbucket-setting",
 		URL: "https://bitbucket.example.com",
 	}
@@ -709,13 +709,13 @@ func TestAlmSettings_UpdateBitbucket_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.UpdateBitbucket(&AlmSettingsUpdateBitbucketOption{
+	_, err = client.AlmSettings.UpdateBitbucket(&AlmSettingsUpdateBitbucketOptions{
 		URL: "https://bitbucket.example.com",
 	})
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.UpdateBitbucket(&AlmSettingsUpdateBitbucketOption{
+	_, err = client.AlmSettings.UpdateBitbucket(&AlmSettingsUpdateBitbucketOptions{
 		Key: "my-key",
 	})
 	assert.Error(t, err)
@@ -729,7 +729,7 @@ func TestAlmSettings_UpdateBitbucketCloud(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/alm_settings/update_bitbucketcloud", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsUpdateBitbucketCloudOption{
+	opt := &AlmSettingsUpdateBitbucketCloudOptions{
 		ClientID:  "my-client-id",
 		Key:       "my-bitbucket-cloud-setting",
 		Workspace: "my-workspace",
@@ -748,14 +748,14 @@ func TestAlmSettings_UpdateBitbucketCloud_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing ClientID
-	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOption{
+	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOptions{
 		Key:       "my-key",
 		Workspace: "workspace",
 	})
 	assert.Error(t, err)
 
 	// Test ClientID too long
-	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOption{
+	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOptions{
 		ClientID:  strings.Repeat("a", MaxBitbucketCloudClientIDUpdateLength+1),
 		Key:       "my-key",
 		Workspace: "workspace",
@@ -763,7 +763,7 @@ func TestAlmSettings_UpdateBitbucketCloud_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test ClientSecret too long
-	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOption{
+	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOptions{
 		ClientID:     "client-id",
 		ClientSecret: strings.Repeat("a", MaxBitbucketCloudClientSecretUpdateLength+1),
 		Key:          "my-key",
@@ -772,21 +772,21 @@ func TestAlmSettings_UpdateBitbucketCloud_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOption{
+	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOptions{
 		ClientID:  "client-id",
 		Workspace: "workspace",
 	})
 	assert.Error(t, err)
 
 	// Test missing Workspace
-	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOption{
+	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOptions{
 		ClientID: "client-id",
 		Key:      "my-key",
 	})
 	assert.Error(t, err)
 
 	// Test Workspace too long
-	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOption{
+	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOptions{
 		ClientID:  "client-id",
 		Key:       "my-key",
 		Workspace: strings.Repeat("a", MaxBitbucketCloudWorkspaceUpdateLength+1),
@@ -802,7 +802,7 @@ func TestAlmSettings_UpdateGithub(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/alm_settings/update_github", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsUpdateGithubOption{
+	opt := &AlmSettingsUpdateGithubOptions{
 		AppID:    "12345",
 		ClientID: "my-client-id",
 		Key:      "my-github-setting",
@@ -818,7 +818,7 @@ func TestAlmSettings_UpdateGithub_WithOptionalFields(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/alm_settings/update_github", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsUpdateGithubOption{
+	opt := &AlmSettingsUpdateGithubOptions{
 		AppID:         "12345",
 		ClientID:      "my-client-id",
 		ClientSecret:  "new-client-secret",
@@ -842,7 +842,7 @@ func TestAlmSettings_UpdateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing AppID
-	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOption{
+	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOptions{
 		ClientID: "client-id",
 		Key:      "my-key",
 		URL:      "https://api.github.com",
@@ -850,7 +850,7 @@ func TestAlmSettings_UpdateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test AppID too long
-	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOption{
+	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOptions{
 		AppID:    strings.Repeat("a", MaxGitHubAppIDLength+1),
 		ClientID: "client-id",
 		Key:      "my-key",
@@ -859,7 +859,7 @@ func TestAlmSettings_UpdateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing ClientID
-	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOption{
+	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOptions{
 		AppID: "12345",
 		Key:   "my-key",
 		URL:   "https://api.github.com",
@@ -867,7 +867,7 @@ func TestAlmSettings_UpdateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOption{
+	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOptions{
 		AppID:    "12345",
 		ClientID: "client-id",
 		URL:      "https://api.github.com",
@@ -875,7 +875,7 @@ func TestAlmSettings_UpdateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOption{
+	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOptions{
 		AppID:    "12345",
 		ClientID: "client-id",
 		Key:      "my-key",
@@ -883,7 +883,7 @@ func TestAlmSettings_UpdateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test PrivateKey too long
-	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOption{
+	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOptions{
 		AppID:      "12345",
 		ClientID:   "client-id",
 		Key:        "my-key",
@@ -893,7 +893,7 @@ func TestAlmSettings_UpdateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test WebhookSecret too long
-	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOption{
+	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOptions{
 		AppID:         "12345",
 		ClientID:      "client-id",
 		Key:           "my-key",
@@ -911,7 +911,7 @@ func TestAlmSettings_UpdateGitlab(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/alm_settings/update_gitlab", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsUpdateGitlabOption{
+	opt := &AlmSettingsUpdateGitlabOptions{
 		Key: "my-gitlab-setting",
 		URL: "https://gitlab.example.com",
 	}
@@ -929,13 +929,13 @@ func TestAlmSettings_UpdateGitlab_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.UpdateGitlab(&AlmSettingsUpdateGitlabOption{
+	_, err = client.AlmSettings.UpdateGitlab(&AlmSettingsUpdateGitlabOptions{
 		URL: "https://gitlab.example.com",
 	})
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.UpdateGitlab(&AlmSettingsUpdateGitlabOption{
+	_, err = client.AlmSettings.UpdateGitlab(&AlmSettingsUpdateGitlabOptions{
 		Key: "my-key",
 	})
 	assert.Error(t, err)
@@ -950,7 +950,7 @@ func TestAlmSettings_Validate(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/alm_settings/validate", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsValidateOption{
+	opt := &AlmSettingsValidateOptions{
 		Key: "my-alm-setting",
 	}
 
@@ -971,7 +971,7 @@ func TestAlmSettings_Validate_WithErrors(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/alm_settings/validate", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &AlmSettingsValidateOption{
+	opt := &AlmSettingsValidateOptions{
 		Key: "my-alm-setting",
 	}
 
@@ -989,11 +989,11 @@ func TestAlmSettings_Validate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, _, err = client.AlmSettings.Validate(&AlmSettingsValidateOption{})
+	_, _, err = client.AlmSettings.Validate(&AlmSettingsValidateOptions{})
 	assert.Error(t, err)
 
 	// Test Key too long
-	_, _, err = client.AlmSettings.Validate(&AlmSettingsValidateOption{
+	_, _, err = client.AlmSettings.Validate(&AlmSettingsValidateOptions{
 		Key: strings.Repeat("a", MaxAlmKeyLength+1),
 	})
 	assert.Error(t, err)
@@ -1011,6 +1011,6 @@ func TestAlmSettings_ValidateListOpt(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Empty options should be valid
-	err = client.AlmSettings.ValidateListOpt(&AlmSettingsListOption{})
+	err = client.AlmSettings.ValidateListOpt(&AlmSettingsListOptions{})
 	assert.NoError(t, err)
 }

--- a/sonar/analysis_cache_service.go
+++ b/sonar/analysis_cache_service.go
@@ -17,8 +17,8 @@ type AnalysisCacheService struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// AnalysisCacheClearOption contains parameters for the Clear method.
-type AnalysisCacheClearOption struct {
+// AnalysisCacheClearOptions contains parameters for the Clear method.
+type AnalysisCacheClearOptions struct {
 	// Branch filters which project's branch's cached data will be cleared.
 	// The 'Project' parameter must be set when using this.
 	Branch string `url:"branch,omitempty"`
@@ -26,8 +26,8 @@ type AnalysisCacheClearOption struct {
 	Project string `url:"project,omitempty"`
 }
 
-// AnalysisCacheGetOption contains parameters for the Get method.
-type AnalysisCacheGetOption struct {
+// AnalysisCacheGetOptions contains parameters for the Get method.
+type AnalysisCacheGetOptions struct {
 	// Branch key. If not provided, main branch will be used.
 	Branch string `url:"branch,omitempty"`
 	// Project key.
@@ -41,7 +41,7 @@ type AnalysisCacheGetOption struct {
 
 // ValidateClearOpt validates the options for the Clear method.
 // Currently, there are no required fields.
-func (s *AnalysisCacheService) ValidateClearOpt(opt *AnalysisCacheClearOption) error {
+func (s *AnalysisCacheService) ValidateClearOpt(opt *AnalysisCacheClearOptions) error {
 	// When filtering by branch, Project must be set as documented.
 	if opt != nil && opt.Branch != "" && opt.Project == "" {
 		return NewValidationError("Project", "Project must be set when Branch is specified", ErrMissingRequired)
@@ -51,7 +51,7 @@ func (s *AnalysisCacheService) ValidateClearOpt(opt *AnalysisCacheClearOption) e
 }
 
 // ValidateGetOpt validates the options for the Get method.
-func (s *AnalysisCacheService) ValidateGetOpt(opt *AnalysisCacheGetOption) error {
+func (s *AnalysisCacheService) ValidateGetOpt(opt *AnalysisCacheGetOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -74,7 +74,7 @@ func (s *AnalysisCacheService) ValidateGetOpt(opt *AnalysisCacheGetOption) error
 //
 // API endpoint: POST /api/analysis_cache/clear.
 // WARNING: This is an internal API and may change without notice.
-func (s *AnalysisCacheService) Clear(opt *AnalysisCacheClearOption) (*http.Response, error) {
+func (s *AnalysisCacheService) Clear(opt *AnalysisCacheClearOptions) (*http.Response, error) {
 	err := s.ValidateClearOpt(opt)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (s *AnalysisCacheService) Clear(opt *AnalysisCacheClearOption) (*http.Respo
 // The response body contains the raw binary data; the caller is responsible for reading and closing it.
 //
 // API endpoint: GET /api/analysis_cache/get.
-func (s *AnalysisCacheService) Get(opt *AnalysisCacheGetOption) (*http.Response, error) {
+func (s *AnalysisCacheService) Get(opt *AnalysisCacheGetOptions) (*http.Response, error) {
 	err := s.ValidateGetOpt(opt)
 	if err != nil {
 		return nil, err

--- a/sonar/analysis_cache_service_test.go
+++ b/sonar/analysis_cache_service_test.go
@@ -30,7 +30,7 @@ func TestAnalysisCache_Clear_WithOptions(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AnalysisCacheClearOption{
+	opt := &AnalysisCacheClearOptions{
 		Project: "my-project",
 		Branch:  "feature",
 	}
@@ -56,7 +56,7 @@ func TestAnalysisCache_Get(t *testing.T) {
 
 	client := newTestClient(t, ts.URL+"/")
 
-	opt := &AnalysisCacheGetOption{
+	opt := &AnalysisCacheGetOptions{
 		Project: "my-project",
 	}
 
@@ -88,7 +88,7 @@ func TestAnalysisCache_Get_WithOptions(t *testing.T) {
 
 	client := newTestClient(t, ts.URL+"/")
 
-	opt := &AnalysisCacheGetOption{
+	opt := &AnalysisCacheGetOptions{
 		Project: "my-project",
 		Branch:  "main",
 	}
@@ -109,11 +109,11 @@ func TestAnalysisCache_ValidateClearOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *AnalysisCacheClearOption
+		opt     *AnalysisCacheClearOptions
 		wantErr bool
 	}{
 		{"nil option", nil, false},
-		{"empty option", &AnalysisCacheClearOption{}, false},
+		{"empty option", &AnalysisCacheClearOptions{}, false},
 	}
 
 	for _, tt := range tests {
@@ -133,12 +133,12 @@ func TestAnalysisCache_ValidateGetOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *AnalysisCacheGetOption
+		opt     *AnalysisCacheGetOptions
 		wantErr bool
 	}{
 		{"nil option", nil, true},
-		{"empty option", &AnalysisCacheGetOption{}, true},
-		{"with Project", &AnalysisCacheGetOption{Project: "my-project"}, false},
+		{"empty option", &AnalysisCacheGetOptions{}, true},
+		{"with Project", &AnalysisCacheGetOptions{Project: "my-project"}, false},
 	}
 
 	for _, tt := range tests {

--- a/sonar/authentication_service.go
+++ b/sonar/authentication_service.go
@@ -24,8 +24,8 @@ type AuthenticationValidation struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// AuthenticationLoginOption contains parameters for the Login method.
-type AuthenticationLoginOption struct {
+// AuthenticationLoginOptions contains parameters for the Login method.
+type AuthenticationLoginOptions struct {
 	// Login is the login/username of the user.
 	// This field is required.
 	Login string `url:"login"`
@@ -39,7 +39,7 @@ type AuthenticationLoginOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateLoginOpt validates the options for the Login method.
-func (s *AuthenticationService) ValidateLoginOpt(opt *AuthenticationLoginOption) error {
+func (s *AuthenticationService) ValidateLoginOpt(opt *AuthenticationLoginOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -64,7 +64,7 @@ func (s *AuthenticationService) ValidateLoginOpt(opt *AuthenticationLoginOption)
 // Login authenticates a user.
 //
 // API endpoint: POST /api/authentication/login.
-func (s *AuthenticationService) Login(opt *AuthenticationLoginOption) (*http.Response, error) {
+func (s *AuthenticationService) Login(opt *AuthenticationLoginOptions) (*http.Response, error) {
 	err := s.ValidateLoginOpt(opt)
 	if err != nil {
 		return nil, err

--- a/sonar/authentication_service_test.go
+++ b/sonar/authentication_service_test.go
@@ -13,7 +13,7 @@ func TestAuthentication_Login(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AuthenticationLoginOption{
+	opt := &AuthenticationLoginOptions{
 		Login:    "admin",
 		Password: "secret",
 	}
@@ -28,11 +28,11 @@ func TestAuthentication_Login_Validation(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *AuthenticationLoginOption
+		opt  *AuthenticationLoginOptions
 	}{
 		{"nil option", nil},
-		{"missing Login", &AuthenticationLoginOption{Password: "secret"}},
-		{"missing Password", &AuthenticationLoginOption{Login: "admin"}},
+		{"missing Login", &AuthenticationLoginOptions{Password: "secret"}},
+		{"missing Password", &AuthenticationLoginOptions{Login: "admin"}},
 	}
 
 	for _, tt := range tests {
@@ -83,13 +83,13 @@ func TestAuthentication_ValidateLoginOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *AuthenticationLoginOption
+		opt     *AuthenticationLoginOptions
 		wantErr bool
 	}{
-		{"valid option", &AuthenticationLoginOption{Login: "admin", Password: "secret"}, false},
+		{"valid option", &AuthenticationLoginOptions{Login: "admin", Password: "secret"}, false},
 		{"nil option", nil, true},
-		{"missing Login", &AuthenticationLoginOption{Password: "secret"}, true},
-		{"missing Password", &AuthenticationLoginOption{Login: "admin"}, true},
+		{"missing Login", &AuthenticationLoginOptions{Password: "secret"}, true},
+		{"missing Password", &AuthenticationLoginOptions{Login: "admin"}, true},
 	}
 
 	for _, tt := range tests {

--- a/sonar/batch_service.go
+++ b/sonar/batch_service.go
@@ -10,13 +10,13 @@ type BatchService struct {
 	client *Client
 }
 
-// BatchFileOption contains parameters for the File endpoint.
-type BatchFileOption struct {
+// BatchFileOptions contains parameters for the File endpoint.
+type BatchFileOptions struct {
 	Name string `url:"name,omitempty"` // Description:"File name",ExampleValue:"batch-library-2.3.jar"
 }
 
-// BatchProjectOption contains parameters for the Project endpoint.
-type BatchProjectOption struct {
+// BatchProjectOptions contains parameters for the Project endpoint.
+type BatchProjectOptions struct {
 	Branch      string `url:"branch,omitempty"`      // Description:"Branch key",ExampleValue:"feature/my_branch"
 	Key         string `url:"key,omitempty"`         // Description:"Project key",ExampleValue:"my_project"
 	Profile     string `url:"profile,omitempty"`     // Description:"Profile name",ExampleValue:"SonarQube Way"
@@ -37,7 +37,7 @@ type BatchFileData struct {
 }
 
 // ValidateFileOpt validates the options for the File endpoint.
-func (s *BatchService) ValidateFileOpt(opt *BatchFileOption) error {
+func (s *BatchService) ValidateFileOpt(opt *BatchFileOptions) error {
 	if opt == nil {
 		return nil
 	}
@@ -46,7 +46,7 @@ func (s *BatchService) ValidateFileOpt(opt *BatchFileOption) error {
 }
 
 // ValidateProjectOpt validates the options for the Project endpoint.
-func (s *BatchService) ValidateProjectOpt(opt *BatchProjectOption) error {
+func (s *BatchService) ValidateProjectOpt(opt *BatchProjectOptions) error {
 	if opt == nil {
 		return nil
 	}
@@ -56,7 +56,7 @@ func (s *BatchService) ValidateProjectOpt(opt *BatchProjectOption) error {
 
 // File downloads a JAR file listed in the index (see batch/index).
 // This endpoint returns binary data for the requested JAR file.
-func (s *BatchService) File(opt *BatchFileOption) (v []byte, resp *http.Response, err error) {
+func (s *BatchService) File(opt *BatchFileOptions) (v []byte, resp *http.Response, err error) {
 	err = s.ValidateFileOpt(opt)
 	if err != nil {
 		return
@@ -99,7 +99,7 @@ func (s *BatchService) Index() (v *string, resp *http.Response, err error) {
 
 // Project returns project repository information including file hashes
 // for incremental analysis.
-func (s *BatchService) Project(opt *BatchProjectOption) (v *BatchProject, resp *http.Response, err error) {
+func (s *BatchService) Project(opt *BatchProjectOptions) (v *BatchProject, resp *http.Response, err error) {
 	err = s.ValidateProjectOpt(opt)
 	if err != nil {
 		return

--- a/sonar/batch_service_test.go
+++ b/sonar/batch_service_test.go
@@ -14,7 +14,7 @@ func TestBatchService_File(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Batch.File(&BatchFileOption{
+		result, resp, err := client.Batch.File(&BatchFileOptions{
 			Name: "batch-library-2.3.jar",
 		})
 
@@ -38,7 +38,7 @@ func TestBatchService_File(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Batch.File(&BatchFileOption{})
+		_, _, err := client.Batch.File(&BatchFileOptions{})
 
 		require.NoError(t, err)
 	})
@@ -77,7 +77,7 @@ func TestBatchService_Project(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Batch.Project(&BatchProjectOption{
+		result, resp, err := client.Batch.Project(&BatchProjectOptions{
 			Key: "my-project",
 		})
 
@@ -92,7 +92,7 @@ func TestBatchService_Project(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Batch.Project(&BatchProjectOption{
+		_, _, err := client.Batch.Project(&BatchProjectOptions{
 			Key:    "my-project",
 			Branch: "feature/my-branch",
 		})
@@ -105,7 +105,7 @@ func TestBatchService_Project(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Batch.Project(&BatchProjectOption{
+		_, _, err := client.Batch.Project(&BatchProjectOptions{
 			Key:         "my-project",
 			PullRequest: "5461",
 		})
@@ -129,12 +129,12 @@ func TestBatchService_ValidateFileOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *BatchFileOption
+		opt     *BatchFileOptions
 		wantErr bool
 	}{
 		{"nil option", nil, false},
-		{"empty option", &BatchFileOption{}, false},
-		{"with name", &BatchFileOption{Name: "test.jar"}, false},
+		{"empty option", &BatchFileOptions{}, false},
+		{"with name", &BatchFileOptions{Name: "test.jar"}, false},
 	}
 
 	for _, tt := range tests {
@@ -154,14 +154,14 @@ func TestBatchService_ValidateProjectOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *BatchProjectOption
+		opt     *BatchProjectOptions
 		wantErr bool
 	}{
 		{"nil option", nil, false},
-		{"empty option", &BatchProjectOption{}, true},
-		{"with key", &BatchProjectOption{Key: "my-project"}, false},
-		{"with branch", &BatchProjectOption{Key: "my-project", Branch: "main"}, false},
-		{"with pull request", &BatchProjectOption{Key: "my-project", PullRequest: "123"}, false},
+		{"empty option", &BatchProjectOptions{}, true},
+		{"with key", &BatchProjectOptions{Key: "my-project"}, false},
+		{"with branch", &BatchProjectOptions{Key: "my-project", Branch: "main"}, false},
+		{"with pull request", &BatchProjectOptions{Key: "my-project", PullRequest: "123"}, false},
 	}
 
 	for _, tt := range tests {

--- a/sonar/ce_service.go
+++ b/sonar/ce_service.go
@@ -255,10 +255,10 @@ type CeWorkerCount struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// CeActivityOption contains parameters for the Activity method.
+// CeActivityOptions contains parameters for the Activity method.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type CeActivityOption struct {
+type CeActivityOptions struct {
 	CePaginationArgs
 
 	// Component is the key of the component (project) to filter on.
@@ -303,14 +303,14 @@ func (p *CePaginationArgs) Validate() error {
 	return nil
 }
 
-// CeActivityStatusOption contains parameters for the ActivityStatus method.
-type CeActivityStatusOption struct {
+// CeActivityStatusOptions contains parameters for the ActivityStatus method.
+type CeActivityStatusOptions struct {
 	// Component is the key of the component (project) to filter on.
 	Component string `url:"component,omitempty"`
 }
 
-// CeAnalysisStatusOption contains parameters for the AnalysisStatus method.
-type CeAnalysisStatusOption struct {
+// CeAnalysisStatusOptions contains parameters for the AnalysisStatus method.
+type CeAnalysisStatusOptions struct {
 	// Branch is the branch key.
 	Branch string `url:"branch,omitempty"`
 	// Component is the component key.
@@ -320,22 +320,22 @@ type CeAnalysisStatusOption struct {
 	PullRequest string `url:"pullRequest,omitempty"`
 }
 
-// CeCancelOption contains parameters for the Cancel method.
-type CeCancelOption struct {
+// CeCancelOptions contains parameters for the Cancel method.
+type CeCancelOptions struct {
 	// ID is the ID of the task to cancel.
 	// This field is required.
 	ID string `url:"id"`
 }
 
-// CeComponentOption contains parameters for the Component method.
-type CeComponentOption struct {
+// CeComponentOptions contains parameters for the Component method.
+type CeComponentOptions struct {
 	// Component is the component key.
 	// This field is required.
 	Component string `url:"component"`
 }
 
-// CeDismissAnalysisWarningOption contains parameters for the DismissAnalysisWarning method.
-type CeDismissAnalysisWarningOption struct {
+// CeDismissAnalysisWarningOptions contains parameters for the DismissAnalysisWarning method.
+type CeDismissAnalysisWarningOptions struct {
 	// Component is the key of the project.
 	// This field is required.
 	Component string `url:"component"`
@@ -344,10 +344,10 @@ type CeDismissAnalysisWarningOption struct {
 	Warning string `url:"warning"`
 }
 
-// CeSubmitOption contains parameters for the Submit method.
+// CeSubmitOptions contains parameters for the Submit method.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type CeSubmitOption struct {
+type CeSubmitOptions struct {
 	// Characteristics contains optional characteristics of the analysis.
 	// Can contain multiple key=value pairs.
 	Characteristics []string `url:"characteristic,omitempty,comma"`
@@ -362,10 +362,10 @@ type CeSubmitOption struct {
 	Report string `url:"report"`
 }
 
-// CeTaskOption contains parameters for the Task method.
+// CeTaskOptions contains parameters for the Task method.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type CeTaskOption struct {
+type CeTaskOptions struct {
 	// AdditionalFields is a list of optional fields to be returned in response.
 	// Allowed values: stacktrace, scannerContext, warnings.
 	AdditionalFields []string `url:"additionalFields,omitempty,comma"`
@@ -379,7 +379,7 @@ type CeTaskOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateActivityOpt validates the options for the Activity method.
-func (s *CeService) ValidateActivityOpt(opt *CeActivityOption) error {
+func (s *CeService) ValidateActivityOpt(opt *CeActivityOptions) error {
 	if opt == nil {
 		// Activity with no options is valid
 		return nil
@@ -408,13 +408,13 @@ func (s *CeService) ValidateActivityOpt(opt *CeActivityOption) error {
 }
 
 // ValidateActivityStatusOpt validates the options for the ActivityStatus method.
-func (s *CeService) ValidateActivityStatusOpt(opt *CeActivityStatusOption) error {
+func (s *CeService) ValidateActivityStatusOpt(opt *CeActivityStatusOptions) error {
 	// Options are optional; nothing to validate.
 	return nil
 }
 
 // ValidateAnalysisStatusOpt validates the options for the AnalysisStatus method.
-func (s *CeService) ValidateAnalysisStatusOpt(opt *CeAnalysisStatusOption) error {
+func (s *CeService) ValidateAnalysisStatusOpt(opt *CeAnalysisStatusOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -428,7 +428,7 @@ func (s *CeService) ValidateAnalysisStatusOpt(opt *CeAnalysisStatusOption) error
 }
 
 // ValidateCancelOpt validates the options for the Cancel method.
-func (s *CeService) ValidateCancelOpt(opt *CeCancelOption) error {
+func (s *CeService) ValidateCancelOpt(opt *CeCancelOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -442,7 +442,7 @@ func (s *CeService) ValidateCancelOpt(opt *CeCancelOption) error {
 }
 
 // ValidateComponentOpt validates the options for the Component method.
-func (s *CeService) ValidateComponentOpt(opt *CeComponentOption) error {
+func (s *CeService) ValidateComponentOpt(opt *CeComponentOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -456,7 +456,7 @@ func (s *CeService) ValidateComponentOpt(opt *CeComponentOption) error {
 }
 
 // ValidateDismissAnalysisWarningOpt validates the options for the DismissAnalysisWarning method.
-func (s *CeService) ValidateDismissAnalysisWarningOpt(opt *CeDismissAnalysisWarningOption) error {
+func (s *CeService) ValidateDismissAnalysisWarningOpt(opt *CeDismissAnalysisWarningOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -475,7 +475,7 @@ func (s *CeService) ValidateDismissAnalysisWarningOpt(opt *CeDismissAnalysisWarn
 }
 
 // ValidateSubmitOpt validates the options for the Submit method.
-func (s *CeService) ValidateSubmitOpt(opt *CeSubmitOption) error {
+func (s *CeService) ValidateSubmitOpt(opt *CeSubmitOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -499,7 +499,7 @@ func (s *CeService) ValidateSubmitOpt(opt *CeSubmitOption) error {
 }
 
 // ValidateTaskOpt validates the options for the Task method.
-func (s *CeService) ValidateTaskOpt(opt *CeTaskOption) error {
+func (s *CeService) ValidateTaskOpt(opt *CeTaskOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -529,7 +529,7 @@ func (s *CeService) ValidateTaskOpt(opt *CeTaskOption) error {
 //
 // API endpoint: GET /api/ce/activity.
 // Since: 5.2.
-func (s *CeService) Activity(opt *CeActivityOption) (*CeActivity, *http.Response, error) {
+func (s *CeService) Activity(opt *CeActivityOptions) (*CeActivity, *http.Response, error) {
 	err := s.ValidateActivityOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -555,7 +555,7 @@ func (s *CeService) Activity(opt *CeActivityOption) (*CeActivity, *http.Response
 //
 // API endpoint: GET /api/ce/activity_status.
 // Since: 5.5.
-func (s *CeService) ActivityStatus(opt *CeActivityStatusOption) (*CeActivityStatus, *http.Response, error) {
+func (s *CeService) ActivityStatus(opt *CeActivityStatusOptions) (*CeActivityStatus, *http.Response, error) {
 	err := s.ValidateActivityStatusOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -581,7 +581,7 @@ func (s *CeService) ActivityStatus(opt *CeActivityStatusOption) (*CeActivityStat
 //
 // API endpoint: GET /api/ce/analysis_status.
 // Since: 7.4.
-func (s *CeService) AnalysisStatus(opt *CeAnalysisStatusOption) (*CeAnalysisStatus, *http.Response, error) {
+func (s *CeService) AnalysisStatus(opt *CeAnalysisStatusOptions) (*CeAnalysisStatus, *http.Response, error) {
 	err := s.ValidateAnalysisStatusOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -608,7 +608,7 @@ func (s *CeService) AnalysisStatus(opt *CeAnalysisStatusOption) (*CeAnalysisStat
 //
 // API endpoint: POST /api/ce/cancel.
 // Since: 5.2.
-func (s *CeService) Cancel(opt *CeCancelOption) (*http.Response, error) {
+func (s *CeService) Cancel(opt *CeCancelOptions) (*http.Response, error) {
 	err := s.ValidateCancelOpt(opt)
 	if err != nil {
 		return nil, err
@@ -652,7 +652,7 @@ func (s *CeService) CancelAll() (*http.Response, error) {
 //
 // API endpoint: GET /api/ce/component.
 // Since: 5.2.
-func (s *CeService) Component(opt *CeComponentOption) (*CeComponent, *http.Response, error) {
+func (s *CeService) Component(opt *CeComponentOptions) (*CeComponent, *http.Response, error) {
 	err := s.ValidateComponentOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -678,7 +678,7 @@ func (s *CeService) Component(opt *CeComponentOption) (*CeComponent, *http.Respo
 //
 // API endpoint: POST /api/ce/dismiss_analysis_warning.
 // Since: 8.5.
-func (s *CeService) DismissAnalysisWarning(opt *CeDismissAnalysisWarningOption) (*http.Response, error) {
+func (s *CeService) DismissAnalysisWarning(opt *CeDismissAnalysisWarningOptions) (*http.Response, error) {
 	err := s.ValidateDismissAnalysisWarningOpt(opt)
 	if err != nil {
 		return nil, err
@@ -782,7 +782,7 @@ func (s *CeService) Resume() (*http.Response, error) {
 //
 // API endpoint: POST /api/ce/submit.
 // Since: 5.2.
-func (s *CeService) Submit(opt *CeSubmitOption) (*CeSubmit, *http.Response, error) {
+func (s *CeService) Submit(opt *CeSubmitOptions) (*CeSubmit, *http.Response, error) {
 	err := s.ValidateSubmitOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -809,7 +809,7 @@ func (s *CeService) Submit(opt *CeSubmitOption) (*CeSubmit, *http.Response, erro
 //
 // API endpoint: GET /api/ce/task.
 // Since: 5.2.
-func (s *CeService) Task(opt *CeTaskOption) (*CeTaskDetails, *http.Response, error) {
+func (s *CeService) Task(opt *CeTaskOptions) (*CeTaskDetails, *http.Response, error) {
 	err := s.ValidateTaskOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/ce_service_test.go
+++ b/sonar/ce_service_test.go
@@ -49,7 +49,7 @@ func TestCe_Activity(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &CeActivityOption{
+	opt := &CeActivityOptions{
 		Component: "my-project",
 		Statuses:  []string{"SUCCESS"},
 	}
@@ -85,7 +85,7 @@ func TestCe_Activity_WithPagination(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &CeActivityOption{
+	opt := &CeActivityOptions{
 		CePaginationArgs: CePaginationArgs{
 			Page:     2,
 			PageSize: 50,
@@ -119,27 +119,27 @@ func TestCe_Activity_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *CeActivityOption
+		opt  *CeActivityOptions
 	}{
 		{
 			name: "invalid status",
-			opt:  &CeActivityOption{Statuses: []string{"INVALID_STATUS"}},
+			opt:  &CeActivityOptions{Statuses: []string{"INVALID_STATUS"}},
 		},
 		{
 			name: "invalid type",
-			opt:  &CeActivityOption{Type: "INVALID_TYPE"},
+			opt:  &CeActivityOptions{Type: "INVALID_TYPE"},
 		},
 		{
 			name: "page size too large",
-			opt:  &CeActivityOption{CePaginationArgs: CePaginationArgs{PageSize: 1001}},
+			opt:  &CeActivityOptions{CePaginationArgs: CePaginationArgs{PageSize: 1001}},
 		},
 		{
 			name: "page size too small",
-			opt:  &CeActivityOption{CePaginationArgs: CePaginationArgs{PageSize: 0}},
+			opt:  &CeActivityOptions{CePaginationArgs: CePaginationArgs{PageSize: 0}},
 		},
 		{
 			name: "page too small",
-			opt:  &CeActivityOption{CePaginationArgs: CePaginationArgs{Page: 0}},
+			opt:  &CeActivityOptions{CePaginationArgs: CePaginationArgs{Page: 0}},
 		},
 	}
 
@@ -169,7 +169,7 @@ func TestCe_ActivityStatus(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &CeActivityStatusOption{
+	opt := &CeActivityStatusOptions{
 		Component: "my-project",
 	}
 
@@ -224,7 +224,7 @@ func TestCe_AnalysisStatus(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &CeAnalysisStatusOption{
+	opt := &CeAnalysisStatusOptions{
 		Component: "my-project",
 		Branch:    "main",
 	}
@@ -247,7 +247,7 @@ func TestCe_AnalysisStatus_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Component should fail validation.
-	_, _, err = client.Ce.AnalysisStatus(&CeAnalysisStatusOption{})
+	_, _, err = client.Ce.AnalysisStatus(&CeAnalysisStatusOptions{})
 	assert.Error(t, err)
 }
 
@@ -262,7 +262,7 @@ func TestCe_Cancel(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &CeCancelOption{
+	opt := &CeCancelOptions{
 		ID: "task-123",
 	}
 
@@ -279,7 +279,7 @@ func TestCe_Cancel_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing ID should fail validation.
-	_, err = client.Ce.Cancel(&CeCancelOption{})
+	_, err = client.Ce.Cancel(&CeCancelOptions{})
 	assert.Error(t, err)
 }
 
@@ -322,7 +322,7 @@ func TestCe_Component(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &CeComponentOption{
+	opt := &CeComponentOptions{
 		Component: "my-project",
 	}
 
@@ -345,7 +345,7 @@ func TestCe_Component_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Component should fail validation.
-	_, _, err = client.Ce.Component(&CeComponentOption{})
+	_, _, err = client.Ce.Component(&CeComponentOptions{})
 	assert.Error(t, err)
 }
 
@@ -361,7 +361,7 @@ func TestCe_DismissAnalysisWarning(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &CeDismissAnalysisWarningOption{
+	opt := &CeDismissAnalysisWarningOptions{
 		Component: "my-project",
 		Warning:   "warning-key-1",
 	}
@@ -376,7 +376,7 @@ func TestCe_DismissAnalysisWarning_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *CeDismissAnalysisWarningOption
+		opt  *CeDismissAnalysisWarningOptions
 	}{
 		{
 			name: "nil option",
@@ -384,11 +384,11 @@ func TestCe_DismissAnalysisWarning_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing component",
-			opt:  &CeDismissAnalysisWarningOption{Warning: "warning-key"},
+			opt:  &CeDismissAnalysisWarningOptions{Warning: "warning-key"},
 		},
 		{
 			name: "missing warning",
-			opt:  &CeDismissAnalysisWarningOption{Component: "my-project"},
+			opt:  &CeDismissAnalysisWarningOptions{Component: "my-project"},
 		},
 	}
 
@@ -472,7 +472,7 @@ func TestCe_Submit(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &CeSubmitOption{
+	opt := &CeSubmitOptions{
 		ProjectKey:  "my-project",
 		ProjectName: "My Project",
 		Report:      "base64-encoded-report",
@@ -491,7 +491,7 @@ func TestCe_Submit_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *CeSubmitOption
+		opt  *CeSubmitOptions
 	}{
 		{
 			name: "nil option",
@@ -499,15 +499,15 @@ func TestCe_Submit_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing project key",
-			opt:  &CeSubmitOption{Report: "report"},
+			opt:  &CeSubmitOptions{Report: "report"},
 		},
 		{
 			name: "missing report",
-			opt:  &CeSubmitOption{ProjectKey: "my-project"},
+			opt:  &CeSubmitOptions{ProjectKey: "my-project"},
 		},
 		{
 			name: "project key too long",
-			opt: &CeSubmitOption{
+			opt: &CeSubmitOptions{
 				ProjectKey: string(make([]byte, 401)),
 				Report:     "report",
 			},
@@ -550,7 +550,7 @@ func TestCe_Task(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &CeTaskOption{
+	opt := &CeTaskOptions{
 		ID:               "task-123",
 		AdditionalFields: []string{"stacktrace"},
 	}
@@ -572,7 +572,7 @@ func TestCe_Task_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *CeTaskOption
+		opt  *CeTaskOptions
 	}{
 		{
 			name: "nil option",
@@ -580,11 +580,11 @@ func TestCe_Task_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing id",
-			opt:  &CeTaskOption{},
+			opt:  &CeTaskOptions{},
 		},
 		{
 			name: "invalid additional field",
-			opt:  &CeTaskOption{ID: "task-123", AdditionalFields: []string{"invalid"}},
+			opt:  &CeTaskOptions{ID: "task-123", AdditionalFields: []string{"invalid"}},
 		},
 	}
 
@@ -686,7 +686,7 @@ func TestCe_ValidateActivityOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *CeActivityOption
+		opt     *CeActivityOptions
 		wantErr bool
 	}{
 		{
@@ -696,40 +696,40 @@ func TestCe_ValidateActivityOpt(t *testing.T) {
 		},
 		{
 			name:    "empty option is valid",
-			opt:     &CeActivityOption{},
+			opt:     &CeActivityOptions{},
 			wantErr: false,
 		},
 		{
 			name: "valid statuses",
-			opt: &CeActivityOption{
+			opt: &CeActivityOptions{
 				Statuses: []string{"SUCCESS", "FAILED"},
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalid status",
-			opt: &CeActivityOption{
+			opt: &CeActivityOptions{
 				Statuses: []string{"SUCCESS", "INVALID"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "valid type",
-			opt: &CeActivityOption{
+			opt: &CeActivityOptions{
 				Type: "REPORT",
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalid type",
-			opt: &CeActivityOption{
+			opt: &CeActivityOptions{
 				Type: "INVALID_TYPE",
 			},
 			wantErr: true,
 		},
 		{
 			name: "valid all fields",
-			opt: &CeActivityOption{
+			opt: &CeActivityOptions{
 				Component:    "my-project",
 				Statuses:     []string{"SUCCESS", "FAILED", "PENDING"},
 				Type:         "REPORT",
@@ -760,7 +760,7 @@ func TestCe_ValidateTaskOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *CeTaskOption
+		opt     *CeTaskOptions
 		wantErr bool
 	}{
 		{
@@ -770,19 +770,19 @@ func TestCe_ValidateTaskOpt(t *testing.T) {
 		},
 		{
 			name:    "missing id is invalid",
-			opt:     &CeTaskOption{},
+			opt:     &CeTaskOptions{},
 			wantErr: true,
 		},
 		{
 			name: "valid with id only",
-			opt: &CeTaskOption{
+			opt: &CeTaskOptions{
 				ID: "task-123",
 			},
 			wantErr: false,
 		},
 		{
 			name: "valid with all additional fields",
-			opt: &CeTaskOption{
+			opt: &CeTaskOptions{
 				ID:               "task-123",
 				AdditionalFields: []string{"stacktrace", "scannerContext", "warnings"},
 			},
@@ -790,7 +790,7 @@ func TestCe_ValidateTaskOpt(t *testing.T) {
 		},
 		{
 			name: "invalid additional field",
-			opt: &CeTaskOption{
+			opt: &CeTaskOptions{
 				ID:               "task-123",
 				AdditionalFields: []string{"invalid"},
 			},

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -100,9 +100,9 @@ type ServicesV2 struct {
 	UsersManagement *UsersManagementService
 }
 
-// ClientCreateOption contains options for creating a new Client.
+// ClientCreateOptions contains options for creating a new Client.
 // Everything is optional and will not throw an error if not provided.
-type ClientCreateOption struct {
+type ClientCreateOptions struct {
 	// URL is the base API URL for the SonarQube instance.
 	URL *string
 	// Username is the username for basic authentication.
@@ -129,7 +129,7 @@ type ClientOptionFunc func(*Client) error
 // provided via options.
 //
 //nolint:exhaustruct // Fields initialized dynamically via options and initServices
-func NewClient(createOpts *ClientCreateOption, options ...ClientOptionFunc) (*Client, error) {
+func NewClient(createOpts *ClientCreateOptions, options ...ClientOptionFunc) (*Client, error) {
 	client := &Client{}
 
 	err := applyCreateOptions(client, createOpts)
@@ -153,7 +153,7 @@ func NewClient(createOpts *ClientCreateOption, options ...ClientOptionFunc) (*Cl
 }
 
 // applyCreateOptions applies initial configuration options to the client.
-func applyCreateOptions(client *Client, createOpts *ClientCreateOption) error {
+func applyCreateOptions(client *Client, createOpts *ClientCreateOptions) error {
 	if createOpts == nil {
 		return nil
 	}

--- a/sonar/client_test.go
+++ b/sonar/client_test.go
@@ -49,7 +49,7 @@ func TestNewClient_WithCreateOptions(t *testing.T) {
 	url := "http://example.com/api/"
 	token := "my-token"
 
-	client, err := NewClient(&ClientCreateOption{
+	client, err := NewClient(&ClientCreateOptions{
 		URL:   &url,
 		Token: &token,
 	})

--- a/sonar/components_service.go
+++ b/sonar/components_service.go
@@ -402,8 +402,8 @@ type ComponentsTree struct {
 // Option Types
 // =============================================================================
 
-// ComponentsAppOption contains parameters for the App method.
-type ComponentsAppOption struct {
+// ComponentsAppOptions contains parameters for the App method.
+type ComponentsAppOptions struct {
 	// Branch is the branch key. Not available in the community edition.
 	// Either branch or pullRequest can be provided, not both.
 	Branch string `url:"branch,omitempty"`
@@ -415,10 +415,10 @@ type ComponentsAppOption struct {
 	PullRequest string `url:"pullRequest,omitempty"`
 }
 
-// ComponentsSearchOption contains parameters for the Search method.
+// ComponentsSearchOptions contains parameters for the Search method.
 //
 //nolint:govet // Field order maintained for API parameter consistency
-type ComponentsSearchOption struct {
+type ComponentsSearchOptions struct {
 	// PaginationArgs contains the pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -433,10 +433,10 @@ type ComponentsSearchOption struct {
 	Qualifiers []string `url:"qualifiers,comma"`
 }
 
-// ComponentsSearchProjectsOption contains parameters for the SearchProjects method.
+// ComponentsSearchProjectsOptions contains parameters for the SearchProjects method.
 //
 //nolint:govet // Field order maintained for API parameter consistency
-type ComponentsSearchProjectsOption struct {
+type ComponentsSearchProjectsOptions struct {
 	// PaginationArgs contains the pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -458,8 +458,8 @@ type ComponentsSearchProjectsOption struct {
 	Sort string `url:"s,omitempty"`
 }
 
-// ComponentsShowOption contains parameters for the Show method.
-type ComponentsShowOption struct {
+// ComponentsShowOptions contains parameters for the Show method.
+type ComponentsShowOptions struct {
 	// Branch is the branch key. Not available in the community edition.
 	Branch string `url:"branch,omitempty"`
 	// Component is the component key.
@@ -469,10 +469,10 @@ type ComponentsShowOption struct {
 	PullRequest string `url:"pullRequest,omitempty"`
 }
 
-// ComponentsSuggestionsOption contains parameters for the Suggestions method.
+// ComponentsSuggestionsOptions contains parameters for the Suggestions method.
 //
 //nolint:govet // Field order maintained for API parameter consistency
-type ComponentsSuggestionsOption struct {
+type ComponentsSuggestionsOptions struct {
 	// More is the category for which to display the next 20 results.
 	// Allowed values: VW, SVW, APP, TRK.
 	More string `url:"more,omitempty"`
@@ -484,10 +484,10 @@ type ComponentsSuggestionsOption struct {
 	Search string `url:"s,omitempty"`
 }
 
-// ComponentsTreeOption contains parameters for the Tree method.
+// ComponentsTreeOptions contains parameters for the Tree method.
 //
 //nolint:govet // Field order maintained for API parameter consistency
-type ComponentsTreeOption struct {
+type ComponentsTreeOptions struct {
 	// PaginationArgs contains the pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -523,7 +523,7 @@ type ComponentsTreeOption struct {
 // =============================================================================
 
 // ValidateAppOpt validates the options for the App method.
-func (s *ComponentsService) ValidateAppOpt(opt *ComponentsAppOption) error {
+func (s *ComponentsService) ValidateAppOpt(opt *ComponentsAppOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -541,7 +541,7 @@ func (s *ComponentsService) ValidateAppOpt(opt *ComponentsAppOption) error {
 }
 
 // ValidateSearchOpt validates the options for the Search method.
-func (s *ComponentsService) ValidateSearchOpt(opt *ComponentsSearchOption) error {
+func (s *ComponentsService) ValidateSearchOpt(opt *ComponentsSearchOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -569,7 +569,7 @@ func (s *ComponentsService) ValidateSearchOpt(opt *ComponentsSearchOption) error
 }
 
 // ValidateSearchProjectsOpt validates the options for the SearchProjects method.
-func (s *ComponentsService) ValidateSearchProjectsOpt(opt *ComponentsSearchProjectsOption) error {
+func (s *ComponentsService) ValidateSearchProjectsOpt(opt *ComponentsSearchProjectsOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -603,7 +603,7 @@ func (s *ComponentsService) ValidateSearchProjectsOpt(opt *ComponentsSearchProje
 }
 
 // ValidateShowOpt validates the options for the Show method.
-func (s *ComponentsService) ValidateShowOpt(opt *ComponentsShowOption) error {
+func (s *ComponentsService) ValidateShowOpt(opt *ComponentsShowOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -621,7 +621,7 @@ func (s *ComponentsService) ValidateShowOpt(opt *ComponentsShowOption) error {
 }
 
 // ValidateSuggestionsOpt validates the options for the Suggestions method.
-func (s *ComponentsService) ValidateSuggestionsOpt(opt *ComponentsSuggestionsOption) error {
+func (s *ComponentsService) ValidateSuggestionsOpt(opt *ComponentsSuggestionsOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -644,7 +644,7 @@ func (s *ComponentsService) ValidateSuggestionsOpt(opt *ComponentsSuggestionsOpt
 }
 
 // ValidateTreeOpt validates the options for the Tree method.
-func (s *ComponentsService) ValidateTreeOpt(opt *ComponentsTreeOption) error {
+func (s *ComponentsService) ValidateTreeOpt(opt *ComponentsTreeOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -697,7 +697,7 @@ func (s *ComponentsService) ValidateTreeOpt(opt *ComponentsTreeOption) error {
 // This is an internal API and may change without notice.
 //
 // Since: 4.4.
-func (s *ComponentsService) App(opt *ComponentsAppOption) (*ComponentsApp, *http.Response, error) {
+func (s *ComponentsService) App(opt *ComponentsAppOptions) (*ComponentsApp, *http.Response, error) {
 	err := s.ValidateAppOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -721,7 +721,7 @@ func (s *ComponentsService) App(opt *ComponentsAppOption) (*ComponentsApp, *http
 // Search searches for components.
 //
 // Since: 6.3.
-func (s *ComponentsService) Search(opt *ComponentsSearchOption) (*ComponentsSearch, *http.Response, error) {
+func (s *ComponentsService) Search(opt *ComponentsSearchOptions) (*ComponentsSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -747,7 +747,7 @@ func (s *ComponentsService) Search(opt *ComponentsSearchOption) (*ComponentsSear
 // This is an internal API and may change without notice.
 //
 // Since: 6.2.
-func (s *ComponentsService) SearchProjects(opt *ComponentsSearchProjectsOption) (*ComponentsSearchProjects, *http.Response, error) {
+func (s *ComponentsService) SearchProjects(opt *ComponentsSearchProjectsOptions) (*ComponentsSearchProjects, *http.Response, error) {
 	err := s.ValidateSearchProjectsOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -773,7 +773,7 @@ func (s *ComponentsService) SearchProjects(opt *ComponentsSearchProjectsOption) 
 // Requires the following permission: 'Browse' on the project of the specified component.
 //
 // Since: 5.4.
-func (s *ComponentsService) Show(opt *ComponentsShowOption) (*ComponentsShow, *http.Response, error) {
+func (s *ComponentsService) Show(opt *ComponentsShowOptions) (*ComponentsShow, *http.Response, error) {
 	err := s.ValidateShowOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -802,7 +802,7 @@ func (s *ComponentsService) Show(opt *ComponentsShowOption) (*ComponentsShow, *h
 // This is an internal API and may change without notice.
 //
 // Since: 4.2.
-func (s *ComponentsService) Suggestions(opt *ComponentsSuggestionsOption) (*ComponentsSuggestions, *http.Response, error) {
+func (s *ComponentsService) Suggestions(opt *ComponentsSuggestionsOptions) (*ComponentsSuggestions, *http.Response, error) {
 	err := s.ValidateSuggestionsOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -828,7 +828,7 @@ func (s *ComponentsService) Suggestions(opt *ComponentsSuggestionsOption) (*Comp
 // When limiting search with the q parameter, directories are not returned.
 //
 // Since: 5.4.
-func (s *ComponentsService) Tree(opt *ComponentsTreeOption) (*ComponentsTree, *http.Response, error) {
+func (s *ComponentsService) Tree(opt *ComponentsTreeOptions) (*ComponentsTree, *http.Response, error) {
 	err := s.ValidateTreeOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/components_service_test.go
+++ b/sonar/components_service_test.go
@@ -40,7 +40,7 @@ func TestComponents_App(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Components.App(&ComponentsAppOption{
+	result, resp, err := client.Components.App(&ComponentsAppOptions{
 		Component: "my_project:src/file.go",
 		Branch:    "feature/my_branch",
 	})
@@ -55,7 +55,7 @@ func TestComponents_App_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *ComponentsAppOption
+		opt  *ComponentsAppOptions
 	}{
 		{
 			name: "nil option",
@@ -63,11 +63,11 @@ func TestComponents_App_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing component",
-			opt:  &ComponentsAppOption{Branch: "main"},
+			opt:  &ComponentsAppOptions{Branch: "main"},
 		},
 		{
 			name: "branch and pullRequest both set",
-			opt: &ComponentsAppOption{
+			opt: &ComponentsAppOptions{
 				Component:   "my_project",
 				Branch:      "main",
 				PullRequest: "123",
@@ -111,7 +111,7 @@ func TestComponents_Search(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Components.Search(&ComponentsSearchOption{
+	result, resp, err := client.Components.Search(&ComponentsSearchOptions{
 		Qualifiers: []string{"TRK"},
 		Query:      "sonar",
 	})
@@ -126,7 +126,7 @@ func TestComponents_Search_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *ComponentsSearchOption
+		opt  *ComponentsSearchOptions
 	}{
 		{
 			name: "nil option",
@@ -134,19 +134,19 @@ func TestComponents_Search_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing qualifiers",
-			opt:  &ComponentsSearchOption{Query: "test"},
+			opt:  &ComponentsSearchOptions{Query: "test"},
 		},
 		{
 			name: "empty qualifiers slice",
-			opt:  &ComponentsSearchOption{Qualifiers: []string{}},
+			opt:  &ComponentsSearchOptions{Qualifiers: []string{}},
 		},
 		{
 			name: "invalid qualifier",
-			opt:  &ComponentsSearchOption{Qualifiers: []string{"INVALID"}},
+			opt:  &ComponentsSearchOptions{Qualifiers: []string{"INVALID"}},
 		},
 		{
 			name: "query too short",
-			opt: &ComponentsSearchOption{
+			opt: &ComponentsSearchOptions{
 				Qualifiers: []string{"TRK"},
 				Query:      "a",
 			},
@@ -201,7 +201,7 @@ func TestComponents_SearchProjects(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Components.SearchProjects(&ComponentsSearchProjectsOption{
+	result, resp, err := client.Components.SearchProjects(&ComponentsSearchProjectsOptions{
 		Facets: []string{"alert_status"},
 		Filter: "coverage >= 80",
 	})
@@ -217,7 +217,7 @@ func TestComponents_SearchProjects_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *ComponentsSearchProjectsOption
+		opt  *ComponentsSearchProjectsOptions
 	}{
 		{
 			name: "nil option",
@@ -225,19 +225,19 @@ func TestComponents_SearchProjects_ValidationError(t *testing.T) {
 		},
 		{
 			name: "invalid field",
-			opt:  &ComponentsSearchProjectsOption{Fields: []string{"invalid_field"}},
+			opt:  &ComponentsSearchProjectsOptions{Fields: []string{"invalid_field"}},
 		},
 		{
 			name: "invalid facet",
-			opt:  &ComponentsSearchProjectsOption{Facets: []string{"invalid_facet"}},
+			opt:  &ComponentsSearchProjectsOptions{Facets: []string{"invalid_facet"}},
 		},
 		{
 			name: "invalid sort field",
-			opt:  &ComponentsSearchProjectsOption{Sort: "invalid_sort"},
+			opt:  &ComponentsSearchProjectsOptions{Sort: "invalid_sort"},
 		},
 		{
 			name: "filter too short",
-			opt:  &ComponentsSearchProjectsOption{Filter: "a"},
+			opt:  &ComponentsSearchProjectsOptions{Filter: "a"},
 		},
 	}
 
@@ -286,7 +286,7 @@ func TestComponents_Show(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Components.Show(&ComponentsShowOption{
+	result, resp, err := client.Components.Show(&ComponentsShowOptions{
 		Component: "my_project:src/file.go",
 	})
 	require.NoError(t, err)
@@ -301,7 +301,7 @@ func TestComponents_Show_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *ComponentsShowOption
+		opt  *ComponentsShowOptions
 	}{
 		{
 			name: "nil option",
@@ -309,7 +309,7 @@ func TestComponents_Show_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing component",
-			opt:  &ComponentsShowOption{Branch: "main"},
+			opt:  &ComponentsShowOptions{Branch: "main"},
 		},
 	}
 
@@ -353,7 +353,7 @@ func TestComponents_Suggestions(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Components.Suggestions(&ComponentsSuggestionsOption{
+	result, resp, err := client.Components.Suggestions(&ComponentsSuggestionsOptions{
 		Search: "sonar",
 	})
 	require.NoError(t, err)
@@ -368,7 +368,7 @@ func TestComponents_Suggestions_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *ComponentsSuggestionsOption
+		opt  *ComponentsSuggestionsOptions
 	}{
 		{
 			name: "nil option",
@@ -376,15 +376,15 @@ func TestComponents_Suggestions_ValidationError(t *testing.T) {
 		},
 		{
 			name: "invalid more value",
-			opt:  &ComponentsSuggestionsOption{More: "INVALID"},
+			opt:  &ComponentsSuggestionsOptions{More: "INVALID"},
 		},
 		{
 			name: "search too short",
-			opt:  &ComponentsSuggestionsOption{Search: "a"},
+			opt:  &ComponentsSuggestionsOptions{Search: "a"},
 		},
 		{
 			name: "too many recently browsed items",
-			opt: &ComponentsSuggestionsOption{
+			opt: &ComponentsSuggestionsOptions{
 				RecentlyBrowsed: make([]string, MaxRecentlyBrowsedItems+1),
 			},
 		},
@@ -442,7 +442,7 @@ func TestComponents_Tree(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Components.Tree(&ComponentsTreeOption{
+	result, resp, err := client.Components.Tree(&ComponentsTreeOptions{
 		Component: "my_project",
 		Strategy:  "children",
 	})
@@ -470,7 +470,7 @@ func TestComponents_Tree_WithQualifiers(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	_, resp, err := client.Components.Tree(&ComponentsTreeOption{
+	_, resp, err := client.Components.Tree(&ComponentsTreeOptions{
 		Component:  "my_project",
 		Qualifiers: []string{"FIL", "UTS"},
 		Sort:       []string{"name", "path"},
@@ -484,7 +484,7 @@ func TestComponents_Tree_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *ComponentsTreeOption
+		opt  *ComponentsTreeOptions
 	}{
 		{
 			name: "nil option",
@@ -492,32 +492,32 @@ func TestComponents_Tree_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing component",
-			opt:  &ComponentsTreeOption{Strategy: "all"},
+			opt:  &ComponentsTreeOptions{Strategy: "all"},
 		},
 		{
 			name: "query too short",
-			opt: &ComponentsTreeOption{
+			opt: &ComponentsTreeOptions{
 				Component: "my_project",
 				Query:     "ab",
 			},
 		},
 		{
 			name: "invalid qualifier",
-			opt: &ComponentsTreeOption{
+			opt: &ComponentsTreeOptions{
 				Component:  "my_project",
 				Qualifiers: []string{"INVALID"},
 			},
 		},
 		{
 			name: "invalid sort field",
-			opt: &ComponentsTreeOption{
+			opt: &ComponentsTreeOptions{
 				Component: "my_project",
 				Sort:      []string{"invalid"},
 			},
 		},
 		{
 			name: "invalid strategy",
-			opt: &ComponentsTreeOption{
+			opt: &ComponentsTreeOptions{
 				Component: "my_project",
 				Strategy:  "invalid",
 			},
@@ -551,7 +551,7 @@ func TestComponents_Search_WithPagination(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, _, err := client.Components.Search(&ComponentsSearchOption{
+	result, _, err := client.Components.Search(&ComponentsSearchOptions{
 		Qualifiers: []string{"TRK"},
 		PaginationArgs: PaginationArgs{
 			Page:     2,
@@ -571,7 +571,7 @@ func TestComponents_Tree_AllowedQualifiers(t *testing.T) {
 
 	validQualifiers := []string{"UTS", "FIL", "DIR", "TRK"}
 	for _, q := range validQualifiers {
-		opt := &ComponentsTreeOption{
+		opt := &ComponentsTreeOptions{
 			Component:  "my_project",
 			Qualifiers: []string{q},
 		}
@@ -585,7 +585,7 @@ func TestComponents_Tree_AllowedStrategies(t *testing.T) {
 
 	validStrategies := []string{"all", "children", "leaves"}
 	for _, s := range validStrategies {
-		opt := &ComponentsTreeOption{
+		opt := &ComponentsTreeOptions{
 			Component: "my_project",
 			Strategy:  s,
 		}
@@ -599,7 +599,7 @@ func TestComponents_Tree_AllowedSortFields(t *testing.T) {
 
 	validSortFields := []string{"name", "path", "qualifier"}
 	for _, s := range validSortFields {
-		opt := &ComponentsTreeOption{
+		opt := &ComponentsTreeOptions{
 			Component: "my_project",
 			Sort:      []string{s},
 		}
@@ -613,7 +613,7 @@ func TestComponents_Suggestions_AllowedMore(t *testing.T) {
 
 	validMoreValues := []string{"VW", "SVW", "APP", "TRK"}
 	for _, m := range validMoreValues {
-		opt := &ComponentsSuggestionsOption{
+		opt := &ComponentsSuggestionsOptions{
 			More: m,
 		}
 		err := client.Components.ValidateSuggestionsOpt(opt)
@@ -626,7 +626,7 @@ func TestComponents_SearchProjects_AllowedFields(t *testing.T) {
 
 	validFields := []string{"analysisDate", "leakPeriodDate", "_all"}
 	for _, f := range validFields {
-		opt := &ComponentsSearchProjectsOption{
+		opt := &ComponentsSearchProjectsOptions{
 			Fields: []string{f},
 		}
 		err := client.Components.ValidateSearchProjectsOpt(opt)

--- a/sonar/developers_service.go
+++ b/sonar/developers_service.go
@@ -36,8 +36,8 @@ type DeveloperEvent struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// DevelopersSearchEventsOption contains parameters for the SearchEvents method.
-type DevelopersSearchEventsOption struct {
+// DevelopersSearchEventsOptions contains parameters for the SearchEvents method.
+type DevelopersSearchEventsOptions struct {
 	// From is a list of datetimes.
 	// Filter events created after the given date (exclusive).
 	// This field is required.
@@ -52,7 +52,7 @@ type DevelopersSearchEventsOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateSearchEventsOpt validates the options for the SearchEvents method.
-func (s *DevelopersService) ValidateSearchEventsOpt(opt *DevelopersSearchEventsOption) error {
+func (s *DevelopersService) ValidateSearchEventsOpt(opt *DevelopersSearchEventsOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -78,7 +78,7 @@ func (s *DevelopersService) ValidateSearchEventsOpt(opt *DevelopersSearchEventsO
 //
 // API endpoint: GET /api/developers/search_events.
 // WARNING: This is an internal API and may change without notice.
-func (s *DevelopersService) SearchEvents(opt *DevelopersSearchEventsOption) (*DevelopersSearchEvents, *http.Response, error) {
+func (s *DevelopersService) SearchEvents(opt *DevelopersSearchEventsOptions) (*DevelopersSearchEvents, *http.Response, error) {
 	err := s.ValidateSearchEventsOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/developers_service_test.go
+++ b/sonar/developers_service_test.go
@@ -23,7 +23,7 @@ func TestDevelopers_SearchEvents(t *testing.T) {
 
 	client := newTestClient(t, server.url())
 
-	opt := &DevelopersSearchEventsOption{
+	opt := &DevelopersSearchEventsOptions{
 		From:     []string{"2017-10-19T13:00:00+0200"},
 		Projects: []string{"my-project"},
 	}
@@ -42,7 +42,7 @@ func TestDevelopers_SearchEvents(t *testing.T) {
 func TestDevelopers_SearchEvents_ValidationErrors(t *testing.T) {
 	tests := []struct {
 		name      string
-		opt       *DevelopersSearchEventsOption
+		opt       *DevelopersSearchEventsOptions
 		wantField string
 	}{
 		{
@@ -52,14 +52,14 @@ func TestDevelopers_SearchEvents_ValidationErrors(t *testing.T) {
 		},
 		{
 			name: "missing from",
-			opt: &DevelopersSearchEventsOption{
+			opt: &DevelopersSearchEventsOptions{
 				Projects: []string{"my-project"},
 			},
 			wantField: "From",
 		},
 		{
 			name: "missing projects",
-			opt: &DevelopersSearchEventsOption{
+			opt: &DevelopersSearchEventsOptions{
 				From: []string{"2017-10-19T13:00:00+0200"},
 			},
 			wantField: "Projects",
@@ -83,7 +83,7 @@ func TestDevelopers_SearchEvents_ValidationErrors(t *testing.T) {
 func TestDevelopers_ValidateSearchEventsOpt(t *testing.T) {
 	tests := []struct {
 		name      string
-		opt       *DevelopersSearchEventsOption
+		opt       *DevelopersSearchEventsOptions
 		wantErr   bool
 		wantField string
 	}{
@@ -95,7 +95,7 @@ func TestDevelopers_ValidateSearchEventsOpt(t *testing.T) {
 		},
 		{
 			name: "missing from",
-			opt: &DevelopersSearchEventsOption{
+			opt: &DevelopersSearchEventsOptions{
 				Projects: []string{"my-project"},
 			},
 			wantErr:   true,
@@ -103,7 +103,7 @@ func TestDevelopers_ValidateSearchEventsOpt(t *testing.T) {
 		},
 		{
 			name: "missing projects",
-			opt: &DevelopersSearchEventsOption{
+			opt: &DevelopersSearchEventsOptions{
 				From: []string{"2017-10-19T13:00:00+0200"},
 			},
 			wantErr:   true,
@@ -111,7 +111,7 @@ func TestDevelopers_ValidateSearchEventsOpt(t *testing.T) {
 		},
 		{
 			name: "valid option",
-			opt: &DevelopersSearchEventsOption{
+			opt: &DevelopersSearchEventsOptions{
 				From:     []string{"2017-10-19T13:00:00+0200"},
 				Projects: []string{"my-project"},
 			},
@@ -119,7 +119,7 @@ func TestDevelopers_ValidateSearchEventsOpt(t *testing.T) {
 		},
 		{
 			name: "valid with multiple values",
-			opt: &DevelopersSearchEventsOption{
+			opt: &DevelopersSearchEventsOptions{
 				From:     []string{"2017-10-19T13:00:00+0200", "2017-10-20T13:00:00+0200"},
 				Projects: []string{"my-project", "other-project"},
 			},

--- a/sonar/dismiss_message_service.go
+++ b/sonar/dismiss_message_service.go
@@ -24,8 +24,8 @@ type DismissMessageCheck struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// DismissMessageCheckOption contains parameters for the Check method.
-type DismissMessageCheckOption struct {
+// DismissMessageCheckOptions contains parameters for the Check method.
+type DismissMessageCheckOptions struct {
 	// MessageType is the type of the message to check.
 	// This field is required.
 	MessageType string `url:"messageType"`
@@ -34,8 +34,8 @@ type DismissMessageCheckOption struct {
 	ProjectKey string `url:"projectKey"`
 }
 
-// DismissMessageDismissOption contains parameters for the Dismiss method.
-type DismissMessageDismissOption struct {
+// DismissMessageDismissOptions contains parameters for the Dismiss method.
+type DismissMessageDismissOptions struct {
 	// MessageType is the type of the message to dismiss.
 	// This field is required.
 	MessageType string `url:"messageType"`
@@ -49,7 +49,7 @@ type DismissMessageDismissOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateCheckOpt validates the options for the Check method.
-func (s *DismissMessageService) ValidateCheckOpt(opt *DismissMessageCheckOption) error {
+func (s *DismissMessageService) ValidateCheckOpt(opt *DismissMessageCheckOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -68,7 +68,7 @@ func (s *DismissMessageService) ValidateCheckOpt(opt *DismissMessageCheckOption)
 }
 
 // ValidateDismissOpt validates the options for the Dismiss method.
-func (s *DismissMessageService) ValidateDismissOpt(opt *DismissMessageDismissOption) error {
+func (s *DismissMessageService) ValidateDismissOpt(opt *DismissMessageDismissOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -94,7 +94,7 @@ func (s *DismissMessageService) ValidateDismissOpt(opt *DismissMessageDismissOpt
 //
 // API endpoint: GET /api/dismiss_message/check.
 // Since: 10.2.
-func (s *DismissMessageService) Check(opt *DismissMessageCheckOption) (*DismissMessageCheck, *http.Response, error) {
+func (s *DismissMessageService) Check(opt *DismissMessageCheckOptions) (*DismissMessageCheck, *http.Response, error) {
 	err := s.ValidateCheckOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -119,7 +119,7 @@ func (s *DismissMessageService) Check(opt *DismissMessageCheckOption) (*DismissM
 //
 // API endpoint: POST /api/dismiss_message/dismiss.
 // Since: 10.2.
-func (s *DismissMessageService) Dismiss(opt *DismissMessageDismissOption) (*http.Response, error) {
+func (s *DismissMessageService) Dismiss(opt *DismissMessageDismissOptions) (*http.Response, error) {
 	err := s.ValidateDismissOpt(opt)
 	if err != nil {
 		return nil, err

--- a/sonar/dismiss_message_service_test.go
+++ b/sonar/dismiss_message_service_test.go
@@ -14,7 +14,7 @@ func TestDismissMessage_Check(t *testing.T) {
 	}))
 	client := newTestClient(t, server.url())
 
-	opt := &DismissMessageCheckOption{
+	opt := &DismissMessageCheckOptions{
 		MessageType: "INFO",
 		ProjectKey:  "my-project",
 	}
@@ -31,7 +31,7 @@ func TestDismissMessage_Check_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *DismissMessageCheckOption
+		opt  *DismissMessageCheckOptions
 	}{
 		{
 			name: "nil option",
@@ -39,13 +39,13 @@ func TestDismissMessage_Check_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing MessageType",
-			opt: &DismissMessageCheckOption{
+			opt: &DismissMessageCheckOptions{
 				ProjectKey: "my-project",
 			},
 		},
 		{
 			name: "missing ProjectKey",
-			opt: &DismissMessageCheckOption{
+			opt: &DismissMessageCheckOptions{
 				MessageType: "INFO",
 			},
 		},
@@ -63,7 +63,7 @@ func TestDismissMessage_Dismiss(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/dismiss_message/dismiss", http.StatusNoContent))
 	client := newTestClient(t, server.url())
 
-	opt := &DismissMessageDismissOption{
+	opt := &DismissMessageDismissOptions{
 		MessageType: "WARNING",
 		ProjectKey:  "my-project",
 	}
@@ -78,7 +78,7 @@ func TestDismissMessage_Dismiss_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *DismissMessageDismissOption
+		opt  *DismissMessageDismissOptions
 	}{
 		{
 			name: "nil option",
@@ -86,13 +86,13 @@ func TestDismissMessage_Dismiss_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing MessageType",
-			opt: &DismissMessageDismissOption{
+			opt: &DismissMessageDismissOptions{
 				ProjectKey: "my-project",
 			},
 		},
 		{
 			name: "missing ProjectKey",
-			opt: &DismissMessageDismissOption{
+			opt: &DismissMessageDismissOptions{
 				MessageType: "INFO",
 			},
 		},
@@ -111,12 +111,12 @@ func TestDismissMessage_ValidateCheckOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *DismissMessageCheckOption
+		opt     *DismissMessageCheckOptions
 		wantErr bool
 	}{
 		{
 			name: "valid option",
-			opt: &DismissMessageCheckOption{
+			opt: &DismissMessageCheckOptions{
 				MessageType: "INFO",
 				ProjectKey:  "my-project",
 			},
@@ -146,12 +146,12 @@ func TestDismissMessage_ValidateDismissOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *DismissMessageDismissOption
+		opt     *DismissMessageDismissOptions
 		wantErr bool
 	}{
 		{
 			name: "valid option",
-			opt: &DismissMessageDismissOption{
+			opt: &DismissMessageDismissOptions{
 				MessageType: "INFO",
 				ProjectKey:  "my-project",
 			},

--- a/sonar/duplications_service.go
+++ b/sonar/duplications_service.go
@@ -56,8 +56,8 @@ type DuplicatedFile struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// DuplicationsShowOption contains parameters for the Show method.
-type DuplicationsShowOption struct {
+// DuplicationsShowOptions contains parameters for the Show method.
+type DuplicationsShowOptions struct {
 	// Branch key.
 	// WARNING: This parameter is internal and may change without notice.
 	Branch string `url:"branch,omitempty"`
@@ -74,7 +74,7 @@ type DuplicationsShowOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateShowOpt validates the options for the Show method.
-func (s *DuplicationsService) ValidateShowOpt(opt *DuplicationsShowOption) error {
+func (s *DuplicationsService) ValidateShowOpt(opt *DuplicationsShowOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -96,7 +96,7 @@ func (s *DuplicationsService) ValidateShowOpt(opt *DuplicationsShowOption) error
 //
 // API endpoint: GET /api/duplications/show.
 // Since: 4.4.
-func (s *DuplicationsService) Show(opt *DuplicationsShowOption) (*DuplicationsShow, *http.Response, error) {
+func (s *DuplicationsService) Show(opt *DuplicationsShowOptions) (*DuplicationsShow, *http.Response, error) {
 	err := s.ValidateShowOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/duplications_service_test.go
+++ b/sonar/duplications_service_test.go
@@ -26,7 +26,7 @@ func TestDuplications_Show(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/duplications/show", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	opt := &DuplicationsShowOption{
+	opt := &DuplicationsShowOptions{
 		Key: "com.example:MyFile.java",
 	}
 
@@ -50,7 +50,7 @@ func TestDuplications_Show_WithBranch(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/duplications/show", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	opt := &DuplicationsShowOption{
+	opt := &DuplicationsShowOptions{
 		Key:    "com.example:MyFile.java",
 		Branch: "feature",
 	}
@@ -65,7 +65,7 @@ func TestDuplications_Show_WithPullRequest(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/duplications/show", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	opt := &DuplicationsShowOption{
+	opt := &DuplicationsShowOptions{
 		Key:         "com.example:MyFile.java",
 		PullRequest: "123",
 	}
@@ -80,7 +80,7 @@ func TestDuplications_Show_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *DuplicationsShowOption
+		opt  *DuplicationsShowOptions
 	}{
 		{
 			name: "nil option",
@@ -88,7 +88,7 @@ func TestDuplications_Show_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing Key",
-			opt:  &DuplicationsShowOption{},
+			opt:  &DuplicationsShowOptions{},
 		},
 	}
 
@@ -105,12 +105,12 @@ func TestDuplications_ValidateShowOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *DuplicationsShowOption
+		opt     *DuplicationsShowOptions
 		wantErr bool
 	}{
 		{
 			name: "valid option",
-			opt: &DuplicationsShowOption{
+			opt: &DuplicationsShowOptions{
 				Key: "com.example:MyFile.java",
 			},
 			wantErr: false,
@@ -122,7 +122,7 @@ func TestDuplications_ValidateShowOpt(t *testing.T) {
 		},
 		{
 			name:    "missing Key",
-			opt:     &DuplicationsShowOption{},
+			opt:     &DuplicationsShowOptions{},
 			wantErr: true,
 		},
 	}

--- a/sonar/emails_service.go
+++ b/sonar/emails_service.go
@@ -14,8 +14,8 @@ type EmailsService struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// EmailsSendOption contains parameters for the Send method.
-type EmailsSendOption struct {
+// EmailsSendOptions contains parameters for the Send method.
+type EmailsSendOptions struct {
 	// Message is the content of the email.
 	// This field is required.
 	Message string `url:"message"`
@@ -32,7 +32,7 @@ type EmailsSendOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateSendOpt validates the options for the Send method.
-func (s *EmailsService) ValidateSendOpt(opt *EmailsSendOption) error {
+func (s *EmailsService) ValidateSendOpt(opt *EmailsSendOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -59,7 +59,7 @@ func (s *EmailsService) ValidateSendOpt(opt *EmailsSendOption) error {
 //
 // API endpoint: POST /api/emails/send.
 // WARNING: This is an internal API and may change without notice.
-func (s *EmailsService) Send(opt *EmailsSendOption) (*http.Response, error) {
+func (s *EmailsService) Send(opt *EmailsSendOptions) (*http.Response, error) {
 	err := s.ValidateSendOpt(opt)
 	if err != nil {
 		return nil, err

--- a/sonar/emails_service_test.go
+++ b/sonar/emails_service_test.go
@@ -13,7 +13,7 @@ func TestEmails_Send(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/emails/send", http.StatusNoContent))
 	client := newTestClient(t, server.url())
 
-	opt := &EmailsSendOption{
+	opt := &EmailsSendOptions{
 		Message: "Test message content",
 		Subject: "Test Subject",
 		To:      "test@example.com",
@@ -27,7 +27,7 @@ func TestEmails_Send(t *testing.T) {
 func TestEmails_Send_ValidationErrors(t *testing.T) {
 	tests := []struct {
 		name      string
-		opt       *EmailsSendOption
+		opt       *EmailsSendOptions
 		wantField string
 	}{
 		{
@@ -37,14 +37,14 @@ func TestEmails_Send_ValidationErrors(t *testing.T) {
 		},
 		{
 			name: "missing message",
-			opt: &EmailsSendOption{
+			opt: &EmailsSendOptions{
 				To: "test@example.com",
 			},
 			wantField: "Message",
 		},
 		{
 			name: "missing to",
-			opt: &EmailsSendOption{
+			opt: &EmailsSendOptions{
 				Message: "Test message",
 			},
 			wantField: "To",
@@ -68,7 +68,7 @@ func TestEmails_Send_ValidationErrors(t *testing.T) {
 func TestEmails_ValidateSendOpt(t *testing.T) {
 	tests := []struct {
 		name      string
-		opt       *EmailsSendOption
+		opt       *EmailsSendOptions
 		wantErr   bool
 		wantField string
 	}{
@@ -80,7 +80,7 @@ func TestEmails_ValidateSendOpt(t *testing.T) {
 		},
 		{
 			name: "missing message",
-			opt: &EmailsSendOption{
+			opt: &EmailsSendOptions{
 				To: "test@example.com",
 			},
 			wantErr:   true,
@@ -88,7 +88,7 @@ func TestEmails_ValidateSendOpt(t *testing.T) {
 		},
 		{
 			name: "missing to",
-			opt: &EmailsSendOption{
+			opt: &EmailsSendOptions{
 				Message: "Test message",
 			},
 			wantErr:   true,
@@ -96,7 +96,7 @@ func TestEmails_ValidateSendOpt(t *testing.T) {
 		},
 		{
 			name: "valid option",
-			opt: &EmailsSendOption{
+			opt: &EmailsSendOptions{
 				Message: "Test message",
 				To:      "test@example.com",
 			},
@@ -104,7 +104,7 @@ func TestEmails_ValidateSendOpt(t *testing.T) {
 		},
 		{
 			name: "valid with subject",
-			opt: &EmailsSendOption{
+			opt: &EmailsSendOptions{
 				Message: "Test message",
 				Subject: "Subject",
 				To:      "test@example.com",

--- a/sonar/favorites_service.go
+++ b/sonar/favorites_service.go
@@ -36,23 +36,23 @@ type Favorite struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// FavoritesAddOption contains parameters for the Add method.
-type FavoritesAddOption struct {
+// FavoritesAddOptions contains parameters for the Add method.
+type FavoritesAddOptions struct {
 	// Component is the component key.
 	// Only components with qualifiers TRK, VW, SVW, APP are supported.
 	// This field is required.
 	Component string `url:"component"`
 }
 
-// FavoritesRemoveOption contains parameters for the Remove method.
-type FavoritesRemoveOption struct {
+// FavoritesRemoveOptions contains parameters for the Remove method.
+type FavoritesRemoveOptions struct {
 	// Component is the component key.
 	// This field is required.
 	Component string `url:"component"`
 }
 
-// FavoritesSearchOption contains parameters for the Search method.
-type FavoritesSearchOption struct {
+// FavoritesSearchOptions contains parameters for the Search method.
+type FavoritesSearchOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 }
@@ -62,7 +62,7 @@ type FavoritesSearchOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateAddOpt validates the options for the Add method.
-func (s *FavoritesService) ValidateAddOpt(opt *FavoritesAddOption) error {
+func (s *FavoritesService) ValidateAddOpt(opt *FavoritesAddOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -76,7 +76,7 @@ func (s *FavoritesService) ValidateAddOpt(opt *FavoritesAddOption) error {
 }
 
 // ValidateRemoveOpt validates the options for the Remove method.
-func (s *FavoritesService) ValidateRemoveOpt(opt *FavoritesRemoveOption) error {
+func (s *FavoritesService) ValidateRemoveOpt(opt *FavoritesRemoveOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -90,7 +90,7 @@ func (s *FavoritesService) ValidateRemoveOpt(opt *FavoritesRemoveOption) error {
 }
 
 // ValidateSearchOpt validates the options for the Search method.
-func (s *FavoritesService) ValidateSearchOpt(opt *FavoritesSearchOption) error {
+func (s *FavoritesService) ValidateSearchOpt(opt *FavoritesSearchOptions) error {
 	if opt == nil {
 		return nil
 	}
@@ -108,7 +108,7 @@ func (s *FavoritesService) ValidateSearchOpt(opt *FavoritesSearchOption) error {
 //
 // API endpoint: POST /api/favorites/add.
 // Since: 6.3.
-func (s *FavoritesService) Add(opt *FavoritesAddOption) (*http.Response, error) {
+func (s *FavoritesService) Add(opt *FavoritesAddOptions) (*http.Response, error) {
 	err := s.ValidateAddOpt(opt)
 	if err != nil {
 		return nil, err
@@ -132,7 +132,7 @@ func (s *FavoritesService) Add(opt *FavoritesAddOption) (*http.Response, error) 
 //
 // API endpoint: POST /api/favorites/remove.
 // Since: 6.3.
-func (s *FavoritesService) Remove(opt *FavoritesRemoveOption) (*http.Response, error) {
+func (s *FavoritesService) Remove(opt *FavoritesRemoveOptions) (*http.Response, error) {
 	err := s.ValidateRemoveOpt(opt)
 	if err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func (s *FavoritesService) Remove(opt *FavoritesRemoveOption) (*http.Response, e
 //
 // API endpoint: GET /api/favorites/search.
 // Since: 6.3.
-func (s *FavoritesService) Search(opt *FavoritesSearchOption) (*FavoritesSearch, *http.Response, error) {
+func (s *FavoritesService) Search(opt *FavoritesSearchOptions) (*FavoritesSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/favorites_service_test.go
+++ b/sonar/favorites_service_test.go
@@ -12,7 +12,7 @@ func TestFavorites_Add(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/favorites/add", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &FavoritesAddOption{
+	opt := &FavoritesAddOptions{
 		Component: "my-project",
 	}
 
@@ -29,7 +29,7 @@ func TestFavorites_Add_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Component should fail validation.
-	_, err = client.Favorites.Add(&FavoritesAddOption{})
+	_, err = client.Favorites.Add(&FavoritesAddOptions{})
 	assert.Error(t, err)
 }
 
@@ -37,7 +37,7 @@ func TestFavorites_Remove(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/favorites/remove", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &FavoritesRemoveOption{
+	opt := &FavoritesRemoveOptions{
 		Component: "my-project",
 	}
 
@@ -54,7 +54,7 @@ func TestFavorites_Remove_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Component should fail validation.
-	_, err = client.Favorites.Remove(&FavoritesRemoveOption{})
+	_, err = client.Favorites.Remove(&FavoritesRemoveOptions{})
 	assert.Error(t, err)
 }
 
@@ -93,7 +93,7 @@ func TestFavorites_Search_WithPagination(t *testing.T) {
 	}))
 	client := newTestClient(t, server.URL)
 
-	opt := &FavoritesSearchOption{
+	opt := &FavoritesSearchOptions{
 		PaginationArgs: PaginationArgs{
 			Page:     2,
 			PageSize: 50,
@@ -109,7 +109,7 @@ func TestFavorites_ValidateAddOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Valid option should pass.
-	err := client.Favorites.ValidateAddOpt(&FavoritesAddOption{
+	err := client.Favorites.ValidateAddOpt(&FavoritesAddOptions{
 		Component: "my-project",
 	})
 	assert.NoError(t, err)
@@ -119,7 +119,7 @@ func TestFavorites_ValidateAddOpt(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Component should fail.
-	err = client.Favorites.ValidateAddOpt(&FavoritesAddOption{})
+	err = client.Favorites.ValidateAddOpt(&FavoritesAddOptions{})
 	assert.Error(t, err)
 }
 
@@ -127,7 +127,7 @@ func TestFavorites_ValidateRemoveOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Valid option should pass.
-	err := client.Favorites.ValidateRemoveOpt(&FavoritesRemoveOption{
+	err := client.Favorites.ValidateRemoveOpt(&FavoritesRemoveOptions{
 		Component: "my-project",
 	})
 	assert.NoError(t, err)
@@ -137,7 +137,7 @@ func TestFavorites_ValidateRemoveOpt(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Component should fail.
-	err = client.Favorites.ValidateRemoveOpt(&FavoritesRemoveOption{})
+	err = client.Favorites.ValidateRemoveOpt(&FavoritesRemoveOptions{})
 	assert.Error(t, err)
 }
 
@@ -149,11 +149,11 @@ func TestFavorites_ValidateSearchOpt(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Empty option should be valid.
-	err = client.Favorites.ValidateSearchOpt(&FavoritesSearchOption{})
+	err = client.Favorites.ValidateSearchOpt(&FavoritesSearchOptions{})
 	assert.NoError(t, err)
 
 	// Valid pagination should be valid.
-	err = client.Favorites.ValidateSearchOpt(&FavoritesSearchOption{
+	err = client.Favorites.ValidateSearchOpt(&FavoritesSearchOptions{
 		PaginationArgs: PaginationArgs{
 			Page:     1,
 			PageSize: 100,

--- a/sonar/hotspots_service.go
+++ b/sonar/hotspots_service.go
@@ -283,8 +283,8 @@ type HotspotsShow struct {
 // Option Types
 // =============================================================================
 
-// HotspotsAddCommentOption contains parameters for the AddComment method.
-type HotspotsAddCommentOption struct {
+// HotspotsAddCommentOptions contains parameters for the AddComment method.
+type HotspotsAddCommentOptions struct {
 	// Comment is the comment text.
 	// This field is required. Maximum length: 1000 characters.
 	Comment string `url:"comment"`
@@ -293,8 +293,8 @@ type HotspotsAddCommentOption struct {
 	Hotspot string `url:"hotspot"`
 }
 
-// HotspotsAssignOption contains parameters for the Assign method.
-type HotspotsAssignOption struct {
+// HotspotsAssignOptions contains parameters for the Assign method.
+type HotspotsAssignOptions struct {
 	// Assignee is the login of the assignee with 'Browse' project permission.
 	// This field is optional (since 8.9).
 	Assignee string `url:"assignee,omitempty"`
@@ -306,8 +306,8 @@ type HotspotsAssignOption struct {
 	Hotspot string `url:"hotspot"`
 }
 
-// HotspotsChangeStatusOption contains parameters for the ChangeStatus method.
-type HotspotsChangeStatusOption struct {
+// HotspotsChangeStatusOptions contains parameters for the ChangeStatus method.
+type HotspotsChangeStatusOptions struct {
 	// Comment is optional comment text.
 	// This field is optional.
 	Comment string `url:"comment,omitempty"`
@@ -324,15 +324,15 @@ type HotspotsChangeStatusOption struct {
 	Status string `url:"status"`
 }
 
-// HotspotsDeleteCommentOption contains parameters for the DeleteComment method.
-type HotspotsDeleteCommentOption struct {
+// HotspotsDeleteCommentOptions contains parameters for the DeleteComment method.
+type HotspotsDeleteCommentOptions struct {
 	// Comment is the key of the comment to delete.
 	// This field is required.
 	Comment string `url:"comment"`
 }
 
-// HotspotsEditCommentOption contains parameters for the EditComment method.
-type HotspotsEditCommentOption struct {
+// HotspotsEditCommentOptions contains parameters for the EditComment method.
+type HotspotsEditCommentOptions struct {
 	// Comment is the key of the comment to edit.
 	// This field is required.
 	Comment string `url:"comment"`
@@ -341,10 +341,10 @@ type HotspotsEditCommentOption struct {
 	Text string `url:"text"`
 }
 
-// HotspotsListOption contains parameters for the List method.
+// HotspotsListOptions contains parameters for the List method.
 //
 //nolint:govet // Field order maintained for API parameter consistency
-type HotspotsListOption struct {
+type HotspotsListOptions struct {
 	// PaginationArgs contains the pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -370,10 +370,10 @@ type HotspotsListOption struct {
 	InNewCodePeriod bool `url:"inNewCodePeriod,omitempty"`
 }
 
-// HotspotsPullOption contains parameters for the Pull method.
+// HotspotsPullOptions contains parameters for the Pull method.
 //
 //nolint:govet // Field order maintained for API parameter consistency
-type HotspotsPullOption struct {
+type HotspotsPullOptions struct {
 	// Languages is a comma-separated list of languages.
 	// If not present, all hotspots regardless of their language are returned.
 	// This field is optional.
@@ -390,10 +390,10 @@ type HotspotsPullOption struct {
 	ChangedSince int64 `url:"changedSince,omitempty"`
 }
 
-// HotspotsSearchOption contains parameters for the Search method.
+// HotspotsSearchOptions contains parameters for the Search method.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type HotspotsSearchOption struct {
+type HotspotsSearchOptions struct {
 	// PaginationArgs contains the pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -469,8 +469,8 @@ type HotspotsSearchOption struct {
 	OnlyMine bool `url:"onlyMine,omitempty"`
 }
 
-// HotspotsShowOption contains parameters for the Show method.
-type HotspotsShowOption struct {
+// HotspotsShowOptions contains parameters for the Show method.
+type HotspotsShowOptions struct {
 	// Hotspot is the key of the Security Hotspot.
 	// This field is required.
 	Hotspot string `url:"hotspot"`
@@ -481,7 +481,7 @@ type HotspotsShowOption struct {
 // =============================================================================
 
 // ValidateAddCommentOpt validates the options for the AddComment method.
-func (s *HotspotsService) ValidateAddCommentOpt(opt *HotspotsAddCommentOption) error {
+func (s *HotspotsService) ValidateAddCommentOpt(opt *HotspotsAddCommentOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -505,7 +505,7 @@ func (s *HotspotsService) ValidateAddCommentOpt(opt *HotspotsAddCommentOption) e
 }
 
 // ValidateAssignOpt validates the options for the Assign method.
-func (s *HotspotsService) ValidateAssignOpt(opt *HotspotsAssignOption) error {
+func (s *HotspotsService) ValidateAssignOpt(opt *HotspotsAssignOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -519,7 +519,7 @@ func (s *HotspotsService) ValidateAssignOpt(opt *HotspotsAssignOption) error {
 }
 
 // ValidateChangeStatusOpt validates the options for the ChangeStatus method.
-func (s *HotspotsService) ValidateChangeStatusOpt(opt *HotspotsChangeStatusOption) error {
+func (s *HotspotsService) ValidateChangeStatusOpt(opt *HotspotsChangeStatusOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -550,7 +550,7 @@ func (s *HotspotsService) ValidateChangeStatusOpt(opt *HotspotsChangeStatusOptio
 }
 
 // ValidateDeleteCommentOpt validates the options for the DeleteComment method.
-func (s *HotspotsService) ValidateDeleteCommentOpt(opt *HotspotsDeleteCommentOption) error {
+func (s *HotspotsService) ValidateDeleteCommentOpt(opt *HotspotsDeleteCommentOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -564,7 +564,7 @@ func (s *HotspotsService) ValidateDeleteCommentOpt(opt *HotspotsDeleteCommentOpt
 }
 
 // ValidateEditCommentOpt validates the options for the EditComment method.
-func (s *HotspotsService) ValidateEditCommentOpt(opt *HotspotsEditCommentOption) error {
+func (s *HotspotsService) ValidateEditCommentOpt(opt *HotspotsEditCommentOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -588,7 +588,7 @@ func (s *HotspotsService) ValidateEditCommentOpt(opt *HotspotsEditCommentOption)
 }
 
 // ValidateListOpt validates the options for the List method.
-func (s *HotspotsService) ValidateListOpt(opt *HotspotsListOption) error {
+func (s *HotspotsService) ValidateListOpt(opt *HotspotsListOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -626,7 +626,7 @@ func (s *HotspotsService) ValidateListOpt(opt *HotspotsListOption) error {
 }
 
 // ValidatePullOpt validates the options for the Pull method.
-func (s *HotspotsService) ValidatePullOpt(opt *HotspotsPullOption) error {
+func (s *HotspotsService) ValidatePullOpt(opt *HotspotsPullOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -647,7 +647,7 @@ func (s *HotspotsService) ValidatePullOpt(opt *HotspotsPullOption) error {
 // ValidateSearchOpt validates the options for the Search method.
 //
 //nolint:cyclop // Validation functions are naturally complex due to multiple checks
-func (s *HotspotsService) ValidateSearchOpt(opt *HotspotsSearchOption) error {
+func (s *HotspotsService) ValidateSearchOpt(opt *HotspotsSearchOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -708,7 +708,7 @@ func (s *HotspotsService) ValidateSearchOpt(opt *HotspotsSearchOption) error {
 }
 
 // ValidateShowOpt validates the options for the Show method.
-func (s *HotspotsService) ValidateShowOpt(opt *HotspotsShowOption) error {
+func (s *HotspotsService) ValidateShowOpt(opt *HotspotsShowOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -731,7 +731,7 @@ func (s *HotspotsService) ValidateShowOpt(opt *HotspotsShowOption) error {
 // API endpoint: POST /api/hotspots/add_comment.
 // Since: 8.1.
 // Internal: true.
-func (s *HotspotsService) AddComment(opt *HotspotsAddCommentOption) (*http.Response, error) {
+func (s *HotspotsService) AddComment(opt *HotspotsAddCommentOptions) (*http.Response, error) {
 	err := s.ValidateAddCommentOpt(opt)
 	if err != nil {
 		return nil, err
@@ -756,7 +756,7 @@ func (s *HotspotsService) AddComment(opt *HotspotsAddCommentOption) (*http.Respo
 // API endpoint: POST /api/hotspots/assign.
 // Since: 8.2.
 // Internal: true.
-func (s *HotspotsService) Assign(opt *HotspotsAssignOption) (*http.Response, error) {
+func (s *HotspotsService) Assign(opt *HotspotsAssignOptions) (*http.Response, error) {
 	err := s.ValidateAssignOpt(opt)
 	if err != nil {
 		return nil, err
@@ -780,7 +780,7 @@ func (s *HotspotsService) Assign(opt *HotspotsAssignOption) (*http.Response, err
 //
 // API endpoint: POST /api/hotspots/change_status.
 // Since: 8.1.
-func (s *HotspotsService) ChangeStatus(opt *HotspotsChangeStatusOption) (*http.Response, error) {
+func (s *HotspotsService) ChangeStatus(opt *HotspotsChangeStatusOptions) (*http.Response, error) {
 	err := s.ValidateChangeStatusOpt(opt)
 	if err != nil {
 		return nil, err
@@ -805,7 +805,7 @@ func (s *HotspotsService) ChangeStatus(opt *HotspotsChangeStatusOption) (*http.R
 // API endpoint: POST /api/hotspots/delete_comment.
 // Since: 8.2.
 // Internal: true.
-func (s *HotspotsService) DeleteComment(opt *HotspotsDeleteCommentOption) (*http.Response, error) {
+func (s *HotspotsService) DeleteComment(opt *HotspotsDeleteCommentOptions) (*http.Response, error) {
 	err := s.ValidateDeleteCommentOpt(opt)
 	if err != nil {
 		return nil, err
@@ -830,7 +830,7 @@ func (s *HotspotsService) DeleteComment(opt *HotspotsDeleteCommentOption) (*http
 // API endpoint: POST /api/hotspots/edit_comment.
 // Since: 8.2.
 // Internal: true.
-func (s *HotspotsService) EditComment(opt *HotspotsEditCommentOption) (*HotspotsEditComment, *http.Response, error) {
+func (s *HotspotsService) EditComment(opt *HotspotsEditCommentOptions) (*HotspotsEditComment, *http.Response, error) {
 	err := s.ValidateEditCommentOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -861,7 +861,7 @@ func (s *HotspotsService) EditComment(opt *HotspotsEditCommentOption) (*Hotspots
 // API endpoint: GET /api/hotspots/list.
 // Since: 10.2.
 // Internal: true.
-func (s *HotspotsService) List(opt *HotspotsListOption) (*HotspotsList, *http.Response, error) {
+func (s *HotspotsService) List(opt *HotspotsListOptions) (*HotspotsList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -889,7 +889,7 @@ func (s *HotspotsService) List(opt *HotspotsListOption) (*HotspotsList, *http.Re
 // API endpoint: GET /api/hotspots/pull.
 // Since: 10.1.
 // Internal: true.
-func (s *HotspotsService) Pull(opt *HotspotsPullOption) ([]byte, *http.Response, error) {
+func (s *HotspotsService) Pull(opt *HotspotsPullOptions) ([]byte, *http.Response, error) {
 	err := s.ValidatePullOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -917,7 +917,7 @@ func (s *HotspotsService) Pull(opt *HotspotsPullOption) ([]byte, *http.Response,
 //
 // API endpoint: GET /api/hotspots/search.
 // Since: 8.1.
-func (s *HotspotsService) Search(opt *HotspotsSearchOption) (*HotspotsSearch, *http.Response, error) {
+func (s *HotspotsService) Search(opt *HotspotsSearchOptions) (*HotspotsSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -942,7 +942,7 @@ func (s *HotspotsService) Search(opt *HotspotsSearchOption) (*HotspotsSearch, *h
 //
 // API endpoint: GET /api/hotspots/show.
 // Since: 8.1.
-func (s *HotspotsService) Show(opt *HotspotsShowOption) (*HotspotsShow, *http.Response, error) {
+func (s *HotspotsService) Show(opt *HotspotsShowOptions) (*HotspotsShow, *http.Response, error) {
 	err := s.ValidateShowOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/hotspots_service_test.go
+++ b/sonar/hotspots_service_test.go
@@ -24,7 +24,7 @@ func TestHotspots_AddComment(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Hotspots.AddComment(&HotspotsAddCommentOption{
+	resp, err := client.Hotspots.AddComment(&HotspotsAddCommentOptions{
 		Hotspot: "hotspot123",
 		Comment: "This is a comment",
 	})
@@ -37,7 +37,7 @@ func TestHotspots_AddComment_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *HotspotsAddCommentOption
+		opt  *HotspotsAddCommentOptions
 	}{
 		{
 			name: "nil option",
@@ -45,15 +45,15 @@ func TestHotspots_AddComment_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing hotspot",
-			opt:  &HotspotsAddCommentOption{Comment: "This is a comment"},
+			opt:  &HotspotsAddCommentOptions{Comment: "This is a comment"},
 		},
 		{
 			name: "missing comment",
-			opt:  &HotspotsAddCommentOption{Hotspot: "hotspot123"},
+			opt:  &HotspotsAddCommentOptions{Hotspot: "hotspot123"},
 		},
 		{
 			name: "comment too long",
-			opt: &HotspotsAddCommentOption{
+			opt: &HotspotsAddCommentOptions{
 				Hotspot: "hotspot123",
 				Comment: string(make([]byte, MaxHotspotCommentLength+1)),
 			},
@@ -84,7 +84,7 @@ func TestHotspots_Assign(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Hotspots.Assign(&HotspotsAssignOption{
+	resp, err := client.Hotspots.Assign(&HotspotsAssignOptions{
 		Hotspot:  "hotspot123",
 		Assignee: "john.doe",
 	})
@@ -97,7 +97,7 @@ func TestHotspots_Assign_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *HotspotsAssignOption
+		opt  *HotspotsAssignOptions
 	}{
 		{
 			name: "nil option",
@@ -105,7 +105,7 @@ func TestHotspots_Assign_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing hotspot",
-			opt:  &HotspotsAssignOption{Assignee: "john.doe"},
+			opt:  &HotspotsAssignOptions{Assignee: "john.doe"},
 		},
 	}
 
@@ -134,7 +134,7 @@ func TestHotspots_ChangeStatus(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Hotspots.ChangeStatus(&HotspotsChangeStatusOption{
+	resp, err := client.Hotspots.ChangeStatus(&HotspotsChangeStatusOptions{
 		Hotspot:    "hotspot123",
 		Status:     "REVIEWED",
 		Resolution: "SAFE",
@@ -148,7 +148,7 @@ func TestHotspots_ChangeStatus_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *HotspotsChangeStatusOption
+		opt  *HotspotsChangeStatusOptions
 	}{
 		{
 			name: "nil option",
@@ -156,19 +156,19 @@ func TestHotspots_ChangeStatus_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing hotspot",
-			opt:  &HotspotsChangeStatusOption{Status: "REVIEWED"},
+			opt:  &HotspotsChangeStatusOptions{Status: "REVIEWED"},
 		},
 		{
 			name: "missing status",
-			opt:  &HotspotsChangeStatusOption{Hotspot: "hotspot123"},
+			opt:  &HotspotsChangeStatusOptions{Hotspot: "hotspot123"},
 		},
 		{
 			name: "invalid status",
-			opt:  &HotspotsChangeStatusOption{Hotspot: "hotspot123", Status: "INVALID"},
+			opt:  &HotspotsChangeStatusOptions{Hotspot: "hotspot123", Status: "INVALID"},
 		},
 		{
 			name: "invalid resolution",
-			opt:  &HotspotsChangeStatusOption{Hotspot: "hotspot123", Status: "REVIEWED", Resolution: "INVALID"},
+			opt:  &HotspotsChangeStatusOptions{Hotspot: "hotspot123", Status: "REVIEWED", Resolution: "INVALID"},
 		},
 	}
 
@@ -195,7 +195,7 @@ func TestHotspots_DeleteComment(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Hotspots.DeleteComment(&HotspotsDeleteCommentOption{
+	resp, err := client.Hotspots.DeleteComment(&HotspotsDeleteCommentOptions{
 		Comment: "comment123",
 	})
 	require.NoError(t, err)
@@ -207,7 +207,7 @@ func TestHotspots_DeleteComment_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *HotspotsDeleteCommentOption
+		opt  *HotspotsDeleteCommentOptions
 	}{
 		{
 			name: "nil option",
@@ -215,7 +215,7 @@ func TestHotspots_DeleteComment_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing comment",
-			opt:  &HotspotsDeleteCommentOption{},
+			opt:  &HotspotsDeleteCommentOptions{},
 		},
 	}
 
@@ -243,7 +243,7 @@ func TestHotspots_EditComment(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Hotspots.EditComment(&HotspotsEditCommentOption{
+	result, resp, err := client.Hotspots.EditComment(&HotspotsEditCommentOptions{
 		Comment: "comment123",
 		Text:    "Updated comment",
 	})
@@ -259,7 +259,7 @@ func TestHotspots_EditComment_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *HotspotsEditCommentOption
+		opt  *HotspotsEditCommentOptions
 	}{
 		{
 			name: "nil option",
@@ -267,15 +267,15 @@ func TestHotspots_EditComment_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing comment",
-			opt:  &HotspotsEditCommentOption{Text: "Updated comment"},
+			opt:  &HotspotsEditCommentOptions{Text: "Updated comment"},
 		},
 		{
 			name: "missing text",
-			opt:  &HotspotsEditCommentOption{Comment: "comment123"},
+			opt:  &HotspotsEditCommentOptions{Comment: "comment123"},
 		},
 		{
 			name: "text too long",
-			opt: &HotspotsEditCommentOption{
+			opt: &HotspotsEditCommentOptions{
 				Comment: "comment123",
 				Text:    string(make([]byte, MaxHotspotCommentLength+1)),
 			},
@@ -320,7 +320,7 @@ func TestHotspots_List(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Hotspots.List(&HotspotsListOption{
+	result, resp, err := client.Hotspots.List(&HotspotsListOptions{
 		Project: "my-project",
 	})
 	require.NoError(t, err)
@@ -335,7 +335,7 @@ func TestHotspots_List_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *HotspotsListOption
+		opt  *HotspotsListOptions
 	}{
 		{
 			name: "nil option",
@@ -343,19 +343,19 @@ func TestHotspots_List_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing project",
-			opt:  &HotspotsListOption{},
+			opt:  &HotspotsListOptions{},
 		},
 		{
 			name: "invalid status",
-			opt:  &HotspotsListOption{Project: "my-project", Status: "INVALID"},
+			opt:  &HotspotsListOptions{Project: "my-project", Status: "INVALID"},
 		},
 		{
 			name: "invalid resolution",
-			opt:  &HotspotsListOption{Project: "my-project", Resolution: "INVALID"},
+			opt:  &HotspotsListOptions{Project: "my-project", Resolution: "INVALID"},
 		},
 		{
 			name: "page size too large",
-			opt:  &HotspotsListOption{Project: "my-project", PaginationArgs: PaginationArgs{PageSize: MaxHotspotListPageSize + 1}},
+			opt:  &HotspotsListOptions{Project: "my-project", PaginationArgs: PaginationArgs{PageSize: MaxHotspotListPageSize + 1}},
 		},
 	}
 
@@ -385,7 +385,7 @@ func TestHotspots_Pull(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Hotspots.Pull(&HotspotsPullOption{
+	result, resp, err := client.Hotspots.Pull(&HotspotsPullOptions{
 		ProjectKey: "my-project",
 		BranchName: "main",
 	})
@@ -399,7 +399,7 @@ func TestHotspots_Pull_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *HotspotsPullOption
+		opt  *HotspotsPullOptions
 	}{
 		{
 			name: "nil option",
@@ -407,11 +407,11 @@ func TestHotspots_Pull_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing project key",
-			opt:  &HotspotsPullOption{BranchName: "main"},
+			opt:  &HotspotsPullOptions{BranchName: "main"},
 		},
 		{
 			name: "missing branch name",
-			opt:  &HotspotsPullOption{ProjectKey: "my-project"},
+			opt:  &HotspotsPullOptions{ProjectKey: "my-project"},
 		},
 	}
 
@@ -453,7 +453,7 @@ func TestHotspots_Search_WithProject(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Hotspots.Search(&HotspotsSearchOption{
+	result, resp, err := client.Hotspots.Search(&HotspotsSearchOptions{
 		Project: "my-project",
 	})
 	require.NoError(t, err)
@@ -475,7 +475,7 @@ func TestHotspots_Search_WithHotspots(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	_, resp, err := client.Hotspots.Search(&HotspotsSearchOption{
+	_, resp, err := client.Hotspots.Search(&HotspotsSearchOptions{
 		Hotspots: []string{"hotspot1", "hotspot2"},
 	})
 	require.NoError(t, err)
@@ -498,7 +498,7 @@ func TestHotspots_Search_WithFilters(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	_, resp, err := client.Hotspots.Search(&HotspotsSearchOption{
+	_, resp, err := client.Hotspots.Search(&HotspotsSearchOptions{
 		Project:         "my-project",
 		Status:          "REVIEWED",
 		Resolution:      "SAFE",
@@ -514,7 +514,7 @@ func TestHotspots_Search_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *HotspotsSearchOption
+		opt  *HotspotsSearchOptions
 	}{
 		{
 			name: "nil option",
@@ -522,27 +522,27 @@ func TestHotspots_Search_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing project and hotspots",
-			opt:  &HotspotsSearchOption{},
+			opt:  &HotspotsSearchOptions{},
 		},
 		{
 			name: "invalid status",
-			opt:  &HotspotsSearchOption{Project: "my-project", Status: "INVALID"},
+			opt:  &HotspotsSearchOptions{Project: "my-project", Status: "INVALID"},
 		},
 		{
 			name: "invalid resolution",
-			opt:  &HotspotsSearchOption{Project: "my-project", Resolution: "INVALID"},
+			opt:  &HotspotsSearchOptions{Project: "my-project", Resolution: "INVALID"},
 		},
 		{
 			name: "invalid owasp asvs level",
-			opt:  &HotspotsSearchOption{Project: "my-project", OwaspAsvsLevel: "5"},
+			opt:  &HotspotsSearchOptions{Project: "my-project", OwaspAsvsLevel: "5"},
 		},
 		{
 			name: "invalid owasp top 10",
-			opt:  &HotspotsSearchOption{Project: "my-project", OwaspTop10: []string{"a1", "invalid"}},
+			opt:  &HotspotsSearchOptions{Project: "my-project", OwaspTop10: []string{"a1", "invalid"}},
 		},
 		{
 			name: "invalid sans top 25",
-			opt:  &HotspotsSearchOption{Project: "my-project", SansTop25: []string{"insecure-interaction", "invalid"}},
+			opt:  &HotspotsSearchOptions{Project: "my-project", SansTop25: []string{"insecure-interaction", "invalid"}},
 		},
 	}
 
@@ -607,7 +607,7 @@ func TestHotspots_Show(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Hotspots.Show(&HotspotsShowOption{
+	result, resp, err := client.Hotspots.Show(&HotspotsShowOptions{
 		Hotspot: "hotspot123",
 	})
 	require.NoError(t, err)
@@ -629,7 +629,7 @@ func TestHotspots_Show_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *HotspotsShowOption
+		opt  *HotspotsShowOptions
 	}{
 		{
 			name: "nil option",
@@ -637,7 +637,7 @@ func TestHotspots_Show_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing hotspot",
-			opt:  &HotspotsShowOption{},
+			opt:  &HotspotsShowOptions{},
 		},
 	}
 
@@ -658,12 +658,12 @@ func TestHotspots_ValidateAddCommentOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *HotspotsAddCommentOption
+		opt     *HotspotsAddCommentOptions
 		wantErr bool
 	}{
 		{
 			name: "valid option",
-			opt: &HotspotsAddCommentOption{
+			opt: &HotspotsAddCommentOptions{
 				Comment: "Valid comment",
 				Hotspot: "hotspot123",
 			},
@@ -676,14 +676,14 @@ func TestHotspots_ValidateAddCommentOpt(t *testing.T) {
 		},
 		{
 			name: "missing comment",
-			opt: &HotspotsAddCommentOption{
+			opt: &HotspotsAddCommentOptions{
 				Hotspot: "hotspot123",
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing hotspot",
-			opt: &HotspotsAddCommentOption{
+			opt: &HotspotsAddCommentOptions{
 				Comment: "Valid comment",
 			},
 			wantErr: true,
@@ -707,12 +707,12 @@ func TestHotspots_ValidateChangeStatusOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *HotspotsChangeStatusOption
+		opt     *HotspotsChangeStatusOptions
 		wantErr bool
 	}{
 		{
 			name: "valid TO_REVIEW status",
-			opt: &HotspotsChangeStatusOption{
+			opt: &HotspotsChangeStatusOptions{
 				Hotspot: "hotspot123",
 				Status:  "TO_REVIEW",
 			},
@@ -720,7 +720,7 @@ func TestHotspots_ValidateChangeStatusOpt(t *testing.T) {
 		},
 		{
 			name: "valid REVIEWED with SAFE resolution",
-			opt: &HotspotsChangeStatusOption{
+			opt: &HotspotsChangeStatusOptions{
 				Hotspot:    "hotspot123",
 				Status:     "REVIEWED",
 				Resolution: "SAFE",
@@ -729,7 +729,7 @@ func TestHotspots_ValidateChangeStatusOpt(t *testing.T) {
 		},
 		{
 			name: "valid REVIEWED with FIXED resolution",
-			opt: &HotspotsChangeStatusOption{
+			opt: &HotspotsChangeStatusOptions{
 				Hotspot:    "hotspot123",
 				Status:     "REVIEWED",
 				Resolution: "FIXED",
@@ -738,7 +738,7 @@ func TestHotspots_ValidateChangeStatusOpt(t *testing.T) {
 		},
 		{
 			name: "valid REVIEWED with ACKNOWLEDGED resolution",
-			opt: &HotspotsChangeStatusOption{
+			opt: &HotspotsChangeStatusOptions{
 				Hotspot:    "hotspot123",
 				Status:     "REVIEWED",
 				Resolution: "ACKNOWLEDGED",
@@ -752,7 +752,7 @@ func TestHotspots_ValidateChangeStatusOpt(t *testing.T) {
 		},
 		{
 			name: "invalid status",
-			opt: &HotspotsChangeStatusOption{
+			opt: &HotspotsChangeStatusOptions{
 				Hotspot: "hotspot123",
 				Status:  "INVALID_STATUS",
 			},
@@ -760,7 +760,7 @@ func TestHotspots_ValidateChangeStatusOpt(t *testing.T) {
 		},
 		{
 			name: "invalid resolution",
-			opt: &HotspotsChangeStatusOption{
+			opt: &HotspotsChangeStatusOptions{
 				Hotspot:    "hotspot123",
 				Status:     "REVIEWED",
 				Resolution: "INVALID",
@@ -786,26 +786,26 @@ func TestHotspots_ValidateSearchOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *HotspotsSearchOption
+		opt     *HotspotsSearchOptions
 		wantErr bool
 	}{
 		{
 			name: "valid with project",
-			opt: &HotspotsSearchOption{
+			opt: &HotspotsSearchOptions{
 				Project: "my-project",
 			},
 			wantErr: false,
 		},
 		{
 			name: "valid with hotspots",
-			opt: &HotspotsSearchOption{
+			opt: &HotspotsSearchOptions{
 				Hotspots: []string{"hotspot1", "hotspot2"},
 			},
 			wantErr: false,
 		},
 		{
 			name: "valid with all OWASP filters",
-			opt: &HotspotsSearchOption{
+			opt: &HotspotsSearchOptions{
 				Project:        "my-project",
 				OwaspTop10:     []string{"a1", "a2"},
 				OwaspTop102021: []string{"a3", "a4"},
@@ -815,7 +815,7 @@ func TestHotspots_ValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "valid with SANS filter",
-			opt: &HotspotsSearchOption{
+			opt: &HotspotsSearchOptions{
 				Project:   "my-project",
 				SansTop25: []string{"insecure-interaction", "porous-defenses"},
 			},
@@ -828,12 +828,12 @@ func TestHotspots_ValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name:    "missing project and hotspots",
-			opt:     &HotspotsSearchOption{},
+			opt:     &HotspotsSearchOptions{},
 			wantErr: true,
 		},
 		{
 			name: "invalid OwaspAsvsLevel",
-			opt: &HotspotsSearchOption{
+			opt: &HotspotsSearchOptions{
 				Project:        "my-project",
 				OwaspAsvsLevel: "4",
 			},
@@ -841,7 +841,7 @@ func TestHotspots_ValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "invalid OwaspTop10 value",
-			opt: &HotspotsSearchOption{
+			opt: &HotspotsSearchOptions{
 				Project:    "my-project",
 				OwaspTop10: []string{"a11"},
 			},
@@ -849,7 +849,7 @@ func TestHotspots_ValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "invalid SansTop25 value",
-			opt: &HotspotsSearchOption{
+			opt: &HotspotsSearchOptions{
 				Project:   "my-project",
 				SansTop25: []string{"invalid-category"},
 			},
@@ -874,19 +874,19 @@ func TestHotspots_ValidateListOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *HotspotsListOption
+		opt     *HotspotsListOptions
 		wantErr bool
 	}{
 		{
 			name: "valid basic option",
-			opt: &HotspotsListOption{
+			opt: &HotspotsListOptions{
 				Project: "my-project",
 			},
 			wantErr: false,
 		},
 		{
 			name: "valid with all optional params",
-			opt: &HotspotsListOption{
+			opt: &HotspotsListOptions{
 				Project:         "my-project",
 				Branch:          "main",
 				InNewCodePeriod: true,
@@ -898,7 +898,7 @@ func TestHotspots_ValidateListOpt(t *testing.T) {
 		},
 		{
 			name: "valid max page size",
-			opt: &HotspotsListOption{
+			opt: &HotspotsListOptions{
 				Project:        "my-project",
 				PaginationArgs: PaginationArgs{PageSize: MaxHotspotListPageSize},
 			},
@@ -911,12 +911,12 @@ func TestHotspots_ValidateListOpt(t *testing.T) {
 		},
 		{
 			name:    "missing project",
-			opt:     &HotspotsListOption{},
+			opt:     &HotspotsListOptions{},
 			wantErr: true,
 		},
 		{
 			name: "page size exceeds max",
-			opt: &HotspotsListOption{
+			opt: &HotspotsListOptions{
 				Project:        "my-project",
 				PaginationArgs: PaginationArgs{PageSize: MaxHotspotListPageSize + 1},
 			},
@@ -924,7 +924,7 @@ func TestHotspots_ValidateListOpt(t *testing.T) {
 		},
 		{
 			name: "invalid status",
-			opt: &HotspotsListOption{
+			opt: &HotspotsListOptions{
 				Project: "my-project",
 				Status:  "CLOSED",
 			},
@@ -932,7 +932,7 @@ func TestHotspots_ValidateListOpt(t *testing.T) {
 		},
 		{
 			name: "invalid resolution",
-			opt: &HotspotsListOption{
+			opt: &HotspotsListOptions{
 				Project:    "my-project",
 				Resolution: "WONTFIX",
 			},

--- a/sonar/issues_service.go
+++ b/sonar/issues_service.go
@@ -398,22 +398,22 @@ type IssuesTags struct {
 // Option Types
 // =============================================================================
 
-// IssuesAddCommentOption contains options for adding a comment to an issue.
-type IssuesAddCommentOption struct {
+// IssuesAddCommentOptions contains options for adding a comment to an issue.
+type IssuesAddCommentOptions struct {
 	// Issue is the key of the issue to comment on (required).
 	Issue string `url:"issue,omitempty"`
 	// Text is the comment text (required).
 	Text string `url:"text,omitempty"`
 }
 
-// IssuesAnticipatedTransitionsOption contains options for anticipated transitions.
-type IssuesAnticipatedTransitionsOption struct {
+// IssuesAnticipatedTransitionsOptions contains options for anticipated transitions.
+type IssuesAnticipatedTransitionsOptions struct {
 	// ProjectKey is the key of the project (required).
 	ProjectKey string `url:"projectKey,omitempty"`
 }
 
-// IssuesAssignOption contains options for assigning an issue.
-type IssuesAssignOption struct {
+// IssuesAssignOptions contains options for assigning an issue.
+type IssuesAssignOptions struct {
 	// Issue is the key of the issue to assign (required).
 	Issue string `url:"issue,omitempty"`
 	// Assignee is the login of the assignee. When not set, it will unassign the issue.
@@ -421,8 +421,8 @@ type IssuesAssignOption struct {
 	Assignee string `url:"assignee,omitempty"`
 }
 
-// IssuesAuthorsOption contains options for listing authors.
-type IssuesAuthorsOption struct {
+// IssuesAuthorsOptions contains options for listing authors.
+type IssuesAuthorsOptions struct {
 	// Project is the project key to limit the search.
 	Project string `url:"project,omitempty"`
 	// Query limits the search to authors that contain the supplied string.
@@ -431,10 +431,10 @@ type IssuesAuthorsOption struct {
 	PageSize int64 `url:"ps,omitempty"`
 }
 
-// IssuesBulkChangeOption contains options for bulk changing issues.
+// IssuesBulkChangeOptions contains options for bulk changing issues.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type IssuesBulkChangeOption struct {
+type IssuesBulkChangeOptions struct {
 	// Issues is the list of issue keys to change (required).
 	Issues []string `url:"issues,omitempty,comma"`
 	// AddTags is the list of tags to add.
@@ -458,14 +458,14 @@ type IssuesBulkChangeOption struct {
 	SendNotifications bool `url:"sendNotifications,omitempty"`
 }
 
-// IssuesChangelogOption contains options for retrieving issue changelog.
-type IssuesChangelogOption struct {
+// IssuesChangelogOptions contains options for retrieving issue changelog.
+type IssuesChangelogOptions struct {
 	// Issue is the key of the issue (required).
 	Issue string `url:"issue,omitempty"`
 }
 
-// IssuesComponentTagsOption contains options for listing component tags.
-type IssuesComponentTagsOption struct {
+// IssuesComponentTagsOptions contains options for listing component tags.
+type IssuesComponentTagsOptions struct {
 	// ComponentUuid is the UUID of the component (required).
 	ComponentUuid string `url:"componentUuid,omitempty"`
 	// CreatedAfter filters issues created after the given date.
@@ -474,14 +474,14 @@ type IssuesComponentTagsOption struct {
 	PageSize int64 `url:"ps,omitempty"`
 }
 
-// IssuesDeleteCommentOption contains options for deleting a comment.
-type IssuesDeleteCommentOption struct {
+// IssuesDeleteCommentOptions contains options for deleting a comment.
+type IssuesDeleteCommentOptions struct {
 	// Comment is the key of the comment to delete (required).
 	Comment string `url:"comment,omitempty"`
 }
 
-// IssuesDoTransitionOption contains options for performing a transition.
-type IssuesDoTransitionOption struct {
+// IssuesDoTransitionOptions contains options for performing a transition.
+type IssuesDoTransitionOptions struct {
 	// Issue is the key of the issue (required).
 	Issue string `url:"issue,omitempty"`
 	// Transition is the transition to perform (required).
@@ -489,18 +489,18 @@ type IssuesDoTransitionOption struct {
 	Transition string `url:"transition,omitempty"`
 }
 
-// IssuesEditCommentOption contains options for editing a comment.
-type IssuesEditCommentOption struct {
+// IssuesEditCommentOptions contains options for editing a comment.
+type IssuesEditCommentOptions struct {
 	// Comment is the key of the comment to edit (required).
 	Comment string `url:"comment,omitempty"`
 	// Text is the new comment text (required).
 	Text string `url:"text,omitempty"`
 }
 
-// IssuesListOption contains options for listing issues.
+// IssuesListOptions contains options for listing issues.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type IssuesListOption struct {
+type IssuesListOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -521,10 +521,10 @@ type IssuesListOption struct {
 	InNewCodePeriod bool `url:"inNewCodePeriod,omitempty"`
 }
 
-// IssuesPullOption contains options for pulling issues.
+// IssuesPullOptions contains options for pulling issues.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type IssuesPullOption struct {
+type IssuesPullOptions struct {
 	// ProjectKey is the project key (required).
 	ProjectKey string `url:"projectKey,omitempty"`
 	// BranchName is the branch name to fetch issues for.
@@ -539,10 +539,10 @@ type IssuesPullOption struct {
 	ResolvedOnly bool `url:"resolvedOnly,omitempty"`
 }
 
-// IssuesPullTaintOption contains options for pulling taint vulnerabilities.
+// IssuesPullTaintOptions contains options for pulling taint vulnerabilities.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type IssuesPullTaintOption struct {
+type IssuesPullTaintOptions struct {
 	// ProjectKey is the project key (required).
 	ProjectKey string `url:"projectKey,omitempty"`
 	// BranchName is the branch name to fetch taint vulnerabilities for.
@@ -553,16 +553,16 @@ type IssuesPullTaintOption struct {
 	ChangedSince string `url:"changedSince,omitempty"`
 }
 
-// IssuesReindexOption contains options for reindexing issues.
-type IssuesReindexOption struct {
+// IssuesReindexOptions contains options for reindexing issues.
+type IssuesReindexOptions struct {
 	// Project is the project key (required).
 	Project string `url:"project,omitempty"`
 }
 
-// IssuesSearchOption contains options for searching issues.
+// IssuesSearchOptions contains options for searching issues.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type IssuesSearchOption struct {
+type IssuesSearchOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -687,8 +687,8 @@ type IssuesSearchOption struct {
 	Asc bool `url:"asc,omitempty"`
 }
 
-// IssuesSetSeverityOption contains options for setting severity.
-type IssuesSetSeverityOption struct {
+// IssuesSetSeverityOptions contains options for setting severity.
+type IssuesSetSeverityOptions struct {
 	// Issue is the key of the issue (required).
 	Issue string `url:"issue,omitempty"`
 	// Severity is the new severity level.
@@ -698,16 +698,16 @@ type IssuesSetSeverityOption struct {
 	Impact string `url:"impact,omitempty"`
 }
 
-// IssuesSetTagsOption contains options for setting tags.
-type IssuesSetTagsOption struct {
+// IssuesSetTagsOptions contains options for setting tags.
+type IssuesSetTagsOptions struct {
 	// Issue is the key of the issue (required).
 	Issue string `url:"issue,omitempty"`
 	// Tags is the list of tags to set. Empty list removes all tags.
 	Tags []string `url:"tags,omitempty,comma"`
 }
 
-// IssuesSetTypeOption contains options for setting type.
-type IssuesSetTypeOption struct {
+// IssuesSetTypeOptions contains options for setting type.
+type IssuesSetTypeOptions struct {
 	// Issue is the key of the issue (required).
 	Issue string `url:"issue,omitempty"`
 	// Type is the new issue type (required).
@@ -715,8 +715,8 @@ type IssuesSetTypeOption struct {
 	Type string `url:"type,omitempty"`
 }
 
-// IssuesTagsOption contains options for listing tags.
-type IssuesTagsOption struct {
+// IssuesTagsOptions contains options for listing tags.
+type IssuesTagsOptions struct {
 	// Project is the project key.
 	Project string `url:"project,omitempty"`
 	// Branch is the branch key.
@@ -735,7 +735,7 @@ type IssuesTagsOption struct {
 
 // AddComment adds a comment to an issue.
 // Requires authentication and 'Browse' permission on the project of the specified issue.
-func (s *IssuesService) AddComment(opt *IssuesAddCommentOption) (v *IssuesAddComment, resp *http.Response, err error) {
+func (s *IssuesService) AddComment(opt *IssuesAddCommentOptions) (v *IssuesAddComment, resp *http.Response, err error) {
 	err = s.ValidateAddCommentOpt(opt)
 	if err != nil {
 		return
@@ -760,7 +760,7 @@ func (s *IssuesService) AddComment(opt *IssuesAddCommentOption) (v *IssuesAddCom
 // Requires 'Administer Issues' permission on the specified project.
 // Only 'falsepositive', 'wontfix' and 'accept' transitions are supported.
 // Upon successful execution, the HTTP status code returned is 202 (Accepted).
-func (s *IssuesService) AnticipatedTransitions(opt *IssuesAnticipatedTransitionsOption) (resp *http.Response, err error) {
+func (s *IssuesService) AnticipatedTransitions(opt *IssuesAnticipatedTransitionsOptions) (resp *http.Response, err error) {
 	err = s.ValidateAnticipatedTransitionsOpt(opt)
 	if err != nil {
 		return
@@ -781,7 +781,7 @@ func (s *IssuesService) AnticipatedTransitions(opt *IssuesAnticipatedTransitions
 
 // Assign assigns or unassigns an issue.
 // Requires authentication and 'Browse' permission on the project.
-func (s *IssuesService) Assign(opt *IssuesAssignOption) (v *IssuesAssign, resp *http.Response, err error) {
+func (s *IssuesService) Assign(opt *IssuesAssignOptions) (v *IssuesAssign, resp *http.Response, err error) {
 	err = s.ValidateAssignOpt(opt)
 	if err != nil {
 		return
@@ -804,7 +804,7 @@ func (s *IssuesService) Assign(opt *IssuesAssignOption) (v *IssuesAssign, resp *
 
 // Authors searches SCM accounts which match a given query.
 // Requires authentication. Returns 503 when issue indexing is in progress.
-func (s *IssuesService) Authors(opt *IssuesAuthorsOption) (v *IssuesAuthors, resp *http.Response, err error) {
+func (s *IssuesService) Authors(opt *IssuesAuthorsOptions) (v *IssuesAuthors, resp *http.Response, err error) {
 	err = s.ValidateAuthorsOpt(opt)
 	if err != nil {
 		return
@@ -827,7 +827,7 @@ func (s *IssuesService) Authors(opt *IssuesAuthorsOption) (v *IssuesAuthors, res
 
 // BulkChange performs bulk changes on issues. Up to 500 issues can be updated.
 // Requires authentication.
-func (s *IssuesService) BulkChange(opt *IssuesBulkChangeOption) (v *IssuesBulkChange, resp *http.Response, err error) {
+func (s *IssuesService) BulkChange(opt *IssuesBulkChangeOptions) (v *IssuesBulkChange, resp *http.Response, err error) {
 	err = s.ValidateBulkChangeOpt(opt)
 	if err != nil {
 		return
@@ -850,7 +850,7 @@ func (s *IssuesService) BulkChange(opt *IssuesBulkChangeOption) (v *IssuesBulkCh
 
 // Changelog displays the changelog of an issue.
 // Requires 'Browse' permission on the project of the specified issue.
-func (s *IssuesService) Changelog(opt *IssuesChangelogOption) (v *IssuesChangelog, resp *http.Response, err error) {
+func (s *IssuesService) Changelog(opt *IssuesChangelogOptions) (v *IssuesChangelog, resp *http.Response, err error) {
 	err = s.ValidateChangelogOpt(opt)
 	if err != nil {
 		return
@@ -873,7 +873,7 @@ func (s *IssuesService) Changelog(opt *IssuesChangelogOption) (v *IssuesChangelo
 
 // ComponentTags lists tags for issues under a given component.
 // Returns 503 when issue indexing is in progress.
-func (s *IssuesService) ComponentTags(opt *IssuesComponentTagsOption) (v *IssuesComponentTags, resp *http.Response, err error) {
+func (s *IssuesService) ComponentTags(opt *IssuesComponentTagsOptions) (v *IssuesComponentTags, resp *http.Response, err error) {
 	err = s.ValidateComponentTagsOpt(opt)
 	if err != nil {
 		return
@@ -896,7 +896,7 @@ func (s *IssuesService) ComponentTags(opt *IssuesComponentTagsOption) (v *Issues
 
 // DeleteComment deletes a comment.
 // Requires authentication and 'Browse' permission on the project of the specified issue.
-func (s *IssuesService) DeleteComment(opt *IssuesDeleteCommentOption) (v *IssuesDeleteComment, resp *http.Response, err error) {
+func (s *IssuesService) DeleteComment(opt *IssuesDeleteCommentOptions) (v *IssuesDeleteComment, resp *http.Response, err error) {
 	err = s.ValidateDeleteCommentOpt(opt)
 	if err != nil {
 		return
@@ -921,7 +921,7 @@ func (s *IssuesService) DeleteComment(opt *IssuesDeleteCommentOption) (v *Issues
 // Requires authentication and 'Browse' permission on the project.
 // Transitions 'accept', 'wontfix', and 'falsepositive' require 'Administer Issues' permission.
 // Security hotspot transitions require 'Administer Security Hotspot' permission.
-func (s *IssuesService) DoTransition(opt *IssuesDoTransitionOption) (v *IssuesDoTransition, resp *http.Response, err error) {
+func (s *IssuesService) DoTransition(opt *IssuesDoTransitionOptions) (v *IssuesDoTransition, resp *http.Response, err error) {
 	err = s.ValidateDoTransitionOpt(opt)
 	if err != nil {
 		return
@@ -944,7 +944,7 @@ func (s *IssuesService) DoTransition(opt *IssuesDoTransitionOption) (v *IssuesDo
 
 // EditComment edits a comment.
 // Requires authentication and 'Browse' permission on the project of the specified issue.
-func (s *IssuesService) EditComment(opt *IssuesEditCommentOption) (v *IssuesEditComment, resp *http.Response, err error) {
+func (s *IssuesService) EditComment(opt *IssuesEditCommentOptions) (v *IssuesEditComment, resp *http.Response, err error) {
 	err = s.ValidateEditCommentOpt(opt)
 	if err != nil {
 		return
@@ -968,7 +968,7 @@ func (s *IssuesService) EditComment(opt *IssuesEditCommentOption) (v *IssuesEdit
 // List lists issues in degraded mode when issue indexing is running.
 // Either 'project' or 'component' parameter is required.
 // Requires 'Browse' permission on the specified project.
-func (s *IssuesService) List(opt *IssuesListOption) (v *IssuesList, resp *http.Response, err error) {
+func (s *IssuesService) List(opt *IssuesListOptions) (v *IssuesList, resp *http.Response, err error) {
 	err = s.ValidateListOpt(opt)
 	if err != nil {
 		return
@@ -992,7 +992,7 @@ func (s *IssuesService) List(opt *IssuesListOption) (v *IssuesList, resp *http.R
 // Pull fetches all issues for a given branch.
 // The issues returned are not paginated, so the response size can be big.
 // Requires 'Browse' permission on the project.
-func (s *IssuesService) Pull(opt *IssuesPullOption) (v []byte, resp *http.Response, err error) {
+func (s *IssuesService) Pull(opt *IssuesPullOptions) (v []byte, resp *http.Response, err error) {
 	err = s.ValidatePullOpt(opt)
 	if err != nil {
 		return
@@ -1014,7 +1014,7 @@ func (s *IssuesService) Pull(opt *IssuesPullOption) (v []byte, resp *http.Respon
 // PullTaint fetches all taint vulnerabilities for a given branch.
 // The vulnerabilities returned are not paginated, so the response size can be big.
 // Requires 'Browse' permission on the project.
-func (s *IssuesService) PullTaint(opt *IssuesPullTaintOption) (v []byte, resp *http.Response, err error) {
+func (s *IssuesService) PullTaint(opt *IssuesPullTaintOptions) (v []byte, resp *http.Response, err error) {
 	err = s.ValidatePullTaintOpt(opt)
 	if err != nil {
 		return
@@ -1035,7 +1035,7 @@ func (s *IssuesService) PullTaint(opt *IssuesPullTaintOption) (v []byte, resp *h
 
 // Reindex triggers reindexing of issues for a project.
 // Requires 'Administer System' permission.
-func (s *IssuesService) Reindex(opt *IssuesReindexOption) (resp *http.Response, err error) {
+func (s *IssuesService) Reindex(opt *IssuesReindexOptions) (resp *http.Response, err error) {
 	err = s.ValidateReindexOpt(opt)
 	if err != nil {
 		return
@@ -1058,7 +1058,7 @@ func (s *IssuesService) Reindex(opt *IssuesReindexOption) (resp *http.Response, 
 // Requires 'Browse' permission on the specified project(s).
 // For applications, it also requires 'Browse' permission on child projects.
 // Returns 503 when issue indexing is in progress.
-func (s *IssuesService) Search(opt *IssuesSearchOption) (v *IssuesSearch, resp *http.Response, err error) {
+func (s *IssuesService) Search(opt *IssuesSearchOptions) (v *IssuesSearch, resp *http.Response, err error) {
 	err = s.ValidateSearchOpt(opt)
 	if err != nil {
 		return
@@ -1081,7 +1081,7 @@ func (s *IssuesService) Search(opt *IssuesSearchOption) (v *IssuesSearch, resp *
 
 // SetSeverity changes the severity of an issue.
 // Requires authentication, 'Browse' and 'Administer Issues' permissions on the project.
-func (s *IssuesService) SetSeverity(opt *IssuesSetSeverityOption) (v *IssuesSetSeverity, resp *http.Response, err error) {
+func (s *IssuesService) SetSeverity(opt *IssuesSetSeverityOptions) (v *IssuesSetSeverity, resp *http.Response, err error) {
 	err = s.ValidateSetSeverityOpt(opt)
 	if err != nil {
 		return
@@ -1104,7 +1104,7 @@ func (s *IssuesService) SetSeverity(opt *IssuesSetSeverityOption) (v *IssuesSetS
 
 // SetTags sets tags on an issue.
 // Requires authentication and 'Browse' permission on the project.
-func (s *IssuesService) SetTags(opt *IssuesSetTagsOption) (v *IssuesSetTags, resp *http.Response, err error) {
+func (s *IssuesService) SetTags(opt *IssuesSetTagsOptions) (v *IssuesSetTags, resp *http.Response, err error) {
 	err = s.ValidateSetTagsOpt(opt)
 	if err != nil {
 		return
@@ -1127,7 +1127,7 @@ func (s *IssuesService) SetTags(opt *IssuesSetTagsOption) (v *IssuesSetTags, res
 
 // SetType changes the type of an issue.
 // Requires authentication, 'Browse' and 'Administer Issues' permissions on the project.
-func (s *IssuesService) SetType(opt *IssuesSetTypeOption) (v *IssuesSetType, resp *http.Response, err error) {
+func (s *IssuesService) SetType(opt *IssuesSetTypeOptions) (v *IssuesSetType, resp *http.Response, err error) {
 	err = s.ValidateSetTypeOpt(opt)
 	if err != nil {
 		return
@@ -1149,7 +1149,7 @@ func (s *IssuesService) SetType(opt *IssuesSetTypeOption) (v *IssuesSetType, res
 }
 
 // Tags lists tags matching a given query.
-func (s *IssuesService) Tags(opt *IssuesTagsOption) (v *IssuesTags, resp *http.Response, err error) {
+func (s *IssuesService) Tags(opt *IssuesTagsOptions) (v *IssuesTags, resp *http.Response, err error) {
 	err = s.ValidateTagsOpt(opt)
 	if err != nil {
 		return
@@ -1175,7 +1175,7 @@ func (s *IssuesService) Tags(opt *IssuesTagsOption) (v *IssuesTags, resp *http.R
 // =============================================================================
 
 // ValidateAddCommentOpt validates the options for adding a comment.
-func (s *IssuesService) ValidateAddCommentOpt(opt *IssuesAddCommentOption) error {
+func (s *IssuesService) ValidateAddCommentOpt(opt *IssuesAddCommentOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesAddCommentOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1194,7 +1194,7 @@ func (s *IssuesService) ValidateAddCommentOpt(opt *IssuesAddCommentOption) error
 }
 
 // ValidateAnticipatedTransitionsOpt validates the options for anticipated transitions.
-func (s *IssuesService) ValidateAnticipatedTransitionsOpt(opt *IssuesAnticipatedTransitionsOption) error {
+func (s *IssuesService) ValidateAnticipatedTransitionsOpt(opt *IssuesAnticipatedTransitionsOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesAnticipatedTransitionsOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1208,7 +1208,7 @@ func (s *IssuesService) ValidateAnticipatedTransitionsOpt(opt *IssuesAnticipated
 }
 
 // ValidateAssignOpt validates the options for assigning an issue.
-func (s *IssuesService) ValidateAssignOpt(opt *IssuesAssignOption) error {
+func (s *IssuesService) ValidateAssignOpt(opt *IssuesAssignOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesAssignOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1222,7 +1222,7 @@ func (s *IssuesService) ValidateAssignOpt(opt *IssuesAssignOption) error {
 }
 
 // ValidateAuthorsOpt validates the options for listing authors.
-func (s *IssuesService) ValidateAuthorsOpt(opt *IssuesAuthorsOption) error {
+func (s *IssuesService) ValidateAuthorsOpt(opt *IssuesAuthorsOptions) error {
 	if opt == nil {
 		return nil
 	}
@@ -1241,7 +1241,7 @@ func (s *IssuesService) ValidateAuthorsOpt(opt *IssuesAuthorsOption) error {
 }
 
 // ValidateBulkChangeOpt validates the options for bulk change.
-func (s *IssuesService) ValidateBulkChangeOpt(opt *IssuesBulkChangeOption) error {
+func (s *IssuesService) ValidateBulkChangeOpt(opt *IssuesBulkChangeOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesBulkChangeOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1278,7 +1278,7 @@ func (s *IssuesService) ValidateBulkChangeOpt(opt *IssuesBulkChangeOption) error
 }
 
 // ValidateChangelogOpt validates the options for changelog.
-func (s *IssuesService) ValidateChangelogOpt(opt *IssuesChangelogOption) error {
+func (s *IssuesService) ValidateChangelogOpt(opt *IssuesChangelogOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesChangelogOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1292,7 +1292,7 @@ func (s *IssuesService) ValidateChangelogOpt(opt *IssuesChangelogOption) error {
 }
 
 // ValidateComponentTagsOpt validates the options for component tags.
-func (s *IssuesService) ValidateComponentTagsOpt(opt *IssuesComponentTagsOption) error {
+func (s *IssuesService) ValidateComponentTagsOpt(opt *IssuesComponentTagsOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesComponentTagsOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1306,7 +1306,7 @@ func (s *IssuesService) ValidateComponentTagsOpt(opt *IssuesComponentTagsOption)
 }
 
 // ValidateDeleteCommentOpt validates the options for deleting a comment.
-func (s *IssuesService) ValidateDeleteCommentOpt(opt *IssuesDeleteCommentOption) error {
+func (s *IssuesService) ValidateDeleteCommentOpt(opt *IssuesDeleteCommentOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesDeleteCommentOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1320,7 +1320,7 @@ func (s *IssuesService) ValidateDeleteCommentOpt(opt *IssuesDeleteCommentOption)
 }
 
 // ValidateDoTransitionOpt validates the options for doing a transition.
-func (s *IssuesService) ValidateDoTransitionOpt(opt *IssuesDoTransitionOption) error {
+func (s *IssuesService) ValidateDoTransitionOpt(opt *IssuesDoTransitionOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesDoTransitionOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1344,7 +1344,7 @@ func (s *IssuesService) ValidateDoTransitionOpt(opt *IssuesDoTransitionOption) e
 }
 
 // ValidateEditCommentOpt validates the options for editing a comment.
-func (s *IssuesService) ValidateEditCommentOpt(opt *IssuesEditCommentOption) error {
+func (s *IssuesService) ValidateEditCommentOpt(opt *IssuesEditCommentOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesEditCommentOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1363,7 +1363,7 @@ func (s *IssuesService) ValidateEditCommentOpt(opt *IssuesEditCommentOption) err
 }
 
 // ValidateListOpt validates the options for listing issues.
-func (s *IssuesService) ValidateListOpt(opt *IssuesListOption) error {
+func (s *IssuesService) ValidateListOpt(opt *IssuesListOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesListOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1391,7 +1391,7 @@ func (s *IssuesService) ValidateListOpt(opt *IssuesListOption) error {
 }
 
 // ValidatePullOpt validates the options for pulling issues.
-func (s *IssuesService) ValidatePullOpt(opt *IssuesPullOption) error {
+func (s *IssuesService) ValidatePullOpt(opt *IssuesPullOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesPullOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1413,7 +1413,7 @@ func (s *IssuesService) ValidatePullOpt(opt *IssuesPullOption) error {
 }
 
 // ValidatePullTaintOpt validates the options for pulling taint vulnerabilities.
-func (s *IssuesService) ValidatePullTaintOpt(opt *IssuesPullTaintOption) error {
+func (s *IssuesService) ValidatePullTaintOpt(opt *IssuesPullTaintOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesPullTaintOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1435,7 +1435,7 @@ func (s *IssuesService) ValidatePullTaintOpt(opt *IssuesPullTaintOption) error {
 }
 
 // ValidateReindexOpt validates the options for reindexing.
-func (s *IssuesService) ValidateReindexOpt(opt *IssuesReindexOption) error {
+func (s *IssuesService) ValidateReindexOpt(opt *IssuesReindexOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesReindexOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1451,7 +1451,7 @@ func (s *IssuesService) ValidateReindexOpt(opt *IssuesReindexOption) error {
 // ValidateSearchOpt validates the options for searching issues.
 //
 //nolint:cyclop,funlen,gocognit,gocyclo // Validation functions are naturally complex due to multiple checks
-func (s *IssuesService) ValidateSearchOpt(opt *IssuesSearchOption) error {
+func (s *IssuesService) ValidateSearchOpt(opt *IssuesSearchOptions) error {
 	if opt == nil {
 		return nil
 	}
@@ -1578,7 +1578,7 @@ func (s *IssuesService) ValidateSearchOpt(opt *IssuesSearchOption) error {
 }
 
 // ValidateSetSeverityOpt validates the options for setting severity.
-func (s *IssuesService) ValidateSetSeverityOpt(opt *IssuesSetSeverityOption) error {
+func (s *IssuesService) ValidateSetSeverityOpt(opt *IssuesSetSeverityOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesSetSeverityOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1600,7 +1600,7 @@ func (s *IssuesService) ValidateSetSeverityOpt(opt *IssuesSetSeverityOption) err
 }
 
 // ValidateSetTagsOpt validates the options for setting tags.
-func (s *IssuesService) ValidateSetTagsOpt(opt *IssuesSetTagsOption) error {
+func (s *IssuesService) ValidateSetTagsOpt(opt *IssuesSetTagsOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesSetTagsOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1614,7 +1614,7 @@ func (s *IssuesService) ValidateSetTagsOpt(opt *IssuesSetTagsOption) error {
 }
 
 // ValidateSetTypeOpt validates the options for setting type.
-func (s *IssuesService) ValidateSetTypeOpt(opt *IssuesSetTypeOption) error {
+func (s *IssuesService) ValidateSetTypeOpt(opt *IssuesSetTypeOptions) error {
 	if opt == nil {
 		return NewValidationError("IssuesSetTypeOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1638,7 +1638,7 @@ func (s *IssuesService) ValidateSetTypeOpt(opt *IssuesSetTypeOption) error {
 }
 
 // ValidateTagsOpt validates the options for listing tags.
-func (s *IssuesService) ValidateTagsOpt(opt *IssuesTagsOption) error {
+func (s *IssuesService) ValidateTagsOpt(opt *IssuesTagsOptions) error {
 	if opt == nil {
 		return nil
 	}

--- a/sonar/issues_service_test.go
+++ b/sonar/issues_service_test.go
@@ -29,7 +29,7 @@ func TestIssues_AddComment(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesAddCommentOption{
+	opt := &IssuesAddCommentOptions{
 		Issue: "AU-Tpxb--iU5OvuD2FLy",
 		Text:  "This is a comment",
 	}
@@ -44,7 +44,7 @@ func TestIssues_AddComment_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *IssuesAddCommentOption
+		opt  *IssuesAddCommentOptions
 	}{
 		{
 			name: "nil option",
@@ -52,11 +52,11 @@ func TestIssues_AddComment_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing Issue",
-			opt:  &IssuesAddCommentOption{Text: "test"},
+			opt:  &IssuesAddCommentOptions{Text: "test"},
 		},
 		{
 			name: "missing Text",
-			opt:  &IssuesAddCommentOption{Issue: "key"},
+			opt:  &IssuesAddCommentOptions{Issue: "key"},
 		},
 	}
 
@@ -89,7 +89,7 @@ func TestIssues_Assign(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesAssignOption{
+	opt := &IssuesAssignOptions{
 		Issue:    "test-key",
 		Assignee: "admin",
 	}
@@ -115,7 +115,7 @@ func TestIssues_Authors(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesAuthorsOption{
+	opt := &IssuesAuthorsOptions{
 		Project:  "my-project",
 		PageSize: 50,
 	}
@@ -128,7 +128,7 @@ func TestIssues_Authors(t *testing.T) {
 func TestIssues_Authors_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.Issues.Authors(&IssuesAuthorsOption{PageSize: 150})
+	_, _, err := client.Issues.Authors(&IssuesAuthorsOptions{PageSize: 150})
 	assert.Error(t, err)
 }
 
@@ -148,7 +148,7 @@ func TestIssues_BulkChange(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesBulkChangeOption{
+	opt := &IssuesBulkChangeOptions{
 		Issues:      []string{"issue1", "issue2"},
 		SetSeverity: "MAJOR",
 		AddTags:     []string{"tag1", "tag2"},
@@ -164,7 +164,7 @@ func TestIssues_BulkChange_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *IssuesBulkChangeOption
+		opt  *IssuesBulkChangeOptions
 	}{
 		{
 			name: "nil option",
@@ -172,25 +172,25 @@ func TestIssues_BulkChange_ValidationError(t *testing.T) {
 		},
 		{
 			name: "empty issues",
-			opt:  &IssuesBulkChangeOption{},
+			opt:  &IssuesBulkChangeOptions{},
 		},
 		{
 			name: "invalid severity",
-			opt: &IssuesBulkChangeOption{
+			opt: &IssuesBulkChangeOptions{
 				Issues:      []string{"issue1"},
 				SetSeverity: "INVALID",
 			},
 		},
 		{
 			name: "invalid type",
-			opt: &IssuesBulkChangeOption{
+			opt: &IssuesBulkChangeOptions{
 				Issues:  []string{"issue1"},
 				SetType: "INVALID",
 			},
 		},
 		{
 			name: "invalid transition",
-			opt: &IssuesBulkChangeOption{
+			opt: &IssuesBulkChangeOptions{
 				Issues:       []string{"issue1"},
 				DoTransition: "invalid",
 			},
@@ -232,7 +232,7 @@ func TestIssues_Changelog(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesChangelogOption{Issue: "test-key"}
+	opt := &IssuesChangelogOptions{Issue: "test-key"}
 	result, resp, err := client.Issues.Changelog(opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -255,7 +255,7 @@ func TestIssues_ComponentTags(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesComponentTagsOption{ComponentUuid: "uuid-123"}
+	opt := &IssuesComponentTagsOptions{ComponentUuid: "uuid-123"}
 	result, resp, err := client.Issues.ComponentTags(opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -278,7 +278,7 @@ func TestIssues_DeleteComment(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesDeleteCommentOption{Comment: "comment-key"}
+	opt := &IssuesDeleteCommentOptions{Comment: "comment-key"}
 	result, resp, err := client.Issues.DeleteComment(opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -301,7 +301,7 @@ func TestIssues_DoTransition(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesDoTransitionOption{
+	opt := &IssuesDoTransitionOptions{
 		Issue:      "test-key",
 		Transition: "confirm",
 	}
@@ -314,7 +314,7 @@ func TestIssues_DoTransition(t *testing.T) {
 func TestIssues_DoTransition_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.Issues.DoTransition(&IssuesDoTransitionOption{
+	_, _, err := client.Issues.DoTransition(&IssuesDoTransitionOptions{
 		Issue:      "test-key",
 		Transition: "invalid",
 	})
@@ -337,7 +337,7 @@ func TestIssues_EditComment(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesEditCommentOption{
+	opt := &IssuesEditCommentOptions{
 		Comment: "comment-key",
 		Text:    "Updated comment",
 	}
@@ -367,7 +367,7 @@ func TestIssues_List(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesListOption{
+	opt := &IssuesListOptions{
 		Project: "my-project",
 	}
 	result, resp, err := client.Issues.List(opt)
@@ -381,7 +381,7 @@ func TestIssues_List_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *IssuesListOption
+		opt  *IssuesListOptions
 	}{
 		{
 			name: "nil option",
@@ -389,11 +389,11 @@ func TestIssues_List_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing project and component",
-			opt:  &IssuesListOption{},
+			opt:  &IssuesListOptions{},
 		},
 		{
 			name: "invalid type",
-			opt: &IssuesListOption{
+			opt: &IssuesListOptions{
 				Project: "my-project",
 				Types:   []string{"INVALID"},
 			},
@@ -431,7 +431,7 @@ func TestIssues_Search(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesSearchOption{
+	opt := &IssuesSearchOptions{
 		Projects:         []string{"my-project"},
 		Severities:       []string{"BLOCKER", "CRITICAL"},
 		Types:            []string{"BUG"},
@@ -448,35 +448,35 @@ func TestIssues_Search_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *IssuesSearchOption
+		opt  *IssuesSearchOptions
 	}{
 		{
 			name: "invalid severity",
-			opt: &IssuesSearchOption{
+			opt: &IssuesSearchOptions{
 				Severities: []string{"INVALID"},
 			},
 		},
 		{
 			name: "invalid type",
-			opt: &IssuesSearchOption{
+			opt: &IssuesSearchOptions{
 				Types: []string{"INVALID"},
 			},
 		},
 		{
 			name: "invalid impact severity",
-			opt: &IssuesSearchOption{
+			opt: &IssuesSearchOptions{
 				ImpactSeverities: []string{"INVALID"},
 			},
 		},
 		{
 			name: "invalid impact software quality",
-			opt: &IssuesSearchOption{
+			opt: &IssuesSearchOptions{
 				ImpactSoftwareQualities: []string{"INVALID"},
 			},
 		},
 		{
 			name: "invalid clean code attribute category",
-			opt: &IssuesSearchOption{
+			opt: &IssuesSearchOptions{
 				CleanCodeAttributeCategories: []string{"INVALID"},
 			},
 		},
@@ -506,7 +506,7 @@ func TestIssues_SetSeverity(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesSetSeverityOption{
+	opt := &IssuesSetSeverityOptions{
 		Issue:    "test-key",
 		Severity: "BLOCKER",
 	}
@@ -519,7 +519,7 @@ func TestIssues_SetSeverity(t *testing.T) {
 func TestIssues_SetSeverity_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.Issues.SetSeverity(&IssuesSetSeverityOption{
+	_, _, err := client.Issues.SetSeverity(&IssuesSetSeverityOptions{
 		Issue:    "test-key",
 		Severity: "INVALID",
 	})
@@ -542,7 +542,7 @@ func TestIssues_SetTags(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesSetTagsOption{
+	opt := &IssuesSetTagsOptions{
 		Issue: "test-key",
 		Tags:  []string{"security", "cwe"},
 	}
@@ -568,7 +568,7 @@ func TestIssues_SetType(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesSetTypeOption{
+	opt := &IssuesSetTypeOptions{
 		Issue: "test-key",
 		Type:  "BUG",
 	}
@@ -583,19 +583,19 @@ func TestIssues_SetType_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *IssuesSetTypeOption
+		opt  *IssuesSetTypeOptions
 	}{
 		{
 			name: "missing issue",
-			opt:  &IssuesSetTypeOption{Type: "BUG"},
+			opt:  &IssuesSetTypeOptions{Type: "BUG"},
 		},
 		{
 			name: "missing type",
-			opt:  &IssuesSetTypeOption{Issue: "test-key"},
+			opt:  &IssuesSetTypeOptions{Issue: "test-key"},
 		},
 		{
 			name: "invalid type",
-			opt: &IssuesSetTypeOption{
+			opt: &IssuesSetTypeOptions{
 				Issue: "test-key",
 				Type:  "INVALID",
 			},
@@ -626,7 +626,7 @@ func TestIssues_Tags(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesTagsOption{
+	opt := &IssuesTagsOptions{
 		Project:  "my-project",
 		PageSize: 100,
 	}
@@ -652,7 +652,7 @@ func TestIssues_Pull(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesPullOption{
+	opt := &IssuesPullOptions{
 		ProjectKey: "my-project",
 		BranchName: "main",
 	}
@@ -667,7 +667,7 @@ func TestIssues_Pull_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *IssuesPullOption
+		opt  *IssuesPullOptions
 	}{
 		{
 			name: "nil option",
@@ -675,11 +675,11 @@ func TestIssues_Pull_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing project key",
-			opt:  &IssuesPullOption{},
+			opt:  &IssuesPullOptions{},
 		},
 		{
 			name: "invalid language",
-			opt: &IssuesPullOption{
+			opt: &IssuesPullOptions{
 				ProjectKey: "my-project",
 				Languages:  []string{"invalid-language"},
 			},
@@ -710,7 +710,7 @@ func TestIssues_PullTaint(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesPullTaintOption{
+	opt := &IssuesPullTaintOptions{
 		ProjectKey: "my-project",
 		BranchName: "main",
 	}
@@ -734,7 +734,7 @@ func TestIssues_Reindex(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesReindexOption{Project: "my-project"}
+	opt := &IssuesReindexOptions{Project: "my-project"}
 	resp, err := client.Issues.Reindex(opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
@@ -754,7 +754,7 @@ func TestIssues_AnticipatedTransitions(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &IssuesAnticipatedTransitionsOption{ProjectKey: "my-project"}
+	opt := &IssuesAnticipatedTransitionsOptions{ProjectKey: "my-project"}
 	resp, err := client.Issues.AnticipatedTransitions(opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
@@ -765,7 +765,7 @@ func TestIssues_AnticipatedTransitions_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *IssuesAnticipatedTransitionsOption
+		opt  *IssuesAnticipatedTransitionsOptions
 	}{
 		{
 			name: "nil option",
@@ -773,7 +773,7 @@ func TestIssues_AnticipatedTransitions_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing project key",
-			opt:  &IssuesAnticipatedTransitionsOption{},
+			opt:  &IssuesAnticipatedTransitionsOptions{},
 		},
 	}
 
@@ -794,7 +794,7 @@ func TestIssues_ValidateAssignOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *IssuesAssignOption
+		opt     *IssuesAssignOptions
 		wantErr bool
 	}{
 		{
@@ -804,12 +804,12 @@ func TestIssues_ValidateAssignOpt(t *testing.T) {
 		},
 		{
 			name:    "missing Issue",
-			opt:     &IssuesAssignOption{},
+			opt:     &IssuesAssignOptions{},
 			wantErr: true,
 		},
 		{
 			name:    "valid option",
-			opt:     &IssuesAssignOption{Issue: "issue-key"},
+			opt:     &IssuesAssignOptions{Issue: "issue-key"},
 			wantErr: false,
 		},
 	}
@@ -831,7 +831,7 @@ func TestIssues_ValidateChangelogOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *IssuesChangelogOption
+		opt     *IssuesChangelogOptions
 		wantErr bool
 	}{
 		{
@@ -841,12 +841,12 @@ func TestIssues_ValidateChangelogOpt(t *testing.T) {
 		},
 		{
 			name:    "missing Issue",
-			opt:     &IssuesChangelogOption{},
+			opt:     &IssuesChangelogOptions{},
 			wantErr: true,
 		},
 		{
 			name:    "valid option",
-			opt:     &IssuesChangelogOption{Issue: "issue-key"},
+			opt:     &IssuesChangelogOptions{Issue: "issue-key"},
 			wantErr: false,
 		},
 	}
@@ -868,7 +868,7 @@ func TestIssues_ValidateComponentTagsOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *IssuesComponentTagsOption
+		opt     *IssuesComponentTagsOptions
 		wantErr bool
 	}{
 		{
@@ -878,12 +878,12 @@ func TestIssues_ValidateComponentTagsOpt(t *testing.T) {
 		},
 		{
 			name:    "missing ComponentUuid",
-			opt:     &IssuesComponentTagsOption{},
+			opt:     &IssuesComponentTagsOptions{},
 			wantErr: true,
 		},
 		{
 			name:    "valid option",
-			opt:     &IssuesComponentTagsOption{ComponentUuid: "uuid"},
+			opt:     &IssuesComponentTagsOptions{ComponentUuid: "uuid"},
 			wantErr: false,
 		},
 	}
@@ -905,7 +905,7 @@ func TestIssues_ValidateDeleteCommentOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *IssuesDeleteCommentOption
+		opt     *IssuesDeleteCommentOptions
 		wantErr bool
 	}{
 		{
@@ -915,12 +915,12 @@ func TestIssues_ValidateDeleteCommentOpt(t *testing.T) {
 		},
 		{
 			name:    "missing Comment",
-			opt:     &IssuesDeleteCommentOption{},
+			opt:     &IssuesDeleteCommentOptions{},
 			wantErr: true,
 		},
 		{
 			name:    "valid option",
-			opt:     &IssuesDeleteCommentOption{Comment: "comment-key"},
+			opt:     &IssuesDeleteCommentOptions{Comment: "comment-key"},
 			wantErr: false,
 		},
 	}
@@ -942,7 +942,7 @@ func TestIssues_ValidateEditCommentOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *IssuesEditCommentOption
+		opt     *IssuesEditCommentOptions
 		wantErr bool
 	}{
 		{
@@ -952,17 +952,17 @@ func TestIssues_ValidateEditCommentOpt(t *testing.T) {
 		},
 		{
 			name:    "missing Comment",
-			opt:     &IssuesEditCommentOption{Text: "new text"},
+			opt:     &IssuesEditCommentOptions{Text: "new text"},
 			wantErr: true,
 		},
 		{
 			name:    "missing Text",
-			opt:     &IssuesEditCommentOption{Comment: "comment-key"},
+			opt:     &IssuesEditCommentOptions{Comment: "comment-key"},
 			wantErr: true,
 		},
 		{
 			name:    "valid option",
-			opt:     &IssuesEditCommentOption{Comment: "comment-key", Text: "new text"},
+			opt:     &IssuesEditCommentOptions{Comment: "comment-key", Text: "new text"},
 			wantErr: false,
 		},
 	}
@@ -984,7 +984,7 @@ func TestIssues_ValidateReindexOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *IssuesReindexOption
+		opt     *IssuesReindexOptions
 		wantErr bool
 	}{
 		{
@@ -994,12 +994,12 @@ func TestIssues_ValidateReindexOpt(t *testing.T) {
 		},
 		{
 			name:    "missing Project",
-			opt:     &IssuesReindexOption{},
+			opt:     &IssuesReindexOptions{},
 			wantErr: true,
 		},
 		{
 			name:    "valid option",
-			opt:     &IssuesReindexOption{Project: "project-key"},
+			opt:     &IssuesReindexOptions{Project: "project-key"},
 			wantErr: false,
 		},
 	}
@@ -1021,7 +1021,7 @@ func TestIssues_ValidateSetTagsOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *IssuesSetTagsOption
+		opt     *IssuesSetTagsOptions
 		wantErr bool
 	}{
 		{
@@ -1031,12 +1031,12 @@ func TestIssues_ValidateSetTagsOpt(t *testing.T) {
 		},
 		{
 			name:    "missing Issue",
-			opt:     &IssuesSetTagsOption{},
+			opt:     &IssuesSetTagsOptions{},
 			wantErr: true,
 		},
 		{
 			name:    "valid option",
-			opt:     &IssuesSetTagsOption{Issue: "issue-key"},
+			opt:     &IssuesSetTagsOptions{Issue: "issue-key"},
 			wantErr: false,
 		},
 	}
@@ -1058,7 +1058,7 @@ func TestIssues_ValidatePullTaintOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *IssuesPullTaintOption
+		opt     *IssuesPullTaintOptions
 		wantErr bool
 	}{
 		{
@@ -1068,17 +1068,17 @@ func TestIssues_ValidatePullTaintOpt(t *testing.T) {
 		},
 		{
 			name:    "missing ProjectKey",
-			opt:     &IssuesPullTaintOption{},
+			opt:     &IssuesPullTaintOptions{},
 			wantErr: true,
 		},
 		{
 			name:    "invalid language",
-			opt:     &IssuesPullTaintOption{ProjectKey: "project", Languages: []string{"invalid"}},
+			opt:     &IssuesPullTaintOptions{ProjectKey: "project", Languages: []string{"invalid"}},
 			wantErr: true,
 		},
 		{
 			name:    "valid option",
-			opt:     &IssuesPullTaintOption{ProjectKey: "project", Languages: []string{"java"}},
+			opt:     &IssuesPullTaintOptions{ProjectKey: "project", Languages: []string{"java"}},
 			wantErr: false,
 		},
 	}
@@ -1100,7 +1100,7 @@ func TestIssues_ValidateTagsOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *IssuesTagsOption
+		opt     *IssuesTagsOptions
 		wantErr bool
 	}{
 		{
@@ -1110,17 +1110,17 @@ func TestIssues_ValidateTagsOpt(t *testing.T) {
 		},
 		{
 			name:    "PageSize 0 (valid)",
-			opt:     &IssuesTagsOption{PageSize: 0},
+			opt:     &IssuesTagsOptions{PageSize: 0},
 			wantErr: false,
 		},
 		{
 			name:    "PageSize 501 (invalid)",
-			opt:     &IssuesTagsOption{PageSize: 501},
+			opt:     &IssuesTagsOptions{PageSize: 501},
 			wantErr: true,
 		},
 		{
 			name:    "PageSize 100 (valid)",
-			opt:     &IssuesTagsOption{PageSize: 100},
+			opt:     &IssuesTagsOptions{PageSize: 100},
 			wantErr: false,
 		},
 	}

--- a/sonar/l10n_service.go
+++ b/sonar/l10n_service.go
@@ -28,8 +28,8 @@ type L10NIndex struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// L10NIndexOption contains parameters for the Index method.
-type L10NIndexOption struct {
+// L10NIndexOptions contains parameters for the Index method.
+type L10NIndexOptions struct {
 	// Locale is the BCP47 language tag, used to override the browser Accept-Language header.
 	Locale string `url:"locale,omitempty"`
 	// Timestamp is the date of the last cache update.
@@ -41,7 +41,7 @@ type L10NIndexOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateIndexOpt validates the options for the Index method.
-func (s *L10NService) ValidateIndexOpt(opt *L10NIndexOption) error {
+func (s *L10NService) ValidateIndexOpt(opt *L10NIndexOptions) error {
 	// Options are optional; nothing to validate.
 	return nil
 }
@@ -54,7 +54,7 @@ func (s *L10NService) ValidateIndexOpt(opt *L10NIndexOption) error {
 //
 // API endpoint: GET /api/l10n/index.
 // Warning: This API is internal and may change without notice.
-func (s *L10NService) Index(opt *L10NIndexOption) (*L10NIndex, *http.Response, error) {
+func (s *L10NService) Index(opt *L10NIndexOptions) (*L10NIndex, *http.Response, error) {
 	err := s.ValidateIndexOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/l10n_service_test.go
+++ b/sonar/l10n_service_test.go
@@ -44,7 +44,7 @@ func TestL10N_Index_WithLocale(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.L10N.Index(&L10NIndexOption{Locale: "fr"})
+	result, resp, err := client.L10N.Index(&L10NIndexOptions{Locale: "fr"})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "fr", result.Locale)
@@ -56,7 +56,7 @@ func TestL10N_Index_WithTimestamp(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	_, _, err := client.L10N.Index(&L10NIndexOption{Timestamp: "2024-01-01T00:00:00+0000"})
+	_, _, err := client.L10N.Index(&L10NIndexOptions{Timestamp: "2024-01-01T00:00:00+0000"})
 	require.NoError(t, err)
 }
 
@@ -76,14 +76,14 @@ func TestL10N_ValidateIndexOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *L10NIndexOption
+		opt     *L10NIndexOptions
 		wantErr bool
 	}{
 		{"nil option", nil, false},
-		{"empty option", &L10NIndexOption{}, false},
-		{"with Locale", &L10NIndexOption{Locale: "en"}, false},
-		{"with Timestamp", &L10NIndexOption{Timestamp: "2024-01-01T00:00:00+0000"}, false},
-		{"with both", &L10NIndexOption{Locale: "fr", Timestamp: "2024-01-01T00:00:00+0000"}, false},
+		{"empty option", &L10NIndexOptions{}, false},
+		{"with Locale", &L10NIndexOptions{Locale: "en"}, false},
+		{"with Timestamp", &L10NIndexOptions{Timestamp: "2024-01-01T00:00:00+0000"}, false},
+		{"with both", &L10NIndexOptions{Locale: "fr", Timestamp: "2024-01-01T00:00:00+0000"}, false},
 	}
 
 	for _, tt := range tests {

--- a/sonar/languages_service.go
+++ b/sonar/languages_service.go
@@ -32,8 +32,8 @@ type Language struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// LanguagesListOption contains parameters for the List method.
-type LanguagesListOption struct {
+// LanguagesListOptions contains parameters for the List method.
+type LanguagesListOptions struct {
 	// Query is a pattern to match language keys/names against.
 	Query string `url:"q,omitempty"`
 	// PageSize is the size of the list to return. Use 0 for all languages.
@@ -48,7 +48,7 @@ type LanguagesListOption struct {
 // ValidateListOpt validates the options for the List method.
 // Currently, there are no validation rules for this method,
 // but this function is provided for consistency and future extensibility.
-func (s *LanguagesService) ValidateListOpt(opt *LanguagesListOption) error {
+func (s *LanguagesService) ValidateListOpt(opt *LanguagesListOptions) error {
 	// No required fields, no validation needed
 	return nil
 }
@@ -61,7 +61,7 @@ func (s *LanguagesService) ValidateListOpt(opt *LanguagesListOption) error {
 //
 // API endpoint: GET /api/languages/list.
 // Since: 5.1.
-func (s *LanguagesService) List(opt *LanguagesListOption) (*LanguagesList, *http.Response, error) {
+func (s *LanguagesService) List(opt *LanguagesListOptions) (*LanguagesList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/languages_service_test.go
+++ b/sonar/languages_service_test.go
@@ -20,7 +20,7 @@ func TestLanguages_List(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.Languages.List(&LanguagesListOption{})
+	result, resp, err := client.Languages.List(&LanguagesListOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -35,7 +35,7 @@ func TestLanguages_List_WithQuery(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.Languages.List(&LanguagesListOption{Query: "java"})
+	result, resp, err := client.Languages.List(&LanguagesListOptions{Query: "java"})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Languages, 1)
@@ -57,12 +57,12 @@ func TestLanguages_ValidateListOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *LanguagesListOption
+		opt     *LanguagesListOptions
 		wantErr bool
 	}{
 		{"nil option", nil, false},
-		{"empty option", &LanguagesListOption{}, false},
-		{"with query", &LanguagesListOption{Query: "java", PageSize: 25}, false},
+		{"empty option", &LanguagesListOptions{}, false},
+		{"with query", &LanguagesListOptions{Query: "java", PageSize: 25}, false},
 	}
 
 	for _, tt := range tests {

--- a/sonar/measures_service.go
+++ b/sonar/measures_service.go
@@ -182,10 +182,10 @@ type MeasurePeriod struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// MeasuresComponentOption represents options for getting component measures.
+// MeasuresComponentOptions represents options for getting component measures.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type MeasuresComponentOption struct {
+type MeasuresComponentOptions struct {
 	// Component is the component key (required).
 	Component string `url:"component,omitempty"`
 	// MetricKeys is the list of metric keys to fetch (required).
@@ -199,10 +199,10 @@ type MeasuresComponentOption struct {
 	PullRequest string `url:"pullRequest,omitempty"`
 }
 
-// MeasuresComponentTreeOption represents options for getting component tree measures.
+// MeasuresComponentTreeOptions represents options for getting component tree measures.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type MeasuresComponentTreeOption struct {
+type MeasuresComponentTreeOptions struct {
 	PaginationArgs
 
 	// Component is the base component key (required).
@@ -238,18 +238,18 @@ type MeasuresComponentTreeOption struct {
 	Strategy string `url:"strategy,omitempty"`
 }
 
-// MeasuresSearchOption represents options for searching measures.
-type MeasuresSearchOption struct {
+// MeasuresSearchOptions represents options for searching measures.
+type MeasuresSearchOptions struct {
 	// MetricKeys is the list of metric keys to fetch (required).
 	MetricKeys []string `url:"metricKeys,omitempty,comma"`
 	// ProjectKeys is the list of project keys (required).
 	ProjectKeys []string `url:"projectKeys,omitempty,comma"`
 }
 
-// MeasuresSearchHistoryOption represents options for getting measures history.
+// MeasuresSearchHistoryOptions represents options for getting measures history.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type MeasuresSearchHistoryOption struct {
+type MeasuresSearchHistoryOptions struct {
 	PaginationArgs
 
 	// Component is the component key (required).
@@ -273,7 +273,7 @@ type MeasuresSearchHistoryOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateComponentOpt validates the options for Component.
-func (s *MeasuresService) ValidateComponentOpt(opt *MeasuresComponentOption) error {
+func (s *MeasuresService) ValidateComponentOpt(opt *MeasuresComponentOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -291,7 +291,7 @@ func (s *MeasuresService) ValidateComponentOpt(opt *MeasuresComponentOption) err
 }
 
 // ValidateComponentTreeOpt validates the options for ComponentTree.
-func (s *MeasuresService) ValidateComponentTreeOpt(opt *MeasuresComponentTreeOption) error {
+func (s *MeasuresService) ValidateComponentTreeOpt(opt *MeasuresComponentTreeOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -328,7 +328,7 @@ func (s *MeasuresService) ValidateComponentTreeOpt(opt *MeasuresComponentTreeOpt
 }
 
 // ValidateSearchOpt validates the options for Search.
-func (s *MeasuresService) ValidateSearchOpt(opt *MeasuresSearchOption) error {
+func (s *MeasuresService) ValidateSearchOpt(opt *MeasuresSearchOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -345,7 +345,7 @@ func (s *MeasuresService) ValidateSearchOpt(opt *MeasuresSearchOption) error {
 }
 
 // ValidateSearchHistoryOpt validates the options for SearchHistory.
-func (s *MeasuresService) ValidateSearchHistoryOpt(opt *MeasuresSearchHistoryOption) error {
+func (s *MeasuresService) ValidateSearchHistoryOpt(opt *MeasuresSearchHistoryOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -375,7 +375,7 @@ func (s *MeasuresService) ValidateSearchHistoryOpt(opt *MeasuresSearchHistoryOpt
 // Requires the following permission: 'Browse' on the project of specified component.
 //
 // Since: 5.4.
-func (s *MeasuresService) Component(opt *MeasuresComponentOption) (*MeasuresComponent, *http.Response, error) {
+func (s *MeasuresService) Component(opt *MeasuresComponentOptions) (*MeasuresComponent, *http.Response, error) {
 	err := s.ValidateComponentOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -402,7 +402,7 @@ func (s *MeasuresService) Component(opt *MeasuresComponentOption) (*MeasuresComp
 // When limiting search with the q parameter, directories are not returned.
 //
 // Since: 5.4.
-func (s *MeasuresService) ComponentTree(opt *MeasuresComponentTreeOption) (*MeasuresComponentTree, *http.Response, error) {
+func (s *MeasuresService) ComponentTree(opt *MeasuresComponentTreeOptions) (*MeasuresComponentTree, *http.Response, error) {
 	err := s.ValidateComponentTreeOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -428,7 +428,7 @@ func (s *MeasuresService) ComponentTree(opt *MeasuresComponentTreeOption) (*Meas
 // At most 100 projects can be provided.
 //
 // Since: 6.2.
-func (s *MeasuresService) Search(opt *MeasuresSearchOption) (*MeasuresSearch, *http.Response, error) {
+func (s *MeasuresService) Search(opt *MeasuresSearchOptions) (*MeasuresSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -454,7 +454,7 @@ func (s *MeasuresService) Search(opt *MeasuresSearchOption) (*MeasuresSearch, *h
 // Requires the following permission: 'Browse' on the specified component.
 //
 // Since: 6.3.
-func (s *MeasuresService) SearchHistory(opt *MeasuresSearchHistoryOption) (*MeasuresSearchHistory, *http.Response, error) {
+func (s *MeasuresService) SearchHistory(opt *MeasuresSearchHistoryOptions) (*MeasuresSearchHistory, *http.Response, error) {
 	err := s.ValidateSearchHistoryOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/measures_service_test.go
+++ b/sonar/measures_service_test.go
@@ -33,7 +33,7 @@ func TestMeasuresService_Component(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &MeasuresComponentOption{
+	opt := &MeasuresComponentOptions{
 		Component:  "my-project",
 		MetricKeys: []string{"coverage", "bugs", "vulnerabilities"},
 	}
@@ -50,14 +50,14 @@ func TestMeasuresService_Component_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing Component
-	opt := &MeasuresComponentOption{
+	opt := &MeasuresComponentOptions{
 		MetricKeys: []string{"coverage"},
 	}
 	_, _, err := client.Measures.Component(opt)
 	assert.Error(t, err)
 
 	// Test missing MetricKeys
-	opt = &MeasuresComponentOption{
+	opt = &MeasuresComponentOptions{
 		Component: "my-project",
 	}
 	_, _, err = client.Measures.Component(opt)
@@ -93,7 +93,7 @@ func TestMeasuresService_ComponentTree(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &MeasuresComponentTreeOption{
+	opt := &MeasuresComponentTreeOptions{
 		Component:  "my-project",
 		MetricKeys: []string{"coverage"},
 		Strategy:   "all",
@@ -111,21 +111,21 @@ func TestMeasuresService_ComponentTree_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing Component
-	opt := &MeasuresComponentTreeOption{
+	opt := &MeasuresComponentTreeOptions{
 		MetricKeys: []string{"coverage"},
 	}
 	_, _, err := client.Measures.ComponentTree(opt)
 	assert.Error(t, err)
 
 	// Test missing MetricKeys
-	opt = &MeasuresComponentTreeOption{
+	opt = &MeasuresComponentTreeOptions{
 		Component: "my-project",
 	}
 	_, _, err = client.Measures.ComponentTree(opt)
 	assert.Error(t, err)
 
 	// Test invalid Strategy
-	opt = &MeasuresComponentTreeOption{
+	opt = &MeasuresComponentTreeOptions{
 		Component:  "my-project",
 		MetricKeys: []string{"coverage"},
 		Strategy:   "invalid",
@@ -134,7 +134,7 @@ func TestMeasuresService_ComponentTree_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test invalid MetricSortFilter
-	opt = &MeasuresComponentTreeOption{
+	opt = &MeasuresComponentTreeOptions{
 		Component:        "my-project",
 		MetricKeys:       []string{"coverage"},
 		MetricSortFilter: "invalid",
@@ -155,7 +155,7 @@ func TestMeasuresService_Search(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &MeasuresSearchOption{
+	opt := &MeasuresSearchOptions{
 		MetricKeys:  []string{"coverage"},
 		ProjectKeys: []string{"project1", "project2"},
 	}
@@ -171,14 +171,14 @@ func TestMeasuresService_Search_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing MetricKeys
-	opt := &MeasuresSearchOption{
+	opt := &MeasuresSearchOptions{
 		ProjectKeys: []string{"project1"},
 	}
 	_, _, err := client.Measures.Search(opt)
 	assert.Error(t, err)
 
 	// Test missing ProjectKeys
-	opt = &MeasuresSearchOption{
+	opt = &MeasuresSearchOptions{
 		MetricKeys: []string{"coverage"},
 	}
 	_, _, err = client.Measures.Search(opt)
@@ -204,7 +204,7 @@ func TestMeasuresService_SearchHistory(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &MeasuresSearchHistoryOption{
+	opt := &MeasuresSearchHistoryOptions{
 		Component: "my-project",
 		Metrics:   []string{"coverage"},
 		From:      "2024-01-01",
@@ -223,14 +223,14 @@ func TestMeasuresService_SearchHistory_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing Component
-	opt := &MeasuresSearchHistoryOption{
+	opt := &MeasuresSearchHistoryOptions{
 		Metrics: []string{"coverage"},
 	}
 	_, _, err := client.Measures.SearchHistory(opt)
 	assert.Error(t, err)
 
 	// Test missing Metrics
-	opt = &MeasuresSearchHistoryOption{
+	opt = &MeasuresSearchHistoryOptions{
 		Component: "my-project",
 	}
 	_, _, err = client.Measures.SearchHistory(opt)

--- a/sonar/metrics_service.go
+++ b/sonar/metrics_service.go
@@ -58,8 +58,8 @@ type MetricsTypes struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// MetricsSearchOption contains parameters for the Search method.
-type MetricsSearchOption struct {
+// MetricsSearchOptions contains parameters for the Search method.
+type MetricsSearchOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 }
@@ -69,7 +69,7 @@ type MetricsSearchOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateSearchOpt validates the options for the Search method.
-func (s *MetricsService) ValidateSearchOpt(opt *MetricsSearchOption) error {
+func (s *MetricsService) ValidateSearchOpt(opt *MetricsSearchOptions) error {
 	if opt == nil {
 		return nil
 	}
@@ -85,7 +85,7 @@ func (s *MetricsService) ValidateSearchOpt(opt *MetricsSearchOption) error {
 //
 // API endpoint: GET /api/metrics/search.
 // Since: 2.6.
-func (s *MetricsService) Search(opt *MetricsSearchOption) (*MetricsSearch, *http.Response, error) {
+func (s *MetricsService) Search(opt *MetricsSearchOptions) (*MetricsSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/metrics_service_test.go
+++ b/sonar/metrics_service_test.go
@@ -62,7 +62,7 @@ func TestMetrics_Search_WithPagination(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &MetricsSearchOption{
+	opt := &MetricsSearchOptions{
 		PaginationArgs: PaginationArgs{
 			Page:     2,
 			PageSize: 50,
@@ -93,12 +93,12 @@ func TestMetrics_ValidateSearchOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *MetricsSearchOption
+		opt     *MetricsSearchOptions
 		wantErr bool
 	}{
 		{"nil option", nil, false},
-		{"empty option", &MetricsSearchOption{}, false},
-		{"valid pagination", &MetricsSearchOption{PaginationArgs: PaginationArgs{Page: 1, PageSize: 100}}, false},
+		{"empty option", &MetricsSearchOptions{}, false},
+		{"valid pagination", &MetricsSearchOptions{PaginationArgs: PaginationArgs{Page: 1, PageSize: 100}}, false},
 	}
 
 	for _, tt := range tests {

--- a/sonar/navigation_service.go
+++ b/sonar/navigation_service.go
@@ -192,8 +192,8 @@ type NavigationSettingsExtension struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// NavigationComponentOption represents options for getting component navigation.
-type NavigationComponentOption struct {
+// NavigationComponentOptions represents options for getting component navigation.
+type NavigationComponentOptions struct {
 	// Branch is the branch key (optional).
 	Branch string `url:"branch,omitempty"`
 	// Component is the component key (optional).
@@ -207,7 +207,7 @@ type NavigationComponentOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateComponentOpt validates the options for the Component method.
-func (s *NavigationService) ValidateComponentOpt(opt *NavigationComponentOption) error {
+func (s *NavigationService) ValidateComponentOpt(opt *NavigationComponentOptions) error {
 	if opt == nil {
 		return nil
 	}
@@ -227,7 +227,7 @@ func (s *NavigationService) ValidateComponentOpt(opt *NavigationComponentOption)
 // API endpoint: GET /api/navigation/component.
 // Since: 5.2.
 // Internal: true.
-func (s *NavigationService) Component(opt *NavigationComponentOption) (*NavigationComponent, *http.Response, error) {
+func (s *NavigationService) Component(opt *NavigationComponentOptions) (*NavigationComponent, *http.Response, error) {
 	err := s.ValidateComponentOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/navigation_service_test.go
+++ b/sonar/navigation_service_test.go
@@ -31,7 +31,7 @@ func TestNavigationService_Component(t *testing.T) {
 		server := newTestServer(t, mockHandler(t, http.MethodGet, "/navigation/component", http.StatusOK, response))
 		client := newTestClient(t, server.URL)
 
-		opt := &NavigationComponentOption{
+		opt := &NavigationComponentOptions{
 			Component: "my-project",
 		}
 
@@ -55,7 +55,7 @@ func TestNavigationService_Component(t *testing.T) {
 		})
 		client := newTestClient(t, server.URL)
 
-		opt := &NavigationComponentOption{
+		opt := &NavigationComponentOptions{
 			Component: "my-project",
 			Branch:    "feature/my-branch",
 		}
@@ -143,10 +143,10 @@ func TestNavigationService_ValidateComponentOpt(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test empty option (should be valid)
-	err = client.Navigation.ValidateComponentOpt(&NavigationComponentOption{})
+	err = client.Navigation.ValidateComponentOpt(&NavigationComponentOptions{})
 	assert.NoError(t, err)
 
 	// Test with component
-	err = client.Navigation.ValidateComponentOpt(&NavigationComponentOption{Component: "my-project"})
+	err = client.Navigation.ValidateComponentOpt(&NavigationComponentOptions{Component: "my-project"})
 	assert.NoError(t, err)
 }

--- a/sonar/new_code_periods_service.go
+++ b/sonar/new_code_periods_service.go
@@ -81,15 +81,15 @@ type NewCodePeriodsShow struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// NewCodePeriodsListOption contains parameters for the List method.
-type NewCodePeriodsListOption struct {
+// NewCodePeriodsListOptions contains parameters for the List method.
+type NewCodePeriodsListOptions struct {
 	// Project is the project key.
 	// This field is required.
 	Project string `url:"project"`
 }
 
-// NewCodePeriodsSetOption contains parameters for the Set method.
-type NewCodePeriodsSetOption struct {
+// NewCodePeriodsSetOptions contains parameters for the Set method.
+type NewCodePeriodsSetOptions struct {
 	// Branch is the branch key.
 	Branch string `url:"branch,omitempty"`
 	// Project is the project key.
@@ -110,16 +110,16 @@ type NewCodePeriodsSetOption struct {
 	Value string `url:"value,omitempty"`
 }
 
-// NewCodePeriodsShowOption contains parameters for the Show method.
-type NewCodePeriodsShowOption struct {
+// NewCodePeriodsShowOptions contains parameters for the Show method.
+type NewCodePeriodsShowOptions struct {
 	// Branch is the branch key.
 	Branch string `url:"branch,omitempty"`
 	// Project is the project key.
 	Project string `url:"project,omitempty"`
 }
 
-// NewCodePeriodsUnsetOption contains parameters for the Unset method.
-type NewCodePeriodsUnsetOption struct {
+// NewCodePeriodsUnsetOptions contains parameters for the Unset method.
+type NewCodePeriodsUnsetOptions struct {
 	// Branch is the branch key.
 	Branch string `url:"branch,omitempty"`
 	// Project is the project key.
@@ -131,7 +131,7 @@ type NewCodePeriodsUnsetOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateListOpt validates the options for the List method.
-func (s *NewCodePeriodsService) ValidateListOpt(opt *NewCodePeriodsListOption) error {
+func (s *NewCodePeriodsService) ValidateListOpt(opt *NewCodePeriodsListOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -145,7 +145,7 @@ func (s *NewCodePeriodsService) ValidateListOpt(opt *NewCodePeriodsListOption) e
 }
 
 // ValidateSetOpt validates the options for the Set method.
-func (s *NewCodePeriodsService) ValidateSetOpt(opt *NewCodePeriodsSetOption) error {
+func (s *NewCodePeriodsService) ValidateSetOpt(opt *NewCodePeriodsSetOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -175,13 +175,13 @@ func (s *NewCodePeriodsService) ValidateSetOpt(opt *NewCodePeriodsSetOption) err
 }
 
 // ValidateShowOpt validates the options for the Show method.
-func (s *NewCodePeriodsService) ValidateShowOpt(opt *NewCodePeriodsShowOption) error {
+func (s *NewCodePeriodsService) ValidateShowOpt(opt *NewCodePeriodsShowOptions) error {
 	// Options are optional; nothing to validate.
 	return nil
 }
 
 // ValidateUnsetOpt validates the options for the Unset method.
-func (s *NewCodePeriodsService) ValidateUnsetOpt(opt *NewCodePeriodsUnsetOption) error {
+func (s *NewCodePeriodsService) ValidateUnsetOpt(opt *NewCodePeriodsUnsetOptions) error {
 	// Options are optional; nothing to validate.
 	return nil
 }
@@ -195,7 +195,7 @@ func (s *NewCodePeriodsService) ValidateUnsetOpt(opt *NewCodePeriodsUnsetOption)
 //
 // API endpoint: GET /api/new_code_periods/list.
 // Since: 8.0.
-func (s *NewCodePeriodsService) List(opt *NewCodePeriodsListOption) (*NewCodePeriodsList, *http.Response, error) {
+func (s *NewCodePeriodsService) List(opt *NewCodePeriodsListOptions) (*NewCodePeriodsList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -227,7 +227,7 @@ func (s *NewCodePeriodsService) List(opt *NewCodePeriodsListOption) (*NewCodePer
 //
 // API endpoint: POST /api/new_code_periods/set.
 // Since: 8.0.
-func (s *NewCodePeriodsService) Set(opt *NewCodePeriodsSetOption) (*http.Response, error) {
+func (s *NewCodePeriodsService) Set(opt *NewCodePeriodsSetOptions) (*http.Response, error) {
 	err := s.ValidateSetOpt(opt)
 	if err != nil {
 		return nil, err
@@ -256,7 +256,7 @@ func (s *NewCodePeriodsService) Set(opt *NewCodePeriodsSetOption) (*http.Respons
 //
 // API endpoint: GET /api/new_code_periods/show.
 // Since: 8.0.
-func (s *NewCodePeriodsService) Show(opt *NewCodePeriodsShowOption) (*NewCodePeriodsShow, *http.Response, error) {
+func (s *NewCodePeriodsService) Show(opt *NewCodePeriodsShowOptions) (*NewCodePeriodsShow, *http.Response, error) {
 	err := s.ValidateShowOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -286,7 +286,7 @@ func (s *NewCodePeriodsService) Show(opt *NewCodePeriodsShowOption) (*NewCodePer
 //
 // API endpoint: POST /api/new_code_periods/unset.
 // Since: 8.0.
-func (s *NewCodePeriodsService) Unset(opt *NewCodePeriodsUnsetOption) (*http.Response, error) {
+func (s *NewCodePeriodsService) Unset(opt *NewCodePeriodsUnsetOptions) (*http.Response, error) {
 	err := s.ValidateUnsetOpt(opt)
 	if err != nil {
 		return nil, err
@@ -306,7 +306,7 @@ func (s *NewCodePeriodsService) Unset(opt *NewCodePeriodsUnsetOption) (*http.Res
 }
 
 // validateNumberOfDays validates the NUMBER_OF_DAYS type.
-func (s *NewCodePeriodsService) validateNumberOfDays(opt *NewCodePeriodsSetOption) error {
+func (s *NewCodePeriodsService) validateNumberOfDays(opt *NewCodePeriodsSetOptions) error {
 	// Convert Value to int64 and validate range
 	intValue, parseErr := strconv.ParseInt(opt.Value, 10, 64)
 	if parseErr != nil {
@@ -317,19 +317,19 @@ func (s *NewCodePeriodsService) validateNumberOfDays(opt *NewCodePeriodsSetOptio
 }
 
 // validateSpecificAnalysis validates the SPECIFIC_ANALYSIS type.
-func (s *NewCodePeriodsService) validateSpecificAnalysis(opt *NewCodePeriodsSetOption) error {
+func (s *NewCodePeriodsService) validateSpecificAnalysis(opt *NewCodePeriodsSetOptions) error {
 	// Branch is required
 	return ValidateRequired(opt.Branch, "Branch")
 }
 
 // validateReferenceBranch validates the REFERENCE_BRANCH type.
-func (s *NewCodePeriodsService) validateReferenceBranch(opt *NewCodePeriodsSetOption) error {
+func (s *NewCodePeriodsService) validateReferenceBranch(opt *NewCodePeriodsSetOptions) error {
 	// Project is required
 	return ValidateRequired(opt.Project, "Project")
 }
 
 // validatePreviousVersion validates the PREVIOUS_VERSION type.
-func (s *NewCodePeriodsService) validatePreviousVersion(opt *NewCodePeriodsSetOption) error {
+func (s *NewCodePeriodsService) validatePreviousVersion(opt *NewCodePeriodsSetOptions) error {
 	// No special requirements
 	return nil
 }

--- a/sonar/new_code_periods_service_test.go
+++ b/sonar/new_code_periods_service_test.go
@@ -39,7 +39,7 @@ func TestNewCodePeriods_List(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &NewCodePeriodsListOption{
+	opt := &NewCodePeriodsListOptions{
 		Project: "my-project",
 	}
 
@@ -60,7 +60,7 @@ func TestNewCodePeriods_List_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, _, err = client.NewCodePeriods.List(&NewCodePeriodsListOption{})
+	_, _, err = client.NewCodePeriods.List(&NewCodePeriodsListOptions{})
 	assert.Error(t, err)
 }
 
@@ -76,7 +76,7 @@ func TestNewCodePeriods_Set(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &NewCodePeriodsSetOption{
+	opt := &NewCodePeriodsSetOptions{
 		Type:  "NUMBER_OF_DAYS",
 		Value: "30",
 	}
@@ -94,23 +94,23 @@ func TestNewCodePeriods_Set_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Type should fail validation.
-	_, err = client.NewCodePeriods.Set(&NewCodePeriodsSetOption{})
+	_, err = client.NewCodePeriods.Set(&NewCodePeriodsSetOptions{})
 	assert.Error(t, err)
 
 	// Invalid Type should fail validation.
-	_, err = client.NewCodePeriods.Set(&NewCodePeriodsSetOption{
+	_, err = client.NewCodePeriods.Set(&NewCodePeriodsSetOptions{
 		Type: "INVALID_TYPE",
 	})
 	assert.Error(t, err)
 
 	// SPECIFIC_ANALYSIS without Branch should fail validation.
-	_, err = client.NewCodePeriods.Set(&NewCodePeriodsSetOption{
+	_, err = client.NewCodePeriods.Set(&NewCodePeriodsSetOptions{
 		Type: "SPECIFIC_ANALYSIS",
 	})
 	assert.Error(t, err)
 
 	// REFERENCE_BRANCH without Project should fail validation.
-	_, err = client.NewCodePeriods.Set(&NewCodePeriodsSetOption{
+	_, err = client.NewCodePeriods.Set(&NewCodePeriodsSetOptions{
 		Type: "REFERENCE_BRANCH",
 	})
 	assert.Error(t, err)
@@ -156,7 +156,7 @@ func TestNewCodePeriods_Show_WithOptions(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &NewCodePeriodsShowOption{
+	opt := &NewCodePeriodsShowOptions{
 		Project: "my-project",
 		Branch:  "main",
 	}
@@ -188,7 +188,7 @@ func TestNewCodePeriods_Unset_WithOptions(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &NewCodePeriodsUnsetOption{
+	opt := &NewCodePeriodsUnsetOptions{
 		Project: "my-project",
 	}
 
@@ -203,28 +203,28 @@ func TestNewCodePeriods_ValidateSetOpt(t *testing.T) {
 	// All valid types without special requirements should pass.
 	validTypes := []string{"PREVIOUS_VERSION"}
 	for _, periodType := range validTypes {
-		err := client.NewCodePeriods.ValidateSetOpt(&NewCodePeriodsSetOption{
+		err := client.NewCodePeriods.ValidateSetOpt(&NewCodePeriodsSetOptions{
 			Type: periodType,
 		})
 		assert.NoError(t, err, "expected nil error for type '%s'", periodType)
 	}
 
 	// NUMBER_OF_DAYS with valid Value should pass.
-	err := client.NewCodePeriods.ValidateSetOpt(&NewCodePeriodsSetOption{
+	err := client.NewCodePeriods.ValidateSetOpt(&NewCodePeriodsSetOptions{
 		Type:  "NUMBER_OF_DAYS",
 		Value: "30",
 	})
 	assert.NoError(t, err)
 
 	// SPECIFIC_ANALYSIS with Branch should pass.
-	err = client.NewCodePeriods.ValidateSetOpt(&NewCodePeriodsSetOption{
+	err = client.NewCodePeriods.ValidateSetOpt(&NewCodePeriodsSetOptions{
 		Type:   "SPECIFIC_ANALYSIS",
 		Branch: "main",
 	})
 	assert.NoError(t, err)
 
 	// REFERENCE_BRANCH with Project should pass.
-	err = client.NewCodePeriods.ValidateSetOpt(&NewCodePeriodsSetOption{
+	err = client.NewCodePeriods.ValidateSetOpt(&NewCodePeriodsSetOptions{
 		Type:    "REFERENCE_BRANCH",
 		Project: "my-project",
 	})

--- a/sonar/notifications_service.go
+++ b/sonar/notifications_service.go
@@ -44,8 +44,8 @@ type Notification struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// NotificationsAddOption contains parameters for the Add method.
-type NotificationsAddOption struct {
+// NotificationsAddOptions contains parameters for the Add method.
+type NotificationsAddOptions struct {
 	// Channel is the channel through which the notification is sent.
 	// Default is email.
 	Channel string `url:"channel,omitempty"`
@@ -58,14 +58,14 @@ type NotificationsAddOption struct {
 	Type string `url:"type"`
 }
 
-// NotificationsListOption contains parameters for the List method.
-type NotificationsListOption struct {
+// NotificationsListOptions contains parameters for the List method.
+type NotificationsListOptions struct {
 	// Login is the user login. If not provided, the authenticated user is used.
 	Login string `url:"login,omitempty"`
 }
 
-// NotificationsRemoveOption contains parameters for the Remove method.
-type NotificationsRemoveOption struct {
+// NotificationsRemoveOptions contains parameters for the Remove method.
+type NotificationsRemoveOptions struct {
 	// Channel is the channel through which the notification is sent.
 	// Default is email.
 	Channel string `url:"channel,omitempty"`
@@ -83,7 +83,7 @@ type NotificationsRemoveOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateAddOpt validates the options for the Add method.
-func (s *NotificationsService) ValidateAddOpt(opt *NotificationsAddOption) error {
+func (s *NotificationsService) ValidateAddOpt(opt *NotificationsAddOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -97,13 +97,13 @@ func (s *NotificationsService) ValidateAddOpt(opt *NotificationsAddOption) error
 }
 
 // ValidateListOpt validates the options for the List method.
-func (s *NotificationsService) ValidateListOpt(opt *NotificationsListOption) error {
+func (s *NotificationsService) ValidateListOpt(opt *NotificationsListOptions) error {
 	// No required fields
 	return nil
 }
 
 // ValidateRemoveOpt validates the options for the Remove method.
-func (s *NotificationsService) ValidateRemoveOpt(opt *NotificationsRemoveOption) error {
+func (s *NotificationsService) ValidateRemoveOpt(opt *NotificationsRemoveOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -127,7 +127,7 @@ func (s *NotificationsService) ValidateRemoveOpt(opt *NotificationsRemoveOption)
 //
 // API endpoint: POST /api/notifications/add.
 // Since: 6.3.
-func (s *NotificationsService) Add(opt *NotificationsAddOption) (*http.Response, error) {
+func (s *NotificationsService) Add(opt *NotificationsAddOptions) (*http.Response, error) {
 	err := s.ValidateAddOpt(opt)
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func (s *NotificationsService) Add(opt *NotificationsAddOption) (*http.Response,
 //
 // API endpoint: GET /api/notifications/list.
 // Since: 6.3.
-func (s *NotificationsService) List(opt *NotificationsListOption) (*NotificationsList, *http.Response, error) {
+func (s *NotificationsService) List(opt *NotificationsListOptions) (*NotificationsList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -179,7 +179,7 @@ func (s *NotificationsService) List(opt *NotificationsListOption) (*Notification
 //
 // API endpoint: POST /api/notifications/remove.
 // Since: 6.3.
-func (s *NotificationsService) Remove(opt *NotificationsRemoveOption) (*http.Response, error) {
+func (s *NotificationsService) Remove(opt *NotificationsRemoveOptions) (*http.Response, error) {
 	err := s.ValidateRemoveOpt(opt)
 	if err != nil {
 		return nil, err

--- a/sonar/notifications_service_test.go
+++ b/sonar/notifications_service_test.go
@@ -18,7 +18,7 @@ func TestNotifications_Add(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &NotificationsAddOption{
+	opt := &NotificationsAddOptions{
 		Type: "NewIssues",
 	}
 
@@ -38,7 +38,7 @@ func TestNotifications_Add_WithAllOptions(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &NotificationsAddOption{
+	opt := &NotificationsAddOptions{
 		Type:    "NewIssues",
 		Channel: "email",
 		Project: "my-project",
@@ -58,7 +58,7 @@ func TestNotifications_Add_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Type should fail validation.
-	_, err = client.Notifications.Add(&NotificationsAddOption{})
+	_, err = client.Notifications.Add(&NotificationsAddOptions{})
 	assert.Error(t, err)
 }
 
@@ -100,7 +100,7 @@ func TestNotifications_List_WithLogin(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &NotificationsListOption{
+	opt := &NotificationsListOptions{
 		Login: "admin",
 	}
 
@@ -119,7 +119,7 @@ func TestNotifications_Remove(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &NotificationsRemoveOption{
+	opt := &NotificationsRemoveOptions{
 		Type: "NewIssues",
 	}
 
@@ -136,7 +136,7 @@ func TestNotifications_Remove_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Type should fail validation.
-	_, err = client.Notifications.Remove(&NotificationsRemoveOption{})
+	_, err = client.Notifications.Remove(&NotificationsRemoveOptions{})
 	assert.Error(t, err)
 }
 
@@ -144,7 +144,7 @@ func TestNotifications_ValidateAddOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Valid option should pass.
-	err := client.Notifications.ValidateAddOpt(&NotificationsAddOption{
+	err := client.Notifications.ValidateAddOpt(&NotificationsAddOptions{
 		Type: "NewIssues",
 	})
 	assert.NoError(t, err)
@@ -154,7 +154,7 @@ func TestNotifications_ValidateAddOpt(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Type should fail.
-	err = client.Notifications.ValidateAddOpt(&NotificationsAddOption{})
+	err = client.Notifications.ValidateAddOpt(&NotificationsAddOptions{})
 	assert.Error(t, err)
 }
 
@@ -166,7 +166,7 @@ func TestNotifications_ValidateListOpt(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Empty option should be valid.
-	err = client.Notifications.ValidateListOpt(&NotificationsListOption{})
+	err = client.Notifications.ValidateListOpt(&NotificationsListOptions{})
 	assert.NoError(t, err)
 }
 
@@ -174,7 +174,7 @@ func TestNotifications_ValidateRemoveOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Valid option should pass.
-	err := client.Notifications.ValidateRemoveOpt(&NotificationsRemoveOption{
+	err := client.Notifications.ValidateRemoveOpt(&NotificationsRemoveOptions{
 		Type: "NewIssues",
 	})
 	assert.NoError(t, err)
@@ -184,6 +184,6 @@ func TestNotifications_ValidateRemoveOpt(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Type should fail.
-	err = client.Notifications.ValidateRemoveOpt(&NotificationsRemoveOption{})
+	err = client.Notifications.ValidateRemoveOpt(&NotificationsRemoveOptions{})
 	assert.Error(t, err)
 }

--- a/sonar/permissions_service.go
+++ b/sonar/permissions_service.go
@@ -251,8 +251,8 @@ type PermissionsUsers struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// PermissionsAddGroupOption contains parameters for the AddGroup method.
-type PermissionsAddGroupOption struct {
+// PermissionsAddGroupOptions contains parameters for the AddGroup method.
+type PermissionsAddGroupOptions struct {
 	// GroupName is the group name or 'anyone' (case insensitive).
 	// This field is required.
 	GroupName string `url:"groupName"`
@@ -267,8 +267,8 @@ type PermissionsAddGroupOption struct {
 	ProjectKey string `url:"projectKey,omitempty"`
 }
 
-// PermissionsAddGroupToTemplateOption contains parameters for the AddGroupToTemplate method.
-type PermissionsAddGroupToTemplateOption struct {
+// PermissionsAddGroupToTemplateOptions contains parameters for the AddGroupToTemplate method.
+type PermissionsAddGroupToTemplateOptions struct {
 	// GroupName is the group name or 'anyone' (case insensitive).
 	// This field is required.
 	GroupName string `url:"groupName"`
@@ -282,8 +282,8 @@ type PermissionsAddGroupToTemplateOption struct {
 	TemplateName string `url:"templateName,omitempty"`
 }
 
-// PermissionsAddProjectCreatorToTemplateOption contains parameters for the AddProjectCreatorToTemplate method.
-type PermissionsAddProjectCreatorToTemplateOption struct {
+// PermissionsAddProjectCreatorToTemplateOptions contains parameters for the AddProjectCreatorToTemplate method.
+type PermissionsAddProjectCreatorToTemplateOptions struct {
 	// Permission is the permission to grant to the project creator.
 	// This field is required.
 	// Allowed values: admin, codeviewer, issueadmin, securityhotspotadmin, scan, user.
@@ -294,8 +294,8 @@ type PermissionsAddProjectCreatorToTemplateOption struct {
 	TemplateName string `url:"templateName,omitempty"`
 }
 
-// PermissionsAddUserOption contains parameters for the AddUser method.
-type PermissionsAddUserOption struct {
+// PermissionsAddUserOptions contains parameters for the AddUser method.
+type PermissionsAddUserOptions struct {
 	// Login is the user login.
 	// This field is required.
 	Login string `url:"login"`
@@ -310,8 +310,8 @@ type PermissionsAddUserOption struct {
 	ProjectKey string `url:"projectKey,omitempty"`
 }
 
-// PermissionsAddUserToTemplateOption contains parameters for the AddUserToTemplate method.
-type PermissionsAddUserToTemplateOption struct {
+// PermissionsAddUserToTemplateOptions contains parameters for the AddUserToTemplate method.
+type PermissionsAddUserToTemplateOptions struct {
 	// Login is the user login.
 	// This field is required.
 	Login string `url:"login"`
@@ -325,8 +325,8 @@ type PermissionsAddUserToTemplateOption struct {
 	TemplateName string `url:"templateName,omitempty"`
 }
 
-// PermissionsApplyTemplateOption contains parameters for the ApplyTemplate method.
-type PermissionsApplyTemplateOption struct {
+// PermissionsApplyTemplateOptions contains parameters for the ApplyTemplate method.
+type PermissionsApplyTemplateOptions struct {
 	// ProjectID is the project id. Use either ProjectID or ProjectKey.
 	ProjectID string `url:"projectId,omitempty"`
 	// ProjectKey is the project key. Use either ProjectID or ProjectKey.
@@ -337,10 +337,10 @@ type PermissionsApplyTemplateOption struct {
 	TemplateName string `url:"templateName,omitempty"`
 }
 
-// PermissionsBulkApplyTemplateOption contains parameters for the BulkApplyTemplate method.
+// PermissionsBulkApplyTemplateOptions contains parameters for the BulkApplyTemplate method.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type PermissionsBulkApplyTemplateOption struct {
+type PermissionsBulkApplyTemplateOptions struct {
 	// AnalyzedBefore filters projects for which last analysis is older than the given date.
 	// Either a date (server timezone) or datetime can be provided.
 	AnalyzedBefore string `url:"analyzedBefore,omitempty"`
@@ -359,8 +359,8 @@ type PermissionsBulkApplyTemplateOption struct {
 	TemplateName string `url:"templateName,omitempty"`
 }
 
-// PermissionsCreateTemplateOption contains parameters for the CreateTemplate method.
-type PermissionsCreateTemplateOption struct {
+// PermissionsCreateTemplateOptions contains parameters for the CreateTemplate method.
+type PermissionsCreateTemplateOptions struct {
 	// Description is the template description.
 	Description string `url:"description,omitempty"`
 	// Name is the template name.
@@ -370,18 +370,18 @@ type PermissionsCreateTemplateOption struct {
 	ProjectKeyPattern string `url:"projectKeyPattern,omitempty"`
 }
 
-// PermissionsDeleteTemplateOption contains parameters for the DeleteTemplate method.
-type PermissionsDeleteTemplateOption struct {
+// PermissionsDeleteTemplateOptions contains parameters for the DeleteTemplate method.
+type PermissionsDeleteTemplateOptions struct {
 	// TemplateID is the template id. Use either TemplateID or TemplateName.
 	TemplateID string `url:"templateId,omitempty"`
 	// TemplateName is the template name. Use either TemplateID or TemplateName.
 	TemplateName string `url:"templateName,omitempty"`
 }
 
-// PermissionsGroupsOption contains parameters for the Groups method.
+// PermissionsGroupsOptions contains parameters for the Groups method.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type PermissionsGroupsOption struct {
+type PermissionsGroupsOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs
 
@@ -397,8 +397,8 @@ type PermissionsGroupsOption struct {
 	Query string `url:"q,omitempty"`
 }
 
-// PermissionsRemoveGroupOption contains parameters for the RemoveGroup method.
-type PermissionsRemoveGroupOption struct {
+// PermissionsRemoveGroupOptions contains parameters for the RemoveGroup method.
+type PermissionsRemoveGroupOptions struct {
 	// GroupName is the group name or 'anyone' (case insensitive).
 	// This field is required.
 	GroupName string `url:"groupName"`
@@ -413,8 +413,8 @@ type PermissionsRemoveGroupOption struct {
 	ProjectKey string `url:"projectKey,omitempty"`
 }
 
-// PermissionsRemoveGroupFromTemplateOption contains parameters for the RemoveGroupFromTemplate method.
-type PermissionsRemoveGroupFromTemplateOption struct {
+// PermissionsRemoveGroupFromTemplateOptions contains parameters for the RemoveGroupFromTemplate method.
+type PermissionsRemoveGroupFromTemplateOptions struct {
 	// GroupName is the group name or 'anyone' (case insensitive).
 	// This field is required.
 	GroupName string `url:"groupName"`
@@ -428,8 +428,8 @@ type PermissionsRemoveGroupFromTemplateOption struct {
 	TemplateName string `url:"templateName,omitempty"`
 }
 
-// PermissionsRemoveProjectCreatorFromTemplateOption contains parameters for the RemoveProjectCreatorFromTemplate method.
-type PermissionsRemoveProjectCreatorFromTemplateOption struct {
+// PermissionsRemoveProjectCreatorFromTemplateOptions contains parameters for the RemoveProjectCreatorFromTemplate method.
+type PermissionsRemoveProjectCreatorFromTemplateOptions struct {
 	// Permission is the permission to revoke from the project creator.
 	// This field is required.
 	// Allowed values: admin, codeviewer, issueadmin, securityhotspotadmin, scan, user.
@@ -440,8 +440,8 @@ type PermissionsRemoveProjectCreatorFromTemplateOption struct {
 	TemplateName string `url:"templateName,omitempty"`
 }
 
-// PermissionsRemoveUserOption contains parameters for the RemoveUser method.
-type PermissionsRemoveUserOption struct {
+// PermissionsRemoveUserOptions contains parameters for the RemoveUser method.
+type PermissionsRemoveUserOptions struct {
 	// Login is the user login.
 	// This field is required.
 	Login string `url:"login"`
@@ -456,8 +456,8 @@ type PermissionsRemoveUserOption struct {
 	ProjectKey string `url:"projectKey,omitempty"`
 }
 
-// PermissionsRemoveUserFromTemplateOption contains parameters for the RemoveUserFromTemplate method.
-type PermissionsRemoveUserFromTemplateOption struct {
+// PermissionsRemoveUserFromTemplateOptions contains parameters for the RemoveUserFromTemplate method.
+type PermissionsRemoveUserFromTemplateOptions struct {
 	// Login is the user login.
 	// This field is required.
 	Login string `url:"login"`
@@ -471,14 +471,14 @@ type PermissionsRemoveUserFromTemplateOption struct {
 	TemplateName string `url:"templateName,omitempty"`
 }
 
-// PermissionsSearchTemplatesOption contains parameters for the SearchTemplates method.
-type PermissionsSearchTemplatesOption struct {
+// PermissionsSearchTemplatesOptions contains parameters for the SearchTemplates method.
+type PermissionsSearchTemplatesOptions struct {
 	// Query limits search to permission template names containing the supplied string.
 	Query string `url:"q,omitempty"`
 }
 
-// PermissionsSetDefaultTemplateOption contains parameters for the SetDefaultTemplate method.
-type PermissionsSetDefaultTemplateOption struct {
+// PermissionsSetDefaultTemplateOptions contains parameters for the SetDefaultTemplate method.
+type PermissionsSetDefaultTemplateOptions struct {
 	// Qualifier is the project qualifier. Default is TRK (projects).
 	Qualifier string `url:"qualifier,omitempty"`
 	// TemplateID is the template id. Use either TemplateID or TemplateName.
@@ -487,10 +487,10 @@ type PermissionsSetDefaultTemplateOption struct {
 	TemplateName string `url:"templateName,omitempty"`
 }
 
-// PermissionsTemplateGroupsOption contains parameters for the TemplateGroups method.
+// PermissionsTemplateGroupsOptions contains parameters for the TemplateGroups method.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type PermissionsTemplateGroupsOption struct {
+type PermissionsTemplateGroupsOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs
 
@@ -505,10 +505,10 @@ type PermissionsTemplateGroupsOption struct {
 	TemplateName string `url:"templateName,omitempty"`
 }
 
-// PermissionsTemplateUsersOption contains parameters for the TemplateUsers method.
+// PermissionsTemplateUsersOptions contains parameters for the TemplateUsers method.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type PermissionsTemplateUsersOption struct {
+type PermissionsTemplateUsersOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs
 
@@ -523,8 +523,8 @@ type PermissionsTemplateUsersOption struct {
 	TemplateName string `url:"templateName,omitempty"`
 }
 
-// PermissionsUpdateTemplateOption contains parameters for the UpdateTemplate method.
-type PermissionsUpdateTemplateOption struct {
+// PermissionsUpdateTemplateOptions contains parameters for the UpdateTemplate method.
+type PermissionsUpdateTemplateOptions struct {
 	// Description is the template description.
 	Description string `url:"description,omitempty"`
 	// ID is the template id.
@@ -536,10 +536,10 @@ type PermissionsUpdateTemplateOption struct {
 	ProjectKeyPattern string `url:"projectKeyPattern,omitempty"`
 }
 
-// PermissionsUsersOption contains parameters for the Users method.
+// PermissionsUsersOptions contains parameters for the Users method.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type PermissionsUsersOption struct {
+type PermissionsUsersOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs
 
@@ -568,7 +568,7 @@ func isValidPermission(permission string) bool {
 }
 
 // ValidateAddGroupOpt validates the options for the AddGroup method.
-func (s *PermissionsService) ValidateAddGroupOpt(opt *PermissionsAddGroupOption) error {
+func (s *PermissionsService) ValidateAddGroupOpt(opt *PermissionsAddGroupOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -591,7 +591,7 @@ func (s *PermissionsService) ValidateAddGroupOpt(opt *PermissionsAddGroupOption)
 }
 
 // ValidateAddGroupToTemplateOpt validates the options for the AddGroupToTemplate method.
-func (s *PermissionsService) ValidateAddGroupToTemplateOpt(opt *PermissionsAddGroupToTemplateOption) error {
+func (s *PermissionsService) ValidateAddGroupToTemplateOpt(opt *PermissionsAddGroupToTemplateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -620,7 +620,7 @@ func (s *PermissionsService) ValidateAddGroupToTemplateOpt(opt *PermissionsAddGr
 }
 
 // ValidateAddProjectCreatorToTemplateOpt validates the options for the AddProjectCreatorToTemplate method.
-func (s *PermissionsService) ValidateAddProjectCreatorToTemplateOpt(opt *PermissionsAddProjectCreatorToTemplateOption) error {
+func (s *PermissionsService) ValidateAddProjectCreatorToTemplateOpt(opt *PermissionsAddProjectCreatorToTemplateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -644,7 +644,7 @@ func (s *PermissionsService) ValidateAddProjectCreatorToTemplateOpt(opt *Permiss
 }
 
 // ValidateAddUserOpt validates the options for the AddUser method.
-func (s *PermissionsService) ValidateAddUserOpt(opt *PermissionsAddUserOption) error {
+func (s *PermissionsService) ValidateAddUserOpt(opt *PermissionsAddUserOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -667,7 +667,7 @@ func (s *PermissionsService) ValidateAddUserOpt(opt *PermissionsAddUserOption) e
 }
 
 // ValidateAddUserToTemplateOpt validates the options for the AddUserToTemplate method.
-func (s *PermissionsService) ValidateAddUserToTemplateOpt(opt *PermissionsAddUserToTemplateOption) error {
+func (s *PermissionsService) ValidateAddUserToTemplateOpt(opt *PermissionsAddUserToTemplateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -696,7 +696,7 @@ func (s *PermissionsService) ValidateAddUserToTemplateOpt(opt *PermissionsAddUse
 }
 
 // ValidateApplyTemplateOpt validates the options for the ApplyTemplate method.
-func (s *PermissionsService) ValidateApplyTemplateOpt(opt *PermissionsApplyTemplateOption) error {
+func (s *PermissionsService) ValidateApplyTemplateOpt(opt *PermissionsApplyTemplateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -715,7 +715,7 @@ func (s *PermissionsService) ValidateApplyTemplateOpt(opt *PermissionsApplyTempl
 }
 
 // ValidateBulkApplyTemplateOpt validates the options for the BulkApplyTemplate method.
-func (s *PermissionsService) ValidateBulkApplyTemplateOpt(opt *PermissionsBulkApplyTemplateOption) error {
+func (s *PermissionsService) ValidateBulkApplyTemplateOpt(opt *PermissionsBulkApplyTemplateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -737,7 +737,7 @@ func (s *PermissionsService) ValidateBulkApplyTemplateOpt(opt *PermissionsBulkAp
 }
 
 // ValidateCreateTemplateOpt validates the options for the CreateTemplate method.
-func (s *PermissionsService) ValidateCreateTemplateOpt(opt *PermissionsCreateTemplateOption) error {
+func (s *PermissionsService) ValidateCreateTemplateOpt(opt *PermissionsCreateTemplateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -751,7 +751,7 @@ func (s *PermissionsService) ValidateCreateTemplateOpt(opt *PermissionsCreateTem
 }
 
 // ValidateDeleteTemplateOpt validates the options for the DeleteTemplate method.
-func (s *PermissionsService) ValidateDeleteTemplateOpt(opt *PermissionsDeleteTemplateOption) error {
+func (s *PermissionsService) ValidateDeleteTemplateOpt(opt *PermissionsDeleteTemplateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -765,7 +765,7 @@ func (s *PermissionsService) ValidateDeleteTemplateOpt(opt *PermissionsDeleteTem
 }
 
 // ValidateGroupsOpt validates the options for the Groups method.
-func (s *PermissionsService) ValidateGroupsOpt(opt *PermissionsGroupsOption) error {
+func (s *PermissionsService) ValidateGroupsOpt(opt *PermissionsGroupsOptions) error {
 	// Options are optional
 	if opt == nil {
 		return nil
@@ -793,7 +793,7 @@ func (s *PermissionsService) ValidateGroupsOpt(opt *PermissionsGroupsOption) err
 }
 
 // ValidateRemoveGroupOpt validates the options for the RemoveGroup method.
-func (s *PermissionsService) ValidateRemoveGroupOpt(opt *PermissionsRemoveGroupOption) error {
+func (s *PermissionsService) ValidateRemoveGroupOpt(opt *PermissionsRemoveGroupOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -816,7 +816,7 @@ func (s *PermissionsService) ValidateRemoveGroupOpt(opt *PermissionsRemoveGroupO
 }
 
 // ValidateRemoveGroupFromTemplateOpt validates the options for the RemoveGroupFromTemplate method.
-func (s *PermissionsService) ValidateRemoveGroupFromTemplateOpt(opt *PermissionsRemoveGroupFromTemplateOption) error {
+func (s *PermissionsService) ValidateRemoveGroupFromTemplateOpt(opt *PermissionsRemoveGroupFromTemplateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -845,7 +845,7 @@ func (s *PermissionsService) ValidateRemoveGroupFromTemplateOpt(opt *Permissions
 }
 
 // ValidateRemoveProjectCreatorFromTemplateOpt validates the options for the RemoveProjectCreatorFromTemplate method.
-func (s *PermissionsService) ValidateRemoveProjectCreatorFromTemplateOpt(opt *PermissionsRemoveProjectCreatorFromTemplateOption) error {
+func (s *PermissionsService) ValidateRemoveProjectCreatorFromTemplateOpt(opt *PermissionsRemoveProjectCreatorFromTemplateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -869,7 +869,7 @@ func (s *PermissionsService) ValidateRemoveProjectCreatorFromTemplateOpt(opt *Pe
 }
 
 // ValidateRemoveUserOpt validates the options for the RemoveUser method.
-func (s *PermissionsService) ValidateRemoveUserOpt(opt *PermissionsRemoveUserOption) error {
+func (s *PermissionsService) ValidateRemoveUserOpt(opt *PermissionsRemoveUserOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -892,7 +892,7 @@ func (s *PermissionsService) ValidateRemoveUserOpt(opt *PermissionsRemoveUserOpt
 }
 
 // ValidateRemoveUserFromTemplateOpt validates the options for the RemoveUserFromTemplate method.
-func (s *PermissionsService) ValidateRemoveUserFromTemplateOpt(opt *PermissionsRemoveUserFromTemplateOption) error {
+func (s *PermissionsService) ValidateRemoveUserFromTemplateOpt(opt *PermissionsRemoveUserFromTemplateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -921,13 +921,13 @@ func (s *PermissionsService) ValidateRemoveUserFromTemplateOpt(opt *PermissionsR
 }
 
 // ValidateSearchTemplatesOpt validates the options for the SearchTemplates method.
-func (s *PermissionsService) ValidateSearchTemplatesOpt(opt *PermissionsSearchTemplatesOption) error {
+func (s *PermissionsService) ValidateSearchTemplatesOpt(opt *PermissionsSearchTemplatesOptions) error {
 	// Options are optional; nothing to validate.
 	return nil
 }
 
 // ValidateSetDefaultTemplateOpt validates the options for the SetDefaultTemplate method.
-func (s *PermissionsService) ValidateSetDefaultTemplateOpt(opt *PermissionsSetDefaultTemplateOption) error {
+func (s *PermissionsService) ValidateSetDefaultTemplateOpt(opt *PermissionsSetDefaultTemplateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -949,7 +949,7 @@ func (s *PermissionsService) ValidateSetDefaultTemplateOpt(opt *PermissionsSetDe
 }
 
 // ValidateTemplateGroupsOpt validates the options for the TemplateGroups method.
-func (s *PermissionsService) ValidateTemplateGroupsOpt(opt *PermissionsTemplateGroupsOption) error {
+func (s *PermissionsService) ValidateTemplateGroupsOpt(opt *PermissionsTemplateGroupsOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -984,7 +984,7 @@ func (s *PermissionsService) ValidateTemplateGroupsOpt(opt *PermissionsTemplateG
 }
 
 // ValidateTemplateUsersOpt validates the options for the TemplateUsers method.
-func (s *PermissionsService) ValidateTemplateUsersOpt(opt *PermissionsTemplateUsersOption) error {
+func (s *PermissionsService) ValidateTemplateUsersOpt(opt *PermissionsTemplateUsersOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -1019,7 +1019,7 @@ func (s *PermissionsService) ValidateTemplateUsersOpt(opt *PermissionsTemplateUs
 }
 
 // ValidateUpdateTemplateOpt validates the options for the UpdateTemplate method.
-func (s *PermissionsService) ValidateUpdateTemplateOpt(opt *PermissionsUpdateTemplateOption) error {
+func (s *PermissionsService) ValidateUpdateTemplateOpt(opt *PermissionsUpdateTemplateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -1033,7 +1033,7 @@ func (s *PermissionsService) ValidateUpdateTemplateOpt(opt *PermissionsUpdateTem
 }
 
 // ValidateUsersOpt validates the options for the Users method.
-func (s *PermissionsService) ValidateUsersOpt(opt *PermissionsUsersOption) error {
+func (s *PermissionsService) ValidateUsersOpt(opt *PermissionsUsersOptions) error {
 	// Options are optional
 	if opt == nil {
 		return nil
@@ -1073,7 +1073,7 @@ func (s *PermissionsService) ValidateUsersOpt(opt *PermissionsUsersOption) error
 //
 // API endpoint: POST /api/permissions/add_group.
 // Since: 5.2.
-func (s *PermissionsService) AddGroup(opt *PermissionsAddGroupOption) (*http.Response, error) {
+func (s *PermissionsService) AddGroup(opt *PermissionsAddGroupOptions) (*http.Response, error) {
 	err := s.ValidateAddGroupOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1098,7 +1098,7 @@ func (s *PermissionsService) AddGroup(opt *PermissionsAddGroupOption) (*http.Res
 //
 // API endpoint: POST /api/permissions/add_group_to_template.
 // Since: 5.2.
-func (s *PermissionsService) AddGroupToTemplate(opt *PermissionsAddGroupToTemplateOption) (*http.Response, error) {
+func (s *PermissionsService) AddGroupToTemplate(opt *PermissionsAddGroupToTemplateOptions) (*http.Response, error) {
 	err := s.ValidateAddGroupToTemplateOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1122,7 +1122,7 @@ func (s *PermissionsService) AddGroupToTemplate(opt *PermissionsAddGroupToTempla
 //
 // API endpoint: POST /api/permissions/add_project_creator_to_template.
 // Since: 6.0.
-func (s *PermissionsService) AddProjectCreatorToTemplate(opt *PermissionsAddProjectCreatorToTemplateOption) (*http.Response, error) {
+func (s *PermissionsService) AddProjectCreatorToTemplate(opt *PermissionsAddProjectCreatorToTemplateOptions) (*http.Response, error) {
 	err := s.ValidateAddProjectCreatorToTemplateOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1150,7 +1150,7 @@ func (s *PermissionsService) AddProjectCreatorToTemplate(opt *PermissionsAddProj
 //
 // API endpoint: POST /api/permissions/add_user.
 // Since: 5.2.
-func (s *PermissionsService) AddUser(opt *PermissionsAddUserOption) (*http.Response, error) {
+func (s *PermissionsService) AddUser(opt *PermissionsAddUserOptions) (*http.Response, error) {
 	err := s.ValidateAddUserOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1174,7 +1174,7 @@ func (s *PermissionsService) AddUser(opt *PermissionsAddUserOption) (*http.Respo
 //
 // API endpoint: POST /api/permissions/add_user_to_template.
 // Since: 5.2.
-func (s *PermissionsService) AddUserToTemplate(opt *PermissionsAddUserToTemplateOption) (*http.Response, error) {
+func (s *PermissionsService) AddUserToTemplate(opt *PermissionsAddUserToTemplateOptions) (*http.Response, error) {
 	err := s.ValidateAddUserToTemplateOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1200,7 +1200,7 @@ func (s *PermissionsService) AddUserToTemplate(opt *PermissionsAddUserToTemplate
 //
 // API endpoint: POST /api/permissions/apply_template.
 // Since: 5.2.
-func (s *PermissionsService) ApplyTemplate(opt *PermissionsApplyTemplateOption) (*http.Response, error) {
+func (s *PermissionsService) ApplyTemplate(opt *PermissionsApplyTemplateOptions) (*http.Response, error) {
 	err := s.ValidateApplyTemplateOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1226,7 +1226,7 @@ func (s *PermissionsService) ApplyTemplate(opt *PermissionsApplyTemplateOption) 
 //
 // API endpoint: POST /api/permissions/bulk_apply_template.
 // Since: 5.5.
-func (s *PermissionsService) BulkApplyTemplate(opt *PermissionsBulkApplyTemplateOption) (*http.Response, error) {
+func (s *PermissionsService) BulkApplyTemplate(opt *PermissionsBulkApplyTemplateOptions) (*http.Response, error) {
 	err := s.ValidateBulkApplyTemplateOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1250,7 +1250,7 @@ func (s *PermissionsService) BulkApplyTemplate(opt *PermissionsBulkApplyTemplate
 //
 // API endpoint: POST /api/permissions/create_template.
 // Since: 5.2.
-func (s *PermissionsService) CreateTemplate(opt *PermissionsCreateTemplateOption) (*PermissionsCreateTemplate, *http.Response, error) {
+func (s *PermissionsService) CreateTemplate(opt *PermissionsCreateTemplateOptions) (*PermissionsCreateTemplate, *http.Response, error) {
 	err := s.ValidateCreateTemplateOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -1276,7 +1276,7 @@ func (s *PermissionsService) CreateTemplate(opt *PermissionsCreateTemplateOption
 //
 // API endpoint: POST /api/permissions/delete_template.
 // Since: 5.2.
-func (s *PermissionsService) DeleteTemplate(opt *PermissionsDeleteTemplateOption) (*http.Response, error) {
+func (s *PermissionsService) DeleteTemplate(opt *PermissionsDeleteTemplateOptions) (*http.Response, error) {
 	err := s.ValidateDeleteTemplateOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1308,7 +1308,7 @@ func (s *PermissionsService) DeleteTemplate(opt *PermissionsDeleteTemplateOption
 //
 // API endpoint: GET /api/permissions/groups.
 // Since: 5.2.
-func (s *PermissionsService) Groups(opt *PermissionsGroupsOption) (*PermissionsGroups, *http.Response, error) {
+func (s *PermissionsService) Groups(opt *PermissionsGroupsOptions) (*PermissionsGroups, *http.Response, error) {
 	err := s.ValidateGroupsOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -1339,7 +1339,7 @@ func (s *PermissionsService) Groups(opt *PermissionsGroupsOption) (*PermissionsG
 //
 // API endpoint: POST /api/permissions/remove_group.
 // Since: 5.2.
-func (s *PermissionsService) RemoveGroup(opt *PermissionsRemoveGroupOption) (*http.Response, error) {
+func (s *PermissionsService) RemoveGroup(opt *PermissionsRemoveGroupOptions) (*http.Response, error) {
 	err := s.ValidateRemoveGroupOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1364,7 +1364,7 @@ func (s *PermissionsService) RemoveGroup(opt *PermissionsRemoveGroupOption) (*ht
 //
 // API endpoint: POST /api/permissions/remove_group_from_template.
 // Since: 5.2.
-func (s *PermissionsService) RemoveGroupFromTemplate(opt *PermissionsRemoveGroupFromTemplateOption) (*http.Response, error) {
+func (s *PermissionsService) RemoveGroupFromTemplate(opt *PermissionsRemoveGroupFromTemplateOptions) (*http.Response, error) {
 	err := s.ValidateRemoveGroupFromTemplateOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1388,7 +1388,7 @@ func (s *PermissionsService) RemoveGroupFromTemplate(opt *PermissionsRemoveGroup
 //
 // API endpoint: POST /api/permissions/remove_project_creator_from_template.
 // Since: 6.0.
-func (s *PermissionsService) RemoveProjectCreatorFromTemplate(opt *PermissionsRemoveProjectCreatorFromTemplateOption) (*http.Response, error) {
+func (s *PermissionsService) RemoveProjectCreatorFromTemplate(opt *PermissionsRemoveProjectCreatorFromTemplateOptions) (*http.Response, error) {
 	err := s.ValidateRemoveProjectCreatorFromTemplateOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1416,7 +1416,7 @@ func (s *PermissionsService) RemoveProjectCreatorFromTemplate(opt *PermissionsRe
 //
 // API endpoint: POST /api/permissions/remove_user.
 // Since: 5.2.
-func (s *PermissionsService) RemoveUser(opt *PermissionsRemoveUserOption) (*http.Response, error) {
+func (s *PermissionsService) RemoveUser(opt *PermissionsRemoveUserOptions) (*http.Response, error) {
 	err := s.ValidateRemoveUserOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1440,7 +1440,7 @@ func (s *PermissionsService) RemoveUser(opt *PermissionsRemoveUserOption) (*http
 //
 // API endpoint: POST /api/permissions/remove_user_from_template.
 // Since: 5.2.
-func (s *PermissionsService) RemoveUserFromTemplate(opt *PermissionsRemoveUserFromTemplateOption) (*http.Response, error) {
+func (s *PermissionsService) RemoveUserFromTemplate(opt *PermissionsRemoveUserFromTemplateOptions) (*http.Response, error) {
 	err := s.ValidateRemoveUserFromTemplateOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1464,7 +1464,7 @@ func (s *PermissionsService) RemoveUserFromTemplate(opt *PermissionsRemoveUserFr
 //
 // API endpoint: GET /api/permissions/search_templates.
 // Since: 5.2.
-func (s *PermissionsService) SearchTemplates(opt *PermissionsSearchTemplatesOption) (*PermissionsSearchTemplates, *http.Response, error) {
+func (s *PermissionsService) SearchTemplates(opt *PermissionsSearchTemplatesOptions) (*PermissionsSearchTemplates, *http.Response, error) {
 	err := s.ValidateSearchTemplatesOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -1490,7 +1490,7 @@ func (s *PermissionsService) SearchTemplates(opt *PermissionsSearchTemplatesOpti
 //
 // API endpoint: POST /api/permissions/set_default_template.
 // Since: 5.2.
-func (s *PermissionsService) SetDefaultTemplate(opt *PermissionsSetDefaultTemplateOption) (*http.Response, error) {
+func (s *PermissionsService) SetDefaultTemplate(opt *PermissionsSetDefaultTemplateOptions) (*http.Response, error) {
 	err := s.ValidateSetDefaultTemplateOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1519,7 +1519,7 @@ func (s *PermissionsService) SetDefaultTemplate(opt *PermissionsSetDefaultTempla
 //
 // API endpoint: GET /api/permissions/template_groups.
 // Since: 5.2.
-func (s *PermissionsService) TemplateGroups(opt *PermissionsTemplateGroupsOption) (*PermissionsTemplateGroups, *http.Response, error) {
+func (s *PermissionsService) TemplateGroups(opt *PermissionsTemplateGroupsOptions) (*PermissionsTemplateGroups, *http.Response, error) {
 	err := s.ValidateTemplateGroupsOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -1550,7 +1550,7 @@ func (s *PermissionsService) TemplateGroups(opt *PermissionsTemplateGroupsOption
 //
 // API endpoint: GET /api/permissions/template_users.
 // Since: 5.2.
-func (s *PermissionsService) TemplateUsers(opt *PermissionsTemplateUsersOption) (*PermissionsTemplateUsers, *http.Response, error) {
+func (s *PermissionsService) TemplateUsers(opt *PermissionsTemplateUsersOptions) (*PermissionsTemplateUsers, *http.Response, error) {
 	err := s.ValidateTemplateUsersOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -1576,7 +1576,7 @@ func (s *PermissionsService) TemplateUsers(opt *PermissionsTemplateUsersOption) 
 //
 // API endpoint: POST /api/permissions/update_template.
 // Since: 5.2.
-func (s *PermissionsService) UpdateTemplate(opt *PermissionsUpdateTemplateOption) (*PermissionsUpdateTemplate, *http.Response, error) {
+func (s *PermissionsService) UpdateTemplate(opt *PermissionsUpdateTemplateOptions) (*PermissionsUpdateTemplate, *http.Response, error) {
 	err := s.ValidateUpdateTemplateOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -1611,7 +1611,7 @@ func (s *PermissionsService) UpdateTemplate(opt *PermissionsUpdateTemplateOption
 //
 // API endpoint: GET /api/permissions/users.
 // Since: 5.2.
-func (s *PermissionsService) Users(opt *PermissionsUsersOption) (*PermissionsUsers, *http.Response, error) {
+func (s *PermissionsService) Users(opt *PermissionsUsersOptions) (*PermissionsUsers, *http.Response, error) {
 	err := s.ValidateUsersOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/permissions_service_test.go
+++ b/sonar/permissions_service_test.go
@@ -16,7 +16,7 @@ func TestPermissions_AddGroup(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/add_group", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsAddGroupOption{
+	opt := &PermissionsAddGroupOptions{
 		GroupName:  "developers",
 		Permission: "admin",
 	}
@@ -30,7 +30,7 @@ func TestPermissions_AddGroup_WithProject(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/add_group", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsAddGroupOption{
+	opt := &PermissionsAddGroupOptions{
 		GroupName:  "developers",
 		Permission: "user",
 		ProjectKey: "my-project",
@@ -49,19 +49,19 @@ func TestPermissions_AddGroup_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing GroupName should fail validation.
-	_, err = client.Permissions.AddGroup(&PermissionsAddGroupOption{
+	_, err = client.Permissions.AddGroup(&PermissionsAddGroupOptions{
 		Permission: "admin",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.AddGroup(&PermissionsAddGroupOption{
+	_, err = client.Permissions.AddGroup(&PermissionsAddGroupOptions{
 		GroupName: "developers",
 	})
 	assert.Error(t, err)
 
 	// Invalid permission should fail validation.
-	_, err = client.Permissions.AddGroup(&PermissionsAddGroupOption{
+	_, err = client.Permissions.AddGroup(&PermissionsAddGroupOptions{
 		GroupName:  "developers",
 		Permission: "invalid",
 	})
@@ -76,7 +76,7 @@ func TestPermissions_AddGroupToTemplate(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/add_group_to_template", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsAddGroupToTemplateOption{
+	opt := &PermissionsAddGroupToTemplateOptions{
 		GroupName:    "developers",
 		Permission:   "admin",
 		TemplateName: "my-template",
@@ -95,21 +95,21 @@ func TestPermissions_AddGroupToTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing GroupName should fail validation.
-	_, err = client.Permissions.AddGroupToTemplate(&PermissionsAddGroupToTemplateOption{
+	_, err = client.Permissions.AddGroupToTemplate(&PermissionsAddGroupToTemplateOptions{
 		Permission:   "admin",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.AddGroupToTemplate(&PermissionsAddGroupToTemplateOption{
+	_, err = client.Permissions.AddGroupToTemplate(&PermissionsAddGroupToTemplateOptions{
 		GroupName:    "developers",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Invalid permission should fail validation.
-	_, err = client.Permissions.AddGroupToTemplate(&PermissionsAddGroupToTemplateOption{
+	_, err = client.Permissions.AddGroupToTemplate(&PermissionsAddGroupToTemplateOptions{
 		GroupName:    "developers",
 		Permission:   "gateadmin", // Not a project permission
 		TemplateName: "my-template",
@@ -117,7 +117,7 @@ func TestPermissions_AddGroupToTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.AddGroupToTemplate(&PermissionsAddGroupToTemplateOption{
+	_, err = client.Permissions.AddGroupToTemplate(&PermissionsAddGroupToTemplateOptions{
 		GroupName:  "developers",
 		Permission: "admin",
 	})
@@ -132,7 +132,7 @@ func TestPermissions_AddProjectCreatorToTemplate(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/add_project_creator_to_template", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsAddProjectCreatorToTemplateOption{
+	opt := &PermissionsAddProjectCreatorToTemplateOptions{
 		Permission:   "admin",
 		TemplateName: "my-template",
 	}
@@ -150,20 +150,20 @@ func TestPermissions_AddProjectCreatorToTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.AddProjectCreatorToTemplate(&PermissionsAddProjectCreatorToTemplateOption{
+	_, err = client.Permissions.AddProjectCreatorToTemplate(&PermissionsAddProjectCreatorToTemplateOptions{
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Invalid permission should fail validation.
-	_, err = client.Permissions.AddProjectCreatorToTemplate(&PermissionsAddProjectCreatorToTemplateOption{
+	_, err = client.Permissions.AddProjectCreatorToTemplate(&PermissionsAddProjectCreatorToTemplateOptions{
 		Permission:   "provisioning", // Not a project permission
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.AddProjectCreatorToTemplate(&PermissionsAddProjectCreatorToTemplateOption{
+	_, err = client.Permissions.AddProjectCreatorToTemplate(&PermissionsAddProjectCreatorToTemplateOptions{
 		Permission: "admin",
 	})
 	assert.Error(t, err)
@@ -177,7 +177,7 @@ func TestPermissions_AddUser(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/add_user", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsAddUserOption{
+	opt := &PermissionsAddUserOptions{
 		Login:      "john.doe",
 		Permission: "admin",
 	}
@@ -195,19 +195,19 @@ func TestPermissions_AddUser_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Login should fail validation.
-	_, err = client.Permissions.AddUser(&PermissionsAddUserOption{
+	_, err = client.Permissions.AddUser(&PermissionsAddUserOptions{
 		Permission: "admin",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.AddUser(&PermissionsAddUserOption{
+	_, err = client.Permissions.AddUser(&PermissionsAddUserOptions{
 		Login: "john.doe",
 	})
 	assert.Error(t, err)
 
 	// Invalid permission should fail validation.
-	_, err = client.Permissions.AddUser(&PermissionsAddUserOption{
+	_, err = client.Permissions.AddUser(&PermissionsAddUserOptions{
 		Login:      "john.doe",
 		Permission: "invalid",
 	})
@@ -222,7 +222,7 @@ func TestPermissions_AddUserToTemplate(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/add_user_to_template", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsAddUserToTemplateOption{
+	opt := &PermissionsAddUserToTemplateOptions{
 		Login:        "john.doe",
 		Permission:   "admin",
 		TemplateName: "my-template",
@@ -241,21 +241,21 @@ func TestPermissions_AddUserToTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Login should fail validation.
-	_, err = client.Permissions.AddUserToTemplate(&PermissionsAddUserToTemplateOption{
+	_, err = client.Permissions.AddUserToTemplate(&PermissionsAddUserToTemplateOptions{
 		Permission:   "admin",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.AddUserToTemplate(&PermissionsAddUserToTemplateOption{
+	_, err = client.Permissions.AddUserToTemplate(&PermissionsAddUserToTemplateOptions{
 		Login:        "john.doe",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Invalid permission should fail validation.
-	_, err = client.Permissions.AddUserToTemplate(&PermissionsAddUserToTemplateOption{
+	_, err = client.Permissions.AddUserToTemplate(&PermissionsAddUserToTemplateOptions{
 		Login:        "john.doe",
 		Permission:   "profileadmin", // Not a project permission
 		TemplateName: "my-template",
@@ -263,7 +263,7 @@ func TestPermissions_AddUserToTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.AddUserToTemplate(&PermissionsAddUserToTemplateOption{
+	_, err = client.Permissions.AddUserToTemplate(&PermissionsAddUserToTemplateOptions{
 		Login:      "john.doe",
 		Permission: "admin",
 	})
@@ -278,7 +278,7 @@ func TestPermissions_ApplyTemplate(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/apply_template", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsApplyTemplateOption{
+	opt := &PermissionsApplyTemplateOptions{
 		ProjectKey:   "my-project",
 		TemplateName: "my-template",
 	}
@@ -296,13 +296,13 @@ func TestPermissions_ApplyTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing ProjectID and ProjectKey should fail validation.
-	_, err = client.Permissions.ApplyTemplate(&PermissionsApplyTemplateOption{
+	_, err = client.Permissions.ApplyTemplate(&PermissionsApplyTemplateOptions{
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.ApplyTemplate(&PermissionsApplyTemplateOption{
+	_, err = client.Permissions.ApplyTemplate(&PermissionsApplyTemplateOptions{
 		ProjectKey: "my-project",
 	})
 	assert.Error(t, err)
@@ -316,7 +316,7 @@ func TestPermissions_BulkApplyTemplate(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/bulk_apply_template", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsBulkApplyTemplateOption{
+	opt := &PermissionsBulkApplyTemplateOptions{
 		TemplateName: "my-template",
 	}
 
@@ -329,7 +329,7 @@ func TestPermissions_BulkApplyTemplate_WithProjects(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/bulk_apply_template", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsBulkApplyTemplateOption{
+	opt := &PermissionsBulkApplyTemplateOptions{
 		TemplateName: "my-template",
 		Projects:     []string{"project1", "project2"},
 	}
@@ -347,11 +347,11 @@ func TestPermissions_BulkApplyTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.BulkApplyTemplate(&PermissionsBulkApplyTemplateOption{})
+	_, err = client.Permissions.BulkApplyTemplate(&PermissionsBulkApplyTemplateOptions{})
 	assert.Error(t, err)
 
 	// Invalid qualifier should fail validation.
-	_, err = client.Permissions.BulkApplyTemplate(&PermissionsBulkApplyTemplateOption{
+	_, err = client.Permissions.BulkApplyTemplate(&PermissionsBulkApplyTemplateOptions{
 		TemplateName: "my-template",
 		Qualifiers:   "INVALID",
 	})
@@ -373,7 +373,7 @@ func TestPermissions_CreateTemplate(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/permissions/create_template", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsCreateTemplateOption{
+	opt := &PermissionsCreateTemplateOptions{
 		Name:              "my-template",
 		Description:       "Template for my projects",
 		ProjectKeyPattern: "my-.*",
@@ -394,7 +394,7 @@ func TestPermissions_CreateTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Name should fail validation.
-	_, _, err = client.Permissions.CreateTemplate(&PermissionsCreateTemplateOption{})
+	_, _, err = client.Permissions.CreateTemplate(&PermissionsCreateTemplateOptions{})
 	assert.Error(t, err)
 }
 
@@ -406,7 +406,7 @@ func TestPermissions_DeleteTemplate(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/delete_template", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsDeleteTemplateOption{
+	opt := &PermissionsDeleteTemplateOptions{
 		TemplateName: "my-template",
 	}
 
@@ -423,7 +423,7 @@ func TestPermissions_DeleteTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.DeleteTemplate(&PermissionsDeleteTemplateOption{})
+	_, err = client.Permissions.DeleteTemplate(&PermissionsDeleteTemplateOptions{})
 	assert.Error(t, err)
 }
 
@@ -475,7 +475,7 @@ func TestPermissions_Groups_WithOptions(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/permissions/groups", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsGroupsOption{
+	opt := &PermissionsGroupsOptions{
 		ProjectKey: "my-project",
 		Permission: "admin",
 	}
@@ -489,13 +489,13 @@ func TestPermissions_Groups_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Invalid permission should fail validation.
-	_, _, err := client.Permissions.Groups(&PermissionsGroupsOption{
+	_, _, err := client.Permissions.Groups(&PermissionsGroupsOptions{
 		Permission: "invalid",
 	})
 	assert.Error(t, err)
 
 	// Query too short should fail validation.
-	_, _, err = client.Permissions.Groups(&PermissionsGroupsOption{
+	_, _, err = client.Permissions.Groups(&PermissionsGroupsOptions{
 		Query: "ab",
 	})
 	assert.Error(t, err)
@@ -509,7 +509,7 @@ func TestPermissions_RemoveGroup(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/remove_group", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsRemoveGroupOption{
+	opt := &PermissionsRemoveGroupOptions{
 		GroupName:  "developers",
 		Permission: "admin",
 	}
@@ -527,13 +527,13 @@ func TestPermissions_RemoveGroup_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing GroupName should fail validation.
-	_, err = client.Permissions.RemoveGroup(&PermissionsRemoveGroupOption{
+	_, err = client.Permissions.RemoveGroup(&PermissionsRemoveGroupOptions{
 		Permission: "admin",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.RemoveGroup(&PermissionsRemoveGroupOption{
+	_, err = client.Permissions.RemoveGroup(&PermissionsRemoveGroupOptions{
 		GroupName: "developers",
 	})
 	assert.Error(t, err)
@@ -547,7 +547,7 @@ func TestPermissions_RemoveGroupFromTemplate(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/remove_group_from_template", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsRemoveGroupFromTemplateOption{
+	opt := &PermissionsRemoveGroupFromTemplateOptions{
 		GroupName:    "developers",
 		Permission:   "admin",
 		TemplateName: "my-template",
@@ -566,21 +566,21 @@ func TestPermissions_RemoveGroupFromTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing GroupName should fail validation.
-	_, err = client.Permissions.RemoveGroupFromTemplate(&PermissionsRemoveGroupFromTemplateOption{
+	_, err = client.Permissions.RemoveGroupFromTemplate(&PermissionsRemoveGroupFromTemplateOptions{
 		Permission:   "admin",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.RemoveGroupFromTemplate(&PermissionsRemoveGroupFromTemplateOption{
+	_, err = client.Permissions.RemoveGroupFromTemplate(&PermissionsRemoveGroupFromTemplateOptions{
 		GroupName:    "developers",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.RemoveGroupFromTemplate(&PermissionsRemoveGroupFromTemplateOption{
+	_, err = client.Permissions.RemoveGroupFromTemplate(&PermissionsRemoveGroupFromTemplateOptions{
 		GroupName:  "developers",
 		Permission: "admin",
 	})
@@ -595,7 +595,7 @@ func TestPermissions_RemoveProjectCreatorFromTemplate(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/remove_project_creator_from_template", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsRemoveProjectCreatorFromTemplateOption{
+	opt := &PermissionsRemoveProjectCreatorFromTemplateOptions{
 		Permission:   "admin",
 		TemplateName: "my-template",
 	}
@@ -613,13 +613,13 @@ func TestPermissions_RemoveProjectCreatorFromTemplate_ValidationError(t *testing
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.RemoveProjectCreatorFromTemplate(&PermissionsRemoveProjectCreatorFromTemplateOption{
+	_, err = client.Permissions.RemoveProjectCreatorFromTemplate(&PermissionsRemoveProjectCreatorFromTemplateOptions{
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.RemoveProjectCreatorFromTemplate(&PermissionsRemoveProjectCreatorFromTemplateOption{
+	_, err = client.Permissions.RemoveProjectCreatorFromTemplate(&PermissionsRemoveProjectCreatorFromTemplateOptions{
 		Permission: "admin",
 	})
 	assert.Error(t, err)
@@ -633,7 +633,7 @@ func TestPermissions_RemoveUser(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/remove_user", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsRemoveUserOption{
+	opt := &PermissionsRemoveUserOptions{
 		Login:      "john.doe",
 		Permission: "admin",
 	}
@@ -651,13 +651,13 @@ func TestPermissions_RemoveUser_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Login should fail validation.
-	_, err = client.Permissions.RemoveUser(&PermissionsRemoveUserOption{
+	_, err = client.Permissions.RemoveUser(&PermissionsRemoveUserOptions{
 		Permission: "admin",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.RemoveUser(&PermissionsRemoveUserOption{
+	_, err = client.Permissions.RemoveUser(&PermissionsRemoveUserOptions{
 		Login: "john.doe",
 	})
 	assert.Error(t, err)
@@ -671,7 +671,7 @@ func TestPermissions_RemoveUserFromTemplate(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/remove_user_from_template", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsRemoveUserFromTemplateOption{
+	opt := &PermissionsRemoveUserFromTemplateOptions{
 		Login:        "john.doe",
 		Permission:   "admin",
 		TemplateName: "my-template",
@@ -690,21 +690,21 @@ func TestPermissions_RemoveUserFromTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Login should fail validation.
-	_, err = client.Permissions.RemoveUserFromTemplate(&PermissionsRemoveUserFromTemplateOption{
+	_, err = client.Permissions.RemoveUserFromTemplate(&PermissionsRemoveUserFromTemplateOptions{
 		Permission:   "admin",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.RemoveUserFromTemplate(&PermissionsRemoveUserFromTemplateOption{
+	_, err = client.Permissions.RemoveUserFromTemplate(&PermissionsRemoveUserFromTemplateOptions{
 		Login:        "john.doe",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.RemoveUserFromTemplate(&PermissionsRemoveUserFromTemplateOption{
+	_, err = client.Permissions.RemoveUserFromTemplate(&PermissionsRemoveUserFromTemplateOptions{
 		Login:      "john.doe",
 		Permission: "admin",
 	})
@@ -754,7 +754,7 @@ func TestPermissions_SetDefaultTemplate(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/permissions/set_default_template", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsSetDefaultTemplateOption{
+	opt := &PermissionsSetDefaultTemplateOptions{
 		TemplateName: "my-template",
 	}
 
@@ -771,11 +771,11 @@ func TestPermissions_SetDefaultTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.SetDefaultTemplate(&PermissionsSetDefaultTemplateOption{})
+	_, err = client.Permissions.SetDefaultTemplate(&PermissionsSetDefaultTemplateOptions{})
 	assert.Error(t, err)
 
 	// Invalid qualifier should fail validation.
-	_, err = client.Permissions.SetDefaultTemplate(&PermissionsSetDefaultTemplateOption{
+	_, err = client.Permissions.SetDefaultTemplate(&PermissionsSetDefaultTemplateOptions{
 		TemplateName: "my-template",
 		Qualifier:    "INVALID",
 	})
@@ -804,7 +804,7 @@ func TestPermissions_TemplateGroups(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/permissions/template_groups", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsTemplateGroupsOption{
+	opt := &PermissionsTemplateGroupsOptions{
 		TemplateName: "my-template",
 	}
 
@@ -824,18 +824,18 @@ func TestPermissions_TemplateGroups_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, _, err = client.Permissions.TemplateGroups(&PermissionsTemplateGroupsOption{})
+	_, _, err = client.Permissions.TemplateGroups(&PermissionsTemplateGroupsOptions{})
 	assert.Error(t, err)
 
 	// Invalid permission should fail validation.
-	_, _, err = client.Permissions.TemplateGroups(&PermissionsTemplateGroupsOption{
+	_, _, err = client.Permissions.TemplateGroups(&PermissionsTemplateGroupsOptions{
 		TemplateName: "my-template",
 		Permission:   "gateadmin", // Not a project permission
 	})
 	assert.Error(t, err)
 
 	// Query too short should fail validation.
-	_, _, err = client.Permissions.TemplateGroups(&PermissionsTemplateGroupsOption{
+	_, _, err = client.Permissions.TemplateGroups(&PermissionsTemplateGroupsOptions{
 		TemplateName: "my-template",
 		Query:        "ab",
 	})
@@ -865,7 +865,7 @@ func TestPermissions_TemplateUsers(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/permissions/template_users", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsTemplateUsersOption{
+	opt := &PermissionsTemplateUsersOptions{
 		TemplateName: "my-template",
 	}
 
@@ -885,18 +885,18 @@ func TestPermissions_TemplateUsers_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, _, err = client.Permissions.TemplateUsers(&PermissionsTemplateUsersOption{})
+	_, _, err = client.Permissions.TemplateUsers(&PermissionsTemplateUsersOptions{})
 	assert.Error(t, err)
 
 	// Invalid permission should fail validation.
-	_, _, err = client.Permissions.TemplateUsers(&PermissionsTemplateUsersOption{
+	_, _, err = client.Permissions.TemplateUsers(&PermissionsTemplateUsersOptions{
 		TemplateName: "my-template",
 		Permission:   "provisioning", // Not a project permission
 	})
 	assert.Error(t, err)
 
 	// Query too short should fail validation.
-	_, _, err = client.Permissions.TemplateUsers(&PermissionsTemplateUsersOption{
+	_, _, err = client.Permissions.TemplateUsers(&PermissionsTemplateUsersOptions{
 		TemplateName: "my-template",
 		Query:        "ab",
 	})
@@ -917,7 +917,7 @@ func TestPermissions_UpdateTemplate(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/permissions/update_template", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsUpdateTemplateOption{
+	opt := &PermissionsUpdateTemplateOptions{
 		ID:                "template-1",
 		Name:              "new-template-name",
 		Description:       "Updated description",
@@ -939,7 +939,7 @@ func TestPermissions_UpdateTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing ID should fail validation.
-	_, _, err = client.Permissions.UpdateTemplate(&PermissionsUpdateTemplateOption{
+	_, _, err = client.Permissions.UpdateTemplate(&PermissionsUpdateTemplateOptions{
 		Name: "new-name",
 	})
 	assert.Error(t, err)
@@ -998,7 +998,7 @@ func TestPermissions_Users_WithOptions(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/permissions/users", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &PermissionsUsersOption{
+	opt := &PermissionsUsersOptions{
 		ProjectKey: "my-project",
 		Permission: "admin",
 	}
@@ -1012,13 +1012,13 @@ func TestPermissions_Users_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Invalid permission should fail validation.
-	_, _, err := client.Permissions.Users(&PermissionsUsersOption{
+	_, _, err := client.Permissions.Users(&PermissionsUsersOptions{
 		Permission: "invalid",
 	})
 	assert.Error(t, err)
 
 	// Query too short should fail validation.
-	_, _, err = client.Permissions.Users(&PermissionsUsersOption{
+	_, _, err = client.Permissions.Users(&PermissionsUsersOptions{
 		Query: "ab",
 	})
 	assert.Error(t, err)

--- a/sonar/plugins_service.go
+++ b/sonar/plugins_service.go
@@ -248,22 +248,22 @@ type PluginUpdateDetail struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// PluginsDownloadOption represents options for downloading a plugin.
-type PluginsDownloadOption struct {
+// PluginsDownloadOptions represents options for downloading a plugin.
+type PluginsDownloadOptions struct {
 	// Plugin is the key identifying the plugin to download (required).
 	Plugin string `url:"plugin,omitempty"`
 }
 
-// PluginsInstallOption represents options for installing a plugin.
-type PluginsInstallOption struct {
+// PluginsInstallOptions represents options for installing a plugin.
+type PluginsInstallOptions struct {
 	// Key is the key identifying the plugin to install (required).
 	Key string `url:"key,omitempty"`
 }
 
-// PluginsInstalledOption represents options for listing installed plugins.
+// PluginsInstalledOptions represents options for listing installed plugins.
 //
 //nolint:govet // fieldalignment - structure kept for readability
-type PluginsInstalledOption struct {
+type PluginsInstalledOptions struct {
 	// Fields is the list of additional fields to return.
 	// Possible values: category.
 	Fields []string `url:"f,omitempty,comma"`
@@ -272,14 +272,14 @@ type PluginsInstalledOption struct {
 	Type string `url:"type,omitempty"`
 }
 
-// PluginsUninstallOption represents options for uninstalling a plugin.
-type PluginsUninstallOption struct {
+// PluginsUninstallOptions represents options for uninstalling a plugin.
+type PluginsUninstallOptions struct {
 	// Key is the key identifying the plugin to uninstall (required).
 	Key string `url:"key,omitempty"`
 }
 
-// PluginsUpdateOption represents options for updating a plugin.
-type PluginsUpdateOption struct {
+// PluginsUpdateOptions represents options for updating a plugin.
+type PluginsUpdateOptions struct {
 	// Key is the key identifying the plugin to update (required).
 	Key string `url:"key,omitempty"`
 }
@@ -305,7 +305,7 @@ var (
 // -----------------------------------------------------------------------------
 
 // ValidateDownloadOpt validates the options for the Download method.
-func (s *PluginsService) ValidateDownloadOpt(opt *PluginsDownloadOption) error {
+func (s *PluginsService) ValidateDownloadOpt(opt *PluginsDownloadOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -314,7 +314,7 @@ func (s *PluginsService) ValidateDownloadOpt(opt *PluginsDownloadOption) error {
 }
 
 // ValidateInstallOpt validates the options for the Install method.
-func (s *PluginsService) ValidateInstallOpt(opt *PluginsInstallOption) error {
+func (s *PluginsService) ValidateInstallOpt(opt *PluginsInstallOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -323,7 +323,7 @@ func (s *PluginsService) ValidateInstallOpt(opt *PluginsInstallOption) error {
 }
 
 // ValidateInstalledOpt validates the options for the Installed method.
-func (s *PluginsService) ValidateInstalledOpt(opt *PluginsInstalledOption) error {
+func (s *PluginsService) ValidateInstalledOpt(opt *PluginsInstalledOptions) error {
 	if opt == nil {
 		return nil
 	}
@@ -346,7 +346,7 @@ func (s *PluginsService) ValidateInstalledOpt(opt *PluginsInstalledOption) error
 }
 
 // ValidateUninstallOpt validates the options for the Uninstall method.
-func (s *PluginsService) ValidateUninstallOpt(opt *PluginsUninstallOption) error {
+func (s *PluginsService) ValidateUninstallOpt(opt *PluginsUninstallOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -355,7 +355,7 @@ func (s *PluginsService) ValidateUninstallOpt(opt *PluginsUninstallOption) error
 }
 
 // ValidateUpdateOpt validates the options for the Update method.
-func (s *PluginsService) ValidateUpdateOpt(opt *PluginsUpdateOption) error {
+func (s *PluginsService) ValidateUpdateOpt(opt *PluginsUpdateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -413,7 +413,7 @@ func (s *PluginsService) CancelAll() (*http.Response, error) {
 // API endpoint: GET /api/plugins/download.
 // Since: 7.2.
 // Internal: true.
-func (s *PluginsService) Download(opt *PluginsDownloadOption) (*string, *http.Response, error) {
+func (s *PluginsService) Download(opt *PluginsDownloadOptions) (*string, *http.Response, error) {
 	err := s.ValidateDownloadOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -441,7 +441,7 @@ func (s *PluginsService) Download(opt *PluginsDownloadOption) (*string, *http.Re
 //
 // API endpoint: POST /api/plugins/install.
 // Since: 5.2.
-func (s *PluginsService) Install(opt *PluginsInstallOption) (*http.Response, error) {
+func (s *PluginsService) Install(opt *PluginsInstallOptions) (*http.Response, error) {
 	err := s.ValidateInstallOpt(opt)
 	if err != nil {
 		return nil, err
@@ -465,7 +465,7 @@ func (s *PluginsService) Install(opt *PluginsInstallOption) (*http.Response, err
 //
 // API endpoint: GET /api/plugins/installed.
 // Since: 5.2.
-func (s *PluginsService) Installed(opt *PluginsInstalledOption) (*PluginsInstalled, *http.Response, error) {
+func (s *PluginsService) Installed(opt *PluginsInstalledOptions) (*PluginsInstalled, *http.Response, error) {
 	err := s.ValidateInstalledOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -512,7 +512,7 @@ func (s *PluginsService) Pending() (*PluginsPending, *http.Response, error) {
 //
 // API endpoint: POST /api/plugins/uninstall.
 // Since: 5.2.
-func (s *PluginsService) Uninstall(opt *PluginsUninstallOption) (*http.Response, error) {
+func (s *PluginsService) Uninstall(opt *PluginsUninstallOptions) (*http.Response, error) {
 	err := s.ValidateUninstallOpt(opt)
 	if err != nil {
 		return nil, err
@@ -537,7 +537,7 @@ func (s *PluginsService) Uninstall(opt *PluginsUninstallOption) (*http.Response,
 //
 // API endpoint: POST /api/plugins/update.
 // Since: 5.2.
-func (s *PluginsService) Update(opt *PluginsUpdateOption) (*http.Response, error) {
+func (s *PluginsService) Update(opt *PluginsUpdateOptions) (*http.Response, error) {
 	err := s.ValidateUpdateOpt(opt)
 	if err != nil {
 		return nil, err

--- a/sonar/plugins_service_test.go
+++ b/sonar/plugins_service_test.go
@@ -64,7 +64,7 @@ func TestPluginsService_Download(t *testing.T) {
 		})
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Plugins.Download(&PluginsDownloadOption{
+		result, resp, err := client.Plugins.Download(&PluginsDownloadOptions{
 			Plugin: "sonar-java",
 		})
 		require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestPluginsService_Download(t *testing.T) {
 	t.Run("missing plugin", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.Plugins.Download(&PluginsDownloadOption{})
+		_, _, err := client.Plugins.Download(&PluginsDownloadOptions{})
 		assert.Error(t, err)
 	})
 }
@@ -97,7 +97,7 @@ func TestPluginsService_Install(t *testing.T) {
 		})
 		client := newTestClient(t, server.URL)
 
-		resp, err := client.Plugins.Install(&PluginsInstallOption{
+		resp, err := client.Plugins.Install(&PluginsInstallOptions{
 			Key: "sonar-java",
 		})
 		require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestPluginsService_Install(t *testing.T) {
 	t.Run("missing key", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.Plugins.Install(&PluginsInstallOption{})
+		_, err := client.Plugins.Install(&PluginsInstallOptions{})
 		assert.Error(t, err)
 	})
 }
@@ -158,7 +158,7 @@ func TestPluginsService_Installed(t *testing.T) {
 		})
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Plugins.Installed(&PluginsInstalledOption{
+		_, _, err := client.Plugins.Installed(&PluginsInstalledOptions{
 			Fields: []string{"category"},
 		})
 		require.NoError(t, err)
@@ -172,7 +172,7 @@ func TestPluginsService_Installed(t *testing.T) {
 		})
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Plugins.Installed(&PluginsInstalledOption{
+		_, _, err := client.Plugins.Installed(&PluginsInstalledOptions{
 			Type: "BUNDLED",
 		})
 		require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestPluginsService_Installed(t *testing.T) {
 	t.Run("invalid field", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.Plugins.Installed(&PluginsInstalledOption{
+		_, _, err := client.Plugins.Installed(&PluginsInstalledOptions{
 			Fields: []string{"invalid"},
 		})
 		assert.Error(t, err)
@@ -190,7 +190,7 @@ func TestPluginsService_Installed(t *testing.T) {
 	t.Run("invalid type", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.Plugins.Installed(&PluginsInstalledOption{
+		_, _, err := client.Plugins.Installed(&PluginsInstalledOptions{
 			Type: "INVALID",
 		})
 		assert.Error(t, err)
@@ -230,7 +230,7 @@ func TestPluginsService_Uninstall(t *testing.T) {
 		})
 		client := newTestClient(t, server.URL)
 
-		resp, err := client.Plugins.Uninstall(&PluginsUninstallOption{
+		resp, err := client.Plugins.Uninstall(&PluginsUninstallOptions{
 			Key: "sonar-java",
 		})
 		require.NoError(t, err)
@@ -247,7 +247,7 @@ func TestPluginsService_Uninstall(t *testing.T) {
 	t.Run("missing key", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.Plugins.Uninstall(&PluginsUninstallOption{})
+		_, err := client.Plugins.Uninstall(&PluginsUninstallOptions{})
 		assert.Error(t, err)
 	})
 }
@@ -262,7 +262,7 @@ func TestPluginsService_Update(t *testing.T) {
 		})
 		client := newTestClient(t, server.URL)
 
-		resp, err := client.Plugins.Update(&PluginsUpdateOption{
+		resp, err := client.Plugins.Update(&PluginsUpdateOptions{
 			Key: "sonar-java",
 		})
 		require.NoError(t, err)
@@ -279,7 +279,7 @@ func TestPluginsService_Update(t *testing.T) {
 	t.Run("missing key", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.Plugins.Update(&PluginsUpdateOption{})
+		_, err := client.Plugins.Update(&PluginsUpdateOptions{})
 		assert.Error(t, err)
 	})
 }
@@ -326,12 +326,12 @@ func TestPluginsService_ValidateDownloadOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *PluginsDownloadOption
+		opt     *PluginsDownloadOptions
 		wantErr bool
 	}{
-		{"valid", &PluginsDownloadOption{Plugin: "sonar-java"}, false},
+		{"valid", &PluginsDownloadOptions{Plugin: "sonar-java"}, false},
 		{"nil option", nil, true},
-		{"empty plugin", &PluginsDownloadOption{}, true},
+		{"empty plugin", &PluginsDownloadOptions{}, true},
 	}
 
 	for _, tt := range tests {
@@ -351,12 +351,12 @@ func TestPluginsService_ValidateInstallOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *PluginsInstallOption
+		opt     *PluginsInstallOptions
 		wantErr bool
 	}{
-		{"valid", &PluginsInstallOption{Key: "sonar-java"}, false},
+		{"valid", &PluginsInstallOptions{Key: "sonar-java"}, false},
 		{"nil option", nil, true},
-		{"empty key", &PluginsInstallOption{}, true},
+		{"empty key", &PluginsInstallOptions{}, true},
 	}
 
 	for _, tt := range tests {
@@ -376,16 +376,16 @@ func TestPluginsService_ValidateInstalledOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *PluginsInstalledOption
+		opt     *PluginsInstalledOptions
 		wantErr bool
 	}{
 		{"nil option", nil, false},
-		{"empty option", &PluginsInstalledOption{}, false},
-		{"valid fields", &PluginsInstalledOption{Fields: []string{"category"}}, false},
-		{"invalid fields", &PluginsInstalledOption{Fields: []string{"invalid"}}, true},
-		{"valid type BUNDLED", &PluginsInstalledOption{Type: "BUNDLED"}, false},
-		{"valid type EXTERNAL", &PluginsInstalledOption{Type: "EXTERNAL"}, false},
-		{"invalid type", &PluginsInstalledOption{Type: "INVALID"}, true},
+		{"empty option", &PluginsInstalledOptions{}, false},
+		{"valid fields", &PluginsInstalledOptions{Fields: []string{"category"}}, false},
+		{"invalid fields", &PluginsInstalledOptions{Fields: []string{"invalid"}}, true},
+		{"valid type BUNDLED", &PluginsInstalledOptions{Type: "BUNDLED"}, false},
+		{"valid type EXTERNAL", &PluginsInstalledOptions{Type: "EXTERNAL"}, false},
+		{"invalid type", &PluginsInstalledOptions{Type: "INVALID"}, true},
 	}
 
 	for _, tt := range tests {
@@ -405,12 +405,12 @@ func TestPluginsService_ValidateUninstallOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *PluginsUninstallOption
+		opt     *PluginsUninstallOptions
 		wantErr bool
 	}{
-		{"valid", &PluginsUninstallOption{Key: "sonar-java"}, false},
+		{"valid", &PluginsUninstallOptions{Key: "sonar-java"}, false},
 		{"nil option", nil, true},
-		{"empty key", &PluginsUninstallOption{}, true},
+		{"empty key", &PluginsUninstallOptions{}, true},
 	}
 
 	for _, tt := range tests {
@@ -430,12 +430,12 @@ func TestPluginsService_ValidateUpdateOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *PluginsUpdateOption
+		opt     *PluginsUpdateOptions
 		wantErr bool
 	}{
-		{"valid", &PluginsUpdateOption{Key: "sonar-java"}, false},
+		{"valid", &PluginsUpdateOptions{Key: "sonar-java"}, false},
 		{"nil option", nil, true},
-		{"empty key", &PluginsUpdateOption{}, true},
+		{"empty key", &PluginsUpdateOptions{}, true},
 	}
 
 	for _, tt := range tests {

--- a/sonar/project_analyses_service.go
+++ b/sonar/project_analyses_service.go
@@ -103,8 +103,8 @@ type ProjectAnalysis struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// ProjectAnalysesCreateEventOption represents options for creating an event.
-type ProjectAnalysesCreateEventOption struct {
+// ProjectAnalysesCreateEventOptions represents options for creating an event.
+type ProjectAnalysesCreateEventOptions struct {
 	// Analysis is the analysis key (required).
 	Analysis string `url:"analysis,omitempty"`
 	// Category is the event category.
@@ -115,22 +115,22 @@ type ProjectAnalysesCreateEventOption struct {
 	Name string `url:"name,omitempty"`
 }
 
-// ProjectAnalysesDeleteOption represents options for deleting an analysis.
-type ProjectAnalysesDeleteOption struct {
+// ProjectAnalysesDeleteOptions represents options for deleting an analysis.
+type ProjectAnalysesDeleteOptions struct {
 	// Analysis is the analysis key (required).
 	Analysis string `url:"analysis,omitempty"`
 }
 
-// ProjectAnalysesDeleteEventOption represents options for deleting an event.
-type ProjectAnalysesDeleteEventOption struct {
+// ProjectAnalysesDeleteEventOptions represents options for deleting an event.
+type ProjectAnalysesDeleteEventOptions struct {
 	// Event is the event key (required).
 	Event string `url:"event,omitempty"`
 }
 
-// ProjectAnalysesSearchOption represents options for searching analyses.
+// ProjectAnalysesSearchOptions represents options for searching analyses.
 //
 //nolint:govet // fieldalignment - structure kept for readability
-type ProjectAnalysesSearchOption struct {
+type ProjectAnalysesSearchOptions struct {
 	// PaginationArgs embeds pagination parameters.
 	PaginationArgs
 
@@ -151,8 +151,8 @@ type ProjectAnalysesSearchOption struct {
 	To string `url:"to,omitempty"`
 }
 
-// ProjectAnalysesUpdateEventOption represents options for updating an event.
-type ProjectAnalysesUpdateEventOption struct {
+// ProjectAnalysesUpdateEventOptions represents options for updating an event.
+type ProjectAnalysesUpdateEventOptions struct {
 	// Event is the event key (required).
 	Event string `url:"event,omitempty"`
 	// Name is the new event name (required).
@@ -185,7 +185,7 @@ var (
 // -----------------------------------------------------------------------------
 
 // ValidateCreateEventOpt validates the options for the CreateEvent method.
-func (s *ProjectAnalysesService) ValidateCreateEventOpt(opt *ProjectAnalysesCreateEventOption) error {
+func (s *ProjectAnalysesService) ValidateCreateEventOpt(opt *ProjectAnalysesCreateEventOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -211,7 +211,7 @@ func (s *ProjectAnalysesService) ValidateCreateEventOpt(opt *ProjectAnalysesCrea
 }
 
 // ValidateDeleteOpt validates the options for the Delete method.
-func (s *ProjectAnalysesService) ValidateDeleteOpt(opt *ProjectAnalysesDeleteOption) error {
+func (s *ProjectAnalysesService) ValidateDeleteOpt(opt *ProjectAnalysesDeleteOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -220,7 +220,7 @@ func (s *ProjectAnalysesService) ValidateDeleteOpt(opt *ProjectAnalysesDeleteOpt
 }
 
 // ValidateDeleteEventOpt validates the options for the DeleteEvent method.
-func (s *ProjectAnalysesService) ValidateDeleteEventOpt(opt *ProjectAnalysesDeleteEventOption) error {
+func (s *ProjectAnalysesService) ValidateDeleteEventOpt(opt *ProjectAnalysesDeleteEventOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -238,7 +238,7 @@ func validateDateFormat(value, fieldName string) error {
 }
 
 // ValidateSearchOpt validates the options for the Search method.
-func (s *ProjectAnalysesService) ValidateSearchOpt(opt *ProjectAnalysesSearchOption) error {
+func (s *ProjectAnalysesService) ValidateSearchOpt(opt *ProjectAnalysesSearchOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -264,7 +264,7 @@ func (s *ProjectAnalysesService) ValidateSearchOpt(opt *ProjectAnalysesSearchOpt
 }
 
 // ValidateUpdateEventOpt validates the options for the UpdateEvent method.
-func (s *ProjectAnalysesService) ValidateUpdateEventOpt(opt *ProjectAnalysesUpdateEventOption) error {
+func (s *ProjectAnalysesService) ValidateUpdateEventOpt(opt *ProjectAnalysesUpdateEventOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -327,7 +327,7 @@ func isValidDateTime(dateTimeStr string) bool {
 //
 // API endpoint: POST /api/project_analyses/create_event.
 // Since: 6.3.
-func (s *ProjectAnalysesService) CreateEvent(opt *ProjectAnalysesCreateEventOption) (*ProjectAnalysesEvent, *http.Response, error) {
+func (s *ProjectAnalysesService) CreateEvent(opt *ProjectAnalysesCreateEventOptions) (*ProjectAnalysesEvent, *http.Response, error) {
 	err := s.ValidateCreateEventOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -353,7 +353,7 @@ func (s *ProjectAnalysesService) CreateEvent(opt *ProjectAnalysesCreateEventOpti
 //
 // API endpoint: POST /api/project_analyses/delete.
 // Since: 6.3.
-func (s *ProjectAnalysesService) Delete(opt *ProjectAnalysesDeleteOption) (*http.Response, error) {
+func (s *ProjectAnalysesService) Delete(opt *ProjectAnalysesDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
@@ -378,7 +378,7 @@ func (s *ProjectAnalysesService) Delete(opt *ProjectAnalysesDeleteOption) (*http
 //
 // API endpoint: POST /api/project_analyses/delete_event.
 // Since: 6.3.
-func (s *ProjectAnalysesService) DeleteEvent(opt *ProjectAnalysesDeleteEventOption) (*http.Response, error) {
+func (s *ProjectAnalysesService) DeleteEvent(opt *ProjectAnalysesDeleteEventOptions) (*http.Response, error) {
 	err := s.ValidateDeleteEventOpt(opt)
 	if err != nil {
 		return nil, err
@@ -402,7 +402,7 @@ func (s *ProjectAnalysesService) DeleteEvent(opt *ProjectAnalysesDeleteEventOpti
 //
 // API endpoint: GET /api/project_analyses/search.
 // Since: 6.3.
-func (s *ProjectAnalysesService) Search(opt *ProjectAnalysesSearchOption) (*ProjectAnalysesSearch, *http.Response, error) {
+func (s *ProjectAnalysesService) Search(opt *ProjectAnalysesSearchOptions) (*ProjectAnalysesSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -425,7 +425,7 @@ func (s *ProjectAnalysesService) Search(opt *ProjectAnalysesSearchOption) (*Proj
 
 // SearchAll is a convenience method to iterate over all analyses.
 // It handles pagination automatically.
-func (s *ProjectAnalysesService) SearchAll(opt *ProjectAnalysesSearchOption) ([]ProjectAnalysis, *http.Response, error) {
+func (s *ProjectAnalysesService) SearchAll(opt *ProjectAnalysesSearchOptions) ([]ProjectAnalysis, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -463,7 +463,7 @@ func (s *ProjectAnalysesService) SearchAll(opt *ProjectAnalysesSearchOption) ([]
 //
 // API endpoint: POST /api/project_analyses/update_event.
 // Since: 6.3.
-func (s *ProjectAnalysesService) UpdateEvent(opt *ProjectAnalysesUpdateEventOption) (*ProjectAnalysesEvent, *http.Response, error) {
+func (s *ProjectAnalysesService) UpdateEvent(opt *ProjectAnalysesUpdateEventOptions) (*ProjectAnalysesEvent, *http.Response, error) {
 	err := s.ValidateUpdateEventOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/project_analyses_service_test.go
+++ b/sonar/project_analyses_service_test.go
@@ -30,7 +30,7 @@ func TestProjectAnalysesService_CreateEvent(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.ProjectAnalyses.CreateEvent(&ProjectAnalysesCreateEventOption{
+		result, resp, err := client.ProjectAnalyses.CreateEvent(&ProjectAnalysesCreateEventOptions{
 			Analysis: "AU-TpxcA-iU5OvuD2FL0",
 			Category: "VERSION",
 			Name:     "1.0",
@@ -50,7 +50,7 @@ func TestProjectAnalysesService_CreateEvent(t *testing.T) {
 	t.Run("missing analysis", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.CreateEvent(&ProjectAnalysesCreateEventOption{
+		_, _, err := client.ProjectAnalyses.CreateEvent(&ProjectAnalysesCreateEventOptions{
 			Name: "1.0",
 		})
 		assert.Error(t, err)
@@ -59,7 +59,7 @@ func TestProjectAnalysesService_CreateEvent(t *testing.T) {
 	t.Run("missing name", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.CreateEvent(&ProjectAnalysesCreateEventOption{
+		_, _, err := client.ProjectAnalyses.CreateEvent(&ProjectAnalysesCreateEventOptions{
 			Analysis: "AU-TpxcA-iU5OvuD2FL0",
 		})
 		assert.Error(t, err)
@@ -68,7 +68,7 @@ func TestProjectAnalysesService_CreateEvent(t *testing.T) {
 	t.Run("invalid category", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.CreateEvent(&ProjectAnalysesCreateEventOption{
+		_, _, err := client.ProjectAnalyses.CreateEvent(&ProjectAnalysesCreateEventOptions{
 			Analysis: "AU-TpxcA-iU5OvuD2FL0",
 			Category: "INVALID",
 			Name:     "1.0",
@@ -88,7 +88,7 @@ func TestProjectAnalysesService_Delete(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		resp, err := client.ProjectAnalyses.Delete(&ProjectAnalysesDeleteOption{
+		resp, err := client.ProjectAnalyses.Delete(&ProjectAnalysesDeleteOptions{
 			Analysis: "AU-TpxcA-iU5OvuD2FL0",
 		})
 		require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestProjectAnalysesService_Delete(t *testing.T) {
 	t.Run("missing analysis", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.ProjectAnalyses.Delete(&ProjectAnalysesDeleteOption{})
+		_, err := client.ProjectAnalyses.Delete(&ProjectAnalysesDeleteOptions{})
 		assert.Error(t, err)
 	})
 }
@@ -121,7 +121,7 @@ func TestProjectAnalysesService_DeleteEvent(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		resp, err := client.ProjectAnalyses.DeleteEvent(&ProjectAnalysesDeleteEventOption{
+		resp, err := client.ProjectAnalyses.DeleteEvent(&ProjectAnalysesDeleteEventOptions{
 			Event: "AU-TpxcA-iU5OvuD2FL1",
 		})
 		require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestProjectAnalysesService_DeleteEvent(t *testing.T) {
 	t.Run("missing event", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.ProjectAnalyses.DeleteEvent(&ProjectAnalysesDeleteEventOption{})
+		_, err := client.ProjectAnalyses.DeleteEvent(&ProjectAnalysesDeleteEventOptions{})
 		assert.Error(t, err)
 	})
 }
@@ -176,7 +176,7 @@ func TestProjectAnalysesService_Search(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOption{
+		result, resp, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOptions{
 			Project: "my-project",
 		})
 		require.NoError(t, err)
@@ -200,7 +200,7 @@ func TestProjectAnalysesService_Search(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOption{
+		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOptions{
 			Project:  "my-project",
 			Branch:   "main",
 			Category: "VERSION",
@@ -218,7 +218,7 @@ func TestProjectAnalysesService_Search(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOption{
+		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOptions{
 			Project: "my-project",
 			From:    "2022-01-01T00:00:00Z",
 			To:      "2022-12-31T23:59:59Z",
@@ -236,14 +236,14 @@ func TestProjectAnalysesService_Search(t *testing.T) {
 	t.Run("missing project", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOption{})
+		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOptions{})
 		assert.Error(t, err)
 	})
 
 	t.Run("invalid category", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOption{
+		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOptions{
 			Project:  "my-project",
 			Category: "INVALID",
 		})
@@ -253,7 +253,7 @@ func TestProjectAnalysesService_Search(t *testing.T) {
 	t.Run("invalid from date", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOption{
+		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOptions{
 			Project: "my-project",
 			From:    "invalid-date",
 		})
@@ -263,7 +263,7 @@ func TestProjectAnalysesService_Search(t *testing.T) {
 	t.Run("invalid to date", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOption{
+		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOptions{
 			Project: "my-project",
 			To:      "invalid-date",
 		})
@@ -292,7 +292,7 @@ func TestProjectAnalysesService_SearchAll(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		opt := &ProjectAnalysesSearchOption{
+		opt := &ProjectAnalysesSearchOptions{
 			Project: "my-project",
 		}
 		opt.PageSize = 1
@@ -331,7 +331,7 @@ func TestProjectAnalysesService_UpdateEvent(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.ProjectAnalyses.UpdateEvent(&ProjectAnalysesUpdateEventOption{
+		result, resp, err := client.ProjectAnalyses.UpdateEvent(&ProjectAnalysesUpdateEventOptions{
 			Event: "AU-TpxcA-iU5OvuD2FL1",
 			Name:  "2.0",
 		})
@@ -350,7 +350,7 @@ func TestProjectAnalysesService_UpdateEvent(t *testing.T) {
 	t.Run("missing event", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.UpdateEvent(&ProjectAnalysesUpdateEventOption{
+		_, _, err := client.ProjectAnalyses.UpdateEvent(&ProjectAnalysesUpdateEventOptions{
 			Name: "2.0",
 		})
 		assert.Error(t, err)
@@ -359,7 +359,7 @@ func TestProjectAnalysesService_UpdateEvent(t *testing.T) {
 	t.Run("missing name", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.UpdateEvent(&ProjectAnalysesUpdateEventOption{
+		_, _, err := client.ProjectAnalyses.UpdateEvent(&ProjectAnalysesUpdateEventOptions{
 			Event: "AU-TpxcA-iU5OvuD2FL1",
 		})
 		assert.Error(t, err)
@@ -371,16 +371,16 @@ func TestProjectAnalysesService_ValidateCreateEventOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *ProjectAnalysesCreateEventOption
+		opt     *ProjectAnalysesCreateEventOptions
 		wantErr bool
 	}{
-		{"valid minimal", &ProjectAnalysesCreateEventOption{Analysis: "a1", Name: "1.0"}, false},
-		{"valid with VERSION", &ProjectAnalysesCreateEventOption{Analysis: "a1", Name: "1.0", Category: "VERSION"}, false},
-		{"valid with OTHER", &ProjectAnalysesCreateEventOption{Analysis: "a1", Name: "1.0", Category: "OTHER"}, false},
+		{"valid minimal", &ProjectAnalysesCreateEventOptions{Analysis: "a1", Name: "1.0"}, false},
+		{"valid with VERSION", &ProjectAnalysesCreateEventOptions{Analysis: "a1", Name: "1.0", Category: "VERSION"}, false},
+		{"valid with OTHER", &ProjectAnalysesCreateEventOptions{Analysis: "a1", Name: "1.0", Category: "OTHER"}, false},
 		{"nil option", nil, true},
-		{"missing analysis", &ProjectAnalysesCreateEventOption{Name: "1.0"}, true},
-		{"missing name", &ProjectAnalysesCreateEventOption{Analysis: "a1"}, true},
-		{"invalid category", &ProjectAnalysesCreateEventOption{Analysis: "a1", Name: "1.0", Category: "INVALID"}, true},
+		{"missing analysis", &ProjectAnalysesCreateEventOptions{Name: "1.0"}, true},
+		{"missing name", &ProjectAnalysesCreateEventOptions{Analysis: "a1"}, true},
+		{"invalid category", &ProjectAnalysesCreateEventOptions{Analysis: "a1", Name: "1.0", Category: "INVALID"}, true},
 	}
 
 	for _, tt := range tests {
@@ -400,12 +400,12 @@ func TestProjectAnalysesService_ValidateDeleteOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *ProjectAnalysesDeleteOption
+		opt     *ProjectAnalysesDeleteOptions
 		wantErr bool
 	}{
-		{"valid", &ProjectAnalysesDeleteOption{Analysis: "a1"}, false},
+		{"valid", &ProjectAnalysesDeleteOptions{Analysis: "a1"}, false},
 		{"nil option", nil, true},
-		{"empty analysis", &ProjectAnalysesDeleteOption{}, true},
+		{"empty analysis", &ProjectAnalysesDeleteOptions{}, true},
 	}
 
 	for _, tt := range tests {
@@ -425,12 +425,12 @@ func TestProjectAnalysesService_ValidateDeleteEventOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *ProjectAnalysesDeleteEventOption
+		opt     *ProjectAnalysesDeleteEventOptions
 		wantErr bool
 	}{
-		{"valid", &ProjectAnalysesDeleteEventOption{Event: "e1"}, false},
+		{"valid", &ProjectAnalysesDeleteEventOptions{Event: "e1"}, false},
 		{"nil option", nil, true},
-		{"empty event", &ProjectAnalysesDeleteEventOption{}, true},
+		{"empty event", &ProjectAnalysesDeleteEventOptions{}, true},
 	}
 
 	for _, tt := range tests {
@@ -450,19 +450,19 @@ func TestProjectAnalysesService_ValidateSearchOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *ProjectAnalysesSearchOption
+		opt     *ProjectAnalysesSearchOptions
 		wantErr bool
 	}{
-		{"valid minimal", &ProjectAnalysesSearchOption{Project: "p1"}, false},
-		{"valid with VERSION", &ProjectAnalysesSearchOption{Project: "p1", Category: "VERSION"}, false},
-		{"valid with QUALITY_GATE", &ProjectAnalysesSearchOption{Project: "p1", Category: "QUALITY_GATE"}, false},
-		{"valid with date", &ProjectAnalysesSearchOption{Project: "p1", From: "2022-01-01"}, false},
-		{"valid with datetime", &ProjectAnalysesSearchOption{Project: "p1", From: "2022-01-01T00:00:00Z"}, false},
+		{"valid minimal", &ProjectAnalysesSearchOptions{Project: "p1"}, false},
+		{"valid with VERSION", &ProjectAnalysesSearchOptions{Project: "p1", Category: "VERSION"}, false},
+		{"valid with QUALITY_GATE", &ProjectAnalysesSearchOptions{Project: "p1", Category: "QUALITY_GATE"}, false},
+		{"valid with date", &ProjectAnalysesSearchOptions{Project: "p1", From: "2022-01-01"}, false},
+		{"valid with datetime", &ProjectAnalysesSearchOptions{Project: "p1", From: "2022-01-01T00:00:00Z"}, false},
 		{"nil option", nil, true},
-		{"missing project", &ProjectAnalysesSearchOption{}, true},
-		{"invalid category", &ProjectAnalysesSearchOption{Project: "p1", Category: "INVALID"}, true},
-		{"invalid from", &ProjectAnalysesSearchOption{Project: "p1", From: "bad"}, true},
-		{"invalid to", &ProjectAnalysesSearchOption{Project: "p1", To: "bad"}, true},
+		{"missing project", &ProjectAnalysesSearchOptions{}, true},
+		{"invalid category", &ProjectAnalysesSearchOptions{Project: "p1", Category: "INVALID"}, true},
+		{"invalid from", &ProjectAnalysesSearchOptions{Project: "p1", From: "bad"}, true},
+		{"invalid to", &ProjectAnalysesSearchOptions{Project: "p1", To: "bad"}, true},
 	}
 
 	for _, tt := range tests {
@@ -482,13 +482,13 @@ func TestProjectAnalysesService_ValidateUpdateEventOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *ProjectAnalysesUpdateEventOption
+		opt     *ProjectAnalysesUpdateEventOptions
 		wantErr bool
 	}{
-		{"valid", &ProjectAnalysesUpdateEventOption{Event: "e1", Name: "2.0"}, false},
+		{"valid", &ProjectAnalysesUpdateEventOptions{Event: "e1", Name: "2.0"}, false},
 		{"nil option", nil, true},
-		{"missing event", &ProjectAnalysesUpdateEventOption{Name: "2.0"}, true},
-		{"missing name", &ProjectAnalysesUpdateEventOption{Event: "e1"}, true},
+		{"missing event", &ProjectAnalysesUpdateEventOptions{Name: "2.0"}, true},
+		{"missing name", &ProjectAnalysesUpdateEventOptions{Event: "e1"}, true},
 	}
 
 	for _, tt := range tests {

--- a/sonar/project_badges_service.go
+++ b/sonar/project_badges_service.go
@@ -50,8 +50,8 @@ type ProjectBadgesToken struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// ProjectBadgesMeasureOption contains parameters for the Measure method.
-type ProjectBadgesMeasureOption struct {
+// ProjectBadgesMeasureOptions contains parameters for the Measure method.
+type ProjectBadgesMeasureOptions struct {
 	// Branch is the branch key.
 	Branch string `url:"branch,omitempty"`
 	// Metric is the metric key.
@@ -70,8 +70,8 @@ type ProjectBadgesMeasureOption struct {
 	Token string `url:"token,omitempty"`
 }
 
-// ProjectBadgesQualityGateOption contains parameters for the QualityGate method.
-type ProjectBadgesQualityGateOption struct {
+// ProjectBadgesQualityGateOptions contains parameters for the QualityGate method.
+type ProjectBadgesQualityGateOptions struct {
 	// Branch is the branch key.
 	Branch string `url:"branch,omitempty"`
 	// Project is the project or application key.
@@ -81,15 +81,15 @@ type ProjectBadgesQualityGateOption struct {
 	Token string `url:"token,omitempty"`
 }
 
-// ProjectBadgesRenewTokenOption contains parameters for the RenewToken method.
-type ProjectBadgesRenewTokenOption struct {
+// ProjectBadgesRenewTokenOptions contains parameters for the RenewToken method.
+type ProjectBadgesRenewTokenOptions struct {
 	// Project is the project or application key.
 	// This field is required.
 	Project string `url:"project"`
 }
 
-// ProjectBadgesTokenOption contains parameters for the Token method.
-type ProjectBadgesTokenOption struct {
+// ProjectBadgesTokenOptions contains parameters for the Token method.
+type ProjectBadgesTokenOptions struct {
 	// Project is the project or application key.
 	// This field is required.
 	Project string `url:"project"`
@@ -100,7 +100,7 @@ type ProjectBadgesTokenOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateMeasureOpt validates the options for the Measure method.
-func (s *ProjectBadgesService) ValidateMeasureOpt(opt *ProjectBadgesMeasureOption) error {
+func (s *ProjectBadgesService) ValidateMeasureOpt(opt *ProjectBadgesMeasureOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -124,7 +124,7 @@ func (s *ProjectBadgesService) ValidateMeasureOpt(opt *ProjectBadgesMeasureOptio
 }
 
 // ValidateQualityGateOpt validates the options for the QualityGate method.
-func (s *ProjectBadgesService) ValidateQualityGateOpt(opt *ProjectBadgesQualityGateOption) error {
+func (s *ProjectBadgesService) ValidateQualityGateOpt(opt *ProjectBadgesQualityGateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -138,7 +138,7 @@ func (s *ProjectBadgesService) ValidateQualityGateOpt(opt *ProjectBadgesQualityG
 }
 
 // ValidateRenewTokenOpt validates the options for the RenewToken method.
-func (s *ProjectBadgesService) ValidateRenewTokenOpt(opt *ProjectBadgesRenewTokenOption) error {
+func (s *ProjectBadgesService) ValidateRenewTokenOpt(opt *ProjectBadgesRenewTokenOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -152,7 +152,7 @@ func (s *ProjectBadgesService) ValidateRenewTokenOpt(opt *ProjectBadgesRenewToke
 }
 
 // ValidateTokenOpt validates the options for the Token method.
-func (s *ProjectBadgesService) ValidateTokenOpt(opt *ProjectBadgesTokenOption) error {
+func (s *ProjectBadgesService) ValidateTokenOpt(opt *ProjectBadgesTokenOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -174,7 +174,7 @@ func (s *ProjectBadgesService) ValidateTokenOpt(opt *ProjectBadgesTokenOption) e
 //
 // API endpoint: GET /api/project_badges/measure.
 // Since: 7.1.
-func (s *ProjectBadgesService) Measure(opt *ProjectBadgesMeasureOption) (*string, *http.Response, error) {
+func (s *ProjectBadgesService) Measure(opt *ProjectBadgesMeasureOptions) (*string, *http.Response, error) {
 	err := s.ValidateMeasureOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -200,7 +200,7 @@ func (s *ProjectBadgesService) Measure(opt *ProjectBadgesMeasureOption) (*string
 //
 // API endpoint: GET /api/project_badges/quality_gate.
 // Since: 7.1.
-func (s *ProjectBadgesService) QualityGate(opt *ProjectBadgesQualityGateOption) (*string, *http.Response, error) {
+func (s *ProjectBadgesService) QualityGate(opt *ProjectBadgesQualityGateOptions) (*string, *http.Response, error) {
 	err := s.ValidateQualityGateOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -227,7 +227,7 @@ func (s *ProjectBadgesService) QualityGate(opt *ProjectBadgesQualityGateOption) 
 //
 // API endpoint: POST /api/project_badges/renew_token.
 // Since: 9.2.
-func (s *ProjectBadgesService) RenewToken(opt *ProjectBadgesRenewTokenOption) (*http.Response, error) {
+func (s *ProjectBadgesService) RenewToken(opt *ProjectBadgesRenewTokenOptions) (*http.Response, error) {
 	err := s.ValidateRenewTokenOpt(opt)
 	if err != nil {
 		return nil, err
@@ -252,7 +252,7 @@ func (s *ProjectBadgesService) RenewToken(opt *ProjectBadgesRenewTokenOption) (*
 //
 // API endpoint: GET /api/project_badges/token.
 // Since: 9.2.
-func (s *ProjectBadgesService) Token(opt *ProjectBadgesTokenOption) (*ProjectBadgesToken, *http.Response, error) {
+func (s *ProjectBadgesService) Token(opt *ProjectBadgesTokenOptions) (*ProjectBadgesToken, *http.Response, error) {
 	err := s.ValidateTokenOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/project_badges_service_test.go
+++ b/sonar/project_badges_service_test.go
@@ -12,7 +12,7 @@ func TestProjectBadges_Measure(t *testing.T) {
 	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/project_badges/measure", http.StatusOK, "image/svg+xml", []byte(`<svg>badge content</svg>`)))
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectBadgesMeasureOption{
+	opt := &ProjectBadgesMeasureOptions{
 		Project: "my-project",
 		Metric:  "coverage",
 	}
@@ -32,19 +32,19 @@ func TestProjectBadges_Measure_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, _, err = client.ProjectBadges.Measure(&ProjectBadgesMeasureOption{
+	_, _, err = client.ProjectBadges.Measure(&ProjectBadgesMeasureOptions{
 		Metric: "coverage",
 	})
 	assert.Error(t, err)
 
 	// Missing Metric should fail validation.
-	_, _, err = client.ProjectBadges.Measure(&ProjectBadgesMeasureOption{
+	_, _, err = client.ProjectBadges.Measure(&ProjectBadgesMeasureOptions{
 		Project: "my-project",
 	})
 	assert.Error(t, err)
 
 	// Invalid Metric should fail validation.
-	_, _, err = client.ProjectBadges.Measure(&ProjectBadgesMeasureOption{
+	_, _, err = client.ProjectBadges.Measure(&ProjectBadgesMeasureOptions{
 		Project: "my-project",
 		Metric:  "invalid_metric",
 	})
@@ -55,7 +55,7 @@ func TestProjectBadges_QualityGate(t *testing.T) {
 	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/project_badges/quality_gate", http.StatusOK, "image/svg+xml", []byte(`<svg>quality gate badge</svg>`)))
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectBadgesQualityGateOption{
+	opt := &ProjectBadgesQualityGateOptions{
 		Project: "my-project",
 	}
 
@@ -73,7 +73,7 @@ func TestProjectBadges_QualityGate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, _, err = client.ProjectBadges.QualityGate(&ProjectBadgesQualityGateOption{})
+	_, _, err = client.ProjectBadges.QualityGate(&ProjectBadgesQualityGateOptions{})
 	assert.Error(t, err)
 }
 
@@ -81,7 +81,7 @@ func TestProjectBadges_RenewToken(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/project_badges/renew_token", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectBadgesRenewTokenOption{
+	opt := &ProjectBadgesRenewTokenOptions{
 		Project: "my-project",
 	}
 
@@ -98,7 +98,7 @@ func TestProjectBadges_RenewToken_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, err = client.ProjectBadges.RenewToken(&ProjectBadgesRenewTokenOption{})
+	_, err = client.ProjectBadges.RenewToken(&ProjectBadgesRenewTokenOptions{})
 	assert.Error(t, err)
 }
 
@@ -108,7 +108,7 @@ func TestProjectBadges_Token(t *testing.T) {
 	}))
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectBadgesTokenOption{
+	opt := &ProjectBadgesTokenOptions{
 		Project: "my-project",
 	}
 
@@ -127,7 +127,7 @@ func TestProjectBadges_Token_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, _, err = client.ProjectBadges.Token(&ProjectBadgesTokenOption{})
+	_, _, err = client.ProjectBadges.Token(&ProjectBadgesTokenOptions{})
 	assert.Error(t, err)
 }
 
@@ -157,7 +157,7 @@ func TestProjectBadges_ValidateMeasureOpt_AllMetrics(t *testing.T) {
 	}
 
 	for _, metric := range validMetrics {
-		err := client.ProjectBadges.ValidateMeasureOpt(&ProjectBadgesMeasureOption{
+		err := client.ProjectBadges.ValidateMeasureOpt(&ProjectBadgesMeasureOptions{
 			Project: "my-project",
 			Metric:  metric,
 		})

--- a/sonar/project_branches_service.go
+++ b/sonar/project_branches_service.go
@@ -54,8 +54,8 @@ type ProjectBranchesList struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// ProjectBranchesDeleteOption contains parameters for the Delete method.
-type ProjectBranchesDeleteOption struct {
+// ProjectBranchesDeleteOptions contains parameters for the Delete method.
+type ProjectBranchesDeleteOptions struct {
 	// Branch is the branch key.
 	// This field is required.
 	Branch string `url:"branch"`
@@ -64,15 +64,15 @@ type ProjectBranchesDeleteOption struct {
 	Project string `url:"project"`
 }
 
-// ProjectBranchesListOption contains parameters for the List method.
-type ProjectBranchesListOption struct {
+// ProjectBranchesListOptions contains parameters for the List method.
+type ProjectBranchesListOptions struct {
 	// Project is the project key.
 	// This field is required.
 	Project string `url:"project"`
 }
 
-// ProjectBranchesRenameOption contains parameters for the Rename method.
-type ProjectBranchesRenameOption struct {
+// ProjectBranchesRenameOptions contains parameters for the Rename method.
+type ProjectBranchesRenameOptions struct {
 	// Name is the new name of the main branch.
 	// This field is required. Maximum length is 255 characters.
 	Name string `url:"name"`
@@ -81,8 +81,8 @@ type ProjectBranchesRenameOption struct {
 	Project string `url:"project"`
 }
 
-// ProjectBranchesSetAutomaticDeletionProtectionOption contains parameters for the SetAutomaticDeletionProtection method.
-type ProjectBranchesSetAutomaticDeletionProtectionOption struct {
+// ProjectBranchesSetAutomaticDeletionProtectionOptions contains parameters for the SetAutomaticDeletionProtection method.
+type ProjectBranchesSetAutomaticDeletionProtectionOptions struct {
 	// Branch is the branch key.
 	// This field is required.
 	Branch string `url:"branch"`
@@ -94,8 +94,8 @@ type ProjectBranchesSetAutomaticDeletionProtectionOption struct {
 	Value bool `url:"value"`
 }
 
-// ProjectBranchesSetMainOption contains parameters for the SetMain method.
-type ProjectBranchesSetMainOption struct {
+// ProjectBranchesSetMainOptions contains parameters for the SetMain method.
+type ProjectBranchesSetMainOptions struct {
 	// Branch is the branch key.
 	// This field is required.
 	Branch string `url:"branch"`
@@ -109,7 +109,7 @@ type ProjectBranchesSetMainOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateDeleteOpt validates the options for the Delete method.
-func (s *ProjectBranchesService) ValidateDeleteOpt(opt *ProjectBranchesDeleteOption) error {
+func (s *ProjectBranchesService) ValidateDeleteOpt(opt *ProjectBranchesDeleteOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -128,7 +128,7 @@ func (s *ProjectBranchesService) ValidateDeleteOpt(opt *ProjectBranchesDeleteOpt
 }
 
 // ValidateListOpt validates the options for the List method.
-func (s *ProjectBranchesService) ValidateListOpt(opt *ProjectBranchesListOption) error {
+func (s *ProjectBranchesService) ValidateListOpt(opt *ProjectBranchesListOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -142,7 +142,7 @@ func (s *ProjectBranchesService) ValidateListOpt(opt *ProjectBranchesListOption)
 }
 
 // ValidateRenameOpt validates the options for the Rename method.
-func (s *ProjectBranchesService) ValidateRenameOpt(opt *ProjectBranchesRenameOption) error {
+func (s *ProjectBranchesService) ValidateRenameOpt(opt *ProjectBranchesRenameOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -166,7 +166,7 @@ func (s *ProjectBranchesService) ValidateRenameOpt(opt *ProjectBranchesRenameOpt
 }
 
 // ValidateSetAutomaticDeletionProtectionOpt validates the options for the SetAutomaticDeletionProtection method.
-func (s *ProjectBranchesService) ValidateSetAutomaticDeletionProtectionOpt(opt *ProjectBranchesSetAutomaticDeletionProtectionOption) error {
+func (s *ProjectBranchesService) ValidateSetAutomaticDeletionProtectionOpt(opt *ProjectBranchesSetAutomaticDeletionProtectionOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -187,7 +187,7 @@ func (s *ProjectBranchesService) ValidateSetAutomaticDeletionProtectionOpt(opt *
 }
 
 // ValidateSetMainOpt validates the options for the SetMain method.
-func (s *ProjectBranchesService) ValidateSetMainOpt(opt *ProjectBranchesSetMainOption) error {
+func (s *ProjectBranchesService) ValidateSetMainOpt(opt *ProjectBranchesSetMainOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -214,7 +214,7 @@ func (s *ProjectBranchesService) ValidateSetMainOpt(opt *ProjectBranchesSetMainO
 //
 // API endpoint: POST /api/project_branches/delete.
 // Since: 6.6.
-func (s *ProjectBranchesService) Delete(opt *ProjectBranchesDeleteOption) (*http.Response, error) {
+func (s *ProjectBranchesService) Delete(opt *ProjectBranchesDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
@@ -238,7 +238,7 @@ func (s *ProjectBranchesService) Delete(opt *ProjectBranchesDeleteOption) (*http
 //
 // API endpoint: GET /api/project_branches/list.
 // Since: 6.6.
-func (s *ProjectBranchesService) List(opt *ProjectBranchesListOption) (*ProjectBranchesList, *http.Response, error) {
+func (s *ProjectBranchesService) List(opt *ProjectBranchesListOptions) (*ProjectBranchesList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -264,7 +264,7 @@ func (s *ProjectBranchesService) List(opt *ProjectBranchesListOption) (*ProjectB
 //
 // API endpoint: POST /api/project_branches/rename.
 // Since: 6.6.
-func (s *ProjectBranchesService) Rename(opt *ProjectBranchesRenameOption) (*http.Response, error) {
+func (s *ProjectBranchesService) Rename(opt *ProjectBranchesRenameOptions) (*http.Response, error) {
 	err := s.ValidateRenameOpt(opt)
 	if err != nil {
 		return nil, err
@@ -289,7 +289,7 @@ func (s *ProjectBranchesService) Rename(opt *ProjectBranchesRenameOption) (*http
 //
 // API endpoint: POST /api/project_branches/set_automatic_deletion_protection.
 // Since: 8.1.
-func (s *ProjectBranchesService) SetAutomaticDeletionProtection(opt *ProjectBranchesSetAutomaticDeletionProtectionOption) (*http.Response, error) {
+func (s *ProjectBranchesService) SetAutomaticDeletionProtection(opt *ProjectBranchesSetAutomaticDeletionProtectionOptions) (*http.Response, error) {
 	err := s.ValidateSetAutomaticDeletionProtectionOpt(opt)
 	if err != nil {
 		return nil, err
@@ -314,7 +314,7 @@ func (s *ProjectBranchesService) SetAutomaticDeletionProtection(opt *ProjectBran
 //
 // API endpoint: POST /api/project_branches/set_main.
 // Since: 10.2.
-func (s *ProjectBranchesService) SetMain(opt *ProjectBranchesSetMainOption) (*http.Response, error) {
+func (s *ProjectBranchesService) SetMain(opt *ProjectBranchesSetMainOptions) (*http.Response, error) {
 	err := s.ValidateSetMainOpt(opt)
 	if err != nil {
 		return nil, err

--- a/sonar/project_branches_service_test.go
+++ b/sonar/project_branches_service_test.go
@@ -14,7 +14,7 @@ func TestProjectBranches_Delete(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectBranchesDeleteOption{
+	opt := &ProjectBranchesDeleteOptions{
 		Branch:  "feature-1",
 		Project: "my-project",
 	}
@@ -32,13 +32,13 @@ func TestProjectBranches_Delete_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Branch should fail validation.
-	_, err = client.ProjectBranches.Delete(&ProjectBranchesDeleteOption{
+	_, err = client.ProjectBranches.Delete(&ProjectBranchesDeleteOptions{
 		Project: "my-project",
 	})
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, err = client.ProjectBranches.Delete(&ProjectBranchesDeleteOption{
+	_, err = client.ProjectBranches.Delete(&ProjectBranchesDeleteOptions{
 		Branch: "feature-1",
 	})
 	assert.Error(t, err)
@@ -70,7 +70,7 @@ func TestProjectBranches_List(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectBranchesListOption{
+	opt := &ProjectBranchesListOptions{
 		Project: "my-project",
 	}
 
@@ -93,7 +93,7 @@ func TestProjectBranches_List_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, _, err = client.ProjectBranches.List(&ProjectBranchesListOption{})
+	_, _, err = client.ProjectBranches.List(&ProjectBranchesListOptions{})
 	assert.Error(t, err)
 }
 
@@ -103,7 +103,7 @@ func TestProjectBranches_Rename(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectBranchesRenameOption{
+	opt := &ProjectBranchesRenameOptions{
 		Name:    "main",
 		Project: "my-project",
 	}
@@ -121,13 +121,13 @@ func TestProjectBranches_Rename_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Name should fail validation.
-	_, err = client.ProjectBranches.Rename(&ProjectBranchesRenameOption{
+	_, err = client.ProjectBranches.Rename(&ProjectBranchesRenameOptions{
 		Project: "my-project",
 	})
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, err = client.ProjectBranches.Rename(&ProjectBranchesRenameOption{
+	_, err = client.ProjectBranches.Rename(&ProjectBranchesRenameOptions{
 		Name: "main",
 	})
 	assert.Error(t, err)
@@ -137,7 +137,7 @@ func TestProjectBranches_Rename_ValidationError(t *testing.T) {
 	for i := 0; i < MaxBranchNameLength+1; i++ {
 		longName += "a"
 	}
-	_, err = client.ProjectBranches.Rename(&ProjectBranchesRenameOption{
+	_, err = client.ProjectBranches.Rename(&ProjectBranchesRenameOptions{
 		Name:    longName,
 		Project: "my-project",
 	})
@@ -150,7 +150,7 @@ func TestProjectBranches_SetAutomaticDeletionProtection(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectBranchesSetAutomaticDeletionProtectionOption{
+	opt := &ProjectBranchesSetAutomaticDeletionProtectionOptions{
 		Branch:  "feature-1",
 		Project: "my-project",
 		Value:   true,
@@ -167,7 +167,7 @@ func TestProjectBranches_SetAutomaticDeletionProtection_False(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectBranchesSetAutomaticDeletionProtectionOption{
+	opt := &ProjectBranchesSetAutomaticDeletionProtectionOptions{
 		Branch:  "feature-1",
 		Project: "my-project",
 		Value:   false,
@@ -186,14 +186,14 @@ func TestProjectBranches_SetAutomaticDeletionProtection_ValidationError(t *testi
 	assert.Error(t, err)
 
 	// Missing Branch should fail validation.
-	_, err = client.ProjectBranches.SetAutomaticDeletionProtection(&ProjectBranchesSetAutomaticDeletionProtectionOption{
+	_, err = client.ProjectBranches.SetAutomaticDeletionProtection(&ProjectBranchesSetAutomaticDeletionProtectionOptions{
 		Project: "my-project",
 		Value:   true,
 	})
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, err = client.ProjectBranches.SetAutomaticDeletionProtection(&ProjectBranchesSetAutomaticDeletionProtectionOption{
+	_, err = client.ProjectBranches.SetAutomaticDeletionProtection(&ProjectBranchesSetAutomaticDeletionProtectionOptions{
 		Branch: "feature-1",
 		Value:  true,
 	})
@@ -206,7 +206,7 @@ func TestProjectBranches_SetMain(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectBranchesSetMainOption{
+	opt := &ProjectBranchesSetMainOptions{
 		Branch:  "main",
 		Project: "my-project",
 	}
@@ -224,13 +224,13 @@ func TestProjectBranches_SetMain_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Branch should fail validation.
-	_, err = client.ProjectBranches.SetMain(&ProjectBranchesSetMainOption{
+	_, err = client.ProjectBranches.SetMain(&ProjectBranchesSetMainOptions{
 		Project: "my-project",
 	})
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, err = client.ProjectBranches.SetMain(&ProjectBranchesSetMainOption{
+	_, err = client.ProjectBranches.SetMain(&ProjectBranchesSetMainOptions{
 		Branch: "main",
 	})
 	assert.Error(t, err)
@@ -240,7 +240,7 @@ func TestProjectBranches_ValidateDeleteOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Valid option should pass.
-	err := client.ProjectBranches.ValidateDeleteOpt(&ProjectBranchesDeleteOption{
+	err := client.ProjectBranches.ValidateDeleteOpt(&ProjectBranchesDeleteOptions{
 		Branch:  "feature-1",
 		Project: "my-project",
 	})
@@ -251,7 +251,7 @@ func TestProjectBranches_ValidateListOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Valid option should pass.
-	err := client.ProjectBranches.ValidateListOpt(&ProjectBranchesListOption{
+	err := client.ProjectBranches.ValidateListOpt(&ProjectBranchesListOptions{
 		Project: "my-project",
 	})
 	assert.NoError(t, err)
@@ -261,7 +261,7 @@ func TestProjectBranches_ValidateRenameOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Valid option should pass.
-	err := client.ProjectBranches.ValidateRenameOpt(&ProjectBranchesRenameOption{
+	err := client.ProjectBranches.ValidateRenameOpt(&ProjectBranchesRenameOptions{
 		Name:    "main",
 		Project: "my-project",
 	})
@@ -272,7 +272,7 @@ func TestProjectBranches_ValidateSetAutomaticDeletionProtectionOpt(t *testing.T)
 	client := newLocalhostClient(t)
 
 	// Valid option with true should pass.
-	err := client.ProjectBranches.ValidateSetAutomaticDeletionProtectionOpt(&ProjectBranchesSetAutomaticDeletionProtectionOption{
+	err := client.ProjectBranches.ValidateSetAutomaticDeletionProtectionOpt(&ProjectBranchesSetAutomaticDeletionProtectionOptions{
 		Branch:  "feature-1",
 		Project: "my-project",
 		Value:   true,
@@ -280,7 +280,7 @@ func TestProjectBranches_ValidateSetAutomaticDeletionProtectionOpt(t *testing.T)
 	assert.NoError(t, err)
 
 	// Valid option with false should pass.
-	err = client.ProjectBranches.ValidateSetAutomaticDeletionProtectionOpt(&ProjectBranchesSetAutomaticDeletionProtectionOption{
+	err = client.ProjectBranches.ValidateSetAutomaticDeletionProtectionOpt(&ProjectBranchesSetAutomaticDeletionProtectionOptions{
 		Branch:  "feature-1",
 		Project: "my-project",
 		Value:   false,
@@ -292,7 +292,7 @@ func TestProjectBranches_ValidateSetMainOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Valid option should pass.
-	err := client.ProjectBranches.ValidateSetMainOpt(&ProjectBranchesSetMainOption{
+	err := client.ProjectBranches.ValidateSetMainOpt(&ProjectBranchesSetMainOptions{
 		Branch:  "main",
 		Project: "my-project",
 	})

--- a/sonar/project_dump_service.go
+++ b/sonar/project_dump_service.go
@@ -44,15 +44,15 @@ type ProjectDumpStatus struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// ProjectDumpExportOption contains parameters for the Export method.
-type ProjectDumpExportOption struct {
+// ProjectDumpExportOptions contains parameters for the Export method.
+type ProjectDumpExportOptions struct {
 	// Key is the project key.
 	// This field is required.
 	Key string `url:"key"`
 }
 
-// ProjectDumpStatusOption contains parameters for the Status method.
-type ProjectDumpStatusOption struct {
+// ProjectDumpStatusOptions contains parameters for the Status method.
+type ProjectDumpStatusOptions struct {
 	// ID is the project id.
 	ID string `url:"id,omitempty"`
 	// Key is the project key.
@@ -64,7 +64,7 @@ type ProjectDumpStatusOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateExportOpt validates the options for the Export method.
-func (s *ProjectDumpService) ValidateExportOpt(opt *ProjectDumpExportOption) error {
+func (s *ProjectDumpService) ValidateExportOpt(opt *ProjectDumpExportOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -79,7 +79,7 @@ func (s *ProjectDumpService) ValidateExportOpt(opt *ProjectDumpExportOption) err
 
 // ValidateStatusOpt validates the options for the Status method.
 // Either ID or Key must be provided.
-func (s *ProjectDumpService) ValidateStatusOpt(opt *ProjectDumpStatusOption) error {
+func (s *ProjectDumpService) ValidateStatusOpt(opt *ProjectDumpStatusOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -100,7 +100,7 @@ func (s *ProjectDumpService) ValidateStatusOpt(opt *ProjectDumpStatusOption) err
 //
 // API endpoint: POST /api/project_dump/export.
 // Since: 1.0.
-func (s *ProjectDumpService) Export(opt *ProjectDumpExportOption) (*ProjectDumpExport, *http.Response, error) {
+func (s *ProjectDumpService) Export(opt *ProjectDumpExportOptions) (*ProjectDumpExport, *http.Response, error) {
 	err := s.ValidateExportOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -126,7 +126,7 @@ func (s *ProjectDumpService) Export(opt *ProjectDumpExportOption) (*ProjectDumpE
 //
 // API endpoint: GET /api/project_dump/status.
 // Since: 1.0.
-func (s *ProjectDumpService) Status(opt *ProjectDumpStatusOption) (*ProjectDumpStatus, *http.Response, error) {
+func (s *ProjectDumpService) Status(opt *ProjectDumpStatusOptions) (*ProjectDumpStatus, *http.Response, error) {
 	err := s.ValidateStatusOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/project_dump_service_test.go
+++ b/sonar/project_dump_service_test.go
@@ -19,7 +19,7 @@ func TestProjectDump_Export(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectDumpExportOption{
+	opt := &ProjectDumpExportOptions{
 		Key: "my-project",
 	}
 
@@ -40,7 +40,7 @@ func TestProjectDump_Export_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Key should fail validation.
-	_, _, err = client.ProjectDump.Export(&ProjectDumpExportOption{})
+	_, _, err = client.ProjectDump.Export(&ProjectDumpExportOptions{})
 	assert.Error(t, err)
 }
 
@@ -55,7 +55,7 @@ func TestProjectDump_Status(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectDumpStatusOption{
+	opt := &ProjectDumpStatusOptions{
 		Key: "my-project",
 	}
 
@@ -77,7 +77,7 @@ func TestProjectDump_Status_WithID(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectDumpStatusOption{
+	opt := &ProjectDumpStatusOptions{
 		ID: "proj-123",
 	}
 
@@ -95,7 +95,7 @@ func TestProjectDump_Status_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing both ID and Key should fail validation.
-	_, _, err = client.ProjectDump.Status(&ProjectDumpStatusOption{})
+	_, _, err = client.ProjectDump.Status(&ProjectDumpStatusOptions{})
 	assert.Error(t, err)
 }
 
@@ -103,7 +103,7 @@ func TestProjectDump_ValidateExportOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Valid option should pass.
-	err := client.ProjectDump.ValidateExportOpt(&ProjectDumpExportOption{
+	err := client.ProjectDump.ValidateExportOpt(&ProjectDumpExportOptions{
 		Key: "my-project",
 	})
 	assert.NoError(t, err)
@@ -113,7 +113,7 @@ func TestProjectDump_ValidateExportOpt(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Key should fail.
-	err = client.ProjectDump.ValidateExportOpt(&ProjectDumpExportOption{})
+	err = client.ProjectDump.ValidateExportOpt(&ProjectDumpExportOptions{})
 	assert.Error(t, err)
 }
 
@@ -121,13 +121,13 @@ func TestProjectDump_ValidateStatusOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Valid option with Key should pass.
-	err := client.ProjectDump.ValidateStatusOpt(&ProjectDumpStatusOption{
+	err := client.ProjectDump.ValidateStatusOpt(&ProjectDumpStatusOptions{
 		Key: "my-project",
 	})
 	assert.NoError(t, err)
 
 	// Valid option with ID should pass.
-	err = client.ProjectDump.ValidateStatusOpt(&ProjectDumpStatusOption{
+	err = client.ProjectDump.ValidateStatusOpt(&ProjectDumpStatusOptions{
 		ID: "proj-123",
 	})
 	assert.NoError(t, err)
@@ -137,6 +137,6 @@ func TestProjectDump_ValidateStatusOpt(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing both ID and Key should fail.
-	err = client.ProjectDump.ValidateStatusOpt(&ProjectDumpStatusOption{})
+	err = client.ProjectDump.ValidateStatusOpt(&ProjectDumpStatusOptions{})
 	assert.Error(t, err)
 }

--- a/sonar/project_links_service.go
+++ b/sonar/project_links_service.go
@@ -46,8 +46,8 @@ type ProjectLinksSearch struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// ProjectLinksCreateOption contains parameters for the Create method.
-type ProjectLinksCreateOption struct {
+// ProjectLinksCreateOptions contains parameters for the Create method.
+type ProjectLinksCreateOptions struct {
 	// Name is the display name of the link.
 	// This field is required. Maximum length is 128 characters.
 	Name string `url:"name"`
@@ -62,15 +62,15 @@ type ProjectLinksCreateOption struct {
 	URL string `url:"url"`
 }
 
-// ProjectLinksDeleteOption contains parameters for the Delete method.
-type ProjectLinksDeleteOption struct {
+// ProjectLinksDeleteOptions contains parameters for the Delete method.
+type ProjectLinksDeleteOptions struct {
 	// ID is the unique identifier of the link to delete.
 	// This field is required.
 	ID string `url:"id"`
 }
 
-// ProjectLinksSearchOption contains parameters for the Search method.
-type ProjectLinksSearchOption struct {
+// ProjectLinksSearchOptions contains parameters for the Search method.
+type ProjectLinksSearchOptions struct {
 	// ProjectID is the project id.
 	// Either ProjectID or ProjectKey must be provided.
 	ProjectID string `url:"projectId,omitempty"`
@@ -84,7 +84,7 @@ type ProjectLinksSearchOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateCreateOpt validates the options for the Create method.
-func (s *ProjectLinksService) ValidateCreateOpt(opt *ProjectLinksCreateOption) error {
+func (s *ProjectLinksService) ValidateCreateOpt(opt *ProjectLinksCreateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -118,7 +118,7 @@ func (s *ProjectLinksService) ValidateCreateOpt(opt *ProjectLinksCreateOption) e
 }
 
 // ValidateDeleteOpt validates the options for the Delete method.
-func (s *ProjectLinksService) ValidateDeleteOpt(opt *ProjectLinksDeleteOption) error {
+func (s *ProjectLinksService) ValidateDeleteOpt(opt *ProjectLinksDeleteOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -132,7 +132,7 @@ func (s *ProjectLinksService) ValidateDeleteOpt(opt *ProjectLinksDeleteOption) e
 }
 
 // ValidateSearchOpt validates the options for the Search method.
-func (s *ProjectLinksService) ValidateSearchOpt(opt *ProjectLinksSearchOption) error {
+func (s *ProjectLinksService) ValidateSearchOpt(opt *ProjectLinksSearchOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -154,7 +154,7 @@ func (s *ProjectLinksService) ValidateSearchOpt(opt *ProjectLinksSearchOption) e
 //
 // API endpoint: POST /api/project_links/create.
 // Since: 6.1.
-func (s *ProjectLinksService) Create(opt *ProjectLinksCreateOption) (*ProjectLinksCreate, *http.Response, error) {
+func (s *ProjectLinksService) Create(opt *ProjectLinksCreateOptions) (*ProjectLinksCreate, *http.Response, error) {
 	err := s.ValidateCreateOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -180,7 +180,7 @@ func (s *ProjectLinksService) Create(opt *ProjectLinksCreateOption) (*ProjectLin
 //
 // API endpoint: POST /api/project_links/delete.
 // Since: 6.1.
-func (s *ProjectLinksService) Delete(opt *ProjectLinksDeleteOption) (*http.Response, error) {
+func (s *ProjectLinksService) Delete(opt *ProjectLinksDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
@@ -208,7 +208,7 @@ func (s *ProjectLinksService) Delete(opt *ProjectLinksDeleteOption) (*http.Respo
 //
 // API endpoint: GET /api/project_links/search.
 // Since: 6.1.
-func (s *ProjectLinksService) Search(opt *ProjectLinksSearchOption) (*ProjectLinksSearch, *http.Response, error) {
+func (s *ProjectLinksService) Search(opt *ProjectLinksSearchOptions) (*ProjectLinksSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/project_links_service_test.go
+++ b/sonar/project_links_service_test.go
@@ -23,7 +23,7 @@ func TestProjectLinks_Create(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectLinksCreateOption{
+	opt := &ProjectLinksCreateOptions{
 		Name:       "Homepage",
 		ProjectKey: "my-project",
 		URL:        "https://example.com",
@@ -45,21 +45,21 @@ func TestProjectLinks_Create_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Name should fail validation.
-	_, _, err = client.ProjectLinks.Create(&ProjectLinksCreateOption{
+	_, _, err = client.ProjectLinks.Create(&ProjectLinksCreateOptions{
 		ProjectKey: "my-project",
 		URL:        "https://example.com",
 	})
 	assert.Error(t, err)
 
 	// Missing URL should fail validation.
-	_, _, err = client.ProjectLinks.Create(&ProjectLinksCreateOption{
+	_, _, err = client.ProjectLinks.Create(&ProjectLinksCreateOptions{
 		Name:       "Homepage",
 		ProjectKey: "my-project",
 	})
 	assert.Error(t, err)
 
 	// Missing ProjectID and ProjectKey should fail validation.
-	_, _, err = client.ProjectLinks.Create(&ProjectLinksCreateOption{
+	_, _, err = client.ProjectLinks.Create(&ProjectLinksCreateOptions{
 		Name: "Homepage",
 		URL:  "https://example.com",
 	})
@@ -72,7 +72,7 @@ func TestProjectLinks_Delete(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectLinksDeleteOption{
+	opt := &ProjectLinksDeleteOptions{
 		ID: "1",
 	}
 
@@ -89,7 +89,7 @@ func TestProjectLinks_Delete_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing ID should fail validation.
-	_, err = client.ProjectLinks.Delete(&ProjectLinksDeleteOption{})
+	_, err = client.ProjectLinks.Delete(&ProjectLinksDeleteOptions{})
 	assert.Error(t, err)
 }
 
@@ -106,7 +106,7 @@ func TestProjectLinks_Search(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectLinksSearchOption{
+	opt := &ProjectLinksSearchOptions{
 		ProjectKey: "my-project",
 	}
 
@@ -126,7 +126,7 @@ func TestProjectLinks_Search_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing ProjectID and ProjectKey should fail validation.
-	_, _, err = client.ProjectLinks.Search(&ProjectLinksSearchOption{})
+	_, _, err = client.ProjectLinks.Search(&ProjectLinksSearchOptions{})
 	assert.Error(t, err)
 }
 
@@ -134,7 +134,7 @@ func TestProjectLinks_ValidateCreateOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Valid option with ProjectKey should pass.
-	err := client.ProjectLinks.ValidateCreateOpt(&ProjectLinksCreateOption{
+	err := client.ProjectLinks.ValidateCreateOpt(&ProjectLinksCreateOptions{
 		Name:       "Homepage",
 		ProjectKey: "my-project",
 		URL:        "https://example.com",
@@ -142,7 +142,7 @@ func TestProjectLinks_ValidateCreateOpt(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Valid option with ProjectID should pass.
-	err = client.ProjectLinks.ValidateCreateOpt(&ProjectLinksCreateOption{
+	err = client.ProjectLinks.ValidateCreateOpt(&ProjectLinksCreateOptions{
 		Name:      "Homepage",
 		ProjectID: "project-id",
 		URL:       "https://example.com",
@@ -154,7 +154,7 @@ func TestProjectLinks_ValidateCreateOpt(t *testing.T) {
 	for i := 0; i < MaxLinkNameLength+1; i++ {
 		longName += "a"
 	}
-	err = client.ProjectLinks.ValidateCreateOpt(&ProjectLinksCreateOption{
+	err = client.ProjectLinks.ValidateCreateOpt(&ProjectLinksCreateOptions{
 		Name:       longName,
 		ProjectKey: "my-project",
 		URL:        "https://example.com",

--- a/sonar/project_tags_service.go
+++ b/sonar/project_tags_service.go
@@ -24,18 +24,18 @@ type ProjectTagsSearch struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// ProjectTagsSearchOption contains parameters for the Search method.
+// ProjectTagsSearchOptions contains parameters for the Search method.
 //
 //nolint:govet // Field alignment is less important than logical grouping.
-type ProjectTagsSearchOption struct {
+type ProjectTagsSearchOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
 	Query string `url:"q,omitempty"`
 }
 
-// ProjectTagsSetOption contains parameters for the Set method.
-type ProjectTagsSetOption struct {
+// ProjectTagsSetOptions contains parameters for the Set method.
+type ProjectTagsSetOptions struct {
 	// Project is the project key.
 	// This field is required.
 	Project string `url:"project"`
@@ -48,7 +48,7 @@ type ProjectTagsSetOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateSearchOpt validates the options for the Search method.
-func (s *ProjectTagsService) ValidateSearchOpt(opt *ProjectTagsSearchOption) error {
+func (s *ProjectTagsService) ValidateSearchOpt(opt *ProjectTagsSearchOptions) error {
 	if opt == nil {
 		// Options are optional; nothing to validate.
 		return nil
@@ -63,7 +63,7 @@ func (s *ProjectTagsService) ValidateSearchOpt(opt *ProjectTagsSearchOption) err
 }
 
 // ValidateSetOpt validates the options for the Set method.
-func (s *ProjectTagsService) ValidateSetOpt(opt *ProjectTagsSetOption) error {
+func (s *ProjectTagsService) ValidateSetOpt(opt *ProjectTagsSetOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -84,7 +84,7 @@ func (s *ProjectTagsService) ValidateSetOpt(opt *ProjectTagsSetOption) error {
 //
 // API endpoint: GET /api/project_tags/search.
 // Since: 6.4.
-func (s *ProjectTagsService) Search(opt *ProjectTagsSearchOption) (*ProjectTagsSearch, *http.Response, error) {
+func (s *ProjectTagsService) Search(opt *ProjectTagsSearchOptions) (*ProjectTagsSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -110,7 +110,7 @@ func (s *ProjectTagsService) Search(opt *ProjectTagsSearchOption) (*ProjectTagsS
 //
 // API endpoint: POST /api/project_tags/set.
 // Since: 6.4.
-func (s *ProjectTagsService) Set(opt *ProjectTagsSetOption) (*http.Response, error) {
+func (s *ProjectTagsService) Set(opt *ProjectTagsSetOptions) (*http.Response, error) {
 	err := s.ValidateSetOpt(opt)
 	if err != nil {
 		return nil, err

--- a/sonar/project_tags_service_test.go
+++ b/sonar/project_tags_service_test.go
@@ -30,7 +30,7 @@ func TestProjectTagsService_Search(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		opt := &ProjectTagsSearchOption{
+		opt := &ProjectTagsSearchOptions{
 			PaginationArgs: PaginationArgs{
 				Page:     2,
 				PageSize: 10,
@@ -52,7 +52,7 @@ func TestProjectTagsService_Set(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		opt := &ProjectTagsSetOption{
+		opt := &ProjectTagsSetOptions{
 			Project: "my-project",
 			Tags:    []string{"security", "performance"},
 		}
@@ -75,7 +75,7 @@ func TestProjectTagsService_Set(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		opt := &ProjectTagsSetOption{
+		opt := &ProjectTagsSetOptions{
 			Project: "my-project",
 			Tags:    []string{},
 		}
@@ -97,7 +97,7 @@ func TestProjectTagsService_Set(t *testing.T) {
 	t.Run("missing project fails validation", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.ProjectTags.Set(&ProjectTagsSetOption{
+		_, err := client.ProjectTags.Set(&ProjectTagsSetOptions{
 			Tags: []string{"tag1"},
 		})
 
@@ -110,12 +110,12 @@ func TestProjectTagsService_ValidateSearchOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *ProjectTagsSearchOption
+		opt     *ProjectTagsSearchOptions
 		wantErr bool
 	}{
 		{"nil option", nil, false},
-		{"empty option", &ProjectTagsSearchOption{}, false},
-		{"with query", &ProjectTagsSearchOption{Query: "test"}, false},
+		{"empty option", &ProjectTagsSearchOptions{}, false},
+		{"with query", &ProjectTagsSearchOptions{Query: "test"}, false},
 	}
 
 	for _, tt := range tests {
@@ -135,13 +135,13 @@ func TestProjectTagsService_ValidateSetOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *ProjectTagsSetOption
+		opt     *ProjectTagsSetOptions
 		wantErr bool
 	}{
-		{"valid", &ProjectTagsSetOption{Project: "my-project", Tags: []string{"tag1", "tag2"}}, false},
-		{"empty tags array", &ProjectTagsSetOption{Project: "my-project", Tags: []string{}}, false},
+		{"valid", &ProjectTagsSetOptions{Project: "my-project", Tags: []string{"tag1", "tag2"}}, false},
+		{"empty tags array", &ProjectTagsSetOptions{Project: "my-project", Tags: []string{}}, false},
 		{"nil option", nil, true},
-		{"missing project", &ProjectTagsSetOption{Tags: []string{"tag1"}}, true},
+		{"missing project", &ProjectTagsSetOptions{Tags: []string{"tag1"}}, true},
 	}
 
 	for _, tt := range tests {

--- a/sonar/projects_service.go
+++ b/sonar/projects_service.go
@@ -130,10 +130,10 @@ type ScannableProject struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// ProjectsBulkDeleteOption represents options for bulk deleting projects.
+// ProjectsBulkDeleteOptions represents options for bulk deleting projects.
 //
 //nolint:govet // Field ordering prioritizes API clarity over memory alignment
-type ProjectsBulkDeleteOption struct {
+type ProjectsBulkDeleteOptions struct {
 	// OnProvisionedOnly filters only provisioned projects (optional).
 	OnProvisionedOnly bool `url:"onProvisionedOnly,omitempty"`
 	// AnalyzedBefore filters projects analyzed before the given date (optional).
@@ -151,8 +151,8 @@ type ProjectsBulkDeleteOption struct {
 	Qualifiers []string `url:"qualifiers,omitempty,comma"`
 }
 
-// ProjectsCreateOption represents options for creating a project.
-type ProjectsCreateOption struct {
+// ProjectsCreateOptions represents options for creating a project.
+type ProjectsCreateOptions struct {
 	// Name is the project name (required).
 	// Maximum length: 500 characters.
 	Name string `url:"name,omitempty"`
@@ -174,16 +174,16 @@ type ProjectsCreateOption struct {
 	Visibility string `url:"visibility,omitempty"`
 }
 
-// ProjectsDeleteOption represents options for deleting a project.
-type ProjectsDeleteOption struct {
+// ProjectsDeleteOptions represents options for deleting a project.
+type ProjectsDeleteOptions struct {
 	// Project is the project key (required).
 	Project string `url:"project,omitempty"`
 }
 
-// ProjectsSearchOption represents options for searching projects.
+// ProjectsSearchOptions represents options for searching projects.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type ProjectsSearchOption struct {
+type ProjectsSearchOptions struct {
 	PaginationArgs
 
 	// AnalyzedBefore filters projects analyzed before the given date (optional).
@@ -203,34 +203,34 @@ type ProjectsSearchOption struct {
 	Visibility string `url:"visibility,omitempty"`
 }
 
-// ProjectsSearchMyProjectsOption represents options for searching my projects.
-type ProjectsSearchMyProjectsOption struct {
+// ProjectsSearchMyProjectsOptions represents options for searching my projects.
+type ProjectsSearchMyProjectsOptions struct {
 	PaginationArgs
 }
 
-// ProjectsSearchMyScannableProjectsOption contains optional parameters for SearchMyScannableProjects.
-type ProjectsSearchMyScannableProjectsOption struct {
+// ProjectsSearchMyScannableProjectsOptions contains optional parameters for SearchMyScannableProjects.
+type ProjectsSearchMyScannableProjectsOptions struct {
 	// Query is used to filter projects by name.
 	Query string `url:"q,omitempty"`
 }
 
-// ProjectsUpdateDefaultVisibilityOption represents options for updating default visibility.
-type ProjectsUpdateDefaultVisibilityOption struct {
+// ProjectsUpdateDefaultVisibilityOptions represents options for updating default visibility.
+type ProjectsUpdateDefaultVisibilityOptions struct {
 	// ProjectVisibility is the new default visibility (required).
 	// Possible values: private, public.
 	ProjectVisibility string `url:"projectVisibility,omitempty"`
 }
 
-// ProjectsUpdateKeyOption represents options for updating a project key.
-type ProjectsUpdateKeyOption struct {
+// ProjectsUpdateKeyOptions represents options for updating a project key.
+type ProjectsUpdateKeyOptions struct {
 	// From is the current project key (required).
 	From string `url:"from,omitempty"`
 	// To is the new project key (required).
 	To string `url:"to,omitempty"`
 }
 
-// ProjectsUpdateVisibilityOption represents options for updating project visibility.
-type ProjectsUpdateVisibilityOption struct {
+// ProjectsUpdateVisibilityOptions represents options for updating project visibility.
+type ProjectsUpdateVisibilityOptions struct {
 	// Project is the project key (required).
 	Project string `url:"project,omitempty"`
 	// Visibility is the new visibility (required).
@@ -243,7 +243,7 @@ type ProjectsUpdateVisibilityOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateBulkDeleteOpt validates the options for BulkDelete.
-func (s *ProjectsService) ValidateBulkDeleteOpt(opt *ProjectsBulkDeleteOption) error {
+func (s *ProjectsService) ValidateBulkDeleteOpt(opt *ProjectsBulkDeleteOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -271,7 +271,7 @@ func (s *ProjectsService) ValidateBulkDeleteOpt(opt *ProjectsBulkDeleteOption) e
 }
 
 // ValidateCreateOpt validates the options for Create.
-func (s *ProjectsService) ValidateCreateOpt(opt *ProjectsCreateOption) error {
+func (s *ProjectsService) ValidateCreateOpt(opt *ProjectsCreateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -307,7 +307,7 @@ func (s *ProjectsService) ValidateCreateOpt(opt *ProjectsCreateOption) error {
 }
 
 // ValidateDeleteOpt validates the options for Delete.
-func (s *ProjectsService) ValidateDeleteOpt(opt *ProjectsDeleteOption) error {
+func (s *ProjectsService) ValidateDeleteOpt(opt *ProjectsDeleteOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -316,7 +316,7 @@ func (s *ProjectsService) ValidateDeleteOpt(opt *ProjectsDeleteOption) error {
 }
 
 // ValidateSearchOpt validates the options for Search.
-func (s *ProjectsService) ValidateSearchOpt(opt *ProjectsSearchOption) error {
+func (s *ProjectsService) ValidateSearchOpt(opt *ProjectsSearchOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -340,7 +340,7 @@ func (s *ProjectsService) ValidateSearchOpt(opt *ProjectsSearchOption) error {
 }
 
 // ValidateSearchMyProjectsOpt validates the options for SearchMyProjects.
-func (s *ProjectsService) ValidateSearchMyProjectsOpt(opt *ProjectsSearchMyProjectsOption) error {
+func (s *ProjectsService) ValidateSearchMyProjectsOpt(opt *ProjectsSearchMyProjectsOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -349,7 +349,7 @@ func (s *ProjectsService) ValidateSearchMyProjectsOpt(opt *ProjectsSearchMyProje
 }
 
 // ValidateUpdateDefaultVisibilityOpt validates the options for UpdateDefaultVisibility.
-func (s *ProjectsService) ValidateUpdateDefaultVisibilityOpt(opt *ProjectsUpdateDefaultVisibilityOption) error {
+func (s *ProjectsService) ValidateUpdateDefaultVisibilityOpt(opt *ProjectsUpdateDefaultVisibilityOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -368,7 +368,7 @@ func (s *ProjectsService) ValidateUpdateDefaultVisibilityOpt(opt *ProjectsUpdate
 }
 
 // ValidateUpdateKeyOpt validates the options for UpdateKey.
-func (s *ProjectsService) ValidateUpdateKeyOpt(opt *ProjectsUpdateKeyOption) error {
+func (s *ProjectsService) ValidateUpdateKeyOpt(opt *ProjectsUpdateKeyOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -387,7 +387,7 @@ func (s *ProjectsService) ValidateUpdateKeyOpt(opt *ProjectsUpdateKeyOption) err
 }
 
 // ValidateUpdateVisibilityOpt validates the options for UpdateVisibility.
-func (s *ProjectsService) ValidateUpdateVisibilityOpt(opt *ProjectsUpdateVisibilityOption) error {
+func (s *ProjectsService) ValidateUpdateVisibilityOpt(opt *ProjectsUpdateVisibilityOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -419,7 +419,7 @@ func (s *ProjectsService) ValidateUpdateVisibilityOpt(opt *ProjectsUpdateVisibil
 // Requires 'Administer System' permission.
 //
 // Since: 5.2.
-func (s *ProjectsService) BulkDelete(opt *ProjectsBulkDeleteOption) (*http.Response, error) {
+func (s *ProjectsService) BulkDelete(opt *ProjectsBulkDeleteOptions) (*http.Response, error) {
 	err := s.ValidateBulkDeleteOpt(opt)
 	if err != nil {
 		return nil, err
@@ -442,7 +442,7 @@ func (s *ProjectsService) BulkDelete(opt *ProjectsBulkDeleteOption) (*http.Respo
 // Requires 'Create Projects' permission.
 //
 // Since: 4.0.
-func (s *ProjectsService) Create(opt *ProjectsCreateOption) (*ProjectsCreate, *http.Response, error) {
+func (s *ProjectsService) Create(opt *ProjectsCreateOptions) (*ProjectsCreate, *http.Response, error) {
 	err := s.ValidateCreateOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -467,7 +467,7 @@ func (s *ProjectsService) Create(opt *ProjectsCreateOption) (*ProjectsCreate, *h
 // Requires 'Administer System' permission or 'Administer' permission on the project.
 //
 // Since: 5.2.
-func (s *ProjectsService) Delete(opt *ProjectsDeleteOption) (*http.Response, error) {
+func (s *ProjectsService) Delete(opt *ProjectsDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
@@ -490,7 +490,7 @@ func (s *ProjectsService) Delete(opt *ProjectsDeleteOption) (*http.Response, err
 // Requires 'Browse' permission on the returned projects.
 //
 // Since: 6.3.
-func (s *ProjectsService) Search(opt *ProjectsSearchOption) (*ProjectsSearch, *http.Response, error) {
+func (s *ProjectsService) Search(opt *ProjectsSearchOptions) (*ProjectsSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -515,7 +515,7 @@ func (s *ProjectsService) Search(opt *ProjectsSearchOption) (*ProjectsSearch, *h
 // Only the favorite and recently analyzed projects will be returned.
 //
 // Since: 6.4.
-func (s *ProjectsService) SearchMyProjects(opt *ProjectsSearchMyProjectsOption) (*ProjectsSearchMyProjects, *http.Response, error) {
+func (s *ProjectsService) SearchMyProjects(opt *ProjectsSearchMyProjectsOptions) (*ProjectsSearchMyProjects, *http.Response, error) {
 	err := s.ValidateSearchMyProjectsOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -540,7 +540,7 @@ func (s *ProjectsService) SearchMyProjects(opt *ProjectsSearchMyProjectsOption) 
 // Requires authentication.
 //
 // Since: 9.5.
-func (s *ProjectsService) SearchMyScannableProjects(opt *ProjectsSearchMyScannableProjectsOption) (*ProjectsSearchMyScannableProjects, *http.Response, error) {
+func (s *ProjectsService) SearchMyScannableProjects(opt *ProjectsSearchMyScannableProjectsOptions) (*ProjectsSearchMyScannableProjects, *http.Response, error) {
 	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "projects/search_my_scannable_projects", opt)
 	if err != nil {
 		return nil, nil, err
@@ -560,7 +560,7 @@ func (s *ProjectsService) SearchMyScannableProjects(opt *ProjectsSearchMyScannab
 // Requires 'Administer System' permission.
 //
 // Since: 6.4.
-func (s *ProjectsService) UpdateDefaultVisibility(opt *ProjectsUpdateDefaultVisibilityOption) (*http.Response, error) {
+func (s *ProjectsService) UpdateDefaultVisibility(opt *ProjectsUpdateDefaultVisibilityOptions) (*http.Response, error) {
 	err := s.ValidateUpdateDefaultVisibilityOpt(opt)
 	if err != nil {
 		return nil, err
@@ -583,7 +583,7 @@ func (s *ProjectsService) UpdateDefaultVisibility(opt *ProjectsUpdateDefaultVisi
 // Requires 'Administer' permission on the project.
 //
 // Since: 6.1.
-func (s *ProjectsService) UpdateKey(opt *ProjectsUpdateKeyOption) (*http.Response, error) {
+func (s *ProjectsService) UpdateKey(opt *ProjectsUpdateKeyOptions) (*http.Response, error) {
 	err := s.ValidateUpdateKeyOpt(opt)
 	if err != nil {
 		return nil, err
@@ -606,7 +606,7 @@ func (s *ProjectsService) UpdateKey(opt *ProjectsUpdateKeyOption) (*http.Respons
 // Requires 'Project administer' permission on the project.
 //
 // Since: 6.4.
-func (s *ProjectsService) UpdateVisibility(opt *ProjectsUpdateVisibilityOption) (*http.Response, error) {
+func (s *ProjectsService) UpdateVisibility(opt *ProjectsUpdateVisibilityOptions) (*http.Response, error) {
 	err := s.ValidateUpdateVisibilityOpt(opt)
 	if err != nil {
 		return nil, err

--- a/sonar/projects_service_test.go
+++ b/sonar/projects_service_test.go
@@ -20,7 +20,7 @@ func TestProjectsService_BulkDelete(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectsBulkDeleteOption{
+	opt := &ProjectsBulkDeleteOptions{
 		Projects: []string{"project1", "project2"},
 	}
 
@@ -34,12 +34,12 @@ func TestProjectsService_BulkDelete_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test no filter provided
-	opt := &ProjectsBulkDeleteOption{}
+	opt := &ProjectsBulkDeleteOptions{}
 	_, err := client.Projects.BulkDelete(opt)
 	assert.Error(t, err)
 
 	// Test invalid qualifier
-	opt = &ProjectsBulkDeleteOption{
+	opt = &ProjectsBulkDeleteOptions{
 		Query:      "test",
 		Qualifiers: []string{"INVALID"},
 	}
@@ -61,7 +61,7 @@ func TestProjectsService_Create(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectsCreateOption{
+	opt := &ProjectsCreateOptions{
 		Name:       "My Project",
 		Project:    "my-project",
 		Visibility: "private",
@@ -79,21 +79,21 @@ func TestProjectsService_Create_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing Name
-	opt := &ProjectsCreateOption{
+	opt := &ProjectsCreateOptions{
 		Project: "my-project",
 	}
 	_, _, err := client.Projects.Create(opt)
 	assert.Error(t, err)
 
 	// Test missing Project
-	opt = &ProjectsCreateOption{
+	opt = &ProjectsCreateOptions{
 		Name: "My Project",
 	}
 	_, _, err = client.Projects.Create(opt)
 	assert.Error(t, err)
 
 	// Test Name too long
-	opt = &ProjectsCreateOption{
+	opt = &ProjectsCreateOptions{
 		Name:    strings.Repeat("a", MaxProjectNameLength+1),
 		Project: "my-project",
 	}
@@ -101,7 +101,7 @@ func TestProjectsService_Create_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test Project key too long
-	opt = &ProjectsCreateOption{
+	opt = &ProjectsCreateOptions{
 		Name:    "My Project",
 		Project: strings.Repeat("a", MaxProjectKeyLength+1),
 	}
@@ -109,7 +109,7 @@ func TestProjectsService_Create_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test invalid visibility
-	opt = &ProjectsCreateOption{
+	opt = &ProjectsCreateOptions{
 		Name:       "My Project",
 		Project:    "my-project",
 		Visibility: "invalid",
@@ -125,7 +125,7 @@ func TestProjectsService_Delete(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectsDeleteOption{
+	opt := &ProjectsDeleteOptions{
 		Project: "my-project",
 	}
 
@@ -139,7 +139,7 @@ func TestProjectsService_Delete_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing Project
-	opt := &ProjectsDeleteOption{}
+	opt := &ProjectsDeleteOptions{}
 	_, err := client.Projects.Delete(opt)
 	assert.Error(t, err)
 }
@@ -169,7 +169,7 @@ func TestProjectsService_Search(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectsSearchOption{
+	opt := &ProjectsSearchOptions{
 		Query:      "project",
 		Qualifiers: []string{"TRK"},
 	}
@@ -186,7 +186,7 @@ func TestProjectsService_Search_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test invalid qualifier
-	opt := &ProjectsSearchOption{
+	opt := &ProjectsSearchOptions{
 		Qualifiers: []string{"INVALID"},
 	}
 	_, _, err := client.Projects.Search(opt)
@@ -210,7 +210,7 @@ func TestProjectsService_SearchMyProjects(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectsSearchMyProjectsOption{}
+	opt := &ProjectsSearchMyProjectsOptions{}
 
 	result, resp, err := client.Projects.SearchMyProjects(opt)
 	require.NoError(t, err)
@@ -230,7 +230,7 @@ func TestProjectsService_SearchMyScannableProjects(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Projects.SearchMyScannableProjects(&ProjectsSearchMyScannableProjectsOption{})
+	result, resp, err := client.Projects.SearchMyScannableProjects(&ProjectsSearchMyScannableProjectsOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Projects, 2)
@@ -243,7 +243,7 @@ func TestProjectsService_UpdateDefaultVisibility(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectsUpdateDefaultVisibilityOption{
+	opt := &ProjectsUpdateDefaultVisibilityOptions{
 		ProjectVisibility: "private",
 	}
 
@@ -257,12 +257,12 @@ func TestProjectsService_UpdateDefaultVisibility_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing ProjectVisibility
-	opt := &ProjectsUpdateDefaultVisibilityOption{}
+	opt := &ProjectsUpdateDefaultVisibilityOptions{}
 	_, err := client.Projects.UpdateDefaultVisibility(opt)
 	assert.Error(t, err)
 
 	// Test invalid visibility
-	opt = &ProjectsUpdateDefaultVisibilityOption{
+	opt = &ProjectsUpdateDefaultVisibilityOptions{
 		ProjectVisibility: "invalid",
 	}
 	_, err = client.Projects.UpdateDefaultVisibility(opt)
@@ -276,7 +276,7 @@ func TestProjectsService_UpdateKey(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectsUpdateKeyOption{
+	opt := &ProjectsUpdateKeyOptions{
 		From: "old-project-key",
 		To:   "new-project-key",
 	}
@@ -291,14 +291,14 @@ func TestProjectsService_UpdateKey_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing From
-	opt := &ProjectsUpdateKeyOption{
+	opt := &ProjectsUpdateKeyOptions{
 		To: "new-key",
 	}
 	_, err := client.Projects.UpdateKey(opt)
 	assert.Error(t, err)
 
 	// Test missing To
-	opt = &ProjectsUpdateKeyOption{
+	opt = &ProjectsUpdateKeyOptions{
 		From: "old-key",
 	}
 	_, err = client.Projects.UpdateKey(opt)
@@ -312,7 +312,7 @@ func TestProjectsService_UpdateVisibility(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &ProjectsUpdateVisibilityOption{
+	opt := &ProjectsUpdateVisibilityOptions{
 		Project:    "my-project",
 		Visibility: "public",
 	}
@@ -327,21 +327,21 @@ func TestProjectsService_UpdateVisibility_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing Project
-	opt := &ProjectsUpdateVisibilityOption{
+	opt := &ProjectsUpdateVisibilityOptions{
 		Visibility: "public",
 	}
 	_, err := client.Projects.UpdateVisibility(opt)
 	assert.Error(t, err)
 
 	// Test missing Visibility
-	opt = &ProjectsUpdateVisibilityOption{
+	opt = &ProjectsUpdateVisibilityOptions{
 		Project: "my-project",
 	}
 	_, err = client.Projects.UpdateVisibility(opt)
 	assert.Error(t, err)
 
 	// Test invalid visibility
-	opt = &ProjectsUpdateVisibilityOption{
+	opt = &ProjectsUpdateVisibilityOptions{
 		Project:    "my-project",
 		Visibility: "invalid",
 	}

--- a/sonar/push_service.go
+++ b/sonar/push_service.go
@@ -26,8 +26,8 @@ type SonarlintEvents struct{}
 // Option Types
 // -----------------------------------------------------------------------------
 
-// PushSonarlintEventsOption contains parameters for the SonarlintEvents method.
-type PushSonarlintEventsOption struct {
+// PushSonarlintEventsOptions contains parameters for the SonarlintEvents method.
+type PushSonarlintEventsOptions struct {
 	// Languages is a list of languages for which events will be delivered.
 	// This field is required.
 	Languages []string `url:"languages,comma"`
@@ -41,7 +41,7 @@ type PushSonarlintEventsOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateSonarlintEventsOpt validates the options for the SonarlintEvents method.
-func (s *PushService) ValidateSonarlintEventsOpt(opt *PushSonarlintEventsOption) error {
+func (s *PushService) ValidateSonarlintEventsOpt(opt *PushSonarlintEventsOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -69,7 +69,7 @@ func (s *PushService) ValidateSonarlintEventsOpt(opt *PushSonarlintEventsOption)
 //
 // API endpoint: GET /api/push/sonarlint_events.
 // WARNING: This is an internal API and may change without notice.
-func (s *PushService) SonarlintEvents(opt *PushSonarlintEventsOption) (*http.Response, error) {
+func (s *PushService) SonarlintEvents(opt *PushSonarlintEventsOptions) (*http.Response, error) {
 	err := s.ValidateSonarlintEventsOpt(opt)
 	if err != nil {
 		return nil, err

--- a/sonar/push_service_test.go
+++ b/sonar/push_service_test.go
@@ -14,7 +14,7 @@ func TestPush_SonarlintEvents(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &PushSonarlintEventsOption{
+	opt := &PushSonarlintEventsOptions{
 		Languages:   []string{"java", "go"},
 		ProjectKeys: []string{"my-project"},
 	}
@@ -29,12 +29,12 @@ func TestPush_SonarlintEvents_Validation(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		opt       *PushSonarlintEventsOption
+		opt       *PushSonarlintEventsOptions
 		wantField string
 	}{
 		{"nil option", nil, "opt"},
-		{"missing languages", &PushSonarlintEventsOption{ProjectKeys: []string{"my-project"}}, "Languages"},
-		{"missing project keys", &PushSonarlintEventsOption{Languages: []string{"java"}}, "ProjectKeys"},
+		{"missing languages", &PushSonarlintEventsOptions{ProjectKeys: []string{"my-project"}}, "Languages"},
+		{"missing project keys", &PushSonarlintEventsOptions{Languages: []string{"java"}}, "ProjectKeys"},
 	}
 
 	for _, tt := range tests {
@@ -54,14 +54,14 @@ func TestPush_ValidateSonarlintEventsOpt(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		opt       *PushSonarlintEventsOption
+		opt       *PushSonarlintEventsOptions
 		wantErr   bool
 		wantField string
 	}{
 		{"nil option", nil, true, "opt"},
-		{"missing languages", &PushSonarlintEventsOption{ProjectKeys: []string{"my-project"}}, true, "Languages"},
-		{"missing project keys", &PushSonarlintEventsOption{Languages: []string{"java"}}, true, "ProjectKeys"},
-		{"valid option", &PushSonarlintEventsOption{Languages: []string{"java", "go"}, ProjectKeys: []string{"my-project"}}, false, ""},
+		{"missing languages", &PushSonarlintEventsOptions{ProjectKeys: []string{"my-project"}}, true, "Languages"},
+		{"missing project keys", &PushSonarlintEventsOptions{Languages: []string{"java"}}, true, "ProjectKeys"},
+		{"valid option", &PushSonarlintEventsOptions{Languages: []string{"java", "go"}, ProjectKeys: []string{"my-project"}}, false, ""},
 	}
 
 	for _, tt := range tests {

--- a/sonar/qualitygates_service.go
+++ b/sonar/qualitygates_service.go
@@ -265,8 +265,8 @@ type QualityGateCondition struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// QualitygatesAddGroupOption contains options for allowing a group to edit a quality gate.
-type QualitygatesAddGroupOption struct {
+// QualitygatesAddGroupOptions contains options for allowing a group to edit a quality gate.
+type QualitygatesAddGroupOptions struct {
 	// GateName is the name of the quality gate (required).
 	// Maximum length: 100 characters
 	GateName string `url:"gateName,omitempty"`
@@ -274,8 +274,8 @@ type QualitygatesAddGroupOption struct {
 	GroupName string `url:"groupName,omitempty"`
 }
 
-// QualitygatesAddUserOption contains options for allowing a user to edit a quality gate.
-type QualitygatesAddUserOption struct {
+// QualitygatesAddUserOptions contains options for allowing a user to edit a quality gate.
+type QualitygatesAddUserOptions struct {
 	// GateName is the name of the quality gate (required).
 	// Maximum length: 100 characters
 	GateName string `url:"gateName,omitempty"`
@@ -283,8 +283,8 @@ type QualitygatesAddUserOption struct {
 	Login string `url:"login,omitempty"`
 }
 
-// QualitygatesCopyOption contains options for copying a quality gate.
-type QualitygatesCopyOption struct {
+// QualitygatesCopyOptions contains options for copying a quality gate.
+type QualitygatesCopyOptions struct {
 	// Name is the name of the new quality gate to create (required).
 	Name string `url:"name,omitempty"`
 	// SourceName is the name of the quality gate to copy (required).
@@ -292,15 +292,15 @@ type QualitygatesCopyOption struct {
 	SourceName string `url:"sourceName,omitempty"`
 }
 
-// QualitygatesCreateOption contains options for creating a quality gate.
-type QualitygatesCreateOption struct {
+// QualitygatesCreateOptions contains options for creating a quality gate.
+type QualitygatesCreateOptions struct {
 	// Name is the name of the quality gate to create (required).
 	// Maximum length: 100 characters
 	Name string `url:"name,omitempty"`
 }
 
-// QualitygatesCreateConditionOption contains options for creating a condition.
-type QualitygatesCreateConditionOption struct {
+// QualitygatesCreateConditionOptions contains options for creating a condition.
+type QualitygatesCreateConditionOptions struct {
 	// Error is the condition error threshold (required).
 	// Maximum length: 64 characters
 	Error string `url:"error,omitempty"`
@@ -315,33 +315,33 @@ type QualitygatesCreateConditionOption struct {
 	Op string `url:"op,omitempty"`
 }
 
-// QualitygatesDeleteConditionOption contains options for deleting a condition.
-type QualitygatesDeleteConditionOption struct {
+// QualitygatesDeleteConditionOptions contains options for deleting a condition.
+type QualitygatesDeleteConditionOptions struct {
 	// ID is the condition UUID (required).
 	ID string `url:"id,omitempty"`
 }
 
-// QualitygatesDeselectOption contains options for removing a project association.
-type QualitygatesDeselectOption struct {
+// QualitygatesDeselectOptions contains options for removing a project association.
+type QualitygatesDeselectOptions struct {
 	// ProjectKey is the project key (required).
 	ProjectKey string `url:"projectKey,omitempty"`
 }
 
-// QualitygatesDestroyOption contains options for deleting a quality gate.
-type QualitygatesDestroyOption struct {
+// QualitygatesDestroyOptions contains options for deleting a quality gate.
+type QualitygatesDestroyOptions struct {
 	// Name is the name of the quality gate to delete (required).
 	// Maximum length: 100 characters
 	Name string `url:"name,omitempty"`
 }
 
-// QualitygatesGetByProjectOption contains options for getting a project's quality gate.
-type QualitygatesGetByProjectOption struct {
+// QualitygatesGetByProjectOptions contains options for getting a project's quality gate.
+type QualitygatesGetByProjectOptions struct {
 	// Project is the project key (required).
 	Project string `url:"project,omitempty"`
 }
 
-// QualitygatesProjectStatusOption contains options for getting project status.
-type QualitygatesProjectStatusOption struct {
+// QualitygatesProjectStatusOptions contains options for getting project status.
+type QualitygatesProjectStatusOptions struct {
 	// AnalysisID is the analysis id (optional).
 	// Either AnalysisID, ProjectID, or ProjectKey must be provided.
 	AnalysisID string `url:"analysisId,omitempty"`
@@ -356,8 +356,8 @@ type QualitygatesProjectStatusOption struct {
 	PullRequest string `url:"pullRequest,omitempty"`
 }
 
-// QualitygatesRemoveGroupOption contains options for removing group permissions.
-type QualitygatesRemoveGroupOption struct {
+// QualitygatesRemoveGroupOptions contains options for removing group permissions.
+type QualitygatesRemoveGroupOptions struct {
 	// GateName is the name of the quality gate (required).
 	// Maximum length: 100 characters
 	GateName string `url:"gateName,omitempty"`
@@ -365,8 +365,8 @@ type QualitygatesRemoveGroupOption struct {
 	GroupName string `url:"groupName,omitempty"`
 }
 
-// QualitygatesRemoveUserOption contains options for removing user permissions.
-type QualitygatesRemoveUserOption struct {
+// QualitygatesRemoveUserOptions contains options for removing user permissions.
+type QualitygatesRemoveUserOptions struct {
 	// GateName is the name of the quality gate (required).
 	// Maximum length: 100 characters
 	GateName string `url:"gateName,omitempty"`
@@ -374,8 +374,8 @@ type QualitygatesRemoveUserOption struct {
 	Login string `url:"login,omitempty"`
 }
 
-// QualitygatesRenameOption contains options for renaming a quality gate.
-type QualitygatesRenameOption struct {
+// QualitygatesRenameOptions contains options for renaming a quality gate.
+type QualitygatesRenameOptions struct {
 	// CurrentName is the current name of the quality gate (required).
 	// Maximum length: 100 characters
 	CurrentName string `url:"currentName,omitempty"`
@@ -384,10 +384,10 @@ type QualitygatesRenameOption struct {
 	Name string `url:"name,omitempty"`
 }
 
-// QualitygatesSearchOption contains options for searching projects.
+// QualitygatesSearchOptions contains options for searching projects.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type QualitygatesSearchOption struct {
+type QualitygatesSearchOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -402,10 +402,10 @@ type QualitygatesSearchOption struct {
 	Selected string `url:"selected,omitempty"`
 }
 
-// QualitygatesSearchGroupsOption contains options for searching groups.
+// QualitygatesSearchGroupsOptions contains options for searching groups.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type QualitygatesSearchGroupsOption struct {
+type QualitygatesSearchGroupsOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -418,10 +418,10 @@ type QualitygatesSearchGroupsOption struct {
 	Selected string `url:"selected,omitempty"`
 }
 
-// QualitygatesSearchUsersOption contains options for searching users.
+// QualitygatesSearchUsersOptions contains options for searching users.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type QualitygatesSearchUsersOption struct {
+type QualitygatesSearchUsersOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -434,8 +434,8 @@ type QualitygatesSearchUsersOption struct {
 	Selected string `url:"selected,omitempty"`
 }
 
-// QualitygatesSelectOption contains options for associating a project.
-type QualitygatesSelectOption struct {
+// QualitygatesSelectOptions contains options for associating a project.
+type QualitygatesSelectOptions struct {
 	// GateName is the name of the quality gate (required).
 	// Maximum length: 100 characters
 	GateName string `url:"gateName,omitempty"`
@@ -443,21 +443,21 @@ type QualitygatesSelectOption struct {
 	ProjectKey string `url:"projectKey,omitempty"`
 }
 
-// QualitygatesSetAsDefaultOption contains options for setting the default gate.
-type QualitygatesSetAsDefaultOption struct {
+// QualitygatesSetAsDefaultOptions contains options for setting the default gate.
+type QualitygatesSetAsDefaultOptions struct {
 	// Name is the name of the quality gate to set as default (required).
 	// Maximum length: 100 characters
 	Name string `url:"name,omitempty"`
 }
 
-// QualitygatesShowOption contains options for showing a quality gate.
-type QualitygatesShowOption struct {
+// QualitygatesShowOptions contains options for showing a quality gate.
+type QualitygatesShowOptions struct {
 	// Name is the name of the quality gate (required).
 	Name string `url:"name,omitempty"`
 }
 
-// QualitygatesUpdateConditionOption contains options for updating a condition.
-type QualitygatesUpdateConditionOption struct {
+// QualitygatesUpdateConditionOptions contains options for updating a condition.
+type QualitygatesUpdateConditionOptions struct {
 	// Error is the condition error threshold (required).
 	// Maximum length: 64 characters
 	Error string `url:"error,omitempty"`
@@ -480,7 +480,7 @@ type QualitygatesUpdateConditionOption struct {
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - Edit right on the specified quality gate
-func (s *QualitygatesService) AddGroup(opt *QualitygatesAddGroupOption) (resp *http.Response, err error) {
+func (s *QualitygatesService) AddGroup(opt *QualitygatesAddGroupOptions) (resp *http.Response, err error) {
 	err = s.ValidateAddGroupOpt(opt)
 	if err != nil {
 		return
@@ -503,7 +503,7 @@ func (s *QualitygatesService) AddGroup(opt *QualitygatesAddGroupOption) (resp *h
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - Edit right on the specified quality gate
-func (s *QualitygatesService) AddUser(opt *QualitygatesAddUserOption) (resp *http.Response, err error) {
+func (s *QualitygatesService) AddUser(opt *QualitygatesAddUserOptions) (resp *http.Response, err error) {
 	err = s.ValidateAddUserOpt(opt)
 	if err != nil {
 		return
@@ -524,7 +524,7 @@ func (s *QualitygatesService) AddUser(opt *QualitygatesAddUserOption) (resp *htt
 
 // Copy copies a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) Copy(opt *QualitygatesCopyOption) (resp *http.Response, err error) {
+func (s *QualitygatesService) Copy(opt *QualitygatesCopyOptions) (resp *http.Response, err error) {
 	err = s.ValidateCopyOpt(opt)
 	if err != nil {
 		return
@@ -545,7 +545,7 @@ func (s *QualitygatesService) Copy(opt *QualitygatesCopyOption) (resp *http.Resp
 
 // Create creates a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) Create(opt *QualitygatesCreateOption) (v *QualitygatesCreate, resp *http.Response, err error) {
+func (s *QualitygatesService) Create(opt *QualitygatesCreateOptions) (v *QualitygatesCreate, resp *http.Response, err error) {
 	err = s.ValidateCreateOpt(opt)
 	if err != nil {
 		return
@@ -568,7 +568,7 @@ func (s *QualitygatesService) Create(opt *QualitygatesCreateOption) (v *Qualityg
 
 // CreateCondition adds a new condition to a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) CreateCondition(opt *QualitygatesCreateConditionOption) (v *QualitygatesCreateCondition, resp *http.Response, err error) {
+func (s *QualitygatesService) CreateCondition(opt *QualitygatesCreateConditionOptions) (v *QualitygatesCreateCondition, resp *http.Response, err error) {
 	err = s.ValidateCreateConditionOpt(opt)
 	if err != nil {
 		return
@@ -591,7 +591,7 @@ func (s *QualitygatesService) CreateCondition(opt *QualitygatesCreateConditionOp
 
 // DeleteCondition deletes a condition from a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) DeleteCondition(opt *QualitygatesDeleteConditionOption) (resp *http.Response, err error) {
+func (s *QualitygatesService) DeleteCondition(opt *QualitygatesDeleteConditionOptions) (resp *http.Response, err error) {
 	err = s.ValidateDeleteConditionOpt(opt)
 	if err != nil {
 		return
@@ -614,7 +614,7 @@ func (s *QualitygatesService) DeleteCondition(opt *QualitygatesDeleteConditionOp
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - 'Administer' rights on the project
-func (s *QualitygatesService) Deselect(opt *QualitygatesDeselectOption) (resp *http.Response, err error) {
+func (s *QualitygatesService) Deselect(opt *QualitygatesDeselectOptions) (resp *http.Response, err error) {
 	err = s.ValidateDeselectOpt(opt)
 	if err != nil {
 		return
@@ -635,7 +635,7 @@ func (s *QualitygatesService) Deselect(opt *QualitygatesDeselectOption) (resp *h
 
 // Destroy deletes a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) Destroy(opt *QualitygatesDestroyOption) (resp *http.Response, err error) {
+func (s *QualitygatesService) Destroy(opt *QualitygatesDestroyOptions) (resp *http.Response, err error) {
 	err = s.ValidateDestroyOpt(opt)
 	if err != nil {
 		return
@@ -659,7 +659,7 @@ func (s *QualitygatesService) Destroy(opt *QualitygatesDestroyOption) (resp *htt
 //   - 'Administer System'
 //   - 'Administer' rights on the specified project
 //   - 'Browse' on the specified project
-func (s *QualitygatesService) GetByProject(opt *QualitygatesGetByProjectOption) (v *QualitygatesGetByProject, resp *http.Response, err error) {
+func (s *QualitygatesService) GetByProject(opt *QualitygatesGetByProjectOptions) (v *QualitygatesGetByProject, resp *http.Response, err error) {
 	err = s.ValidateGetByProjectOpt(opt)
 	if err != nil {
 		return
@@ -706,7 +706,7 @@ func (s *QualitygatesService) List() (v *QualitygatesList, resp *http.Response, 
 //   - 'Administer' rights on the specified project
 //   - 'Browse' on the specified project
 //   - 'Execute Analysis' on the specified project
-func (s *QualitygatesService) ProjectStatus(opt *QualitygatesProjectStatusOption) (v *QualitygatesProjectStatus, resp *http.Response, err error) {
+func (s *QualitygatesService) ProjectStatus(opt *QualitygatesProjectStatusOptions) (v *QualitygatesProjectStatus, resp *http.Response, err error) {
 	err = s.ValidateProjectStatusOpt(opt)
 	if err != nil {
 		return
@@ -731,7 +731,7 @@ func (s *QualitygatesService) ProjectStatus(opt *QualitygatesProjectStatusOption
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - Edit right on the specified quality gate
-func (s *QualitygatesService) RemoveGroup(opt *QualitygatesRemoveGroupOption) (resp *http.Response, err error) {
+func (s *QualitygatesService) RemoveGroup(opt *QualitygatesRemoveGroupOptions) (resp *http.Response, err error) {
 	err = s.ValidateRemoveGroupOpt(opt)
 	if err != nil {
 		return
@@ -754,7 +754,7 @@ func (s *QualitygatesService) RemoveGroup(opt *QualitygatesRemoveGroupOption) (r
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - Edit right on the specified quality gate
-func (s *QualitygatesService) RemoveUser(opt *QualitygatesRemoveUserOption) (resp *http.Response, err error) {
+func (s *QualitygatesService) RemoveUser(opt *QualitygatesRemoveUserOptions) (resp *http.Response, err error) {
 	err = s.ValidateRemoveUserOpt(opt)
 	if err != nil {
 		return
@@ -775,7 +775,7 @@ func (s *QualitygatesService) RemoveUser(opt *QualitygatesRemoveUserOption) (res
 
 // Rename renames a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) Rename(opt *QualitygatesRenameOption) (resp *http.Response, err error) {
+func (s *QualitygatesService) Rename(opt *QualitygatesRenameOptions) (resp *http.Response, err error) {
 	err = s.ValidateRenameOpt(opt)
 	if err != nil {
 		return
@@ -796,7 +796,7 @@ func (s *QualitygatesService) Rename(opt *QualitygatesRenameOption) (resp *http.
 
 // Search searches for projects associated (or not) to a quality gate.
 // Only authorized projects for the current user will be returned.
-func (s *QualitygatesService) Search(opt *QualitygatesSearchOption) (v *QualitygatesSearch, resp *http.Response, err error) {
+func (s *QualitygatesService) Search(opt *QualitygatesSearchOptions) (v *QualitygatesSearch, resp *http.Response, err error) {
 	err = s.ValidateSearchOpt(opt)
 	if err != nil {
 		return
@@ -821,7 +821,7 @@ func (s *QualitygatesService) Search(opt *QualitygatesSearchOption) (v *Qualityg
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - Edit right on the specified quality gate
-func (s *QualitygatesService) SearchGroups(opt *QualitygatesSearchGroupsOption) (v *QualitygatesSearchGroups, resp *http.Response, err error) {
+func (s *QualitygatesService) SearchGroups(opt *QualitygatesSearchGroupsOptions) (v *QualitygatesSearchGroups, resp *http.Response, err error) {
 	err = s.ValidateSearchGroupsOpt(opt)
 	if err != nil {
 		return
@@ -846,7 +846,7 @@ func (s *QualitygatesService) SearchGroups(opt *QualitygatesSearchGroupsOption) 
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - Edit right on the specified quality gate
-func (s *QualitygatesService) SearchUsers(opt *QualitygatesSearchUsersOption) (v *QualitygatesSearchUsers, resp *http.Response, err error) {
+func (s *QualitygatesService) SearchUsers(opt *QualitygatesSearchUsersOptions) (v *QualitygatesSearchUsers, resp *http.Response, err error) {
 	err = s.ValidateSearchUsersOpt(opt)
 	if err != nil {
 		return
@@ -871,7 +871,7 @@ func (s *QualitygatesService) SearchUsers(opt *QualitygatesSearchUsersOption) (v
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - 'Administer' right on the specified project
-func (s *QualitygatesService) Select(opt *QualitygatesSelectOption) (resp *http.Response, err error) {
+func (s *QualitygatesService) Select(opt *QualitygatesSelectOptions) (resp *http.Response, err error) {
 	err = s.ValidateSelectOpt(opt)
 	if err != nil {
 		return
@@ -892,7 +892,7 @@ func (s *QualitygatesService) Select(opt *QualitygatesSelectOption) (resp *http.
 
 // SetAsDefault sets a quality gate as the default quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) SetAsDefault(opt *QualitygatesSetAsDefaultOption) (resp *http.Response, err error) {
+func (s *QualitygatesService) SetAsDefault(opt *QualitygatesSetAsDefaultOptions) (resp *http.Response, err error) {
 	err = s.ValidateSetAsDefaultOpt(opt)
 	if err != nil {
 		return
@@ -912,7 +912,7 @@ func (s *QualitygatesService) SetAsDefault(opt *QualitygatesSetAsDefaultOption) 
 }
 
 // Show displays the details of a quality gate.
-func (s *QualitygatesService) Show(opt *QualitygatesShowOption) (v *QualitygatesShow, resp *http.Response, err error) {
+func (s *QualitygatesService) Show(opt *QualitygatesShowOptions) (v *QualitygatesShow, resp *http.Response, err error) {
 	err = s.ValidateShowOpt(opt)
 	if err != nil {
 		return
@@ -935,7 +935,7 @@ func (s *QualitygatesService) Show(opt *QualitygatesShowOption) (v *Qualitygates
 
 // UpdateCondition updates a condition attached to a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) UpdateCondition(opt *QualitygatesUpdateConditionOption) (resp *http.Response, err error) {
+func (s *QualitygatesService) UpdateCondition(opt *QualitygatesUpdateConditionOptions) (resp *http.Response, err error) {
 	err = s.ValidateUpdateConditionOpt(opt)
 	if err != nil {
 		return
@@ -959,7 +959,7 @@ func (s *QualitygatesService) UpdateCondition(opt *QualitygatesUpdateConditionOp
 // -----------------------------------------------------------------------------
 
 // ValidateAddGroupOpt validates the options for adding a group to a quality gate.
-func (s *QualitygatesService) ValidateAddGroupOpt(opt *QualitygatesAddGroupOption) error {
+func (s *QualitygatesService) ValidateAddGroupOpt(opt *QualitygatesAddGroupOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesAddGroupOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -983,7 +983,7 @@ func (s *QualitygatesService) ValidateAddGroupOpt(opt *QualitygatesAddGroupOptio
 }
 
 // ValidateAddUserOpt validates the options for adding a user to a quality gate.
-func (s *QualitygatesService) ValidateAddUserOpt(opt *QualitygatesAddUserOption) error {
+func (s *QualitygatesService) ValidateAddUserOpt(opt *QualitygatesAddUserOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesAddUserOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1007,7 +1007,7 @@ func (s *QualitygatesService) ValidateAddUserOpt(opt *QualitygatesAddUserOption)
 }
 
 // ValidateCopyOpt validates the options for copying a quality gate.
-func (s *QualitygatesService) ValidateCopyOpt(opt *QualitygatesCopyOption) error {
+func (s *QualitygatesService) ValidateCopyOpt(opt *QualitygatesCopyOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesCopyOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1031,7 +1031,7 @@ func (s *QualitygatesService) ValidateCopyOpt(opt *QualitygatesCopyOption) error
 }
 
 // ValidateCreateOpt validates the options for creating a quality gate.
-func (s *QualitygatesService) ValidateCreateOpt(opt *QualitygatesCreateOption) error {
+func (s *QualitygatesService) ValidateCreateOpt(opt *QualitygatesCreateOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesCreateOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1050,7 +1050,7 @@ func (s *QualitygatesService) ValidateCreateOpt(opt *QualitygatesCreateOption) e
 }
 
 // ValidateCreateConditionOpt validates the options for creating a condition.
-func (s *QualitygatesService) ValidateCreateConditionOpt(opt *QualitygatesCreateConditionOption) error {
+func (s *QualitygatesService) ValidateCreateConditionOpt(opt *QualitygatesCreateConditionOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesCreateConditionOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1089,7 +1089,7 @@ func (s *QualitygatesService) ValidateCreateConditionOpt(opt *QualitygatesCreate
 }
 
 // ValidateDeleteConditionOpt validates the options for deleting a condition.
-func (s *QualitygatesService) ValidateDeleteConditionOpt(opt *QualitygatesDeleteConditionOption) error {
+func (s *QualitygatesService) ValidateDeleteConditionOpt(opt *QualitygatesDeleteConditionOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesDeleteConditionOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1103,7 +1103,7 @@ func (s *QualitygatesService) ValidateDeleteConditionOpt(opt *QualitygatesDelete
 }
 
 // ValidateDeselectOpt validates the options for deselecting a project.
-func (s *QualitygatesService) ValidateDeselectOpt(opt *QualitygatesDeselectOption) error {
+func (s *QualitygatesService) ValidateDeselectOpt(opt *QualitygatesDeselectOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesDeselectOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1117,7 +1117,7 @@ func (s *QualitygatesService) ValidateDeselectOpt(opt *QualitygatesDeselectOptio
 }
 
 // ValidateDestroyOpt validates the options for destroying a quality gate.
-func (s *QualitygatesService) ValidateDestroyOpt(opt *QualitygatesDestroyOption) error {
+func (s *QualitygatesService) ValidateDestroyOpt(opt *QualitygatesDestroyOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesDestroyOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1136,7 +1136,7 @@ func (s *QualitygatesService) ValidateDestroyOpt(opt *QualitygatesDestroyOption)
 }
 
 // ValidateGetByProjectOpt validates the options for getting a project's quality gate.
-func (s *QualitygatesService) ValidateGetByProjectOpt(opt *QualitygatesGetByProjectOption) error {
+func (s *QualitygatesService) ValidateGetByProjectOpt(opt *QualitygatesGetByProjectOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesGetByProjectOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1150,7 +1150,7 @@ func (s *QualitygatesService) ValidateGetByProjectOpt(opt *QualitygatesGetByProj
 }
 
 // ValidateProjectStatusOpt validates the options for getting project status.
-func (s *QualitygatesService) ValidateProjectStatusOpt(opt *QualitygatesProjectStatusOption) error {
+func (s *QualitygatesService) ValidateProjectStatusOpt(opt *QualitygatesProjectStatusOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesProjectStatusOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1168,7 +1168,7 @@ func (s *QualitygatesService) ValidateProjectStatusOpt(opt *QualitygatesProjectS
 }
 
 // ValidateRemoveGroupOpt validates the options for removing a group from a quality gate.
-func (s *QualitygatesService) ValidateRemoveGroupOpt(opt *QualitygatesRemoveGroupOption) error {
+func (s *QualitygatesService) ValidateRemoveGroupOpt(opt *QualitygatesRemoveGroupOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesRemoveGroupOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1192,7 +1192,7 @@ func (s *QualitygatesService) ValidateRemoveGroupOpt(opt *QualitygatesRemoveGrou
 }
 
 // ValidateRemoveUserOpt validates the options for removing a user from a quality gate.
-func (s *QualitygatesService) ValidateRemoveUserOpt(opt *QualitygatesRemoveUserOption) error {
+func (s *QualitygatesService) ValidateRemoveUserOpt(opt *QualitygatesRemoveUserOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesRemoveUserOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1216,7 +1216,7 @@ func (s *QualitygatesService) ValidateRemoveUserOpt(opt *QualitygatesRemoveUserO
 }
 
 // ValidateRenameOpt validates the options for renaming a quality gate.
-func (s *QualitygatesService) ValidateRenameOpt(opt *QualitygatesRenameOption) error {
+func (s *QualitygatesService) ValidateRenameOpt(opt *QualitygatesRenameOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesRenameOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1245,7 +1245,7 @@ func (s *QualitygatesService) ValidateRenameOpt(opt *QualitygatesRenameOption) e
 }
 
 // ValidateSearchOpt validates the options for searching projects.
-func (s *QualitygatesService) ValidateSearchOpt(opt *QualitygatesSearchOption) error {
+func (s *QualitygatesService) ValidateSearchOpt(opt *QualitygatesSearchOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesSearchOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1272,7 +1272,7 @@ func (s *QualitygatesService) ValidateSearchOpt(opt *QualitygatesSearchOption) e
 }
 
 // ValidateSearchGroupsOpt validates the options for searching groups.
-func (s *QualitygatesService) ValidateSearchGroupsOpt(opt *QualitygatesSearchGroupsOption) error {
+func (s *QualitygatesService) ValidateSearchGroupsOpt(opt *QualitygatesSearchGroupsOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesSearchGroupsOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1294,7 +1294,7 @@ func (s *QualitygatesService) ValidateSearchGroupsOpt(opt *QualitygatesSearchGro
 }
 
 // ValidateSearchUsersOpt validates the options for searching users.
-func (s *QualitygatesService) ValidateSearchUsersOpt(opt *QualitygatesSearchUsersOption) error {
+func (s *QualitygatesService) ValidateSearchUsersOpt(opt *QualitygatesSearchUsersOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesSearchUsersOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1316,7 +1316,7 @@ func (s *QualitygatesService) ValidateSearchUsersOpt(opt *QualitygatesSearchUser
 }
 
 // ValidateSelectOpt validates the options for selecting a project.
-func (s *QualitygatesService) ValidateSelectOpt(opt *QualitygatesSelectOption) error {
+func (s *QualitygatesService) ValidateSelectOpt(opt *QualitygatesSelectOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesSelectOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1340,7 +1340,7 @@ func (s *QualitygatesService) ValidateSelectOpt(opt *QualitygatesSelectOption) e
 }
 
 // ValidateSetAsDefaultOpt validates the options for setting a default quality gate.
-func (s *QualitygatesService) ValidateSetAsDefaultOpt(opt *QualitygatesSetAsDefaultOption) error {
+func (s *QualitygatesService) ValidateSetAsDefaultOpt(opt *QualitygatesSetAsDefaultOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesSetAsDefaultOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1359,7 +1359,7 @@ func (s *QualitygatesService) ValidateSetAsDefaultOpt(opt *QualitygatesSetAsDefa
 }
 
 // ValidateShowOpt validates the options for showing a quality gate.
-func (s *QualitygatesService) ValidateShowOpt(opt *QualitygatesShowOption) error {
+func (s *QualitygatesService) ValidateShowOpt(opt *QualitygatesShowOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesShowOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1373,7 +1373,7 @@ func (s *QualitygatesService) ValidateShowOpt(opt *QualitygatesShowOption) error
 }
 
 // ValidateUpdateConditionOpt validates the options for updating a condition.
-func (s *QualitygatesService) ValidateUpdateConditionOpt(opt *QualitygatesUpdateConditionOption) error {
+func (s *QualitygatesService) ValidateUpdateConditionOpt(opt *QualitygatesUpdateConditionOptions) error {
 	if opt == nil {
 		return NewValidationError("QualitygatesUpdateConditionOption", "cannot be nil", ErrMissingRequired)
 	}

--- a/sonar/qualitygates_service_test.go
+++ b/sonar/qualitygates_service_test.go
@@ -14,7 +14,7 @@ func TestQualityGates_AddGroup(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/add_group", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesAddGroupOption{
+	opt := &QualitygatesAddGroupOptions{
 		GateName:  "SonarSource Way",
 		GroupName: "sonar-administrators",
 	}
@@ -32,19 +32,19 @@ func TestQualityGates_AddGroup_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing GateName
-	_, err = client.Qualitygates.AddGroup(&QualitygatesAddGroupOption{
+	_, err = client.Qualitygates.AddGroup(&QualitygatesAddGroupOptions{
 		GroupName: "group",
 	})
 	assert.Error(t, err)
 
 	// Test missing GroupName
-	_, err = client.Qualitygates.AddGroup(&QualitygatesAddGroupOption{
+	_, err = client.Qualitygates.AddGroup(&QualitygatesAddGroupOptions{
 		GateName: "gate",
 	})
 	assert.Error(t, err)
 
 	// Test GateName too long
-	_, err = client.Qualitygates.AddGroup(&QualitygatesAddGroupOption{
+	_, err = client.Qualitygates.AddGroup(&QualitygatesAddGroupOptions{
 		GateName:  strings.Repeat("a", MaxQualityGateNameLength+1),
 		GroupName: "group",
 	})
@@ -55,7 +55,7 @@ func TestQualityGates_AddUser(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/add_user", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesAddUserOption{
+	opt := &QualitygatesAddUserOptions{
 		GateName: "SonarSource Way",
 		Login:    "john.doe",
 	}
@@ -69,7 +69,7 @@ func TestQualityGates_Copy(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/copy", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesCopyOption{
+	opt := &QualitygatesCopyOptions{
 		Name:       "My New Quality Gate",
 		SourceName: "SonarSource Way",
 	}
@@ -83,7 +83,7 @@ func TestQualityGates_Create(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/qualitygates/create", http.StatusOK, `{"name":"My Quality Gate"}`))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesCreateOption{
+	opt := &QualitygatesCreateOptions{
 		Name: "My Quality Gate",
 	}
 
@@ -98,7 +98,7 @@ func TestQualityGates_CreateCondition(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/qualitygates/create_condition", http.StatusOK, `{"id":"1","metric":"coverage","op":"LT","error":"80"}`))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesCreateConditionOption{
+	opt := &QualitygatesCreateConditionOptions{
 		Error:    "80",
 		GateName: "My Quality Gate",
 		Metric:   "coverage",
@@ -116,7 +116,7 @@ func TestQualityGates_CreateCondition_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test invalid Op value
-	_, _, err := client.Qualitygates.CreateCondition(&QualitygatesCreateConditionOption{
+	_, _, err := client.Qualitygates.CreateCondition(&QualitygatesCreateConditionOptions{
 		Error:    "80",
 		GateName: "gate",
 		Metric:   "coverage",
@@ -125,7 +125,7 @@ func TestQualityGates_CreateCondition_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing required fields
-	_, _, err = client.Qualitygates.CreateCondition(&QualitygatesCreateConditionOption{
+	_, _, err = client.Qualitygates.CreateCondition(&QualitygatesCreateConditionOptions{
 		GateName: "gate",
 		Metric:   "coverage",
 	})
@@ -136,7 +136,7 @@ func TestQualityGates_DeleteCondition(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/delete_condition", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesDeleteConditionOption{
+	opt := &QualitygatesDeleteConditionOptions{
 		ID: "1",
 	}
 
@@ -149,7 +149,7 @@ func TestQualityGates_Deselect(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/deselect", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesDeselectOption{
+	opt := &QualitygatesDeselectOptions{
 		ProjectKey: "my_project",
 	}
 
@@ -162,7 +162,7 @@ func TestQualityGates_Destroy(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/destroy", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesDestroyOption{
+	opt := &QualitygatesDestroyOptions{
 		Name: "My Quality Gate",
 	}
 
@@ -175,7 +175,7 @@ func TestQualityGates_GetByProject(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualitygates/get_by_project", http.StatusOK, `{"qualityGate":{"name":"SonarSource Way","default":true}}`))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesGetByProjectOption{
+	opt := &QualitygatesGetByProjectOptions{
 		Project: "my_project",
 	}
 
@@ -221,7 +221,7 @@ func TestQualityGates_ProjectStatus(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualitygates/project_status", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesProjectStatusOption{
+	opt := &QualitygatesProjectStatusOptions{
 		ProjectKey: "my_project",
 	}
 
@@ -242,7 +242,7 @@ func TestQualityGates_ProjectStatus_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing all required fields
-	_, _, err = client.Qualitygates.ProjectStatus(&QualitygatesProjectStatusOption{})
+	_, _, err = client.Qualitygates.ProjectStatus(&QualitygatesProjectStatusOptions{})
 	assert.Error(t, err)
 }
 
@@ -250,7 +250,7 @@ func TestQualityGates_RemoveGroup(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/remove_group", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesRemoveGroupOption{
+	opt := &QualitygatesRemoveGroupOptions{
 		GateName:  "SonarSource Way",
 		GroupName: "sonar-administrators",
 	}
@@ -264,7 +264,7 @@ func TestQualityGates_RemoveUser(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/remove_user", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesRemoveUserOption{
+	opt := &QualitygatesRemoveUserOptions{
 		GateName: "SonarSource Way",
 		Login:    "john.doe",
 	}
@@ -278,7 +278,7 @@ func TestQualityGates_Rename(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/rename", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesRenameOption{
+	opt := &QualitygatesRenameOptions{
 		CurrentName: "Old Name",
 		Name:        "New Name",
 	}
@@ -299,7 +299,7 @@ func TestQualityGates_Search(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualitygates/search", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesSearchOption{
+	opt := &QualitygatesSearchOptions{
 		GateName: "SonarSource Way",
 	}
 
@@ -315,7 +315,7 @@ func TestQualityGates_Search_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test invalid Selected value
-	_, _, err := client.Qualitygates.Search(&QualitygatesSearchOption{
+	_, _, err := client.Qualitygates.Search(&QualitygatesSearchOptions{
 		GateName: "gate",
 		Selected: "invalid",
 	})
@@ -332,7 +332,7 @@ func TestQualityGates_SearchGroups(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualitygates/search_groups", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesSearchGroupsOption{
+	opt := &QualitygatesSearchGroupsOptions{
 		GateName: "SonarSource Way",
 	}
 
@@ -354,7 +354,7 @@ func TestQualityGates_SearchUsers(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualitygates/search_users", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesSearchUsersOption{
+	opt := &QualitygatesSearchUsersOptions{
 		GateName: "SonarSource Way",
 	}
 
@@ -370,7 +370,7 @@ func TestQualityGates_Select(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/select", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesSelectOption{
+	opt := &QualitygatesSelectOptions{
 		GateName:   "SonarSource Way",
 		ProjectKey: "my_project",
 	}
@@ -384,7 +384,7 @@ func TestQualityGates_SetAsDefault(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/set_as_default", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesSetAsDefaultOption{
+	opt := &QualitygatesSetAsDefaultOptions{
 		Name: "SonarSource Way",
 	}
 
@@ -411,7 +411,7 @@ func TestQualityGates_Show(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualitygates/show", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesShowOption{
+	opt := &QualitygatesShowOptions{
 		Name: "SonarSource Way",
 	}
 
@@ -431,7 +431,7 @@ func TestQualityGates_UpdateCondition(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/update_condition", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesUpdateConditionOption{
+	opt := &QualitygatesUpdateConditionOptions{
 		Error:  "85",
 		ID:     "1",
 		Metric: "coverage",
@@ -451,7 +451,7 @@ func TestQualityGates_UpdateCondition_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test invalid Op value
-	_, err = client.Qualitygates.UpdateCondition(&QualitygatesUpdateConditionOption{
+	_, err = client.Qualitygates.UpdateCondition(&QualitygatesUpdateConditionOptions{
 		Error:  "80",
 		ID:     "1",
 		Metric: "coverage",
@@ -460,7 +460,7 @@ func TestQualityGates_UpdateCondition_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing required fields
-	_, err = client.Qualitygates.UpdateCondition(&QualitygatesUpdateConditionOption{
+	_, err = client.Qualitygates.UpdateCondition(&QualitygatesUpdateConditionOptions{
 		ID:     "1",
 		Metric: "coverage",
 	})
@@ -597,7 +597,7 @@ func TestValidation_EdgeCases(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test Copy validation - missing name
-	err := client.Qualitygates.ValidateCopyOpt(&QualitygatesCopyOption{
+	err := client.Qualitygates.ValidateCopyOpt(&QualitygatesCopyOptions{
 		SourceName: "source",
 	})
 	assert.Error(t, err)
@@ -607,7 +607,7 @@ func TestValidation_EdgeCases(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test Rename - both names too long
-	err = client.Qualitygates.ValidateRenameOpt(&QualitygatesRenameOption{
+	err = client.Qualitygates.ValidateRenameOpt(&QualitygatesRenameOptions{
 		CurrentName: strings.Repeat("a", MaxQualityGateNameLength+1),
 		Name:        "new",
 	})
@@ -618,14 +618,14 @@ func TestValidation_EdgeCases(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test Search groups - invalid selected
-	err = client.Qualitygates.ValidateSearchGroupsOpt(&QualitygatesSearchGroupsOption{
+	err = client.Qualitygates.ValidateSearchGroupsOpt(&QualitygatesSearchGroupsOptions{
 		GateName: "gate",
 		Selected: "invalid",
 	})
 	assert.Error(t, err)
 
 	// Test Search users - invalid selected
-	err = client.Qualitygates.ValidateSearchUsersOpt(&QualitygatesSearchUsersOption{
+	err = client.Qualitygates.ValidateSearchUsersOpt(&QualitygatesSearchUsersOptions{
 		GateName: "gate",
 		Selected: "invalid",
 	})
@@ -664,7 +664,7 @@ func TestValidation_EdgeCases(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test CreateCondition - Error too long
-	err = client.Qualitygates.ValidateCreateConditionOpt(&QualitygatesCreateConditionOption{
+	err = client.Qualitygates.ValidateCreateConditionOpt(&QualitygatesCreateConditionOptions{
 		Error:    strings.Repeat("a", MaxConditionErrorLength+1),
 		GateName: "gate",
 		Metric:   "coverage",

--- a/sonar/qualityprofiles_service.go
+++ b/sonar/qualityprofiles_service.go
@@ -428,10 +428,10 @@ type ShownProfile struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// QualityprofilesActivateRuleOption contains options for activating a rule.
+// QualityprofilesActivateRuleOptions contains options for activating a rule.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type QualityprofilesActivateRuleOption struct {
+type QualityprofilesActivateRuleOptions struct {
 	// Key is the quality profile key (required).
 	Key string `url:"key,omitempty"`
 	// Rule is the rule key (required).
@@ -452,10 +452,10 @@ type QualityprofilesActivateRuleOption struct {
 	Severity string `url:"severity,omitempty"`
 }
 
-// QualityprofilesActivateRulesOption contains options for bulk activating rules.
+// QualityprofilesActivateRulesOptions contains options for bulk activating rules.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type QualityprofilesActivateRulesOption struct {
+type QualityprofilesActivateRulesOptions struct {
 	// TargetKey is the quality profile key on which rules are activated (required).
 	TargetKey string `url:"targetKey,omitempty"`
 	// Activation filters rules that are activated or deactivated on the selected quality profile.
@@ -543,8 +543,8 @@ type QualityprofilesActivateRulesOption struct {
 	Types []string `url:"types,omitempty,comma"`
 }
 
-// QualityprofilesAddGroupOption contains options for allowing a group to edit a profile.
-type QualityprofilesAddGroupOption struct {
+// QualityprofilesAddGroupOptions contains options for allowing a group to edit a profile.
+type QualityprofilesAddGroupOptions struct {
 	// Group is the group name (required).
 	Group string `url:"group,omitempty"`
 	// Language is the quality profile language (required).
@@ -556,8 +556,8 @@ type QualityprofilesAddGroupOption struct {
 	QualityProfile string `url:"qualityProfile,omitempty"`
 }
 
-// QualityprofilesAddProjectOption contains options for associating a project.
-type QualityprofilesAddProjectOption struct {
+// QualityprofilesAddProjectOptions contains options for associating a project.
+type QualityprofilesAddProjectOptions struct {
 	// Language is the quality profile language (required).
 	// Allowed values: 'kubernetes', 'css', 'scala', 'jsp', 'py', 'js', 'docker', 'rust',
 	// 'java', 'web', 'flex', 'xml', 'json', 'ipynb', 'text', 'vbnet', 'cloudformation',
@@ -569,8 +569,8 @@ type QualityprofilesAddProjectOption struct {
 	QualityProfile string `url:"qualityProfile,omitempty"`
 }
 
-// QualityprofilesAddUserOption contains options for allowing a user to edit a profile.
-type QualityprofilesAddUserOption struct {
+// QualityprofilesAddUserOptions contains options for allowing a user to edit a profile.
+type QualityprofilesAddUserOptions struct {
 	// Language is the quality profile language (required).
 	// Allowed values: 'kubernetes', 'css', 'scala', 'jsp', 'py', 'js', 'docker', 'rust',
 	// 'java', 'web', 'flex', 'xml', 'json', 'ipynb', 'text', 'vbnet', 'cloudformation',
@@ -582,8 +582,8 @@ type QualityprofilesAddUserOption struct {
 	QualityProfile string `url:"qualityProfile,omitempty"`
 }
 
-// QualityprofilesBackupOption contains options for backing up a profile.
-type QualityprofilesBackupOption struct {
+// QualityprofilesBackupOptions contains options for backing up a profile.
+type QualityprofilesBackupOptions struct {
 	// Language is the quality profile language (required).
 	// Allowed values: 'kubernetes', 'css', 'scala', 'jsp', 'py', 'js', 'docker', 'rust',
 	// 'java', 'web', 'flex', 'xml', 'json', 'ipynb', 'text', 'vbnet', 'cloudformation',
@@ -593,8 +593,8 @@ type QualityprofilesBackupOption struct {
 	QualityProfile string `url:"qualityProfile,omitempty"`
 }
 
-// QualityprofilesChangeParentOption contains options for changing a profile's parent.
-type QualityprofilesChangeParentOption struct {
+// QualityprofilesChangeParentOptions contains options for changing a profile's parent.
+type QualityprofilesChangeParentOptions struct {
 	// Language is the quality profile language (required).
 	// Allowed values: 'kubernetes', 'css', 'scala', 'jsp', 'py', 'js', 'docker', 'rust',
 	// 'java', 'web', 'flex', 'xml', 'json', 'ipynb', 'text', 'vbnet', 'cloudformation',
@@ -607,10 +607,10 @@ type QualityprofilesChangeParentOption struct {
 	ParentQualityProfile string `url:"parentQualityProfile,omitempty"`
 }
 
-// QualityprofilesChangelogOption contains options for getting a profile's changelog.
+// QualityprofilesChangelogOptions contains options for getting a profile's changelog.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type QualityprofilesChangelogOption struct {
+type QualityprofilesChangelogOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -630,17 +630,17 @@ type QualityprofilesChangelogOption struct {
 	To string `url:"to,omitempty"`
 }
 
-// QualityprofilesCompareOption contains options for comparing two profiles.
+// QualityprofilesCompareOptions contains options for comparing two profiles.
 // WARNING: This endpoint is internal and may change without notice.
-type QualityprofilesCompareOption struct {
+type QualityprofilesCompareOptions struct {
 	// LeftKey is the left profile key (required).
 	LeftKey string `url:"leftKey,omitempty"`
 	// RightKey is the right profile key (required).
 	RightKey string `url:"rightKey,omitempty"`
 }
 
-// QualityprofilesCopyOption contains options for copying a profile.
-type QualityprofilesCopyOption struct {
+// QualityprofilesCopyOptions contains options for copying a profile.
+type QualityprofilesCopyOptions struct {
 	// FromKey is the source quality profile key (required).
 	FromKey string `url:"fromKey,omitempty"`
 	// ToName is the name for the new quality profile (required).
@@ -648,8 +648,8 @@ type QualityprofilesCopyOption struct {
 	ToName string `url:"toName,omitempty"`
 }
 
-// QualityprofilesCreateOption contains options for creating a profile.
-type QualityprofilesCreateOption struct {
+// QualityprofilesCreateOptions contains options for creating a profile.
+type QualityprofilesCreateOptions struct {
 	// Language is the quality profile language (required).
 	// Allowed values: 'kubernetes', 'css', 'scala', 'jsp', 'py', 'js', 'docker', 'rust',
 	// 'java', 'web', 'flex', 'xml', 'json', 'ipynb', 'text', 'vbnet', 'cloudformation',
@@ -660,19 +660,19 @@ type QualityprofilesCreateOption struct {
 	Name string `url:"name,omitempty"`
 }
 
-// QualityprofilesDeactivateRuleOption contains options for deactivating a rule.
-type QualityprofilesDeactivateRuleOption struct {
+// QualityprofilesDeactivateRuleOptions contains options for deactivating a rule.
+type QualityprofilesDeactivateRuleOptions struct {
 	// Key is the quality profile key (required).
 	Key string `url:"key,omitempty"`
 	// Rule is the rule key (required).
 	Rule string `url:"rule,omitempty"`
 }
 
-// QualityprofilesDeactivateRulesOption contains options for bulk deactivating rules.
+// QualityprofilesDeactivateRulesOptions contains options for bulk deactivating rules.
 // Uses the same filter parameters as QualityprofilesActivateRulesOption.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type QualityprofilesDeactivateRulesOption struct {
+type QualityprofilesDeactivateRulesOptions struct {
 	// TargetKey is the quality profile key on which rules are deactivated (required).
 	TargetKey string `url:"targetKey,omitempty"`
 	// Activation filters rules that are activated or deactivated on the selected quality profile.
@@ -753,8 +753,8 @@ type QualityprofilesDeactivateRulesOption struct {
 	Types []string `url:"types,omitempty,comma"`
 }
 
-// QualityprofilesDeleteOption contains options for deleting a profile.
-type QualityprofilesDeleteOption struct {
+// QualityprofilesDeleteOptions contains options for deleting a profile.
+type QualityprofilesDeleteOptions struct {
 	// Language is the quality profile language (required).
 	// Allowed values: 'kubernetes', 'css', 'scala', 'jsp', 'py', 'js', 'docker', 'rust',
 	// 'java', 'web', 'flex', 'xml', 'json', 'ipynb', 'text', 'vbnet', 'cloudformation',
@@ -764,10 +764,10 @@ type QualityprofilesDeleteOption struct {
 	QualityProfile string `url:"qualityProfile,omitempty"`
 }
 
-// QualityprofilesExportOption contains options for exporting a profile.
+// QualityprofilesExportOptions contains options for exporting a profile.
 //
 // Deprecated: Since SonarQube 25.4. Use Backup instead.
-type QualityprofilesExportOption struct {
+type QualityprofilesExportOptions struct {
 	// Language is the quality profile language (required).
 	// Allowed values: 'kubernetes', 'css', 'scala', 'jsp', 'py', 'js', 'docker', 'rust',
 	// 'java', 'web', 'flex', 'xml', 'json', 'ipynb', 'text', 'vbnet', 'cloudformation',
@@ -778,8 +778,8 @@ type QualityprofilesExportOption struct {
 	QualityProfile string `url:"qualityProfile,omitempty"`
 }
 
-// QualityprofilesInheritanceOption contains options for getting inheritance info.
-type QualityprofilesInheritanceOption struct {
+// QualityprofilesInheritanceOptions contains options for getting inheritance info.
+type QualityprofilesInheritanceOptions struct {
 	// Language is the quality profile language (required).
 	// Allowed values: 'kubernetes', 'css', 'scala', 'jsp', 'py', 'js', 'docker', 'rust',
 	// 'java', 'web', 'flex', 'xml', 'json', 'ipynb', 'text', 'vbnet', 'cloudformation',
@@ -789,10 +789,10 @@ type QualityprofilesInheritanceOption struct {
 	QualityProfile string `url:"qualityProfile,omitempty"`
 }
 
-// QualityprofilesProjectsOption contains options for listing associated projects.
+// QualityprofilesProjectsOptions contains options for listing associated projects.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type QualityprofilesProjectsOption struct {
+type QualityprofilesProjectsOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -805,8 +805,8 @@ type QualityprofilesProjectsOption struct {
 	Selected string `url:"selected,omitempty"`
 }
 
-// QualityprofilesRemoveGroupOption contains options for removing group permissions.
-type QualityprofilesRemoveGroupOption struct {
+// QualityprofilesRemoveGroupOptions contains options for removing group permissions.
+type QualityprofilesRemoveGroupOptions struct {
 	// Group is the group name (required).
 	Group string `url:"group,omitempty"`
 	// Language is the quality profile language (required).
@@ -818,8 +818,8 @@ type QualityprofilesRemoveGroupOption struct {
 	QualityProfile string `url:"qualityProfile,omitempty"`
 }
 
-// QualityprofilesRemoveProjectOption contains options for removing a project association.
-type QualityprofilesRemoveProjectOption struct {
+// QualityprofilesRemoveProjectOptions contains options for removing a project association.
+type QualityprofilesRemoveProjectOptions struct {
 	// Language is the quality profile language (required).
 	// Allowed values: 'kubernetes', 'css', 'scala', 'jsp', 'py', 'js', 'docker', 'rust',
 	// 'java', 'web', 'flex', 'xml', 'json', 'ipynb', 'text', 'vbnet', 'cloudformation',
@@ -831,8 +831,8 @@ type QualityprofilesRemoveProjectOption struct {
 	QualityProfile string `url:"qualityProfile,omitempty"`
 }
 
-// QualityprofilesRemoveUserOption contains options for removing user permissions.
-type QualityprofilesRemoveUserOption struct {
+// QualityprofilesRemoveUserOptions contains options for removing user permissions.
+type QualityprofilesRemoveUserOptions struct {
 	// Language is the quality profile language (required).
 	// Allowed values: 'kubernetes', 'css', 'scala', 'jsp', 'py', 'js', 'docker', 'rust',
 	// 'java', 'web', 'flex', 'xml', 'json', 'ipynb', 'text', 'vbnet', 'cloudformation',
@@ -844,8 +844,8 @@ type QualityprofilesRemoveUserOption struct {
 	QualityProfile string `url:"qualityProfile,omitempty"`
 }
 
-// QualityprofilesRenameOption contains options for renaming a profile.
-type QualityprofilesRenameOption struct {
+// QualityprofilesRenameOptions contains options for renaming a profile.
+type QualityprofilesRenameOptions struct {
 	// Key is the quality profile key (required).
 	Key string `url:"key,omitempty"`
 	// Name is the new quality profile name (required).
@@ -853,16 +853,16 @@ type QualityprofilesRenameOption struct {
 	Name string `url:"name,omitempty"`
 }
 
-// QualityprofilesRestoreOption contains options for restoring a profile from backup.
-type QualityprofilesRestoreOption struct {
+// QualityprofilesRestoreOptions contains options for restoring a profile from backup.
+type QualityprofilesRestoreOptions struct {
 	// Backup is the profile backup file content in XML format (required).
 	Backup string `url:"backup,omitempty"`
 }
 
-// QualityprofilesSearchOption contains options for searching profiles.
+// QualityprofilesSearchOptions contains options for searching profiles.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type QualityprofilesSearchOption struct {
+type QualityprofilesSearchOptions struct {
 	// Defaults returns only default profiles if true.
 	Defaults bool `url:"defaults,omitempty"`
 	// Language is the quality profile language.
@@ -876,11 +876,11 @@ type QualityprofilesSearchOption struct {
 	QualityProfile string `url:"qualityProfile,omitempty"`
 }
 
-// QualityprofilesSearchGroupsOption contains options for searching groups.
+// QualityprofilesSearchGroupsOptions contains options for searching groups.
 // WARNING: This endpoint is internal and may change without notice.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type QualityprofilesSearchGroupsOption struct {
+type QualityprofilesSearchGroupsOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -898,10 +898,10 @@ type QualityprofilesSearchGroupsOption struct {
 	Selected string `url:"selected,omitempty"`
 }
 
-// QualityprofilesSearchUsersOption contains options for searching users.
+// QualityprofilesSearchUsersOptions contains options for searching users.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type QualityprofilesSearchUsersOption struct {
+type QualityprofilesSearchUsersOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -916,8 +916,8 @@ type QualityprofilesSearchUsersOption struct {
 	Selected string `url:"selected,omitempty"`
 }
 
-// QualityprofilesSetDefaultOption contains options for setting the default profile.
-type QualityprofilesSetDefaultOption struct {
+// QualityprofilesSetDefaultOptions contains options for setting the default profile.
+type QualityprofilesSetDefaultOptions struct {
 	// Language is the quality profile language (required).
 	// Allowed values: 'kubernetes', 'css', 'scala', 'jsp', 'py', 'js', 'docker', 'rust',
 	// 'java', 'web', 'flex', 'xml', 'json', 'ipynb', 'text', 'vbnet', 'cloudformation',
@@ -927,8 +927,8 @@ type QualityprofilesSetDefaultOption struct {
 	QualityProfile string `url:"qualityProfile,omitempty"`
 }
 
-// QualityprofilesShowOption contains options for showing a profile.
-type QualityprofilesShowOption struct {
+// QualityprofilesShowOptions contains options for showing a profile.
+type QualityprofilesShowOptions struct {
 	// Key is the quality profile key (required).
 	Key string `url:"key,omitempty"`
 	// CompareToSonarWay adds the number of missing rules from related Sonar way profile.
@@ -943,7 +943,7 @@ type QualityprofilesShowOption struct {
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) ActivateRule(opt *QualityprofilesActivateRuleOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) ActivateRule(opt *QualityprofilesActivateRuleOptions) (resp *http.Response, err error) {
 	err = s.ValidateActivateRuleOpt(opt)
 	if err != nil {
 		return
@@ -969,7 +969,7 @@ func (s *QualityprofilesService) ActivateRule(opt *QualityprofilesActivateRuleOp
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) ActivateRules(opt *QualityprofilesActivateRulesOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) ActivateRules(opt *QualityprofilesActivateRulesOptions) (resp *http.Response, err error) {
 	err = s.ValidateActivateRulesOpt(opt)
 	if err != nil {
 		return
@@ -992,7 +992,7 @@ func (s *QualityprofilesService) ActivateRules(opt *QualityprofilesActivateRules
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) AddGroup(opt *QualityprofilesAddGroupOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) AddGroup(opt *QualityprofilesAddGroupOptions) (resp *http.Response, err error) {
 	err = s.ValidateAddGroupOpt(opt)
 	if err != nil {
 		return
@@ -1015,7 +1015,7 @@ func (s *QualityprofilesService) AddGroup(opt *QualityprofilesAddGroupOption) (r
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Administer right on the specified project
-func (s *QualityprofilesService) AddProject(opt *QualityprofilesAddProjectOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) AddProject(opt *QualityprofilesAddProjectOptions) (resp *http.Response, err error) {
 	err = s.ValidateAddProjectOpt(opt)
 	if err != nil {
 		return
@@ -1038,7 +1038,7 @@ func (s *QualityprofilesService) AddProject(opt *QualityprofilesAddProjectOption
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) AddUser(opt *QualityprofilesAddUserOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) AddUser(opt *QualityprofilesAddUserOptions) (resp *http.Response, err error) {
 	err = s.ValidateAddUserOpt(opt)
 	if err != nil {
 		return
@@ -1059,7 +1059,7 @@ func (s *QualityprofilesService) AddUser(opt *QualityprofilesAddUserOption) (res
 
 // Backup backs up a quality profile in XML form.
 // The exported profile can be restored through Restore.
-func (s *QualityprofilesService) Backup(opt *QualityprofilesBackupOption) (v *string, resp *http.Response, err error) {
+func (s *QualityprofilesService) Backup(opt *QualityprofilesBackupOptions) (v *string, resp *http.Response, err error) {
 	err = s.ValidateBackupOpt(opt)
 	if err != nil {
 		return
@@ -1084,7 +1084,7 @@ func (s *QualityprofilesService) Backup(opt *QualityprofilesBackupOption) (v *st
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) ChangeParent(opt *QualityprofilesChangeParentOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) ChangeParent(opt *QualityprofilesChangeParentOptions) (resp *http.Response, err error) {
 	err = s.ValidateChangeParentOpt(opt)
 	if err != nil {
 		return
@@ -1105,7 +1105,7 @@ func (s *QualityprofilesService) ChangeParent(opt *QualityprofilesChangeParentOp
 
 // Changelog gets the history of changes on a quality profile.
 // Events are ordered by date in descending order (most recent first).
-func (s *QualityprofilesService) Changelog(opt *QualityprofilesChangelogOption) (v *QualityprofilesChangelog, resp *http.Response, err error) {
+func (s *QualityprofilesService) Changelog(opt *QualityprofilesChangelogOptions) (v *QualityprofilesChangelog, resp *http.Response, err error) {
 	err = s.ValidateChangelogOpt(opt)
 	if err != nil {
 		return
@@ -1127,7 +1127,7 @@ func (s *QualityprofilesService) Changelog(opt *QualityprofilesChangelogOption) 
 }
 
 // Compare compares two quality profiles.
-func (s *QualityprofilesService) Compare(opt *QualityprofilesCompareOption) (v *QualityprofilesCompare, resp *http.Response, err error) {
+func (s *QualityprofilesService) Compare(opt *QualityprofilesCompareOptions) (v *QualityprofilesCompare, resp *http.Response, err error) {
 	err = s.ValidateCompareOpt(opt)
 	if err != nil {
 		return
@@ -1150,7 +1150,7 @@ func (s *QualityprofilesService) Compare(opt *QualityprofilesCompareOption) (v *
 
 // Copy copies a quality profile.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *QualityprofilesService) Copy(opt *QualityprofilesCopyOption) (v *QualityprofilesCopy, resp *http.Response, err error) {
+func (s *QualityprofilesService) Copy(opt *QualityprofilesCopyOptions) (v *QualityprofilesCopy, resp *http.Response, err error) {
 	err = s.ValidateCopyOpt(opt)
 	if err != nil {
 		return
@@ -1173,7 +1173,7 @@ func (s *QualityprofilesService) Copy(opt *QualityprofilesCopyOption) (v *Qualit
 
 // Create creates a quality profile.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *QualityprofilesService) Create(opt *QualityprofilesCreateOption) (v *QualityprofilesCreate, resp *http.Response, err error) {
+func (s *QualityprofilesService) Create(opt *QualityprofilesCreateOptions) (v *QualityprofilesCreate, resp *http.Response, err error) {
 	err = s.ValidateCreateOpt(opt)
 	if err != nil {
 		return
@@ -1198,7 +1198,7 @@ func (s *QualityprofilesService) Create(opt *QualityprofilesCreateOption) (v *Qu
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) DeactivateRule(opt *QualityprofilesDeactivateRuleOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) DeactivateRule(opt *QualityprofilesDeactivateRuleOptions) (resp *http.Response, err error) {
 	err = s.ValidateDeactivateRuleOpt(opt)
 	if err != nil {
 		return
@@ -1221,7 +1221,7 @@ func (s *QualityprofilesService) DeactivateRule(opt *QualityprofilesDeactivateRu
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) DeactivateRules(opt *QualityprofilesDeactivateRulesOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) DeactivateRules(opt *QualityprofilesDeactivateRulesOptions) (resp *http.Response, err error) {
 	err = s.ValidateDeactivateRulesOpt(opt)
 	if err != nil {
 		return
@@ -1245,7 +1245,7 @@ func (s *QualityprofilesService) DeactivateRules(opt *QualityprofilesDeactivateR
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) Delete(opt *QualityprofilesDeleteOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) Delete(opt *QualityprofilesDeleteOptions) (resp *http.Response, err error) {
 	err = s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return
@@ -1267,7 +1267,7 @@ func (s *QualityprofilesService) Delete(opt *QualityprofilesDeleteOption) (resp 
 // Export exports a quality profile.
 //
 // Deprecated: Since SonarQube 25.4. Use Backup instead.
-func (s *QualityprofilesService) Export(opt *QualityprofilesExportOption) (v *string, resp *http.Response, err error) {
+func (s *QualityprofilesService) Export(opt *QualityprofilesExportOptions) (v *string, resp *http.Response, err error) {
 	err = s.ValidateExportOpt(opt)
 	if err != nil {
 		return
@@ -1327,7 +1327,7 @@ func (s *QualityprofilesService) Importers() (v *QualityprofilesImporters, resp 
 }
 
 // Inheritance shows a quality profile's ancestors and children.
-func (s *QualityprofilesService) Inheritance(opt *QualityprofilesInheritanceOption) (v *QualityprofilesInheritance, resp *http.Response, err error) {
+func (s *QualityprofilesService) Inheritance(opt *QualityprofilesInheritanceOptions) (v *QualityprofilesInheritance, resp *http.Response, err error) {
 	err = s.ValidateInheritanceOpt(opt)
 	if err != nil {
 		return
@@ -1350,7 +1350,7 @@ func (s *QualityprofilesService) Inheritance(opt *QualityprofilesInheritanceOpti
 
 // Projects lists projects with their association status regarding a quality profile.
 // Only projects explicitly bound to the profile are returned.
-func (s *QualityprofilesService) Projects(opt *QualityprofilesProjectsOption) (v *QualityprofilesProjects, resp *http.Response, err error) {
+func (s *QualityprofilesService) Projects(opt *QualityprofilesProjectsOptions) (v *QualityprofilesProjects, resp *http.Response, err error) {
 	err = s.ValidateProjectsOpt(opt)
 	if err != nil {
 		return
@@ -1375,7 +1375,7 @@ func (s *QualityprofilesService) Projects(opt *QualityprofilesProjectsOption) (v
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) RemoveGroup(opt *QualityprofilesRemoveGroupOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) RemoveGroup(opt *QualityprofilesRemoveGroupOptions) (resp *http.Response, err error) {
 	err = s.ValidateRemoveGroupOpt(opt)
 	if err != nil {
 		return
@@ -1399,7 +1399,7 @@ func (s *QualityprofilesService) RemoveGroup(opt *QualityprofilesRemoveGroupOpti
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
 //   - Administer right on the specified project
-func (s *QualityprofilesService) RemoveProject(opt *QualityprofilesRemoveProjectOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) RemoveProject(opt *QualityprofilesRemoveProjectOptions) (resp *http.Response, err error) {
 	err = s.ValidateRemoveProjectOpt(opt)
 	if err != nil {
 		return
@@ -1422,7 +1422,7 @@ func (s *QualityprofilesService) RemoveProject(opt *QualityprofilesRemoveProject
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) RemoveUser(opt *QualityprofilesRemoveUserOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) RemoveUser(opt *QualityprofilesRemoveUserOptions) (resp *http.Response, err error) {
 	err = s.ValidateRemoveUserOpt(opt)
 	if err != nil {
 		return
@@ -1445,7 +1445,7 @@ func (s *QualityprofilesService) RemoveUser(opt *QualityprofilesRemoveUserOption
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) Rename(opt *QualityprofilesRenameOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) Rename(opt *QualityprofilesRenameOptions) (resp *http.Response, err error) {
 	err = s.ValidateRenameOpt(opt)
 	if err != nil {
 		return
@@ -1468,7 +1468,7 @@ func (s *QualityprofilesService) Rename(opt *QualityprofilesRenameOption) (resp 
 // The restored profile name is taken from the backup file.
 // If a profile with the same name and language exists, it will be overwritten.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *QualityprofilesService) Restore(opt *QualityprofilesRestoreOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) Restore(opt *QualityprofilesRestoreOptions) (resp *http.Response, err error) {
 	err = s.ValidateRestoreOpt(opt)
 	if err != nil {
 		return
@@ -1488,7 +1488,7 @@ func (s *QualityprofilesService) Restore(opt *QualityprofilesRestoreOption) (res
 }
 
 // Search searches for quality profiles.
-func (s *QualityprofilesService) Search(opt *QualityprofilesSearchOption) (v *QualityprofilesSearch, resp *http.Response, err error) {
+func (s *QualityprofilesService) Search(opt *QualityprofilesSearchOptions) (v *QualityprofilesSearch, resp *http.Response, err error) {
 	err = s.ValidateSearchOpt(opt)
 	if err != nil {
 		return
@@ -1513,7 +1513,7 @@ func (s *QualityprofilesService) Search(opt *QualityprofilesSearchOption) (v *Qu
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) SearchGroups(opt *QualityprofilesSearchGroupsOption) (v *QualityprofilesSearchGroups, resp *http.Response, err error) {
+func (s *QualityprofilesService) SearchGroups(opt *QualityprofilesSearchGroupsOptions) (v *QualityprofilesSearchGroups, resp *http.Response, err error) {
 	err = s.ValidateSearchGroupsOpt(opt)
 	if err != nil {
 		return
@@ -1538,7 +1538,7 @@ func (s *QualityprofilesService) SearchGroups(opt *QualityprofilesSearchGroupsOp
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) SearchUsers(opt *QualityprofilesSearchUsersOption) (v *QualityprofilesSearchUsers, resp *http.Response, err error) {
+func (s *QualityprofilesService) SearchUsers(opt *QualityprofilesSearchUsersOptions) (v *QualityprofilesSearchUsers, resp *http.Response, err error) {
 	err = s.ValidateSearchUsersOpt(opt)
 	if err != nil {
 		return
@@ -1561,7 +1561,7 @@ func (s *QualityprofilesService) SearchUsers(opt *QualityprofilesSearchUsersOpti
 
 // SetDefault selects the default profile for a given language.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *QualityprofilesService) SetDefault(opt *QualityprofilesSetDefaultOption) (resp *http.Response, err error) {
+func (s *QualityprofilesService) SetDefault(opt *QualityprofilesSetDefaultOptions) (resp *http.Response, err error) {
 	err = s.ValidateSetDefaultOpt(opt)
 	if err != nil {
 		return
@@ -1581,7 +1581,7 @@ func (s *QualityprofilesService) SetDefault(opt *QualityprofilesSetDefaultOption
 }
 
 // Show shows a quality profile.
-func (s *QualityprofilesService) Show(opt *QualityprofilesShowOption) (v *QualityprofilesShow, resp *http.Response, err error) {
+func (s *QualityprofilesService) Show(opt *QualityprofilesShowOptions) (v *QualityprofilesShow, resp *http.Response, err error) {
 	err = s.ValidateShowOpt(opt)
 	if err != nil {
 		return
@@ -1607,7 +1607,7 @@ func (s *QualityprofilesService) Show(opt *QualityprofilesShowOption) (v *Qualit
 // -----------------------------------------------------------------------------
 
 // ValidateActivateRuleOpt validates the options for activating a rule.
-func (s *QualityprofilesService) ValidateActivateRuleOpt(opt *QualityprofilesActivateRuleOption) error {
+func (s *QualityprofilesService) ValidateActivateRuleOpt(opt *QualityprofilesActivateRuleOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesActivateRuleOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1650,7 +1650,7 @@ func (s *QualityprofilesService) ValidateActivateRuleOpt(opt *QualityprofilesAct
 // ValidateActivateRulesOpt validates the options for bulk activating rules.
 //
 //nolint:cyclop,funlen // Validation functions are naturally complex due to multiple checks
-func (s *QualityprofilesService) ValidateActivateRulesOpt(opt *QualityprofilesActivateRulesOption) error {
+func (s *QualityprofilesService) ValidateActivateRulesOpt(opt *QualityprofilesActivateRulesOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesActivateRulesOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1759,7 +1759,7 @@ func (s *QualityprofilesService) ValidateActivateRulesOpt(opt *QualityprofilesAc
 }
 
 // ValidateAddGroupOpt validates the options for adding a group to a quality profile.
-func (s *QualityprofilesService) ValidateAddGroupOpt(opt *QualityprofilesAddGroupOption) error {
+func (s *QualityprofilesService) ValidateAddGroupOpt(opt *QualityprofilesAddGroupOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesAddGroupOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1788,7 +1788,7 @@ func (s *QualityprofilesService) ValidateAddGroupOpt(opt *QualityprofilesAddGrou
 }
 
 // ValidateAddProjectOpt validates the options for associating a project.
-func (s *QualityprofilesService) ValidateAddProjectOpt(opt *QualityprofilesAddProjectOption) error {
+func (s *QualityprofilesService) ValidateAddProjectOpt(opt *QualityprofilesAddProjectOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesAddProjectOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1817,7 +1817,7 @@ func (s *QualityprofilesService) ValidateAddProjectOpt(opt *QualityprofilesAddPr
 }
 
 // ValidateAddUserOpt validates the options for adding a user to a quality profile.
-func (s *QualityprofilesService) ValidateAddUserOpt(opt *QualityprofilesAddUserOption) error {
+func (s *QualityprofilesService) ValidateAddUserOpt(opt *QualityprofilesAddUserOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesAddUserOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1846,7 +1846,7 @@ func (s *QualityprofilesService) ValidateAddUserOpt(opt *QualityprofilesAddUserO
 }
 
 // ValidateBackupOpt validates the options for backing up a profile.
-func (s *QualityprofilesService) ValidateBackupOpt(opt *QualityprofilesBackupOption) error {
+func (s *QualityprofilesService) ValidateBackupOpt(opt *QualityprofilesBackupOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesBackupOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1870,7 +1870,7 @@ func (s *QualityprofilesService) ValidateBackupOpt(opt *QualityprofilesBackupOpt
 }
 
 // ValidateChangeParentOpt validates the options for changing a profile's parent.
-func (s *QualityprofilesService) ValidateChangeParentOpt(opt *QualityprofilesChangeParentOption) error {
+func (s *QualityprofilesService) ValidateChangeParentOpt(opt *QualityprofilesChangeParentOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesChangeParentOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1896,7 +1896,7 @@ func (s *QualityprofilesService) ValidateChangeParentOpt(opt *QualityprofilesCha
 }
 
 // ValidateChangelogOpt validates the options for getting a profile's changelog.
-func (s *QualityprofilesService) ValidateChangelogOpt(opt *QualityprofilesChangelogOption) error {
+func (s *QualityprofilesService) ValidateChangelogOpt(opt *QualityprofilesChangelogOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesChangelogOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1930,7 +1930,7 @@ func (s *QualityprofilesService) ValidateChangelogOpt(opt *QualityprofilesChange
 }
 
 // ValidateCompareOpt validates the options for comparing two profiles.
-func (s *QualityprofilesService) ValidateCompareOpt(opt *QualityprofilesCompareOption) error {
+func (s *QualityprofilesService) ValidateCompareOpt(opt *QualityprofilesCompareOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesCompareOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1949,7 +1949,7 @@ func (s *QualityprofilesService) ValidateCompareOpt(opt *QualityprofilesCompareO
 }
 
 // ValidateCopyOpt validates the options for copying a profile.
-func (s *QualityprofilesService) ValidateCopyOpt(opt *QualityprofilesCopyOption) error {
+func (s *QualityprofilesService) ValidateCopyOpt(opt *QualityprofilesCopyOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesCopyOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1973,7 +1973,7 @@ func (s *QualityprofilesService) ValidateCopyOpt(opt *QualityprofilesCopyOption)
 }
 
 // ValidateCreateOpt validates the options for creating a profile.
-func (s *QualityprofilesService) ValidateCreateOpt(opt *QualityprofilesCreateOption) error {
+func (s *QualityprofilesService) ValidateCreateOpt(opt *QualityprofilesCreateOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesCreateOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2002,7 +2002,7 @@ func (s *QualityprofilesService) ValidateCreateOpt(opt *QualityprofilesCreateOpt
 }
 
 // ValidateDeactivateRuleOpt validates the options for deactivating a rule.
-func (s *QualityprofilesService) ValidateDeactivateRuleOpt(opt *QualityprofilesDeactivateRuleOption) error {
+func (s *QualityprofilesService) ValidateDeactivateRuleOpt(opt *QualityprofilesDeactivateRuleOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesDeactivateRuleOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2021,7 +2021,7 @@ func (s *QualityprofilesService) ValidateDeactivateRuleOpt(opt *QualityprofilesD
 }
 
 // ValidateDeactivateRulesOpt validates the options for bulk deactivating rules.
-func (s *QualityprofilesService) ValidateDeactivateRulesOpt(opt *QualityprofilesDeactivateRulesOption) error {
+func (s *QualityprofilesService) ValidateDeactivateRulesOpt(opt *QualityprofilesDeactivateRulesOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesDeactivateRulesOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2031,14 +2031,14 @@ func (s *QualityprofilesService) ValidateDeactivateRulesOpt(opt *Qualityprofiles
 		return err
 	}
 
-	// Note: DeactivateRulesOption uses string fields for filters instead of slices,
+	// Note: DeactivateRulesOptions uses string fields for filters instead of slices,
 	// which limits granular validation. The API will validate the format.
 
 	return nil
 }
 
 // ValidateDeleteOpt validates the options for deleting a profile.
-func (s *QualityprofilesService) ValidateDeleteOpt(opt *QualityprofilesDeleteOption) error {
+func (s *QualityprofilesService) ValidateDeleteOpt(opt *QualityprofilesDeleteOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesDeleteOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2062,7 +2062,7 @@ func (s *QualityprofilesService) ValidateDeleteOpt(opt *QualityprofilesDeleteOpt
 }
 
 // ValidateExportOpt validates the options for exporting a profile.
-func (s *QualityprofilesService) ValidateExportOpt(opt *QualityprofilesExportOption) error {
+func (s *QualityprofilesService) ValidateExportOpt(opt *QualityprofilesExportOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesExportOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2083,7 +2083,7 @@ func (s *QualityprofilesService) ValidateExportOpt(opt *QualityprofilesExportOpt
 }
 
 // ValidateInheritanceOpt validates the options for getting inheritance info.
-func (s *QualityprofilesService) ValidateInheritanceOpt(opt *QualityprofilesInheritanceOption) error {
+func (s *QualityprofilesService) ValidateInheritanceOpt(opt *QualityprofilesInheritanceOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesInheritanceOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2107,7 +2107,7 @@ func (s *QualityprofilesService) ValidateInheritanceOpt(opt *QualityprofilesInhe
 }
 
 // ValidateProjectsOpt validates the options for listing associated projects.
-func (s *QualityprofilesService) ValidateProjectsOpt(opt *QualityprofilesProjectsOption) error {
+func (s *QualityprofilesService) ValidateProjectsOpt(opt *QualityprofilesProjectsOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesProjectsOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2127,7 +2127,7 @@ func (s *QualityprofilesService) ValidateProjectsOpt(opt *QualityprofilesProject
 }
 
 // ValidateRemoveGroupOpt validates the options for removing group permissions.
-func (s *QualityprofilesService) ValidateRemoveGroupOpt(opt *QualityprofilesRemoveGroupOption) error {
+func (s *QualityprofilesService) ValidateRemoveGroupOpt(opt *QualityprofilesRemoveGroupOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesRemoveGroupOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2156,7 +2156,7 @@ func (s *QualityprofilesService) ValidateRemoveGroupOpt(opt *QualityprofilesRemo
 }
 
 // ValidateRemoveProjectOpt validates the options for removing a project association.
-func (s *QualityprofilesService) ValidateRemoveProjectOpt(opt *QualityprofilesRemoveProjectOption) error {
+func (s *QualityprofilesService) ValidateRemoveProjectOpt(opt *QualityprofilesRemoveProjectOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesRemoveProjectOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2185,7 +2185,7 @@ func (s *QualityprofilesService) ValidateRemoveProjectOpt(opt *QualityprofilesRe
 }
 
 // ValidateRemoveUserOpt validates the options for removing user permissions.
-func (s *QualityprofilesService) ValidateRemoveUserOpt(opt *QualityprofilesRemoveUserOption) error {
+func (s *QualityprofilesService) ValidateRemoveUserOpt(opt *QualityprofilesRemoveUserOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesRemoveUserOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2214,7 +2214,7 @@ func (s *QualityprofilesService) ValidateRemoveUserOpt(opt *QualityprofilesRemov
 }
 
 // ValidateRenameOpt validates the options for renaming a profile.
-func (s *QualityprofilesService) ValidateRenameOpt(opt *QualityprofilesRenameOption) error {
+func (s *QualityprofilesService) ValidateRenameOpt(opt *QualityprofilesRenameOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesRenameOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2238,7 +2238,7 @@ func (s *QualityprofilesService) ValidateRenameOpt(opt *QualityprofilesRenameOpt
 }
 
 // ValidateRestoreOpt validates the options for restoring a profile.
-func (s *QualityprofilesService) ValidateRestoreOpt(opt *QualityprofilesRestoreOption) error {
+func (s *QualityprofilesService) ValidateRestoreOpt(opt *QualityprofilesRestoreOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesRestoreOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2252,7 +2252,7 @@ func (s *QualityprofilesService) ValidateRestoreOpt(opt *QualityprofilesRestoreO
 }
 
 // ValidateSearchOpt validates the options for searching profiles.
-func (s *QualityprofilesService) ValidateSearchOpt(opt *QualityprofilesSearchOption) error {
+func (s *QualityprofilesService) ValidateSearchOpt(opt *QualityprofilesSearchOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesSearchOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2271,7 +2271,7 @@ func (s *QualityprofilesService) ValidateSearchOpt(opt *QualityprofilesSearchOpt
 }
 
 // ValidateSearchGroupsOpt validates the options for searching groups.
-func (s *QualityprofilesService) ValidateSearchGroupsOpt(opt *QualityprofilesSearchGroupsOption) error {
+func (s *QualityprofilesService) ValidateSearchGroupsOpt(opt *QualityprofilesSearchGroupsOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesSearchGroupsOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2301,7 +2301,7 @@ func (s *QualityprofilesService) ValidateSearchGroupsOpt(opt *QualityprofilesSea
 }
 
 // ValidateSearchUsersOpt validates the options for searching users.
-func (s *QualityprofilesService) ValidateSearchUsersOpt(opt *QualityprofilesSearchUsersOption) error {
+func (s *QualityprofilesService) ValidateSearchUsersOpt(opt *QualityprofilesSearchUsersOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesSearchUsersOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2331,7 +2331,7 @@ func (s *QualityprofilesService) ValidateSearchUsersOpt(opt *QualityprofilesSear
 }
 
 // ValidateSetDefaultOpt validates the options for setting the default profile.
-func (s *QualityprofilesService) ValidateSetDefaultOpt(opt *QualityprofilesSetDefaultOption) error {
+func (s *QualityprofilesService) ValidateSetDefaultOpt(opt *QualityprofilesSetDefaultOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesSetDefaultOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2355,7 +2355,7 @@ func (s *QualityprofilesService) ValidateSetDefaultOpt(opt *QualityprofilesSetDe
 }
 
 // ValidateShowOpt validates the options for showing a profile.
-func (s *QualityprofilesService) ValidateShowOpt(opt *QualityprofilesShowOption) error {
+func (s *QualityprofilesService) ValidateShowOpt(opt *QualityprofilesShowOptions) error {
 	if opt == nil {
 		return NewValidationError("QualityprofilesShowOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -2372,10 +2372,10 @@ func (s *QualityprofilesService) ValidateShowOpt(opt *QualityprofilesShowOption)
 // Conversion Functions
 // -----------------------------------------------------------------------------
 
-// convertActivateRuleOptForURL converts QualityprofilesActivateRuleOption to a URL-encodable format.
-func (s *QualityprofilesService) convertActivateRuleOptForURL(opt *QualityprofilesActivateRuleOption) *qualityprofilesActivateRuleURLOption {
+// convertActivateRuleOptForURL converts QualityprofilesActivateRuleOptions to a URL-encodable format.
+func (s *QualityprofilesService) convertActivateRuleOptForURL(opt *QualityprofilesActivateRuleOptions) *qualityprofilesActivateRuleURLOptions {
 	//nolint:exhaustruct // Only populate fields that have values
-	urlOpt := &qualityprofilesActivateRuleURLOption{
+	urlOpt := &qualityprofilesActivateRuleURLOptions{
 		Key:             opt.Key,
 		Rule:            opt.Rule,
 		PrioritizedRule: opt.PrioritizedRule,
@@ -2395,10 +2395,10 @@ func (s *QualityprofilesService) convertActivateRuleOptForURL(opt *Qualityprofil
 	return urlOpt
 }
 
-// qualityprofilesActivateRuleURLOption is the URL-encodable version of QualityprofilesActivateRuleOption.
+// qualityprofilesActivateRuleURLOptions is the URL-encodable version of QualityprofilesActivateRuleOption.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type qualityprofilesActivateRuleURLOption struct {
+type qualityprofilesActivateRuleURLOptions struct {
 	Key             string `url:"key,omitempty"`
 	Rule            string `url:"rule,omitempty"`
 	Impacts         string `url:"impacts,omitempty"`

--- a/sonar/qualityprofiles_service_test.go
+++ b/sonar/qualityprofiles_service_test.go
@@ -13,7 +13,7 @@ func TestQualityprofiles_ActivateRule(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/activate_rule", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesActivateRuleOption{
+	opt := &QualityprofilesActivateRuleOptions{
 		Key:  "AU-TpxcA-iU5OvuD2FL0",
 		Rule: "squid:AvoidCycles",
 	}
@@ -31,19 +31,19 @@ func TestQualityprofiles_ActivateRule_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOption{
+	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
 		Rule: "squid:AvoidCycles",
 	})
 	assert.Error(t, err)
 
 	// Test missing Rule
-	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOption{
+	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
 		Key: "AU-TpxcA-iU5OvuD2FL0",
 	})
 	assert.Error(t, err)
 
 	// Test both Impacts and Severity set
-	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOption{
+	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
 		Key:      "AU-TpxcA-iU5OvuD2FL0",
 		Rule:     "squid:AvoidCycles",
 		Impacts:  map[string]string{"MAINTAINABILITY": "HIGH"},
@@ -52,7 +52,7 @@ func TestQualityprofiles_ActivateRule_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test invalid Severity
-	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOption{
+	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
 		Key:      "AU-TpxcA-iU5OvuD2FL0",
 		Rule:     "squid:AvoidCycles",
 		Severity: "INVALID",
@@ -60,7 +60,7 @@ func TestQualityprofiles_ActivateRule_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test invalid Impacts map key (software quality)
-	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOption{
+	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
 		Key:     "AU-TpxcA-iU5OvuD2FL0",
 		Rule:    "squid:AvoidCycles",
 		Impacts: map[string]string{"INVALID_QUALITY": "HIGH"},
@@ -68,7 +68,7 @@ func TestQualityprofiles_ActivateRule_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test invalid Impacts map value (severity)
-	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOption{
+	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
 		Key:     "AU-TpxcA-iU5OvuD2FL0",
 		Rule:    "squid:AvoidCycles",
 		Impacts: map[string]string{"MAINTAINABILITY": "INVALID_SEVERITY"},
@@ -80,7 +80,7 @@ func TestQualityprofiles_ActivateRules(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/activate_rules", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesActivateRulesOption{
+	opt := &QualityprofilesActivateRulesOptions{
 		TargetKey: "AU-TpxcA-iU5OvuD2FL0",
 		Languages: []string{"java"},
 	}
@@ -98,39 +98,39 @@ func TestQualityprofiles_ActivateRules_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing TargetKey
-	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOption{})
+	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOptions{})
 	assert.Error(t, err)
 
 	// Test invalid language
-	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOption{
+	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOptions{
 		TargetKey: "AU-TpxcA-iU5OvuD2FL0",
 		Languages: []string{"invalid_language"},
 	})
 	assert.Error(t, err)
 
 	// Test invalid severity
-	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOption{
+	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOptions{
 		TargetKey:  "AU-TpxcA-iU5OvuD2FL0",
 		Severities: []string{"INVALID_SEVERITY"},
 	})
 	assert.Error(t, err)
 
 	// Test invalid impact severity
-	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOption{
+	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOptions{
 		TargetKey:        "AU-TpxcA-iU5OvuD2FL0",
 		ImpactSeverities: []string{"INVALID"},
 	})
 	assert.Error(t, err)
 
 	// Test invalid software quality
-	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOption{
+	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOptions{
 		TargetKey:               "AU-TpxcA-iU5OvuD2FL0",
 		ImpactSoftwareQualities: []string{"INVALID"},
 	})
 	assert.Error(t, err)
 
 	// Test invalid sort field
-	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOption{
+	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOptions{
 		TargetKey: "AU-TpxcA-iU5OvuD2FL0",
 		Sort:      "invalid_sort",
 	})
@@ -141,7 +141,7 @@ func TestQualityprofiles_AddGroup(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/add_group", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesAddGroupOption{
+	opt := &QualityprofilesAddGroupOptions{
 		Group:          "sonar-administrators",
 		Language:       "java",
 		QualityProfile: "Sonar way",
@@ -160,21 +160,21 @@ func TestQualityprofiles_AddGroup_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Group
-	_, err = client.Qualityprofiles.AddGroup(&QualityprofilesAddGroupOption{
+	_, err = client.Qualityprofiles.AddGroup(&QualityprofilesAddGroupOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.AddGroup(&QualityprofilesAddGroupOption{
+	_, err = client.Qualityprofiles.AddGroup(&QualityprofilesAddGroupOptions{
 		Group:          "sonar-administrators",
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test invalid Language
-	_, err = client.Qualityprofiles.AddGroup(&QualityprofilesAddGroupOption{
+	_, err = client.Qualityprofiles.AddGroup(&QualityprofilesAddGroupOptions{
 		Group:          "sonar-administrators",
 		Language:       "invalid_lang",
 		QualityProfile: "Sonar way",
@@ -182,7 +182,7 @@ func TestQualityprofiles_AddGroup_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, err = client.Qualityprofiles.AddGroup(&QualityprofilesAddGroupOption{
+	_, err = client.Qualityprofiles.AddGroup(&QualityprofilesAddGroupOptions{
 		Group:    "sonar-administrators",
 		Language: "java",
 	})
@@ -193,7 +193,7 @@ func TestQualityprofiles_AddProject(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/add_project", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesAddProjectOption{
+	opt := &QualityprofilesAddProjectOptions{
 		Language:       "java",
 		Project:        "my_project",
 		QualityProfile: "Sonar way",
@@ -212,21 +212,21 @@ func TestQualityprofiles_AddProject_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.AddProject(&QualityprofilesAddProjectOption{
+	_, err = client.Qualityprofiles.AddProject(&QualityprofilesAddProjectOptions{
 		Project:        "my_project",
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing Project
-	_, err = client.Qualityprofiles.AddProject(&QualityprofilesAddProjectOption{
+	_, err = client.Qualityprofiles.AddProject(&QualityprofilesAddProjectOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, err = client.Qualityprofiles.AddProject(&QualityprofilesAddProjectOption{
+	_, err = client.Qualityprofiles.AddProject(&QualityprofilesAddProjectOptions{
 		Language: "java",
 		Project:  "my_project",
 	})
@@ -237,7 +237,7 @@ func TestQualityprofiles_AddUser(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/add_user", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesAddUserOption{
+	opt := &QualityprofilesAddUserOptions{
 		Language:       "java",
 		Login:          "john.doe",
 		QualityProfile: "Sonar way",
@@ -256,21 +256,21 @@ func TestQualityprofiles_AddUser_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.AddUser(&QualityprofilesAddUserOption{
+	_, err = client.Qualityprofiles.AddUser(&QualityprofilesAddUserOptions{
 		Login:          "john.doe",
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing Login
-	_, err = client.Qualityprofiles.AddUser(&QualityprofilesAddUserOption{
+	_, err = client.Qualityprofiles.AddUser(&QualityprofilesAddUserOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, err = client.Qualityprofiles.AddUser(&QualityprofilesAddUserOption{
+	_, err = client.Qualityprofiles.AddUser(&QualityprofilesAddUserOptions{
 		Language: "java",
 		Login:    "john.doe",
 	})
@@ -287,7 +287,7 @@ func TestQualityprofiles_Backup(t *testing.T) {
 	})
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesBackupOption{
+	opt := &QualityprofilesBackupOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 	}
@@ -307,13 +307,13 @@ func TestQualityprofiles_Backup_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, _, err = client.Qualityprofiles.Backup(&QualityprofilesBackupOption{
+	_, _, err = client.Qualityprofiles.Backup(&QualityprofilesBackupOptions{
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, _, err = client.Qualityprofiles.Backup(&QualityprofilesBackupOption{
+	_, _, err = client.Qualityprofiles.Backup(&QualityprofilesBackupOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
@@ -323,7 +323,7 @@ func TestQualityprofiles_ChangeParent(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/change_parent", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesChangeParentOption{
+	opt := &QualityprofilesChangeParentOptions{
 		Language:             "java",
 		QualityProfile:       "My Profile",
 		ParentQualityProfile: "Sonar way",
@@ -342,13 +342,13 @@ func TestQualityprofiles_ChangeParent_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.ChangeParent(&QualityprofilesChangeParentOption{
+	_, err = client.Qualityprofiles.ChangeParent(&QualityprofilesChangeParentOptions{
 		QualityProfile: "My Profile",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, err = client.Qualityprofiles.ChangeParent(&QualityprofilesChangeParentOption{
+	_, err = client.Qualityprofiles.ChangeParent(&QualityprofilesChangeParentOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
@@ -370,7 +370,7 @@ func TestQualityprofiles_Changelog(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualityprofiles/changelog", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesChangelogOption{
+	opt := &QualityprofilesChangelogOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 	}
@@ -391,19 +391,19 @@ func TestQualityprofiles_Changelog_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, _, err = client.Qualityprofiles.Changelog(&QualityprofilesChangelogOption{
+	_, _, err = client.Qualityprofiles.Changelog(&QualityprofilesChangelogOptions{
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, _, err = client.Qualityprofiles.Changelog(&QualityprofilesChangelogOption{
+	_, _, err = client.Qualityprofiles.Changelog(&QualityprofilesChangelogOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
 
 	// Test invalid FilterMode
-	_, _, err = client.Qualityprofiles.Changelog(&QualityprofilesChangelogOption{
+	_, _, err = client.Qualityprofiles.Changelog(&QualityprofilesChangelogOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 		FilterMode:     "INVALID",
@@ -426,7 +426,7 @@ func TestQualityprofiles_Compare(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualityprofiles/compare", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesCompareOption{
+	opt := &QualityprofilesCompareOptions{
 		LeftKey:  "profile1",
 		RightKey: "profile2",
 	}
@@ -447,13 +447,13 @@ func TestQualityprofiles_Compare_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing LeftKey
-	_, _, err = client.Qualityprofiles.Compare(&QualityprofilesCompareOption{
+	_, _, err = client.Qualityprofiles.Compare(&QualityprofilesCompareOptions{
 		RightKey: "profile2",
 	})
 	assert.Error(t, err)
 
 	// Test missing RightKey
-	_, _, err = client.Qualityprofiles.Compare(&QualityprofilesCompareOption{
+	_, _, err = client.Qualityprofiles.Compare(&QualityprofilesCompareOptions{
 		LeftKey: "profile1",
 	})
 	assert.Error(t, err)
@@ -472,7 +472,7 @@ func TestQualityprofiles_Copy(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/qualityprofiles/copy", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesCopyOption{
+	opt := &QualityprofilesCopyOptions{
 		FromKey: "source-profile-key",
 		ToName:  "My Profile Copy",
 	}
@@ -492,19 +492,19 @@ func TestQualityprofiles_Copy_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing FromKey
-	_, _, err = client.Qualityprofiles.Copy(&QualityprofilesCopyOption{
+	_, _, err = client.Qualityprofiles.Copy(&QualityprofilesCopyOptions{
 		ToName: "New Profile",
 	})
 	assert.Error(t, err)
 
 	// Test missing ToName
-	_, _, err = client.Qualityprofiles.Copy(&QualityprofilesCopyOption{
+	_, _, err = client.Qualityprofiles.Copy(&QualityprofilesCopyOptions{
 		FromKey: "source-key",
 	})
 	assert.Error(t, err)
 
 	// Test ToName too long
-	_, _, err = client.Qualityprofiles.Copy(&QualityprofilesCopyOption{
+	_, _, err = client.Qualityprofiles.Copy(&QualityprofilesCopyOptions{
 		FromKey: "source-key",
 		ToName:  strings.Repeat("a", MaxQualityProfileNameLength+1),
 	})
@@ -525,7 +525,7 @@ func TestQualityprofiles_Create(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/qualityprofiles/create", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesCreateOption{
+	opt := &QualityprofilesCreateOptions{
 		Language: "java",
 		Name:     "My New Profile",
 	}
@@ -545,19 +545,19 @@ func TestQualityprofiles_Create_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, _, err = client.Qualityprofiles.Create(&QualityprofilesCreateOption{
+	_, _, err = client.Qualityprofiles.Create(&QualityprofilesCreateOptions{
 		Name: "My Profile",
 	})
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, _, err = client.Qualityprofiles.Create(&QualityprofilesCreateOption{
+	_, _, err = client.Qualityprofiles.Create(&QualityprofilesCreateOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
 
 	// Test Name too long
-	_, _, err = client.Qualityprofiles.Create(&QualityprofilesCreateOption{
+	_, _, err = client.Qualityprofiles.Create(&QualityprofilesCreateOptions{
 		Language: "java",
 		Name:     strings.Repeat("a", MaxQualityProfileNameLength+1),
 	})
@@ -568,7 +568,7 @@ func TestQualityprofiles_DeactivateRule(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/deactivate_rule", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesDeactivateRuleOption{
+	opt := &QualityprofilesDeactivateRuleOptions{
 		Key:  "AU-TpxcA-iU5OvuD2FL0",
 		Rule: "squid:AvoidCycles",
 	}
@@ -586,13 +586,13 @@ func TestQualityprofiles_DeactivateRule_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.Qualityprofiles.DeactivateRule(&QualityprofilesDeactivateRuleOption{
+	_, err = client.Qualityprofiles.DeactivateRule(&QualityprofilesDeactivateRuleOptions{
 		Rule: "squid:AvoidCycles",
 	})
 	assert.Error(t, err)
 
 	// Test missing Rule
-	_, err = client.Qualityprofiles.DeactivateRule(&QualityprofilesDeactivateRuleOption{
+	_, err = client.Qualityprofiles.DeactivateRule(&QualityprofilesDeactivateRuleOptions{
 		Key: "AU-TpxcA-iU5OvuD2FL0",
 	})
 	assert.Error(t, err)
@@ -602,7 +602,7 @@ func TestQualityprofiles_DeactivateRules(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/deactivate_rules", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesDeactivateRulesOption{
+	opt := &QualityprofilesDeactivateRulesOptions{
 		TargetKey: "AU-TpxcA-iU5OvuD2FL0",
 		Languages: []string{"java"},
 	}
@@ -620,7 +620,7 @@ func TestQualityprofiles_DeactivateRules_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing TargetKey
-	_, err = client.Qualityprofiles.DeactivateRules(&QualityprofilesDeactivateRulesOption{})
+	_, err = client.Qualityprofiles.DeactivateRules(&QualityprofilesDeactivateRulesOptions{})
 	assert.Error(t, err)
 }
 
@@ -628,7 +628,7 @@ func TestQualityprofiles_Delete(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/delete", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesDeleteOption{
+	opt := &QualityprofilesDeleteOptions{
 		Language:       "java",
 		QualityProfile: "My Profile",
 	}
@@ -646,13 +646,13 @@ func TestQualityprofiles_Delete_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.Delete(&QualityprofilesDeleteOption{
+	_, err = client.Qualityprofiles.Delete(&QualityprofilesDeleteOptions{
 		QualityProfile: "My Profile",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, err = client.Qualityprofiles.Delete(&QualityprofilesDeleteOption{
+	_, err = client.Qualityprofiles.Delete(&QualityprofilesDeleteOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
@@ -668,7 +668,7 @@ func TestQualityprofiles_Export(t *testing.T) {
 	})
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesExportOption{
+	opt := &QualityprofilesExportOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 	}
@@ -688,7 +688,7 @@ func TestQualityprofiles_Export_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, _, err = client.Qualityprofiles.Export(&QualityprofilesExportOption{})
+	_, _, err = client.Qualityprofiles.Export(&QualityprofilesExportOptions{})
 	assert.Error(t, err)
 }
 
@@ -744,7 +744,7 @@ func TestQualityprofiles_Inheritance(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualityprofiles/inheritance", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesInheritanceOption{
+	opt := &QualityprofilesInheritanceOptions{
 		Language:       "java",
 		QualityProfile: "My Profile",
 	}
@@ -766,13 +766,13 @@ func TestQualityprofiles_Inheritance_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, _, err = client.Qualityprofiles.Inheritance(&QualityprofilesInheritanceOption{
+	_, _, err = client.Qualityprofiles.Inheritance(&QualityprofilesInheritanceOptions{
 		QualityProfile: "My Profile",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, _, err = client.Qualityprofiles.Inheritance(&QualityprofilesInheritanceOption{
+	_, _, err = client.Qualityprofiles.Inheritance(&QualityprofilesInheritanceOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
@@ -790,7 +790,7 @@ func TestQualityprofiles_Projects(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualityprofiles/projects", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesProjectsOption{
+	opt := &QualityprofilesProjectsOptions{
 		Key: "profile-key",
 	}
 
@@ -810,11 +810,11 @@ func TestQualityprofiles_Projects_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, _, err = client.Qualityprofiles.Projects(&QualityprofilesProjectsOption{})
+	_, _, err = client.Qualityprofiles.Projects(&QualityprofilesProjectsOptions{})
 	assert.Error(t, err)
 
 	// Test invalid Selected
-	_, _, err = client.Qualityprofiles.Projects(&QualityprofilesProjectsOption{
+	_, _, err = client.Qualityprofiles.Projects(&QualityprofilesProjectsOptions{
 		Key:      "profile-key",
 		Selected: "invalid",
 	})
@@ -825,7 +825,7 @@ func TestQualityprofiles_RemoveGroup(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/remove_group", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesRemoveGroupOption{
+	opt := &QualityprofilesRemoveGroupOptions{
 		Group:          "sonar-administrators",
 		Language:       "java",
 		QualityProfile: "Sonar way",
@@ -844,7 +844,7 @@ func TestQualityprofiles_RemoveGroup_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Group
-	_, err = client.Qualityprofiles.RemoveGroup(&QualityprofilesRemoveGroupOption{
+	_, err = client.Qualityprofiles.RemoveGroup(&QualityprofilesRemoveGroupOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 	})
@@ -855,7 +855,7 @@ func TestQualityprofiles_RemoveProject(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/remove_project", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesRemoveProjectOption{
+	opt := &QualityprofilesRemoveProjectOptions{
 		Language:       "java",
 		Project:        "my_project",
 		QualityProfile: "Sonar way",
@@ -874,7 +874,7 @@ func TestQualityprofiles_RemoveProject_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.RemoveProject(&QualityprofilesRemoveProjectOption{
+	_, err = client.Qualityprofiles.RemoveProject(&QualityprofilesRemoveProjectOptions{
 		Project:        "my_project",
 		QualityProfile: "Sonar way",
 	})
@@ -885,7 +885,7 @@ func TestQualityprofiles_RemoveUser(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/remove_user", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesRemoveUserOption{
+	opt := &QualityprofilesRemoveUserOptions{
 		Language:       "java",
 		Login:          "john.doe",
 		QualityProfile: "Sonar way",
@@ -904,7 +904,7 @@ func TestQualityprofiles_RemoveUser_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.RemoveUser(&QualityprofilesRemoveUserOption{
+	_, err = client.Qualityprofiles.RemoveUser(&QualityprofilesRemoveUserOptions{
 		Login:          "john.doe",
 		QualityProfile: "Sonar way",
 	})
@@ -915,7 +915,7 @@ func TestQualityprofiles_Rename(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/rename", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesRenameOption{
+	opt := &QualityprofilesRenameOptions{
 		Key:  "profile-key",
 		Name: "New Profile Name",
 	}
@@ -933,19 +933,19 @@ func TestQualityprofiles_Rename_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.Qualityprofiles.Rename(&QualityprofilesRenameOption{
+	_, err = client.Qualityprofiles.Rename(&QualityprofilesRenameOptions{
 		Name: "New Name",
 	})
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, err = client.Qualityprofiles.Rename(&QualityprofilesRenameOption{
+	_, err = client.Qualityprofiles.Rename(&QualityprofilesRenameOptions{
 		Key: "profile-key",
 	})
 	assert.Error(t, err)
 
 	// Test Name too long
-	_, err = client.Qualityprofiles.Rename(&QualityprofilesRenameOption{
+	_, err = client.Qualityprofiles.Rename(&QualityprofilesRenameOptions{
 		Key:  "profile-key",
 		Name: strings.Repeat("a", MaxQualityProfileNameLength+1),
 	})
@@ -956,7 +956,7 @@ func TestQualityprofiles_Restore(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/restore", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesRestoreOption{
+	opt := &QualityprofilesRestoreOptions{
 		Backup: `<?xml version='1.0'?><profile><name>My Profile</name></profile>`,
 	}
 
@@ -973,7 +973,7 @@ func TestQualityprofiles_Restore_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Backup
-	_, err = client.Qualityprofiles.Restore(&QualityprofilesRestoreOption{})
+	_, err = client.Qualityprofiles.Restore(&QualityprofilesRestoreOptions{})
 	assert.Error(t, err)
 }
 
@@ -1005,7 +1005,7 @@ func TestQualityprofiles_Search(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualityprofiles/search", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesSearchOption{
+	opt := &QualityprofilesSearchOptions{
 		Language: "java",
 	}
 
@@ -1037,7 +1037,7 @@ func TestQualityprofiles_SearchGroups(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualityprofiles/search_groups", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesSearchGroupsOption{
+	opt := &QualityprofilesSearchGroupsOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 	}
@@ -1058,19 +1058,19 @@ func TestQualityprofiles_SearchGroups_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, _, err = client.Qualityprofiles.SearchGroups(&QualityprofilesSearchGroupsOption{
+	_, _, err = client.Qualityprofiles.SearchGroups(&QualityprofilesSearchGroupsOptions{
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, _, err = client.Qualityprofiles.SearchGroups(&QualityprofilesSearchGroupsOption{
+	_, _, err = client.Qualityprofiles.SearchGroups(&QualityprofilesSearchGroupsOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
 
 	// Test invalid Selected
-	_, _, err = client.Qualityprofiles.SearchGroups(&QualityprofilesSearchGroupsOption{
+	_, _, err = client.Qualityprofiles.SearchGroups(&QualityprofilesSearchGroupsOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 		Selected:       "invalid",
@@ -1089,7 +1089,7 @@ func TestQualityprofiles_SearchUsers(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualityprofiles/search_users", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesSearchUsersOption{
+	opt := &QualityprofilesSearchUsersOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 	}
@@ -1110,19 +1110,19 @@ func TestQualityprofiles_SearchUsers_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, _, err = client.Qualityprofiles.SearchUsers(&QualityprofilesSearchUsersOption{
+	_, _, err = client.Qualityprofiles.SearchUsers(&QualityprofilesSearchUsersOptions{
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, _, err = client.Qualityprofiles.SearchUsers(&QualityprofilesSearchUsersOption{
+	_, _, err = client.Qualityprofiles.SearchUsers(&QualityprofilesSearchUsersOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
 
 	// Test invalid Selected
-	_, _, err = client.Qualityprofiles.SearchUsers(&QualityprofilesSearchUsersOption{
+	_, _, err = client.Qualityprofiles.SearchUsers(&QualityprofilesSearchUsersOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 		Selected:       "invalid",
@@ -1134,7 +1134,7 @@ func TestQualityprofiles_SetDefault(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualityprofiles/set_default", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesSetDefaultOption{
+	opt := &QualityprofilesSetDefaultOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 	}
@@ -1152,13 +1152,13 @@ func TestQualityprofiles_SetDefault_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.SetDefault(&QualityprofilesSetDefaultOption{
+	_, err = client.Qualityprofiles.SetDefault(&QualityprofilesSetDefaultOptions{
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, err = client.Qualityprofiles.SetDefault(&QualityprofilesSetDefaultOption{
+	_, err = client.Qualityprofiles.SetDefault(&QualityprofilesSetDefaultOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
@@ -1180,7 +1180,7 @@ func TestQualityprofiles_Show(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualityprofiles/show", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualityprofilesShowOption{
+	opt := &QualityprofilesShowOptions{
 		Key: "sonar-way-java",
 	}
 
@@ -1200,14 +1200,14 @@ func TestQualityprofiles_Show_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, _, err = client.Qualityprofiles.Show(&QualityprofilesShowOption{})
+	_, _, err = client.Qualityprofiles.Show(&QualityprofilesShowOptions{})
 	assert.Error(t, err)
 }
 
 func TestQualityprofiles_ConvertActivateRuleOptForURL(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	opt := &QualityprofilesActivateRuleOption{
+	opt := &QualityprofilesActivateRuleOptions{
 		Key:             "AU-TpxcA-iU5OvuD2FL0",
 		Rule:            "squid:AvoidCycles",
 		Impacts:         map[string]string{"MAINTAINABILITY": "HIGH", "SECURITY": "MEDIUM"},

--- a/sonar/rules_service.go
+++ b/sonar/rules_service.go
@@ -280,8 +280,8 @@ type RulesUpdate struct {
 	Rule Rule `json:"rule,omitzero"`
 }
 
-// RulesCreateOption contains options for creating a custom rule.
-type RulesCreateOption struct {
+// RulesCreateOptions contains options for creating a custom rule.
+type RulesCreateOptions struct {
 	// CleanCodeAttribute represents the Clean Code Attribute associated with the rule.
 	// Allowed values: CONVENTIONAL, FORMATTED, IDENTIFIABLE, CLEAR, COMPLETE, EFFICIENT,
 	// LOGICAL, DISTINCT, FOCUSED, MODULAR, TESTED, LAWFUL, RESPECTFUL, TRUSTWORTHY
@@ -317,17 +317,17 @@ type RulesCreateOption struct {
 	Type string `url:"type,omitempty"`
 }
 
-// RulesDeleteOption contains options for deleting a custom rule.
-type RulesDeleteOption struct {
+// RulesDeleteOptions contains options for deleting a custom rule.
+type RulesDeleteOptions struct {
 	// Key is the unique identifier of the rule to be deleted (required).
 	Key string `url:"key,omitempty"`
 }
 
-// RulesListOption contains options for listing rules.
+// RulesListOptions contains options for listing rules.
 // WARNING: Internal endpoint, may change without notice.
 //
 //nolint:govet // Field alignment is less important than logical grouping and readability
-type RulesListOption struct {
+type RulesListOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -343,8 +343,8 @@ type RulesListOption struct {
 	Asc bool `url:"asc,omitempty"`
 }
 
-// RulesRepositoriesOption contains options for listing rule repositories.
-type RulesRepositoriesOption struct {
+// RulesRepositoriesOptions contains options for listing rule repositories.
+type RulesRepositoriesOptions struct {
 	// Language filters repositories by programming language.
 	// If provided, only repositories for the given language will be returned.
 	Language string `url:"language,omitempty"`
@@ -352,10 +352,10 @@ type RulesRepositoriesOption struct {
 	Query string `url:"q,omitempty"`
 }
 
-// RulesSearchOption contains options for searching rules.
+// RulesSearchOptions contains options for searching rules.
 //
 //nolint:govet // Field alignment is less important than logical grouping and readability
-type RulesSearchOption struct {
+type RulesSearchOptions struct {
 	// PaginationArgs contains pagination parameters.
 	PaginationArgs `url:",inline"`
 
@@ -462,24 +462,24 @@ type RulesSearchOption struct {
 	Types []string `url:"types,omitempty,comma"`
 }
 
-// RulesShowOption contains options for showing a specific rule.
-type RulesShowOption struct {
+// RulesShowOptions contains options for showing a specific rule.
+type RulesShowOptions struct {
 	// Key is the unique identifier of the rule to be retrieved (required).
 	Key string `url:"key,omitempty"`
 	// Actives determines whether to include the list of quality profiles where the rule is active.
 	Actives bool `url:"actives,omitempty"`
 }
 
-// RulesTagsOption contains options for listing rule tags.
-type RulesTagsOption struct {
+// RulesTagsOptions contains options for listing rule tags.
+type RulesTagsOptions struct {
 	// Query limits the search to tags containing the supplied string.
 	Query string `url:"q,omitempty"`
 	// PageSize is the response page size (must be greater than 0 and less than or equal to 500).
 	PageSize int64 `url:"ps,omitempty"`
 }
 
-// RulesUpdateOption contains options for updating a rule.
-type RulesUpdateOption struct {
+// RulesUpdateOptions contains options for updating a rule.
+type RulesUpdateOptions struct {
 	// Impacts is a map of software quality to severity (e.g., MAINTAINABILITY: HIGH, SECURITY: LOW).
 	// Allowed keys: MAINTAINABILITY, RELIABILITY, SECURITY
 	// Allowed values: INFO, LOW, MEDIUM, HIGH, BLOCKER
@@ -537,7 +537,7 @@ func (s *RulesService) App() (v *RulesApp, resp *http.Response, err error) {
 
 // Create creates a custom rule.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *RulesService) Create(opt *RulesCreateOption) (v *RulesCreate, resp *http.Response, err error) {
+func (s *RulesService) Create(opt *RulesCreateOptions) (v *RulesCreate, resp *http.Response, err error) {
 	err = s.ValidateCreateOpt(opt)
 	if err != nil {
 		return
@@ -563,7 +563,7 @@ func (s *RulesService) Create(opt *RulesCreateOption) (v *RulesCreate, resp *htt
 
 // Delete deletes a custom rule.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *RulesService) Delete(opt *RulesDeleteOption) (resp *http.Response, err error) {
+func (s *RulesService) Delete(opt *RulesDeleteOptions) (resp *http.Response, err error) {
 	err = s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return
@@ -583,7 +583,7 @@ func (s *RulesService) Delete(opt *RulesDeleteOption) (resp *http.Response, err 
 }
 
 // List lists rules, excluding external rules and rules with status REMOVED.
-func (s *RulesService) List(opt *RulesListOption) (v *string, resp *http.Response, err error) {
+func (s *RulesService) List(opt *RulesListOptions) (v *string, resp *http.Response, err error) {
 	err = s.ValidateListOpt(opt)
 	if err != nil {
 		return
@@ -605,7 +605,7 @@ func (s *RulesService) List(opt *RulesListOption) (v *string, resp *http.Respons
 }
 
 // Repositories lists available rule repositories.
-func (s *RulesService) Repositories(opt *RulesRepositoriesOption) (v *RulesRepositories, resp *http.Response, err error) {
+func (s *RulesService) Repositories(opt *RulesRepositoriesOptions) (v *RulesRepositories, resp *http.Response, err error) {
 	err = s.ValidateRepositoriesOpt(opt)
 	if err != nil {
 		return
@@ -627,7 +627,7 @@ func (s *RulesService) Repositories(opt *RulesRepositoriesOption) (v *RulesRepos
 }
 
 // Search searches for a collection of relevant rules matching a specified query.
-func (s *RulesService) Search(opt *RulesSearchOption) (v *RulesSearch, resp *http.Response, err error) {
+func (s *RulesService) Search(opt *RulesSearchOptions) (v *RulesSearch, resp *http.Response, err error) {
 	err = s.ValidateSearchOpt(opt)
 	if err != nil {
 		return
@@ -652,7 +652,7 @@ func (s *RulesService) Search(opt *RulesSearchOption) (v *RulesSearch, resp *htt
 }
 
 // Show retrieves detailed information about a specific rule.
-func (s *RulesService) Show(opt *RulesShowOption) (v *RulesShow, resp *http.Response, err error) {
+func (s *RulesService) Show(opt *RulesShowOptions) (v *RulesShow, resp *http.Response, err error) {
 	err = s.ValidateShowOpt(opt)
 	if err != nil {
 		return
@@ -674,7 +674,7 @@ func (s *RulesService) Show(opt *RulesShowOption) (v *RulesShow, resp *http.Resp
 }
 
 // Tags lists all available rule tags.
-func (s *RulesService) Tags(opt *RulesTagsOption) (v *RulesTags, resp *http.Response, err error) {
+func (s *RulesService) Tags(opt *RulesTagsOptions) (v *RulesTags, resp *http.Response, err error) {
 	err = s.ValidateTagsOpt(opt)
 	if err != nil {
 		return
@@ -697,7 +697,7 @@ func (s *RulesService) Tags(opt *RulesTagsOption) (v *RulesTags, resp *http.Resp
 
 // Update updates an existing rule.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *RulesService) Update(opt *RulesUpdateOption) (v *RulesUpdate, resp *http.Response, err error) {
+func (s *RulesService) Update(opt *RulesUpdateOptions) (v *RulesUpdate, resp *http.Response, err error) {
 	err = s.ValidateUpdateOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -735,7 +735,7 @@ func (s *RulesService) Update(opt *RulesUpdateOption) (v *RulesUpdate, resp *htt
 // ValidateCreateOpt validates the options for creating a custom rule.
 //
 //nolint:cyclop,funlen // Validation functions are naturally complex due to multiple checks
-func (s *RulesService) ValidateCreateOpt(opt *RulesCreateOption) error {
+func (s *RulesService) ValidateCreateOpt(opt *RulesCreateOptions) error {
 	if opt == nil {
 		return NewValidationError("RulesCreateOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -818,7 +818,7 @@ func (s *RulesService) ValidateCreateOpt(opt *RulesCreateOption) error {
 }
 
 // ValidateDeleteOpt validates the options for deleting a custom rule.
-func (s *RulesService) ValidateDeleteOpt(opt *RulesDeleteOption) error {
+func (s *RulesService) ValidateDeleteOpt(opt *RulesDeleteOptions) error {
 	if opt == nil {
 		return NewValidationError("RulesDeleteOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -832,7 +832,7 @@ func (s *RulesService) ValidateDeleteOpt(opt *RulesDeleteOption) error {
 }
 
 // ValidateListOpt validates the options for listing rules.
-func (s *RulesService) ValidateListOpt(opt *RulesListOption) error {
+func (s *RulesService) ValidateListOpt(opt *RulesListOptions) error {
 	if opt == nil {
 		return nil
 	}
@@ -855,7 +855,7 @@ func (s *RulesService) ValidateListOpt(opt *RulesListOption) error {
 }
 
 // ValidateRepositoriesOpt validates the options for listing rule repositories.
-func (s *RulesService) ValidateRepositoriesOpt(opt *RulesRepositoriesOption) error {
+func (s *RulesService) ValidateRepositoriesOpt(opt *RulesRepositoriesOptions) error {
 	// No specific validations needed for this endpoint
 	return nil
 }
@@ -863,7 +863,7 @@ func (s *RulesService) ValidateRepositoriesOpt(opt *RulesRepositoriesOption) err
 // ValidateSearchOpt validates the options for searching rules.
 //
 //nolint:cyclop,funlen // Validation functions are naturally complex due to multiple checks
-func (s *RulesService) ValidateSearchOpt(opt *RulesSearchOption) error {
+func (s *RulesService) ValidateSearchOpt(opt *RulesSearchOptions) error {
 	if opt == nil {
 		return nil
 	}
@@ -968,7 +968,7 @@ func (s *RulesService) ValidateSearchOpt(opt *RulesSearchOption) error {
 }
 
 // ValidateShowOpt validates the options for showing a specific rule.
-func (s *RulesService) ValidateShowOpt(opt *RulesShowOption) error {
+func (s *RulesService) ValidateShowOpt(opt *RulesShowOptions) error {
 	if opt == nil {
 		return NewValidationError("RulesShowOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -982,7 +982,7 @@ func (s *RulesService) ValidateShowOpt(opt *RulesShowOption) error {
 }
 
 // ValidateTagsOpt validates the options for listing rule tags.
-func (s *RulesService) ValidateTagsOpt(opt *RulesTagsOption) error {
+func (s *RulesService) ValidateTagsOpt(opt *RulesTagsOptions) error {
 	if opt == nil {
 		return nil
 	}
@@ -998,7 +998,7 @@ func (s *RulesService) ValidateTagsOpt(opt *RulesTagsOption) error {
 // ValidateUpdateOpt validates the options for updating a rule.
 //
 //nolint:cyclop // Validation functions are naturally complex due to multiple checks
-func (s *RulesService) ValidateUpdateOpt(opt *RulesUpdateOption) error {
+func (s *RulesService) ValidateUpdateOpt(opt *RulesUpdateOptions) error {
 	if opt == nil {
 		return NewValidationError("RulesUpdateOption", "cannot be nil", ErrMissingRequired)
 	}
@@ -1058,10 +1058,10 @@ func (s *RulesService) ValidateUpdateOpt(opt *RulesUpdateOption) error {
 	return nil
 }
 
-// convertCreateOptForURL converts RulesCreateOption to a URL-encodable format.
-func (s *RulesService) convertCreateOptForURL(opt *RulesCreateOption) *rulesCreateURLOption {
+// convertCreateOptForURL converts RulesCreateOptions to a URL-encodable format.
+func (s *RulesService) convertCreateOptForURL(opt *RulesCreateOptions) *rulesCreateURLOptions {
 	//nolint:exhaustruct // Only populate fields that have values
-	urlOpt := &rulesCreateURLOption{
+	urlOpt := &rulesCreateURLOptions{
 		CleanCodeAttribute:  opt.CleanCodeAttribute,
 		CustomKey:           opt.CustomKey,
 		MarkdownDescription: opt.MarkdownDescription,
@@ -1085,8 +1085,8 @@ func (s *RulesService) convertCreateOptForURL(opt *RulesCreateOption) *rulesCrea
 	return urlOpt
 }
 
-// rulesCreateURLOption is the URL-encodable version of RulesCreateOption.
-type rulesCreateURLOption struct {
+// rulesCreateURLOptions is the URL-encodable version of RulesCreateOption.
+type rulesCreateURLOptions struct {
 	CleanCodeAttribute  string `url:"cleanCodeAttribute,omitempty"`
 	CustomKey           string `url:"customKey,omitempty"`
 	Impacts             string `url:"impacts,omitempty"`
@@ -1100,10 +1100,10 @@ type rulesCreateURLOption struct {
 	Type                string `url:"type,omitempty"`
 }
 
-// convertUpdateOptForURL converts RulesUpdateOption to a URL-encodable format.
-func (s *RulesService) convertUpdateOptForURL(opt *RulesUpdateOption) *rulesUpdateURLOption {
+// convertUpdateOptForURL converts RulesUpdateOptions to a URL-encodable format.
+func (s *RulesService) convertUpdateOptForURL(opt *RulesUpdateOptions) *rulesUpdateURLOptions {
 	//nolint:exhaustruct // Only populate fields that have values
-	urlOpt := &rulesUpdateURLOption{
+	urlOpt := &rulesUpdateURLOptions{
 		Key:                        opt.Key,
 		MarkdownDescription:        opt.MarkdownDescription,
 		MarkdownNote:               opt.MarkdownNote,
@@ -1132,8 +1132,8 @@ func (s *RulesService) convertUpdateOptForURL(opt *RulesUpdateOption) *rulesUpda
 	return urlOpt
 }
 
-// rulesUpdateURLOption is the URL-encodable version of RulesUpdateOption.
-type rulesUpdateURLOption struct {
+// rulesUpdateURLOptions is the URL-encodable version of RulesUpdateOption.
+type rulesUpdateURLOptions struct {
 	Impacts                    string `url:"impacts,omitempty"`
 	Key                        string `url:"key,omitempty"`
 	MarkdownDescription        string `url:"markdownDescription,omitempty"`
@@ -1148,16 +1148,16 @@ type rulesUpdateURLOption struct {
 	Tags                       string `url:"tags,omitempty"`
 }
 
-// convertSearchOptForURL converts RulesSearchOption to a URL-encodable format.
+// convertSearchOptForURL converts RulesSearchOptions to a URL-encodable format.
 //
 //nolint:cyclop,funlen // Conversion functions need to handle many optional fields
-func (s *RulesService) convertSearchOptForURL(opt *RulesSearchOption) *rulesSearchURLOption {
+func (s *RulesService) convertSearchOptForURL(opt *RulesSearchOptions) *rulesSearchURLOptions {
 	if opt == nil {
 		return nil
 	}
 
 	//nolint:exhaustruct // Only populate fields that have values
-	urlOpt := &rulesSearchURLOption{
+	urlOpt := &rulesSearchURLOptions{
 		Page:             opt.Page,
 		PageSize:         opt.PageSize,
 		Activation:       opt.Activation,
@@ -1262,10 +1262,10 @@ func (s *RulesService) convertSearchOptForURL(opt *RulesSearchOption) *rulesSear
 	return urlOpt
 }
 
-// rulesSearchURLOption is the URL-encodable version of RulesSearchOption.
+// rulesSearchURLOptions is the URL-encodable version of RulesSearchOption.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order
-type rulesSearchURLOption struct {
+type rulesSearchURLOptions struct {
 	Page                         int64  `url:"p,omitempty"`
 	PageSize                     int64  `url:"ps,omitempty"`
 	Activation                   bool   `url:"activation,omitempty"`

--- a/sonar/rules_service_test.go
+++ b/sonar/rules_service_test.go
@@ -25,7 +25,7 @@ func TestRules_Create(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/rules/create", 200, `{"rule":{"key":"java:MyRule","name":"My Rule"}}`))
 	client := newTestClient(t, server.URL)
 
-	opt := &RulesCreateOption{
+	opt := &RulesCreateOptions{
 		CustomKey:           "MyRule",
 		Name:                "My Rule",
 		MarkdownDescription: "Test description",
@@ -42,7 +42,7 @@ func TestRules_Delete(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/rules/delete", 204))
 	client := newTestClient(t, server.URL)
 
-	opt := &RulesDeleteOption{Key: "java:MyRule"}
+	opt := &RulesDeleteOptions{Key: "java:MyRule"}
 	resp, err := client.Rules.Delete(opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
@@ -52,7 +52,7 @@ func TestRules_Search(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/rules/search", 200, `{"paging":{"total":0},"rules":[],"actives":{}}`))
 	client := newTestClient(t, server.URL)
 
-	opt := &RulesSearchOption{Languages: []string{"java"}}
+	opt := &RulesSearchOptions{Languages: []string{"java"}}
 	result, resp, err := client.Rules.Search(opt)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -98,7 +98,7 @@ func TestRules_Show(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/rules/show", 200, `{"rule":{"key":"java:S1067","name":"Test Rule"}}`))
 	client := newTestClient(t, server.URL)
 
-	opt := &RulesShowOption{Key: "java:S1067"}
+	opt := &RulesShowOptions{Key: "java:S1067"}
 	result, resp, err := client.Rules.Show(opt)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -110,7 +110,7 @@ func TestRules_Tags(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/rules/tags", 200, `{"tags":["security","bug"]}`))
 	client := newTestClient(t, server.URL)
 
-	opt := &RulesTagsOption{PageSize: 100}
+	opt := &RulesTagsOptions{PageSize: 100}
 	result, resp, err := client.Rules.Tags(opt)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -122,7 +122,7 @@ func TestRules_Update(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/rules/update", 200, `{"rule":{"key":"java:MyRule","name":"Updated Rule"}}`))
 	client := newTestClient(t, server.URL)
 
-	opt := &RulesUpdateOption{Key: "java:MyRule", Name: "Updated Rule"}
+	opt := &RulesUpdateOptions{Key: "java:MyRule", Name: "Updated Rule"}
 	result, resp, err := client.Rules.Update(opt)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -139,7 +139,7 @@ func TestRules_UpdateClearTags(t *testing.T) {
 	}))
 	client := newTestClient(t, server.URL)
 
-	opt := &RulesUpdateOption{Key: "java:MyRule", Tags: []string{}}
+	opt := &RulesUpdateOptions{Key: "java:MyRule", Tags: []string{}}
 	result, resp, err := client.Rules.Update(opt)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -153,7 +153,7 @@ func TestRules_Repositories(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/rules/repositories", 200, `{"repositories":[{"key":"java","language":"java","name":"SonarAnalyzer"}]}`))
 	client := newTestClient(t, server.URL)
 
-	opt := &RulesRepositoriesOption{}
+	opt := &RulesRepositoriesOptions{}
 	result, resp, err := client.Rules.Repositories(opt)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -165,7 +165,7 @@ func TestRules_List(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/rules/list", 200, `{"rules":[]}`))
 	client := newTestClient(t, server.URL)
 
-	opt := &RulesListOption{
+	opt := &RulesListOptions{
 		PaginationArgs: PaginationArgs{
 			PageSize: 50,
 		},
@@ -182,7 +182,7 @@ func TestValidateCreateOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *RulesCreateOption
+		opt     *RulesCreateOptions
 		wantErr bool
 		errMsg  string
 	}{
@@ -194,7 +194,7 @@ func TestValidateCreateOpt(t *testing.T) {
 		},
 		{
 			name: "missing CustomKey",
-			opt: &RulesCreateOption{
+			opt: &RulesCreateOptions{
 				Name:                "Test",
 				MarkdownDescription: "Test",
 				TemplateKey:         "java:Template",
@@ -204,7 +204,7 @@ func TestValidateCreateOpt(t *testing.T) {
 		},
 		{
 			name: "missing Name",
-			opt: &RulesCreateOption{
+			opt: &RulesCreateOptions{
 				CustomKey:           "MyRule",
 				MarkdownDescription: "Test",
 				TemplateKey:         "java:Template",
@@ -214,7 +214,7 @@ func TestValidateCreateOpt(t *testing.T) {
 		},
 		{
 			name: "missing MarkdownDescription",
-			opt: &RulesCreateOption{
+			opt: &RulesCreateOptions{
 				CustomKey:   "MyRule",
 				Name:        "Test",
 				TemplateKey: "java:Template",
@@ -224,7 +224,7 @@ func TestValidateCreateOpt(t *testing.T) {
 		},
 		{
 			name: "missing TemplateKey",
-			opt: &RulesCreateOption{
+			opt: &RulesCreateOptions{
 				CustomKey:           "MyRule",
 				Name:                "Test",
 				MarkdownDescription: "Test",
@@ -234,7 +234,7 @@ func TestValidateCreateOpt(t *testing.T) {
 		},
 		{
 			name: "CustomKey too long",
-			opt: &RulesCreateOption{
+			opt: &RulesCreateOptions{
 				CustomKey:           strings.Repeat("a", 201),
 				Name:                "Test",
 				MarkdownDescription: "Test",
@@ -245,7 +245,7 @@ func TestValidateCreateOpt(t *testing.T) {
 		},
 		{
 			name: "invalid Severity",
-			opt: &RulesCreateOption{
+			opt: &RulesCreateOptions{
 				CustomKey:           "MyRule",
 				Name:                "Test",
 				MarkdownDescription: "Test",
@@ -257,7 +257,7 @@ func TestValidateCreateOpt(t *testing.T) {
 		},
 		{
 			name: "invalid Status",
-			opt: &RulesCreateOption{
+			opt: &RulesCreateOptions{
 				CustomKey:           "MyRule",
 				Name:                "Test",
 				MarkdownDescription: "Test",
@@ -269,7 +269,7 @@ func TestValidateCreateOpt(t *testing.T) {
 		},
 		{
 			name: "invalid Type",
-			opt: &RulesCreateOption{
+			opt: &RulesCreateOptions{
 				CustomKey:           "MyRule",
 				Name:                "Test",
 				MarkdownDescription: "Test",
@@ -281,7 +281,7 @@ func TestValidateCreateOpt(t *testing.T) {
 		},
 		{
 			name: "invalid Impacts key",
-			opt: &RulesCreateOption{
+			opt: &RulesCreateOptions{
 				CustomKey:           "MyRule",
 				Name:                "Test",
 				MarkdownDescription: "Test",
@@ -295,7 +295,7 @@ func TestValidateCreateOpt(t *testing.T) {
 		},
 		{
 			name: "invalid Impacts value",
-			opt: &RulesCreateOption{
+			opt: &RulesCreateOptions{
 				CustomKey:           "MyRule",
 				Name:                "Test",
 				MarkdownDescription: "Test",
@@ -309,7 +309,7 @@ func TestValidateCreateOpt(t *testing.T) {
 		},
 		{
 			name: "valid option",
-			opt: &RulesCreateOption{
+			opt: &RulesCreateOptions{
 				CustomKey:           "MyRule",
 				Name:                "Test Rule",
 				MarkdownDescription: "Test description",
@@ -346,7 +346,7 @@ func TestValidateSearchOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *RulesSearchOption
+		opt     *RulesSearchOptions
 		wantErr bool
 		errMsg  string
 	}{
@@ -357,7 +357,7 @@ func TestValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "invalid Page",
-			opt: &RulesSearchOption{
+			opt: &RulesSearchOptions{
 				PaginationArgs: PaginationArgs{Page: -1},
 			},
 			wantErr: true,
@@ -365,7 +365,7 @@ func TestValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "invalid PageSize",
-			opt: &RulesSearchOption{
+			opt: &RulesSearchOptions{
 				PaginationArgs: PaginationArgs{PageSize: 600},
 			},
 			wantErr: true,
@@ -373,7 +373,7 @@ func TestValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "Query too short",
-			opt: &RulesSearchOption{
+			opt: &RulesSearchOptions{
 				Query: "a",
 			},
 			wantErr: true,
@@ -381,7 +381,7 @@ func TestValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "invalid ActiveSeverities",
-			opt: &RulesSearchOption{
+			opt: &RulesSearchOptions{
 				ActiveSeverities: []string{"INVALID"},
 			},
 			wantErr: true,
@@ -389,7 +389,7 @@ func TestValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "invalid CleanCodeAttributeCategories",
-			opt: &RulesSearchOption{
+			opt: &RulesSearchOptions{
 				CleanCodeAttributeCategories: []string{"INVALID"},
 			},
 			wantErr: true,
@@ -397,7 +397,7 @@ func TestValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "invalid ImpactSoftwareQualities",
-			opt: &RulesSearchOption{
+			opt: &RulesSearchOptions{
 				ImpactSoftwareQualities: []string{"INVALID"},
 			},
 			wantErr: true,
@@ -405,7 +405,7 @@ func TestValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "invalid Inheritance",
-			opt: &RulesSearchOption{
+			opt: &RulesSearchOptions{
 				Inheritance: []string{"INVALID"},
 			},
 			wantErr: true,
@@ -413,7 +413,7 @@ func TestValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "invalid OwaspTop10",
-			opt: &RulesSearchOption{
+			opt: &RulesSearchOptions{
 				OwaspTop10: []string{"a11"},
 			},
 			wantErr: true,
@@ -421,7 +421,7 @@ func TestValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "invalid Statuses",
-			opt: &RulesSearchOption{
+			opt: &RulesSearchOptions{
 				Statuses: []string{"INVALID"},
 			},
 			wantErr: true,
@@ -429,7 +429,7 @@ func TestValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "invalid Types",
-			opt: &RulesSearchOption{
+			opt: &RulesSearchOptions{
 				Types: []string{"INVALID"},
 			},
 			wantErr: true,
@@ -437,7 +437,7 @@ func TestValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "invalid Sort",
-			opt: &RulesSearchOption{
+			opt: &RulesSearchOptions{
 				Sort: "invalid",
 			},
 			wantErr: true,
@@ -445,7 +445,7 @@ func TestValidateSearchOpt(t *testing.T) {
 		},
 		{
 			name: "valid option",
-			opt: &RulesSearchOption{
+			opt: &RulesSearchOptions{
 				PaginationArgs: PaginationArgs{Page: 1, PageSize: 50},
 				Query:          "test",
 				Languages:      []string{"java", "go"},
@@ -478,7 +478,7 @@ func TestValidateUpdateOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *RulesUpdateOption
+		opt     *RulesUpdateOptions
 		wantErr bool
 		errMsg  string
 	}{
@@ -490,13 +490,13 @@ func TestValidateUpdateOpt(t *testing.T) {
 		},
 		{
 			name:    "missing Key",
-			opt:     &RulesUpdateOption{},
+			opt:     &RulesUpdateOptions{},
 			wantErr: true,
 			errMsg:  "Key",
 		},
 		{
 			name: "Key too long",
-			opt: &RulesUpdateOption{
+			opt: &RulesUpdateOptions{
 				Key: strings.Repeat("a", 201),
 			},
 			wantErr: true,
@@ -504,7 +504,7 @@ func TestValidateUpdateOpt(t *testing.T) {
 		},
 		{
 			name: "invalid Severity",
-			opt: &RulesUpdateOption{
+			opt: &RulesUpdateOptions{
 				Key:      "java:MyRule",
 				Severity: "INVALID",
 			},
@@ -513,7 +513,7 @@ func TestValidateUpdateOpt(t *testing.T) {
 		},
 		{
 			name: "invalid Status",
-			opt: &RulesUpdateOption{
+			opt: &RulesUpdateOptions{
 				Key:    "java:MyRule",
 				Status: "INVALID",
 			},
@@ -522,7 +522,7 @@ func TestValidateUpdateOpt(t *testing.T) {
 		},
 		{
 			name: "invalid RemediationFnType",
-			opt: &RulesUpdateOption{
+			opt: &RulesUpdateOptions{
 				Key:               "java:MyRule",
 				RemediationFnType: "INVALID",
 			},
@@ -531,7 +531,7 @@ func TestValidateUpdateOpt(t *testing.T) {
 		},
 		{
 			name: "invalid Impacts key",
-			opt: &RulesUpdateOption{
+			opt: &RulesUpdateOptions{
 				Key: "java:MyRule",
 				Impacts: map[string]string{
 					"INVALID": "HIGH",
@@ -542,7 +542,7 @@ func TestValidateUpdateOpt(t *testing.T) {
 		},
 		{
 			name: "valid option",
-			opt: &RulesUpdateOption{
+			opt: &RulesUpdateOptions{
 				Key:      "java:MyRule",
 				Name:     "Updated Rule",
 				Severity: "CRITICAL",
@@ -576,7 +576,7 @@ func TestValidateShowOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *RulesShowOption
+		opt     *RulesShowOptions
 		wantErr bool
 		errMsg  string
 	}{
@@ -588,13 +588,13 @@ func TestValidateShowOpt(t *testing.T) {
 		},
 		{
 			name:    "missing Key",
-			opt:     &RulesShowOption{},
+			opt:     &RulesShowOptions{},
 			wantErr: true,
 			errMsg:  "Key",
 		},
 		{
 			name: "valid option",
-			opt: &RulesShowOption{
+			opt: &RulesShowOptions{
 				Key:     "java:S1067",
 				Actives: true,
 			},
@@ -622,7 +622,7 @@ func TestValidateDeleteOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *RulesDeleteOption
+		opt     *RulesDeleteOptions
 		wantErr bool
 		errMsg  string
 	}{
@@ -634,13 +634,13 @@ func TestValidateDeleteOpt(t *testing.T) {
 		},
 		{
 			name:    "missing Key",
-			opt:     &RulesDeleteOption{},
+			opt:     &RulesDeleteOptions{},
 			wantErr: true,
 			errMsg:  "Key",
 		},
 		{
 			name: "valid option",
-			opt: &RulesDeleteOption{
+			opt: &RulesDeleteOptions{
 				Key: "java:MyRule",
 			},
 			wantErr: false,
@@ -667,7 +667,7 @@ func TestValidateTagsOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *RulesTagsOption
+		opt     *RulesTagsOptions
 		wantErr bool
 		errMsg  string
 	}{
@@ -678,7 +678,7 @@ func TestValidateTagsOpt(t *testing.T) {
 		},
 		{
 			name: "invalid PageSize - too large",
-			opt: &RulesTagsOption{
+			opt: &RulesTagsOptions{
 				PageSize: 600,
 			},
 			wantErr: true,
@@ -686,7 +686,7 @@ func TestValidateTagsOpt(t *testing.T) {
 		},
 		{
 			name: "invalid PageSize - negative",
-			opt: &RulesTagsOption{
+			opt: &RulesTagsOptions{
 				PageSize: -1,
 			},
 			wantErr: true,
@@ -694,7 +694,7 @@ func TestValidateTagsOpt(t *testing.T) {
 		},
 		{
 			name: "valid option",
-			opt: &RulesTagsOption{
+			opt: &RulesTagsOptions{
 				PageSize: 100,
 				Query:    "security",
 			},
@@ -722,7 +722,7 @@ func TestValidateTagsOpt(t *testing.T) {
 func TestConvertCreateOptForURL(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	opt := &RulesCreateOption{
+	opt := &RulesCreateOptions{
 		CustomKey:           "MyRule",
 		Name:                "Test Rule",
 		MarkdownDescription: "Description",
@@ -754,7 +754,7 @@ func TestConvertCreateOptForURL(t *testing.T) {
 func TestConvertSearchOptForURL(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	opt := &RulesSearchOption{
+	opt := &RulesSearchOptions{
 		PaginationArgs: PaginationArgs{Page: 1, PageSize: 50},
 		Languages:      []string{"java", "go"},
 		Severities:     []string{"MAJOR", "CRITICAL"},
@@ -776,7 +776,7 @@ func TestConvertSearchOptForURL(t *testing.T) {
 func TestConvertUpdateOptForURL(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	opt := &RulesUpdateOption{
+	opt := &RulesUpdateOptions{
 		Key:  "java:MyRule",
 		Name: "Updated",
 		Impacts: map[string]string{
@@ -834,7 +834,7 @@ func TestEmptySlicesAndMaps(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test with empty slices and maps
-	opt := &RulesSearchOption{
+	opt := &RulesSearchOptions{
 		Languages:  []string{},
 		Severities: []string{},
 		Tags:       []string{},

--- a/sonar/settings_service.go
+++ b/sonar/settings_service.go
@@ -117,20 +117,20 @@ type SettingValue struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// SettingsEncryptOption represents options for encrypting a value.
-type SettingsEncryptOption struct {
+// SettingsEncryptOptions represents options for encrypting a value.
+type SettingsEncryptOptions struct {
 	// Value is the setting value to encrypt (required).
 	Value string `url:"value,omitempty"`
 }
 
-// SettingsListDefinitionsOption represents options for listing setting definitions.
-type SettingsListDefinitionsOption struct {
+// SettingsListDefinitionsOptions represents options for listing setting definitions.
+type SettingsListDefinitionsOptions struct {
 	// Component is the component key to get definitions for (optional).
 	Component string `url:"component,omitempty"`
 }
 
-// SettingsResetOption represents options for resetting settings.
-type SettingsResetOption struct {
+// SettingsResetOptions represents options for resetting settings.
+type SettingsResetOptions struct {
 	// Component is the component key (optional).
 	// Only keys for projects, applications, portfolios or subportfolios are accepted.
 	Component string `url:"component,omitempty"`
@@ -158,10 +158,10 @@ func (m JSONEncodedMap) EncodeValues(key string, values *url.Values) error {
 	return nil
 }
 
-// SettingsSetOption represents options for setting a value.
+// SettingsSetOptions represents options for setting a value.
 //
 //nolint:govet // Field ordering prioritizes API clarity over memory alignment
-type SettingsSetOption struct {
+type SettingsSetOptions struct {
 	// Component is the component key (optional).
 	// Only keys for projects, applications, portfolios or subportfolios are accepted.
 	Component string `url:"component,omitempty"`
@@ -179,8 +179,8 @@ type SettingsSetOption struct {
 	FieldValues JSONEncodedMap `url:"fieldValues,omitempty"`
 }
 
-// SettingsValuesOption represents options for listing setting values.
-type SettingsValuesOption struct {
+// SettingsValuesOptions represents options for listing setting values.
+type SettingsValuesOptions struct {
 	// Component is the component key (optional).
 	Component string `url:"component,omitempty"`
 	// Keys is the list of setting keys (optional).
@@ -192,7 +192,7 @@ type SettingsValuesOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateEncryptOpt validates the options for Encrypt.
-func (s *SettingsService) ValidateEncryptOpt(opt *SettingsEncryptOption) error {
+func (s *SettingsService) ValidateEncryptOpt(opt *SettingsEncryptOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -201,7 +201,7 @@ func (s *SettingsService) ValidateEncryptOpt(opt *SettingsEncryptOption) error {
 }
 
 // ValidateListDefinitionsOpt validates the options for ListDefinitions.
-func (s *SettingsService) ValidateListDefinitionsOpt(opt *SettingsListDefinitionsOption) error {
+func (s *SettingsService) ValidateListDefinitionsOpt(opt *SettingsListDefinitionsOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -210,7 +210,7 @@ func (s *SettingsService) ValidateListDefinitionsOpt(opt *SettingsListDefinition
 }
 
 // ValidateResetOpt validates the options for Reset.
-func (s *SettingsService) ValidateResetOpt(opt *SettingsResetOption) error {
+func (s *SettingsService) ValidateResetOpt(opt *SettingsResetOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -223,7 +223,7 @@ func (s *SettingsService) ValidateResetOpt(opt *SettingsResetOption) error {
 }
 
 // ValidateSetOpt validates the options for Set.
-func (s *SettingsService) ValidateSetOpt(opt *SettingsSetOption) error {
+func (s *SettingsService) ValidateSetOpt(opt *SettingsSetOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -249,7 +249,7 @@ func (s *SettingsService) ValidateSetOpt(opt *SettingsSetOption) error {
 }
 
 // ValidateValuesOpt validates the options for Values.
-func (s *SettingsService) ValidateValuesOpt(opt *SettingsValuesOption) error {
+func (s *SettingsService) ValidateValuesOpt(opt *SettingsValuesOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -285,7 +285,7 @@ func (s *SettingsService) CheckSecretKey() (*SettingsCheckSecretKey, *http.Respo
 // Requires 'Administer System' permission.
 //
 // Since: 6.1.
-func (s *SettingsService) Encrypt(opt *SettingsEncryptOption) (*SettingsEncrypt, *http.Response, error) {
+func (s *SettingsService) Encrypt(opt *SettingsEncryptOptions) (*SettingsEncrypt, *http.Response, error) {
 	err := s.ValidateEncryptOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -335,7 +335,7 @@ func (s *SettingsService) GenerateSecretKey() (*SettingsGenerateSecretKey, *http
 //   - 'Administer' rights on the specified component
 //
 // Since: 6.3.
-func (s *SettingsService) ListDefinitions(opt *SettingsListDefinitionsOption) (*SettingsListDefinitions, *http.Response, error) {
+func (s *SettingsService) ListDefinitions(opt *SettingsListDefinitionsOptions) (*SettingsListDefinitions, *http.Response, error) {
 	err := s.ValidateListDefinitionsOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -382,7 +382,7 @@ func (s *SettingsService) LoginMessage() (*SettingsLoginMessage, *http.Response,
 //   - 'Administer' rights on the specified component
 //
 // Since: 6.1.
-func (s *SettingsService) Reset(opt *SettingsResetOption) (*http.Response, error) {
+func (s *SettingsService) Reset(opt *SettingsResetOptions) (*http.Response, error) {
 	err := s.ValidateResetOpt(opt)
 	if err != nil {
 		return nil, err
@@ -409,7 +409,7 @@ func (s *SettingsService) Reset(opt *SettingsResetOption) (*http.Response, error
 //   - 'Administer' rights on the specified component
 //
 // Since: 6.1.
-func (s *SettingsService) Set(opt *SettingsSetOption) (*http.Response, error) {
+func (s *SettingsService) Set(opt *SettingsSetOptions) (*http.Response, error) {
 	err := s.ValidateSetOpt(opt)
 	if err != nil {
 		return nil, err
@@ -437,7 +437,7 @@ func (s *SettingsService) Set(opt *SettingsSetOption) (*http.Response, error) {
 // Secured settings values are not returned by the endpoint.
 //
 // Since: 6.3.
-func (s *SettingsService) Values(opt *SettingsValuesOption) (*SettingsValues, *http.Response, error) {
+func (s *SettingsService) Values(opt *SettingsValuesOptions) (*SettingsValues, *http.Response, error) {
 	err := s.ValidateValuesOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/settings_service_test.go
+++ b/sonar/settings_service_test.go
@@ -38,7 +38,7 @@ func TestSettingsService_Encrypt(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &SettingsEncryptOption{
+	opt := &SettingsEncryptOptions{
 		Value: "my-secret-value",
 	}
 
@@ -53,7 +53,7 @@ func TestSettingsService_Encrypt_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing Value
-	opt := &SettingsEncryptOption{}
+	opt := &SettingsEncryptOptions{}
 	_, _, err := client.Settings.Encrypt(opt)
 	assert.Error(t, err)
 }
@@ -92,7 +92,7 @@ func TestSettingsService_ListDefinitions(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &SettingsListDefinitionsOption{
+	opt := &SettingsListDefinitionsOptions{
 		Component: "my-project",
 	}
 
@@ -135,7 +135,7 @@ func TestSettingsService_Reset(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &SettingsResetOption{
+	opt := &SettingsResetOptions{
 		Keys: []string{"sonar.test.key", "sonar.other.key"},
 	}
 
@@ -149,7 +149,7 @@ func TestSettingsService_Reset_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing Keys
-	opt := &SettingsResetOption{}
+	opt := &SettingsResetOptions{}
 	_, err := client.Settings.Reset(opt)
 	assert.Error(t, err)
 }
@@ -171,7 +171,7 @@ func TestSettingsService_Set(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &SettingsSetOption{
+	opt := &SettingsSetOptions{
 		Key:   "sonar.test.key",
 		Value: "test-value",
 	}
@@ -186,14 +186,14 @@ func TestSettingsService_Set_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing Key
-	opt := &SettingsSetOption{
+	opt := &SettingsSetOptions{
 		Value: "test-value",
 	}
 	_, err := client.Settings.Set(opt)
 	assert.Error(t, err)
 
 	// Test Value too long
-	opt = &SettingsSetOption{
+	opt = &SettingsSetOptions{
 		Key:   "sonar.test.key",
 		Value: strings.Repeat("a", MaxSettingValueLength+1),
 	}
@@ -201,7 +201,7 @@ func TestSettingsService_Set_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Value, Values, and FieldValues
-	opt = &SettingsSetOption{
+	opt = &SettingsSetOptions{
 		Key: "sonar.test.key",
 	}
 	_, err = client.Settings.Set(opt)
@@ -227,7 +227,7 @@ func TestSettingsService_Set_WithMultiValues(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &SettingsSetOption{
+	opt := &SettingsSetOptions{
 		Key:    "sonar.test.multikey",
 		Values: []string{"value1", "value2", "value3"},
 	}
@@ -265,7 +265,7 @@ func TestSettingsService_Set_WithFieldValues(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &SettingsSetOption{
+	opt := &SettingsSetOptions{
 		Key: "sonar.test.fieldkey",
 		FieldValues: map[string]any{
 			"field1": "value1",
@@ -299,7 +299,7 @@ func TestSettingsService_Values(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &SettingsValuesOption{
+	opt := &SettingsValuesOptions{
 		Keys: []string{"sonar.test.key", "sonar.multi.key"},
 	}
 

--- a/sonar/sources_service.go
+++ b/sonar/sources_service.go
@@ -98,8 +98,8 @@ type SourcesShow struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// SourcesIndexOption represents options for getting source file lines.
-type SourcesIndexOption struct {
+// SourcesIndexOptions represents options for getting source file lines.
+type SourcesIndexOptions struct {
 	// Resource is the file key (API parameter: "resource", required).
 	Resource string `url:"resource,omitempty"`
 	// From is the starting line number (optional, default: 1).
@@ -108,14 +108,14 @@ type SourcesIndexOption struct {
 	To int64 `url:"to,omitempty"`
 }
 
-// SourcesIssueSnippetsOption represents options for getting issue snippets.
-type SourcesIssueSnippetsOption struct {
+// SourcesIssueSnippetsOptions represents options for getting issue snippets.
+type SourcesIssueSnippetsOptions struct {
 	// IssueKey is the issue key (required).
 	IssueKey string `url:"issueKey,omitempty"`
 }
 
-// SourcesLinesOption represents options for getting source file lines.
-type SourcesLinesOption struct {
+// SourcesLinesOptions represents options for getting source file lines.
+type SourcesLinesOptions struct {
 	// Key is the file key (required).
 	Key string `url:"key,omitempty"`
 	// Branch is the branch key (optional).
@@ -128,8 +128,8 @@ type SourcesLinesOption struct {
 	To int64 `url:"to,omitempty"`
 }
 
-// SourcesRawOption represents options for getting raw source file content.
-type SourcesRawOption struct {
+// SourcesRawOptions represents options for getting raw source file content.
+type SourcesRawOptions struct {
 	// Key is the file key (required).
 	Key string `url:"key,omitempty"`
 	// Branch is the branch key (optional).
@@ -138,8 +138,8 @@ type SourcesRawOption struct {
 	PullRequest string `url:"pullRequest,omitempty"`
 }
 
-// SourcesScmOption represents options for getting SCM data.
-type SourcesScmOption struct {
+// SourcesScmOptions represents options for getting SCM data.
+type SourcesScmOptions struct {
 	// Key is the file key (required).
 	Key string `url:"key,omitempty"`
 	// CommitsByLine indicates whether to group commits by line (optional, default: false).
@@ -150,8 +150,8 @@ type SourcesScmOption struct {
 	To int64 `url:"to,omitempty"`
 }
 
-// SourcesShowOption represents options for showing source file content.
-type SourcesShowOption struct {
+// SourcesShowOptions represents options for showing source file content.
+type SourcesShowOptions struct {
 	// Key is the file key (required).
 	Key string `url:"key,omitempty"`
 	// From is the starting line number (optional, default: 1).
@@ -165,7 +165,7 @@ type SourcesShowOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateIndexOpt validates the options for Index.
-func (s *SourcesService) ValidateIndexOpt(opt *SourcesIndexOption) error {
+func (s *SourcesService) ValidateIndexOpt(opt *SourcesIndexOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -174,7 +174,7 @@ func (s *SourcesService) ValidateIndexOpt(opt *SourcesIndexOption) error {
 }
 
 // ValidateIssueSnippetsOpt validates the options for IssueSnippets.
-func (s *SourcesService) ValidateIssueSnippetsOpt(opt *SourcesIssueSnippetsOption) error {
+func (s *SourcesService) ValidateIssueSnippetsOpt(opt *SourcesIssueSnippetsOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -183,7 +183,7 @@ func (s *SourcesService) ValidateIssueSnippetsOpt(opt *SourcesIssueSnippetsOptio
 }
 
 // ValidateLinesOpt validates the options for Lines.
-func (s *SourcesService) ValidateLinesOpt(opt *SourcesLinesOption) error {
+func (s *SourcesService) ValidateLinesOpt(opt *SourcesLinesOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -192,7 +192,7 @@ func (s *SourcesService) ValidateLinesOpt(opt *SourcesLinesOption) error {
 }
 
 // ValidateRawOpt validates the options for Raw.
-func (s *SourcesService) ValidateRawOpt(opt *SourcesRawOption) error {
+func (s *SourcesService) ValidateRawOpt(opt *SourcesRawOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -201,7 +201,7 @@ func (s *SourcesService) ValidateRawOpt(opt *SourcesRawOption) error {
 }
 
 // ValidateScmOpt validates the options for Scm.
-func (s *SourcesService) ValidateScmOpt(opt *SourcesScmOption) error {
+func (s *SourcesService) ValidateScmOpt(opt *SourcesScmOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -210,7 +210,7 @@ func (s *SourcesService) ValidateScmOpt(opt *SourcesScmOption) error {
 }
 
 // ValidateShowOpt validates the options for Show.
-func (s *SourcesService) ValidateShowOpt(opt *SourcesShowOption) error {
+func (s *SourcesService) ValidateShowOpt(opt *SourcesShowOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -230,7 +230,7 @@ func (s *SourcesService) ValidateShowOpt(opt *SourcesShowOption) error {
 // Since: 5.0.
 //
 // Deprecated: This web service is deprecated since 5.1. Use api/sources/lines instead.
-func (s *SourcesService) Index(opt *SourcesIndexOption) (*SourcesIndex, *http.Response, error) {
+func (s *SourcesService) Index(opt *SourcesIndexOptions) (*SourcesIndex, *http.Response, error) {
 	err := s.ValidateIndexOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -256,7 +256,7 @@ func (s *SourcesService) Index(opt *SourcesIndexOption) (*SourcesIndex, *http.Re
 // Returns source code snippets relevant to the given issue.
 //
 // Since: 7.8.
-func (s *SourcesService) IssueSnippets(opt *SourcesIssueSnippetsOption) (*SourcesIssueSnippets, *http.Response, error) {
+func (s *SourcesService) IssueSnippets(opt *SourcesIssueSnippetsOptions) (*SourcesIssueSnippets, *http.Response, error) {
 	err := s.ValidateIssueSnippetsOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -282,7 +282,7 @@ func (s *SourcesService) IssueSnippets(opt *SourcesIssueSnippetsOption) (*Source
 // Returns source code with additional info like SCM data, coverage, and duplications.
 //
 // Since: 5.0.
-func (s *SourcesService) Lines(opt *SourcesLinesOption) (*SourcesLines, *http.Response, error) {
+func (s *SourcesService) Lines(opt *SourcesLinesOptions) (*SourcesLines, *http.Response, error) {
 	err := s.ValidateLinesOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -308,7 +308,7 @@ func (s *SourcesService) Lines(opt *SourcesLinesOption) (*SourcesLines, *http.Re
 // Requires 'See Source Code' permission on file's project.
 //
 // Since: 5.0.
-func (s *SourcesService) Raw(opt *SourcesRawOption) (string, *http.Response, error) {
+func (s *SourcesService) Raw(opt *SourcesRawOptions) (string, *http.Response, error) {
 	err := s.ValidateRawOpt(opt)
 	if err != nil {
 		return "", nil, err
@@ -334,7 +334,7 @@ func (s *SourcesService) Raw(opt *SourcesRawOption) (string, *http.Response, err
 // Returns source code modification information.
 //
 // Since: 4.4.
-func (s *SourcesService) Scm(opt *SourcesScmOption) (*SourcesScm, *http.Response, error) {
+func (s *SourcesService) Scm(opt *SourcesScmOptions) (*SourcesScm, *http.Response, error) {
 	err := s.ValidateScmOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -359,7 +359,7 @@ func (s *SourcesService) Scm(opt *SourcesScmOption) (*SourcesScm, *http.Response
 // Requires 'See Source Code' permission on file's project.
 //
 // Since: 4.4.
-func (s *SourcesService) Show(opt *SourcesShowOption) (*SourcesShow, *http.Response, error) {
+func (s *SourcesService) Show(opt *SourcesShowOptions) (*SourcesShow, *http.Response, error) {
 	err := s.ValidateShowOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/sources_service_test.go
+++ b/sonar/sources_service_test.go
@@ -25,7 +25,7 @@ func TestSourcesService_Index(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &SourcesIndexOption{
+	opt := &SourcesIndexOptions{
 		Resource: "my-project:src/main.go",
 		From:     1,
 		To:       10,
@@ -42,7 +42,7 @@ func TestSourcesService_Index_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing Resource
-	opt := &SourcesIndexOption{}
+	opt := &SourcesIndexOptions{}
 	_, _, err := client.Sources.Index(opt)
 	assert.Error(t, err)
 }
@@ -65,7 +65,7 @@ func TestSourcesService_IssueSnippets(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &SourcesIssueSnippetsOption{
+	opt := &SourcesIssueSnippetsOptions{
 		IssueKey: "AX1234567890",
 	}
 
@@ -82,7 +82,7 @@ func TestSourcesService_IssueSnippets_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing IssueKey
-	opt := &SourcesIssueSnippetsOption{}
+	opt := &SourcesIssueSnippetsOptions{}
 	_, _, err := client.Sources.IssueSnippets(opt)
 	assert.Error(t, err)
 }
@@ -105,7 +105,7 @@ func TestSourcesService_Lines(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &SourcesLinesOption{
+	opt := &SourcesLinesOptions{
 		Key:    "my-project:src/main.go",
 		Branch: "main",
 		From:   1,
@@ -125,7 +125,7 @@ func TestSourcesService_Lines_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing Key
-	opt := &SourcesLinesOption{
+	opt := &SourcesLinesOptions{
 		Branch: "main",
 	}
 	_, _, err := client.Sources.Lines(opt)
@@ -146,7 +146,7 @@ func TestSourcesService_Raw(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &SourcesRawOption{
+	opt := &SourcesRawOptions{
 		Key: "my-project:src/main.go",
 	}
 
@@ -161,7 +161,7 @@ func TestSourcesService_Raw_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing Key
-	opt := &SourcesRawOption{}
+	opt := &SourcesRawOptions{}
 	_, _, err := client.Sources.Raw(opt)
 	assert.Error(t, err)
 }
@@ -178,7 +178,7 @@ func TestSourcesService_Scm(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &SourcesScmOption{
+	opt := &SourcesScmOptions{
 		Key:           "my-project:src/main.go",
 		CommitsByLine: true,
 	}
@@ -194,7 +194,7 @@ func TestSourcesService_Scm_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing Key
-	opt := &SourcesScmOption{
+	opt := &SourcesScmOptions{
 		CommitsByLine: true,
 	}
 	_, _, err := client.Sources.Scm(opt)
@@ -214,7 +214,7 @@ func TestSourcesService_Show(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	opt := &SourcesShowOption{
+	opt := &SourcesShowOptions{
 		Key:  "my-project:src/main.go",
 		From: 1,
 		To:   10,
@@ -231,7 +231,7 @@ func TestSourcesService_Show_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test missing Key
-	opt := &SourcesShowOption{}
+	opt := &SourcesShowOptions{}
 	_, _, err := client.Sources.Show(opt)
 	assert.Error(t, err)
 }

--- a/sonar/system_service.go
+++ b/sonar/system_service.go
@@ -542,16 +542,16 @@ type PluginUpdate struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// SystemChangeLogLevelOption contains options for the ChangeLogLevel method.
-type SystemChangeLogLevelOption struct {
+// SystemChangeLogLevelOptions contains options for the ChangeLogLevel method.
+type SystemChangeLogLevelOptions struct {
 	// Level is the new log level.
 	// Possible values: TRACE, DEBUG, INFO.
 	// Be cautious: DEBUG, and even more TRACE, may have performance impacts.
 	Level string `url:"level,omitempty"`
 }
 
-// SystemLogsOption contains options for the Logs method.
-type SystemLogsOption struct {
+// SystemLogsOptions contains options for the Logs method.
+type SystemLogsOptions struct {
 	// Name is the name of the logs to retrieve.
 	// Possible values: access, app, ce, deprecation, es, web.
 	// Default: app.
@@ -567,7 +567,7 @@ type SystemLogsOption struct {
 // Requires system administration permission.
 //
 // API Docs: https://next.sonarqube.com/sonarqube/web_api/api/system/change_log_level
-func (s *SystemService) ChangeLogLevel(opt *SystemChangeLogLevelOption) (*http.Response, error) {
+func (s *SystemService) ChangeLogLevel(opt *SystemChangeLogLevelOptions) (*http.Response, error) {
 	err := s.ValidateChangeLogLevelOpt(opt)
 	if err != nil {
 		return nil, err
@@ -700,7 +700,7 @@ func (s *SystemService) Liveness() (*SystemLiveness, *http.Response, error) {
 // Requires system administration permission.
 //
 // API Docs: https://next.sonarqube.com/sonarqube/web_api/api/system/logs
-func (s *SystemService) Logs(opt *SystemLogsOption) (*string, *http.Response, error) {
+func (s *SystemService) Logs(opt *SystemLogsOptions) (*string, *http.Response, error) {
 	err := s.ValidateLogsOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -842,7 +842,7 @@ func (s *SystemService) Upgrades() (*SystemUpgrades, *http.Response, error) {
 // -----------------------------------------------------------------------------
 
 // ValidateChangeLogLevelOpt validates the options for ChangeLogLevel.
-func (s *SystemService) ValidateChangeLogLevelOpt(opt *SystemChangeLogLevelOption) error {
+func (s *SystemService) ValidateChangeLogLevelOpt(opt *SystemChangeLogLevelOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "options cannot be nil", ErrMissingRequired)
 	}
@@ -861,7 +861,7 @@ func (s *SystemService) ValidateChangeLogLevelOpt(opt *SystemChangeLogLevelOptio
 }
 
 // ValidateLogsOpt validates the options for Logs.
-func (s *SystemService) ValidateLogsOpt(opt *SystemLogsOption) error {
+func (s *SystemService) ValidateLogsOpt(opt *SystemLogsOptions) error {
 	// opt can be nil (uses defaults)
 	if opt == nil {
 		return nil

--- a/sonar/system_service_test.go
+++ b/sonar/system_service_test.go
@@ -17,7 +17,7 @@ func TestSystem_ChangeLogLevel(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &SystemChangeLogLevelOption{Level: "INFO"}
+	opt := &SystemChangeLogLevelOptions{Level: "INFO"}
 	resp, err := client.System.ChangeLogLevel(opt)
 
 	require.NoError(t, err)
@@ -29,11 +29,11 @@ func TestSystem_ChangeLogLevel_ValidationErrors(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *SystemChangeLogLevelOption
+		opt  *SystemChangeLogLevelOptions
 	}{
 		{"nil options", nil},
-		{"missing level", &SystemChangeLogLevelOption{}},
-		{"invalid level", &SystemChangeLogLevelOption{Level: "INVALID"}},
+		{"missing level", &SystemChangeLogLevelOptions{}},
+		{"invalid level", &SystemChangeLogLevelOptions{Level: "INVALID"}},
 	}
 
 	for _, tc := range tests {
@@ -127,7 +127,7 @@ func TestSystem_Logs(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &SystemLogsOption{Name: "app"}
+	opt := &SystemLogsOptions{Name: "app"}
 	result, resp, err := client.System.Logs(opt)
 
 	require.NoError(t, err)
@@ -152,7 +152,7 @@ func TestSystem_Logs_NilOption(t *testing.T) {
 func TestSystem_Logs_ValidationErrors(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	opt := &SystemLogsOption{Name: "invalid_log"}
+	opt := &SystemLogsOptions{Name: "invalid_log"}
 	_, _, err := client.System.Logs(opt)
 
 	assert.Error(t, err, "expected validation error for invalid log name")
@@ -269,7 +269,7 @@ func TestValidateChangeLogLevelOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *SystemChangeLogLevelOption
+		opt     *SystemChangeLogLevelOptions
 		wantErr bool
 	}{
 		{
@@ -279,27 +279,27 @@ func TestValidateChangeLogLevelOpt(t *testing.T) {
 		},
 		{
 			name:    "missing level",
-			opt:     &SystemChangeLogLevelOption{},
+			opt:     &SystemChangeLogLevelOptions{},
 			wantErr: true,
 		},
 		{
 			name:    "invalid level",
-			opt:     &SystemChangeLogLevelOption{Level: "VERBOSE"},
+			opt:     &SystemChangeLogLevelOptions{Level: "VERBOSE"},
 			wantErr: true,
 		},
 		{
 			name:    "valid TRACE",
-			opt:     &SystemChangeLogLevelOption{Level: "TRACE"},
+			opt:     &SystemChangeLogLevelOptions{Level: "TRACE"},
 			wantErr: false,
 		},
 		{
 			name:    "valid DEBUG",
-			opt:     &SystemChangeLogLevelOption{Level: "DEBUG"},
+			opt:     &SystemChangeLogLevelOptions{Level: "DEBUG"},
 			wantErr: false,
 		},
 		{
 			name:    "valid INFO",
-			opt:     &SystemChangeLogLevelOption{Level: "INFO"},
+			opt:     &SystemChangeLogLevelOptions{Level: "INFO"},
 			wantErr: false,
 		},
 	}
@@ -321,7 +321,7 @@ func TestValidateLogsOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *SystemLogsOption
+		opt     *SystemLogsOptions
 		wantErr bool
 	}{
 		{
@@ -331,42 +331,42 @@ func TestValidateLogsOpt(t *testing.T) {
 		},
 		{
 			name:    "empty name (allowed, uses default)",
-			opt:     &SystemLogsOption{},
+			opt:     &SystemLogsOptions{},
 			wantErr: false,
 		},
 		{
 			name:    "invalid name",
-			opt:     &SystemLogsOption{Name: "invalid_log_type"},
+			opt:     &SystemLogsOptions{Name: "invalid_log_type"},
 			wantErr: true,
 		},
 		{
 			name:    "valid access",
-			opt:     &SystemLogsOption{Name: "access"},
+			opt:     &SystemLogsOptions{Name: "access"},
 			wantErr: false,
 		},
 		{
 			name:    "valid app",
-			opt:     &SystemLogsOption{Name: "app"},
+			opt:     &SystemLogsOptions{Name: "app"},
 			wantErr: false,
 		},
 		{
 			name:    "valid ce",
-			opt:     &SystemLogsOption{Name: "ce"},
+			opt:     &SystemLogsOptions{Name: "ce"},
 			wantErr: false,
 		},
 		{
 			name:    "valid deprecation",
-			opt:     &SystemLogsOption{Name: "deprecation"},
+			opt:     &SystemLogsOptions{Name: "deprecation"},
 			wantErr: false,
 		},
 		{
 			name:    "valid es",
-			opt:     &SystemLogsOption{Name: "es"},
+			opt:     &SystemLogsOptions{Name: "es"},
 			wantErr: false,
 		},
 		{
 			name:    "valid web",
-			opt:     &SystemLogsOption{Name: "web"},
+			opt:     &SystemLogsOptions{Name: "web"},
 			wantErr: false,
 		},
 	}

--- a/sonar/user_groups_service.go
+++ b/sonar/user_groups_service.go
@@ -99,16 +99,16 @@ type UserGroupsUsers struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// UserGroupsAddUserOption represents options for adding a user to a group.
-type UserGroupsAddUserOption struct {
+// UserGroupsAddUserOptions represents options for adding a user to a group.
+type UserGroupsAddUserOptions struct {
 	// Login is the user login (optional - for internal accounts).
 	Login string `url:"login,omitempty"`
 	// Name is the group name (required).
 	Name string `url:"name,omitempty"`
 }
 
-// UserGroupsCreateOption represents options for creating a group.
-type UserGroupsCreateOption struct {
+// UserGroupsCreateOptions represents options for creating a group.
+type UserGroupsCreateOptions struct {
 	// Description is the description for the new group.
 	// Maximum length: 200 characters.
 	Description string `url:"description,omitempty"`
@@ -118,24 +118,24 @@ type UserGroupsCreateOption struct {
 	Name string `url:"name,omitempty"`
 }
 
-// UserGroupsDeleteOption represents options for deleting a group.
-type UserGroupsDeleteOption struct {
+// UserGroupsDeleteOptions represents options for deleting a group.
+type UserGroupsDeleteOptions struct {
 	// Name is the group name (required).
 	Name string `url:"name,omitempty"`
 }
 
-// UserGroupsRemoveUserOption represents options for removing a user from a group.
-type UserGroupsRemoveUserOption struct {
+// UserGroupsRemoveUserOptions represents options for removing a user from a group.
+type UserGroupsRemoveUserOptions struct {
 	// Login is the user login (optional - for internal accounts).
 	Login string `url:"login,omitempty"`
 	// Name is the group name (required).
 	Name string `url:"name,omitempty"`
 }
 
-// UserGroupsSearchOption represents options for searching groups.
+// UserGroupsSearchOptions represents options for searching groups.
 //
 //nolint:govet // Embedded PaginationArgs makes optimal alignment impractical
-type UserGroupsSearchOption struct {
+type UserGroupsSearchOptions struct {
 	PaginationArgs
 
 	// Managed filters by managed status.
@@ -148,8 +148,8 @@ type UserGroupsSearchOption struct {
 	Query string `url:"q,omitempty"`
 }
 
-// UserGroupsUpdateOption represents options for updating a group.
-type UserGroupsUpdateOption struct {
+// UserGroupsUpdateOptions represents options for updating a group.
+type UserGroupsUpdateOptions struct {
 	// CurrentName is the current name of the group to update (required).
 	CurrentName string `url:"currentName,omitempty"`
 	// Description is the new optional description for the group.
@@ -161,10 +161,10 @@ type UserGroupsUpdateOption struct {
 	Name string `url:"name,omitempty"`
 }
 
-// UserGroupsUsersOption represents options for listing users in a group.
+// UserGroupsUsersOptions represents options for listing users in a group.
 //
 //nolint:govet // Embedded PaginationArgs makes optimal alignment impractical
-type UserGroupsUsersOption struct {
+type UserGroupsUsersOptions struct {
 	PaginationArgs
 
 	// Name is the group name (required).
@@ -181,7 +181,7 @@ type UserGroupsUsersOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateAddUserOpt validates the options for AddUser.
-func (s *UserGroupsService) ValidateAddUserOpt(opt *UserGroupsAddUserOption) error {
+func (s *UserGroupsService) ValidateAddUserOpt(opt *UserGroupsAddUserOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -190,7 +190,7 @@ func (s *UserGroupsService) ValidateAddUserOpt(opt *UserGroupsAddUserOption) err
 }
 
 // ValidateCreateOpt validates the options for Create.
-func (s *UserGroupsService) ValidateCreateOpt(opt *UserGroupsCreateOption) error {
+func (s *UserGroupsService) ValidateCreateOpt(opt *UserGroupsCreateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -216,7 +216,7 @@ func (s *UserGroupsService) ValidateCreateOpt(opt *UserGroupsCreateOption) error
 }
 
 // ValidateDeleteOpt validates the options for Delete.
-func (s *UserGroupsService) ValidateDeleteOpt(opt *UserGroupsDeleteOption) error {
+func (s *UserGroupsService) ValidateDeleteOpt(opt *UserGroupsDeleteOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -225,7 +225,7 @@ func (s *UserGroupsService) ValidateDeleteOpt(opt *UserGroupsDeleteOption) error
 }
 
 // ValidateRemoveUserOpt validates the options for RemoveUser.
-func (s *UserGroupsService) ValidateRemoveUserOpt(opt *UserGroupsRemoveUserOption) error {
+func (s *UserGroupsService) ValidateRemoveUserOpt(opt *UserGroupsRemoveUserOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -234,7 +234,7 @@ func (s *UserGroupsService) ValidateRemoveUserOpt(opt *UserGroupsRemoveUserOptio
 }
 
 // ValidateSearchOpt validates the options for Search.
-func (s *UserGroupsService) ValidateSearchOpt(opt *UserGroupsSearchOption) error {
+func (s *UserGroupsService) ValidateSearchOpt(opt *UserGroupsSearchOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -248,7 +248,7 @@ func (s *UserGroupsService) ValidateSearchOpt(opt *UserGroupsSearchOption) error
 }
 
 // ValidateUpdateOpt validates the options for Update.
-func (s *UserGroupsService) ValidateUpdateOpt(opt *UserGroupsUpdateOption) error {
+func (s *UserGroupsService) ValidateUpdateOpt(opt *UserGroupsUpdateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -276,7 +276,7 @@ func (s *UserGroupsService) ValidateUpdateOpt(opt *UserGroupsUpdateOption) error
 }
 
 // ValidateUsersOpt validates the options for Users.
-func (s *UserGroupsService) ValidateUsersOpt(opt *UserGroupsUsersOption) error {
+func (s *UserGroupsService) ValidateUsersOpt(opt *UserGroupsUsersOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -305,7 +305,7 @@ func (s *UserGroupsService) ValidateUsersOpt(opt *UserGroupsUsersOption) error {
 // Deprecated: Since 10.4. Use POST /api/v2/authorizations/group-memberships instead.
 //
 // Since: 5.2.
-func (s *UserGroupsService) AddUser(opt *UserGroupsAddUserOption) (*http.Response, error) {
+func (s *UserGroupsService) AddUser(opt *UserGroupsAddUserOptions) (*http.Response, error) {
 	err := s.ValidateAddUserOpt(opt)
 	if err != nil {
 		return nil, err
@@ -330,7 +330,7 @@ func (s *UserGroupsService) AddUser(opt *UserGroupsAddUserOption) (*http.Respons
 // Deprecated: Since 10.4. Use POST /api/v2/authorizations/groups instead.
 //
 // Since: 5.2.
-func (s *UserGroupsService) Create(opt *UserGroupsCreateOption) (*UserGroupsCreate, *http.Response, error) {
+func (s *UserGroupsService) Create(opt *UserGroupsCreateOptions) (*UserGroupsCreate, *http.Response, error) {
 	err := s.ValidateCreateOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -358,7 +358,7 @@ func (s *UserGroupsService) Create(opt *UserGroupsCreateOption) (*UserGroupsCrea
 // Deprecated: Since 10.4. Use DELETE /api/v2/authorizations/groups instead.
 //
 // Since: 5.2.
-func (s *UserGroupsService) Delete(opt *UserGroupsDeleteOption) (*http.Response, error) {
+func (s *UserGroupsService) Delete(opt *UserGroupsDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
@@ -384,7 +384,7 @@ func (s *UserGroupsService) Delete(opt *UserGroupsDeleteOption) (*http.Response,
 // Deprecated: Since 10.4. Use DELETE /api/v2/authorizations/group-memberships instead.
 //
 // Since: 5.2.
-func (s *UserGroupsService) RemoveUser(opt *UserGroupsRemoveUserOption) (*http.Response, error) {
+func (s *UserGroupsService) RemoveUser(opt *UserGroupsRemoveUserOptions) (*http.Response, error) {
 	err := s.ValidateRemoveUserOpt(opt)
 	if err != nil {
 		return nil, err
@@ -409,7 +409,7 @@ func (s *UserGroupsService) RemoveUser(opt *UserGroupsRemoveUserOption) (*http.R
 // Deprecated: Since 10.4. Use GET /api/v2/authorizations/groups instead.
 //
 // Since: 5.2.
-func (s *UserGroupsService) Search(opt *UserGroupsSearchOption) (*UserGroupsSearch, *http.Response, error) {
+func (s *UserGroupsService) Search(opt *UserGroupsSearchOptions) (*UserGroupsSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -436,7 +436,7 @@ func (s *UserGroupsService) Search(opt *UserGroupsSearchOption) (*UserGroupsSear
 // Deprecated: Since 10.4. Use PATCH /api/v2/authorizations/groups instead.
 //
 // Since: 5.2.
-func (s *UserGroupsService) Update(opt *UserGroupsUpdateOption) (*http.Response, error) {
+func (s *UserGroupsService) Update(opt *UserGroupsUpdateOptions) (*http.Response, error) {
 	err := s.ValidateUpdateOpt(opt)
 	if err != nil {
 		return nil, err
@@ -461,7 +461,7 @@ func (s *UserGroupsService) Update(opt *UserGroupsUpdateOption) (*http.Response,
 // Deprecated: Since 10.4. Use GET /api/v2/authorizations/group-memberships instead.
 //
 // Since: 5.2.
-func (s *UserGroupsService) Users(opt *UserGroupsUsersOption) (*UserGroupsUsers, *http.Response, error) {
+func (s *UserGroupsService) Users(opt *UserGroupsUsersOptions) (*UserGroupsUsers, *http.Response, error) {
 	err := s.ValidateUsersOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/user_groups_service_test.go
+++ b/sonar/user_groups_service_test.go
@@ -13,7 +13,7 @@ func TestUserGroups_AddUser(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/user_groups/add_user", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &UserGroupsAddUserOption{
+	opt := &UserGroupsAddUserOptions{
 		Name:  "sonar-administrators",
 		Login: "g.hopper",
 	}
@@ -31,7 +31,7 @@ func TestUserGroups_AddUser_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, err = client.UserGroups.AddUser(&UserGroupsAddUserOption{
+	_, err = client.UserGroups.AddUser(&UserGroupsAddUserOptions{
 		Login: "user",
 	})
 	assert.Error(t, err)
@@ -51,7 +51,7 @@ func TestUserGroups_Create(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/user_groups/create", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &UserGroupsCreateOption{
+	opt := &UserGroupsCreateOptions{
 		Name:        "sonar-users",
 		Description: "Default group",
 	}
@@ -70,19 +70,19 @@ func TestUserGroups_Create_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, _, err = client.UserGroups.Create(&UserGroupsCreateOption{
+	_, _, err = client.UserGroups.Create(&UserGroupsCreateOptions{
 		Description: "test",
 	})
 	assert.Error(t, err)
 
 	// Test Name too long
-	_, _, err = client.UserGroups.Create(&UserGroupsCreateOption{
+	_, _, err = client.UserGroups.Create(&UserGroupsCreateOptions{
 		Name: strings.Repeat("a", MaxGroupNameLength+1),
 	})
 	assert.Error(t, err)
 
 	// Test Description too long
-	_, _, err = client.UserGroups.Create(&UserGroupsCreateOption{
+	_, _, err = client.UserGroups.Create(&UserGroupsCreateOptions{
 		Name:        "test",
 		Description: strings.Repeat("a", MaxGroupDescriptionLength+1),
 	})
@@ -93,7 +93,7 @@ func TestUserGroups_Delete(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/user_groups/delete", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &UserGroupsDeleteOption{
+	opt := &UserGroupsDeleteOptions{
 		Name: "sonar-users",
 	}
 
@@ -110,7 +110,7 @@ func TestUserGroups_Delete_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, err = client.UserGroups.Delete(&UserGroupsDeleteOption{})
+	_, err = client.UserGroups.Delete(&UserGroupsDeleteOptions{})
 	assert.Error(t, err)
 }
 
@@ -118,7 +118,7 @@ func TestUserGroups_RemoveUser(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/user_groups/remove_user", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &UserGroupsRemoveUserOption{
+	opt := &UserGroupsRemoveUserOptions{
 		Name:  "sonar-administrators",
 		Login: "g.hopper",
 	}
@@ -149,7 +149,7 @@ func TestUserGroups_Search(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/user_groups/search", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &UserGroupsSearchOption{
+	opt := &UserGroupsSearchOptions{
 		Query:  "admin",
 		Fields: []string{"name", "description"},
 	}
@@ -168,7 +168,7 @@ func TestUserGroups_Search_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test invalid field
-	_, _, err = client.UserGroups.Search(&UserGroupsSearchOption{
+	_, _, err = client.UserGroups.Search(&UserGroupsSearchOptions{
 		Fields: []string{"invalid_field"},
 	})
 	assert.Error(t, err)
@@ -178,7 +178,7 @@ func TestUserGroups_Update(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/user_groups/update", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &UserGroupsUpdateOption{
+	opt := &UserGroupsUpdateOptions{
 		CurrentName: "old-group",
 		Name:        "new-group",
 		Description: "Updated description",
@@ -197,7 +197,7 @@ func TestUserGroups_Update_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing CurrentName
-	_, err = client.UserGroups.Update(&UserGroupsUpdateOption{
+	_, err = client.UserGroups.Update(&UserGroupsUpdateOptions{
 		Name: "new-group",
 	})
 	assert.Error(t, err)
@@ -223,7 +223,7 @@ func TestUserGroups_Users(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/user_groups/users", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &UserGroupsUsersOption{
+	opt := &UserGroupsUsersOptions{
 		Name:     "sonar-administrators",
 		Selected: "selected",
 	}
@@ -242,11 +242,11 @@ func TestUserGroups_Users_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, _, err = client.UserGroups.Users(&UserGroupsUsersOption{})
+	_, _, err = client.UserGroups.Users(&UserGroupsUsersOptions{})
 	assert.Error(t, err)
 
 	// Test invalid Selected value
-	_, _, err = client.UserGroups.Users(&UserGroupsUsersOption{
+	_, _, err = client.UserGroups.Users(&UserGroupsUsersOptions{
 		Name:     "test",
 		Selected: "invalid",
 	})

--- a/sonar/user_tokens_service.go
+++ b/sonar/user_tokens_service.go
@@ -82,8 +82,8 @@ type UserTokensSearch struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// UserTokensGenerateOption contains parameters for the Generate method.
-type UserTokensGenerateOption struct {
+// UserTokensGenerateOptions contains parameters for the Generate method.
+type UserTokensGenerateOptions struct {
 	// ExpirationDate is the expiration date of the token in ISO 8601 format (YYYY-MM-DD).
 	// If not set, defaults to no expiration.
 	ExpirationDate string `url:"expirationDate,omitempty"`
@@ -102,8 +102,8 @@ type UserTokensGenerateOption struct {
 	Type string `url:"type,omitempty"`
 }
 
-// UserTokensRevokeOption contains parameters for the Revoke method.
-type UserTokensRevokeOption struct {
+// UserTokensRevokeOptions contains parameters for the Revoke method.
+type UserTokensRevokeOptions struct {
 	// Login is the user login.
 	Login string `url:"login,omitempty"`
 	// Name is the token name.
@@ -111,8 +111,8 @@ type UserTokensRevokeOption struct {
 	Name string `url:"name"`
 }
 
-// UserTokensSearchOption contains parameters for the Search method.
-type UserTokensSearchOption struct {
+// UserTokensSearchOptions contains parameters for the Search method.
+type UserTokensSearchOptions struct {
 	// Login is the user login.
 	Login string `url:"login,omitempty"`
 }
@@ -122,7 +122,7 @@ type UserTokensSearchOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateGenerateOpt validates the options for the Generate method.
-func (s *UserTokensService) ValidateGenerateOpt(opt *UserTokensGenerateOption) error {
+func (s *UserTokensService) ValidateGenerateOpt(opt *UserTokensGenerateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -153,7 +153,7 @@ func (s *UserTokensService) ValidateGenerateOpt(opt *UserTokensGenerateOption) e
 }
 
 // ValidateRevokeOpt validates the options for the Revoke method.
-func (s *UserTokensService) ValidateRevokeOpt(opt *UserTokensRevokeOption) error {
+func (s *UserTokensService) ValidateRevokeOpt(opt *UserTokensRevokeOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -167,7 +167,7 @@ func (s *UserTokensService) ValidateRevokeOpt(opt *UserTokensRevokeOption) error
 }
 
 // ValidateSearchOpt validates the options for the Search method.
-func (s *UserTokensService) ValidateSearchOpt(opt *UserTokensSearchOption) error {
+func (s *UserTokensService) ValidateSearchOpt(opt *UserTokensSearchOptions) error {
 	// Options are optional; nothing to validate.
 	return nil
 }
@@ -183,7 +183,7 @@ func (s *UserTokensService) ValidateSearchOpt(opt *UserTokensSearchOption) error
 //
 // API endpoint: POST /api/user_tokens/generate.
 // Since: 5.3.
-func (s *UserTokensService) Generate(opt *UserTokensGenerateOption) (*UserTokensGenerate, *http.Response, error) {
+func (s *UserTokensService) Generate(opt *UserTokensGenerateOptions) (*UserTokensGenerate, *http.Response, error) {
 	err := s.ValidateGenerateOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -210,7 +210,7 @@ func (s *UserTokensService) Generate(opt *UserTokensGenerateOption) (*UserTokens
 //
 // API endpoint: POST /api/user_tokens/revoke.
 // Since: 5.3.
-func (s *UserTokensService) Revoke(opt *UserTokensRevokeOption) (*http.Response, error) {
+func (s *UserTokensService) Revoke(opt *UserTokensRevokeOptions) (*http.Response, error) {
 	err := s.ValidateRevokeOpt(opt)
 	if err != nil {
 		return nil, err
@@ -238,7 +238,7 @@ func (s *UserTokensService) Revoke(opt *UserTokensRevokeOption) (*http.Response,
 //
 // API endpoint: GET /api/user_tokens/search.
 // Since: 5.3.
-func (s *UserTokensService) Search(opt *UserTokensSearchOption) (*UserTokensSearch, *http.Response, error) {
+func (s *UserTokensService) Search(opt *UserTokensSearchOptions) (*UserTokensSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/user_tokens_service_test.go
+++ b/sonar/user_tokens_service_test.go
@@ -21,7 +21,7 @@ func TestUserTokens_Generate(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &UserTokensGenerateOption{
+	opt := &UserTokensGenerateOptions{
 		Name: "my-token",
 	}
 
@@ -47,7 +47,7 @@ func TestUserTokens_Generate_WithType(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &UserTokensGenerateOption{
+	opt := &UserTokensGenerateOptions{
 		Name:       "project-token",
 		Type:       "PROJECT_ANALYSIS_TOKEN",
 		ProjectKey: "my-project",
@@ -67,18 +67,18 @@ func TestUserTokens_Generate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Name should fail validation.
-	_, _, err = client.UserTokens.Generate(&UserTokensGenerateOption{})
+	_, _, err = client.UserTokens.Generate(&UserTokensGenerateOptions{})
 	assert.Error(t, err)
 
 	// Invalid Type should fail validation.
-	_, _, err = client.UserTokens.Generate(&UserTokensGenerateOption{
+	_, _, err = client.UserTokens.Generate(&UserTokensGenerateOptions{
 		Name: "my-token",
 		Type: "INVALID_TYPE",
 	})
 	assert.Error(t, err)
 
 	// PROJECT_ANALYSIS_TOKEN without ProjectKey should fail validation.
-	_, _, err = client.UserTokens.Generate(&UserTokensGenerateOption{
+	_, _, err = client.UserTokens.Generate(&UserTokensGenerateOptions{
 		Name: "my-token",
 		Type: "PROJECT_ANALYSIS_TOKEN",
 	})
@@ -90,7 +90,7 @@ func TestUserTokens_Revoke(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &UserTokensRevokeOption{
+	opt := &UserTokensRevokeOptions{
 		Name: "my-token",
 	}
 
@@ -107,7 +107,7 @@ func TestUserTokens_Revoke_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Name should fail validation.
-	_, err = client.UserTokens.Revoke(&UserTokensRevokeOption{})
+	_, err = client.UserTokens.Revoke(&UserTokensRevokeOptions{})
 	assert.Error(t, err)
 }
 
@@ -151,7 +151,7 @@ func TestUserTokens_Search_WithLogin(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &UserTokensSearchOption{
+	opt := &UserTokensSearchOptions{
 		Login: "testuser",
 	}
 
@@ -164,7 +164,7 @@ func TestUserTokens_ValidateGenerateOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Valid option should pass.
-	err := client.UserTokens.ValidateGenerateOpt(&UserTokensGenerateOption{
+	err := client.UserTokens.ValidateGenerateOpt(&UserTokensGenerateOptions{
 		Name: "my-token",
 	})
 	assert.NoError(t, err)
@@ -172,7 +172,7 @@ func TestUserTokens_ValidateGenerateOpt(t *testing.T) {
 	// All valid token types should pass.
 	validTypes := []string{"USER_TOKEN", "GLOBAL_ANALYSIS_TOKEN"}
 	for _, tokenType := range validTypes {
-		err := client.UserTokens.ValidateGenerateOpt(&UserTokensGenerateOption{
+		err := client.UserTokens.ValidateGenerateOpt(&UserTokensGenerateOptions{
 			Name: "my-token",
 			Type: tokenType,
 		})
@@ -180,7 +180,7 @@ func TestUserTokens_ValidateGenerateOpt(t *testing.T) {
 	}
 
 	// PROJECT_ANALYSIS_TOKEN with ProjectKey should pass.
-	err = client.UserTokens.ValidateGenerateOpt(&UserTokensGenerateOption{
+	err = client.UserTokens.ValidateGenerateOpt(&UserTokensGenerateOptions{
 		Name:       "project-token",
 		Type:       "PROJECT_ANALYSIS_TOKEN",
 		ProjectKey: "my-project",
@@ -192,7 +192,7 @@ func TestUserTokens_ValidateGenerateOpt(t *testing.T) {
 	for i := 0; i < MaxTokenNameLength+1; i++ {
 		longName += "a"
 	}
-	err = client.UserTokens.ValidateGenerateOpt(&UserTokensGenerateOption{
+	err = client.UserTokens.ValidateGenerateOpt(&UserTokensGenerateOptions{
 		Name: longName,
 	})
 	assert.Error(t, err)

--- a/sonar/users_service.go
+++ b/sonar/users_service.go
@@ -274,15 +274,15 @@ type UsersUpdate struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// UsersAnonymizeOption contains parameters for the Anonymize method.
-type UsersAnonymizeOption struct {
+// UsersAnonymizeOptions contains parameters for the Anonymize method.
+type UsersAnonymizeOptions struct {
 	// Login is the user login.
 	// This field is required.
 	Login string `url:"login"`
 }
 
-// UsersChangePasswordOption contains parameters for the ChangePassword method.
-type UsersChangePasswordOption struct {
+// UsersChangePasswordOptions contains parameters for the ChangePassword method.
+type UsersChangePasswordOptions struct {
 	// Login is the user login.
 	// This field is required.
 	Login string `url:"login"`
@@ -293,10 +293,10 @@ type UsersChangePasswordOption struct {
 	PreviousPassword string `url:"previousPassword,omitempty"`
 }
 
-// UsersCreateOption contains parameters for the Create method.
+// UsersCreateOptions contains parameters for the Create method.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type UsersCreateOption struct {
+type UsersCreateOptions struct {
 	// Email is the user email address.
 	Email string `url:"email,omitempty"`
 	// Local specifies if the user should be authenticated from SonarQube server.
@@ -316,8 +316,8 @@ type UsersCreateOption struct {
 	ScmAccounts []string `url:"scmAccount,omitempty"`
 }
 
-// UsersDeactivateOption contains parameters for the Deactivate method.
-type UsersDeactivateOption struct {
+// UsersDeactivateOptions contains parameters for the Deactivate method.
+type UsersDeactivateOptions struct {
 	// Login is the user login.
 	// This field is required.
 	Login string `url:"login"`
@@ -325,8 +325,8 @@ type UsersDeactivateOption struct {
 	Anonymize bool `url:"anonymize,omitempty"`
 }
 
-// UsersDismissNoticeOption contains parameters for the DismissNotice method.
-type UsersDismissNoticeOption struct {
+// UsersDismissNoticeOptions contains parameters for the DismissNotice method.
+type UsersDismissNoticeOptions struct {
 	// Notice is the notice key to dismiss.
 	// This field is required.
 	// Allowed values: educationPrinciples, sonarlintAd, showDesignAndArchitectureBanner,
@@ -336,10 +336,10 @@ type UsersDismissNoticeOption struct {
 	Notice string `url:"notice"`
 }
 
-// UsersGroupsOption contains parameters for the Groups method.
+// UsersGroupsOptions contains parameters for the Groups method.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type UsersGroupsOption struct {
+type UsersGroupsOptions struct {
 	PaginationArgs
 
 	// Login is the user login.
@@ -352,10 +352,10 @@ type UsersGroupsOption struct {
 	Selected string `url:"selected,omitempty"`
 }
 
-// UsersSearchOption contains parameters for the Search method.
+// UsersSearchOptions contains parameters for the Search method.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type UsersSearchOption struct {
+type UsersSearchOptions struct {
 	PaginationArgs
 
 	// Deactivated returns deactivated users instead of active users when true.
@@ -382,8 +382,8 @@ type UsersSearchOption struct {
 	SlLastConnectedBefore string `url:"slLastConnectedBefore,omitempty"`
 }
 
-// UsersSetHomepageOption contains parameters for the SetHomepage method.
-type UsersSetHomepageOption struct {
+// UsersSetHomepageOptions contains parameters for the SetHomepage method.
+type UsersSetHomepageOptions struct {
 	// Branch is the branch key. Only used when Type is PROJECT.
 	Branch string `url:"branch,omitempty"`
 	// Component is the project key. Only used when Type is PROJECT.
@@ -394,8 +394,8 @@ type UsersSetHomepageOption struct {
 	Type string `url:"type"`
 }
 
-// UsersUpdateOption contains parameters for the Update method.
-type UsersUpdateOption struct {
+// UsersUpdateOptions contains parameters for the Update method.
+type UsersUpdateOptions struct {
 	// Email is the user's new email address.
 	Email string `url:"email,omitempty"`
 	// Login is the user login.
@@ -407,8 +407,8 @@ type UsersUpdateOption struct {
 	ScmAccounts []string `url:"scmAccount,omitempty"`
 }
 
-// UsersUpdateIdentityProviderOption contains parameters for the UpdateIdentityProvider method.
-type UsersUpdateIdentityProviderOption struct {
+// UsersUpdateIdentityProviderOptions contains parameters for the UpdateIdentityProvider method.
+type UsersUpdateIdentityProviderOptions struct {
 	// Login is the user login.
 	// This field is required.
 	Login string `url:"login"`
@@ -420,8 +420,8 @@ type UsersUpdateIdentityProviderOption struct {
 	NewExternalProvider string `url:"newExternalProvider"`
 }
 
-// UsersUpdateLoginOption contains parameters for the UpdateLogin method.
-type UsersUpdateLoginOption struct {
+// UsersUpdateLoginOptions contains parameters for the UpdateLogin method.
+type UsersUpdateLoginOptions struct {
 	// Login is the current login (case-sensitive).
 	// This field is required.
 	Login string `url:"login"`
@@ -435,7 +435,7 @@ type UsersUpdateLoginOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateAnonymizeOpt validates the options for the Anonymize method.
-func (s *UsersService) ValidateAnonymizeOpt(opt *UsersAnonymizeOption) error {
+func (s *UsersService) ValidateAnonymizeOpt(opt *UsersAnonymizeOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -449,7 +449,7 @@ func (s *UsersService) ValidateAnonymizeOpt(opt *UsersAnonymizeOption) error {
 }
 
 // ValidateChangePasswordOpt validates the options for the ChangePassword method.
-func (s *UsersService) ValidateChangePasswordOpt(opt *UsersChangePasswordOption) error {
+func (s *UsersService) ValidateChangePasswordOpt(opt *UsersChangePasswordOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -502,7 +502,7 @@ func validateUserPassword(password string, isLocal bool) error {
 }
 
 // ValidateCreateOpt validates the options for the Create method.
-func (s *UsersService) ValidateCreateOpt(opt *UsersCreateOption) error {
+func (s *UsersService) ValidateCreateOpt(opt *UsersCreateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -533,7 +533,7 @@ func (s *UsersService) ValidateCreateOpt(opt *UsersCreateOption) error {
 }
 
 // ValidateDeactivateOpt validates the options for the Deactivate method.
-func (s *UsersService) ValidateDeactivateOpt(opt *UsersDeactivateOption) error {
+func (s *UsersService) ValidateDeactivateOpt(opt *UsersDeactivateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -547,7 +547,7 @@ func (s *UsersService) ValidateDeactivateOpt(opt *UsersDeactivateOption) error {
 }
 
 // ValidateDismissNoticeOpt validates the options for the DismissNotice method.
-func (s *UsersService) ValidateDismissNoticeOpt(opt *UsersDismissNoticeOption) error {
+func (s *UsersService) ValidateDismissNoticeOpt(opt *UsersDismissNoticeOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -566,7 +566,7 @@ func (s *UsersService) ValidateDismissNoticeOpt(opt *UsersDismissNoticeOption) e
 }
 
 // ValidateGroupsOpt validates the options for the Groups method.
-func (s *UsersService) ValidateGroupsOpt(opt *UsersGroupsOption) error {
+func (s *UsersService) ValidateGroupsOpt(opt *UsersGroupsOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -592,7 +592,7 @@ func (s *UsersService) ValidateGroupsOpt(opt *UsersGroupsOption) error {
 }
 
 // ValidateSearchOpt validates the options for the Search method.
-func (s *UsersService) ValidateSearchOpt(opt *UsersSearchOption) error {
+func (s *UsersService) ValidateSearchOpt(opt *UsersSearchOptions) error {
 	if opt == nil {
 		// Search with no options is valid
 		return nil
@@ -607,7 +607,7 @@ func (s *UsersService) ValidateSearchOpt(opt *UsersSearchOption) error {
 }
 
 // ValidateSetHomepageOpt validates the options for the SetHomepage method.
-func (s *UsersService) ValidateSetHomepageOpt(opt *UsersSetHomepageOption) error {
+func (s *UsersService) ValidateSetHomepageOpt(opt *UsersSetHomepageOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -626,7 +626,7 @@ func (s *UsersService) ValidateSetHomepageOpt(opt *UsersSetHomepageOption) error
 }
 
 // ValidateUpdateOpt validates the options for the Update method.
-func (s *UsersService) ValidateUpdateOpt(opt *UsersUpdateOption) error {
+func (s *UsersService) ValidateUpdateOpt(opt *UsersUpdateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -654,7 +654,7 @@ func (s *UsersService) ValidateUpdateOpt(opt *UsersUpdateOption) error {
 }
 
 // ValidateUpdateIdentityProviderOpt validates the options for the UpdateIdentityProvider method.
-func (s *UsersService) ValidateUpdateIdentityProviderOpt(opt *UsersUpdateIdentityProviderOption) error {
+func (s *UsersService) ValidateUpdateIdentityProviderOpt(opt *UsersUpdateIdentityProviderOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -673,7 +673,7 @@ func (s *UsersService) ValidateUpdateIdentityProviderOpt(opt *UsersUpdateIdentit
 }
 
 // ValidateUpdateLoginOpt validates the options for the UpdateLogin method.
-func (s *UsersService) ValidateUpdateLoginOpt(opt *UsersUpdateLoginOption) error {
+func (s *UsersService) ValidateUpdateLoginOpt(opt *UsersUpdateLoginOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -711,7 +711,7 @@ func (s *UsersService) ValidateUpdateLoginOpt(opt *UsersUpdateLoginOption) error
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: POST /api/users/anonymize.
 // Since: 9.7.
-func (s *UsersService) Anonymize(opt *UsersAnonymizeOption) (*http.Response, error) {
+func (s *UsersService) Anonymize(opt *UsersAnonymizeOptions) (*http.Response, error) {
 	err := s.ValidateAnonymizeOpt(opt)
 	if err != nil {
 		return nil, err
@@ -737,7 +737,7 @@ func (s *UsersService) Anonymize(opt *UsersAnonymizeOption) (*http.Response, err
 //
 // API endpoint: POST /api/users/change_password.
 // Since: 5.2.
-func (s *UsersService) ChangePassword(opt *UsersChangePasswordOption) (*http.Response, error) {
+func (s *UsersService) ChangePassword(opt *UsersChangePasswordOptions) (*http.Response, error) {
 	err := s.ValidateChangePasswordOpt(opt)
 	if err != nil {
 		return nil, err
@@ -763,7 +763,7 @@ func (s *UsersService) ChangePassword(opt *UsersChangePasswordOption) (*http.Res
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: POST /api/users/create.
 // Since: 3.7.
-func (s *UsersService) Create(opt *UsersCreateOption) (*UsersCreate, *http.Response, error) {
+func (s *UsersService) Create(opt *UsersCreateOptions) (*UsersCreate, *http.Response, error) {
 	err := s.ValidateCreateOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -810,7 +810,7 @@ func (s *UsersService) Current() (*UsersCurrent, *http.Response, error) {
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: POST /api/users/deactivate.
 // Since: 3.7.
-func (s *UsersService) Deactivate(opt *UsersDeactivateOption) (*UsersDeactivate, *http.Response, error) {
+func (s *UsersService) Deactivate(opt *UsersDeactivateOptions) (*UsersDeactivate, *http.Response, error) {
 	err := s.ValidateDeactivateOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -836,7 +836,7 @@ func (s *UsersService) Deactivate(opt *UsersDeactivateOption) (*UsersDeactivate,
 //
 // API endpoint: POST /api/users/dismiss_notice.
 // Since: 9.6.
-func (s *UsersService) DismissNotice(opt *UsersDismissNoticeOption) (*http.Response, error) {
+func (s *UsersService) DismissNotice(opt *UsersDismissNoticeOptions) (*http.Response, error) {
 	err := s.ValidateDismissNoticeOpt(opt)
 	if err != nil {
 		return nil, err
@@ -861,7 +861,7 @@ func (s *UsersService) DismissNotice(opt *UsersDismissNoticeOption) (*http.Respo
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: GET /api/users/groups.
 // Since: 5.2.
-func (s *UsersService) Groups(opt *UsersGroupsOption) (*UsersGroups, *http.Response, error) {
+func (s *UsersService) Groups(opt *UsersGroupsOptions) (*UsersGroups, *http.Response, error) {
 	err := s.ValidateGroupsOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -912,7 +912,7 @@ func (s *UsersService) IdentityProviders() (*UsersIdentityProviders, *http.Respo
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: GET /api/users/search.
 // Since: 3.6.
-func (s *UsersService) Search(opt *UsersSearchOption) (*UsersSearch, *http.Response, error) {
+func (s *UsersService) Search(opt *UsersSearchOptions) (*UsersSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -938,7 +938,7 @@ func (s *UsersService) Search(opt *UsersSearchOption) (*UsersSearch, *http.Respo
 //
 // API endpoint: POST /api/users/set_homepage.
 // Since: 7.0.
-func (s *UsersService) SetHomepage(opt *UsersSetHomepageOption) (*http.Response, error) {
+func (s *UsersService) SetHomepage(opt *UsersSetHomepageOptions) (*http.Response, error) {
 	err := s.ValidateSetHomepageOpt(opt)
 	if err != nil {
 		return nil, err
@@ -963,7 +963,7 @@ func (s *UsersService) SetHomepage(opt *UsersSetHomepageOption) (*http.Response,
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: POST /api/users/update.
 // Since: 3.7.
-func (s *UsersService) Update(opt *UsersUpdateOption) (*UsersUpdate, *http.Response, error) {
+func (s *UsersService) Update(opt *UsersUpdateOptions) (*UsersUpdate, *http.Response, error) {
 	err := s.ValidateUpdateOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -993,7 +993,7 @@ func (s *UsersService) Update(opt *UsersUpdateOption) (*UsersUpdate, *http.Respo
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: POST /api/users/update_identity_provider.
 // Since: 8.7.
-func (s *UsersService) UpdateIdentityProvider(opt *UsersUpdateIdentityProviderOption) (*http.Response, error) {
+func (s *UsersService) UpdateIdentityProvider(opt *UsersUpdateIdentityProviderOptions) (*http.Response, error) {
 	err := s.ValidateUpdateIdentityProviderOpt(opt)
 	if err != nil {
 		return nil, err
@@ -1019,7 +1019,7 @@ func (s *UsersService) UpdateIdentityProvider(opt *UsersUpdateIdentityProviderOp
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: POST /api/users/update_login.
 // Since: 7.6.
-func (s *UsersService) UpdateLogin(opt *UsersUpdateLoginOption) (*http.Response, error) {
+func (s *UsersService) UpdateLogin(opt *UsersUpdateLoginOptions) (*http.Response, error) {
 	err := s.ValidateUpdateLoginOpt(opt)
 	if err != nil {
 		return nil, err

--- a/sonar/users_service_test.go
+++ b/sonar/users_service_test.go
@@ -12,7 +12,7 @@ func TestUsers_Anonymize(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/users/anonymize", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &UsersAnonymizeOption{
+	opt := &UsersAnonymizeOptions{
 		Login: "deactivated-user",
 	}
 
@@ -29,7 +29,7 @@ func TestUsers_Anonymize_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Login should fail validation.
-	_, err = client.Users.Anonymize(&UsersAnonymizeOption{})
+	_, err = client.Users.Anonymize(&UsersAnonymizeOptions{})
 	assert.Error(t, err)
 }
 
@@ -37,7 +37,7 @@ func TestUsers_ChangePassword(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/users/change_password", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &UsersChangePasswordOption{
+	opt := &UsersChangePasswordOptions{
 		Login:    "myuser",
 		Password: "MyNewPassword123!",
 	}
@@ -52,7 +52,7 @@ func TestUsers_ChangePassword_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *UsersChangePasswordOption
+		opt  *UsersChangePasswordOptions
 	}{
 		{
 			name: "nil option",
@@ -60,15 +60,15 @@ func TestUsers_ChangePassword_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing login",
-			opt:  &UsersChangePasswordOption{Password: "MyNewPassword123!"},
+			opt:  &UsersChangePasswordOptions{Password: "MyNewPassword123!"},
 		},
 		{
 			name: "missing password",
-			opt:  &UsersChangePasswordOption{Login: "myuser"},
+			opt:  &UsersChangePasswordOptions{Login: "myuser"},
 		},
 		{
 			name: "password too short",
-			opt:  &UsersChangePasswordOption{Login: "myuser", Password: "short"},
+			opt:  &UsersChangePasswordOptions{Login: "myuser", Password: "short"},
 		},
 	}
 
@@ -95,7 +95,7 @@ func TestUsers_Create(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/users/create", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &UsersCreateOption{
+	opt := &UsersCreateOptions{
 		Login:       "newuser",
 		Name:        "New User",
 		Email:       "newuser@example.com",
@@ -119,7 +119,7 @@ func TestUsers_Create_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *UsersCreateOption
+		opt  *UsersCreateOptions
 	}{
 		{
 			name: "nil option",
@@ -127,23 +127,23 @@ func TestUsers_Create_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing login",
-			opt:  &UsersCreateOption{Name: "Test User"},
+			opt:  &UsersCreateOptions{Name: "Test User"},
 		},
 		{
 			name: "missing name",
-			opt:  &UsersCreateOption{Login: "testuser"},
+			opt:  &UsersCreateOptions{Login: "testuser"},
 		},
 		{
 			name: "login too short",
-			opt:  &UsersCreateOption{Login: "x", Name: "Test User"},
+			opt:  &UsersCreateOptions{Login: "x", Name: "Test User"},
 		},
 		{
 			name: "local user without password",
-			opt:  &UsersCreateOption{Login: "testuser", Name: "Test User", Local: true},
+			opt:  &UsersCreateOptions{Login: "testuser", Name: "Test User", Local: true},
 		},
 		{
 			name: "password too short",
-			opt:  &UsersCreateOption{Login: "testuser", Name: "Test User", Local: true, Password: "short"},
+			opt:  &UsersCreateOptions{Login: "testuser", Name: "Test User", Local: true, Password: "short"},
 		},
 	}
 
@@ -208,7 +208,7 @@ func TestUsers_Deactivate(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/users/deactivate", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &UsersDeactivateOption{
+	opt := &UsersDeactivateOptions{
 		Login:     "myuser",
 		Anonymize: false,
 	}
@@ -235,7 +235,7 @@ func TestUsers_Deactivate_WithAnonymize(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/users/deactivate", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &UsersDeactivateOption{
+	opt := &UsersDeactivateOptions{
 		Login:     "myuser",
 		Anonymize: true,
 	}
@@ -254,7 +254,7 @@ func TestUsers_Deactivate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Login should fail validation.
-	_, _, err = client.Users.Deactivate(&UsersDeactivateOption{})
+	_, _, err = client.Users.Deactivate(&UsersDeactivateOptions{})
 	assert.Error(t, err)
 }
 
@@ -262,7 +262,7 @@ func TestUsers_DismissNotice(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/users/dismiss_notice", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &UsersDismissNoticeOption{
+	opt := &UsersDismissNoticeOptions{
 		Notice: "educationPrinciples",
 	}
 
@@ -276,7 +276,7 @@ func TestUsers_DismissNotice_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *UsersDismissNoticeOption
+		opt  *UsersDismissNoticeOptions
 	}{
 		{
 			name: "nil option",
@@ -284,11 +284,11 @@ func TestUsers_DismissNotice_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing notice",
-			opt:  &UsersDismissNoticeOption{},
+			opt:  &UsersDismissNoticeOptions{},
 		},
 		{
 			name: "invalid notice",
-			opt:  &UsersDismissNoticeOption{Notice: "invalidNotice"},
+			opt:  &UsersDismissNoticeOptions{Notice: "invalidNotice"},
 		},
 	}
 
@@ -328,7 +328,7 @@ func TestUsers_Groups(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/users/groups", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &UsersGroupsOption{
+	opt := &UsersGroupsOptions{
 		Login: "myuser",
 	}
 
@@ -355,7 +355,7 @@ func TestUsers_Groups_WithPagination(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/users/groups", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &UsersGroupsOption{
+	opt := &UsersGroupsOptions{
 		Login: "myuser",
 		PaginationArgs: PaginationArgs{
 			Page:     2,
@@ -382,7 +382,7 @@ func TestUsers_Groups_WithFilter(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/users/groups", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &UsersGroupsOption{
+	opt := &UsersGroupsOptions{
 		Login:    "myuser",
 		Query:    "admin",
 		Selected: "selected",
@@ -398,7 +398,7 @@ func TestUsers_Groups_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *UsersGroupsOption
+		opt  *UsersGroupsOptions
 	}{
 		{
 			name: "nil option",
@@ -406,15 +406,15 @@ func TestUsers_Groups_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing login",
-			opt:  &UsersGroupsOption{},
+			opt:  &UsersGroupsOptions{},
 		},
 		{
 			name: "invalid selected",
-			opt:  &UsersGroupsOption{Login: "myuser", Selected: "invalid"},
+			opt:  &UsersGroupsOptions{Login: "myuser", Selected: "invalid"},
 		},
 		{
 			name: "invalid page size",
-			opt:  &UsersGroupsOption{Login: "myuser", PaginationArgs: PaginationArgs{PageSize: 1000}},
+			opt:  &UsersGroupsOptions{Login: "myuser", PaginationArgs: PaginationArgs{PageSize: 1000}},
 		},
 	}
 
@@ -518,7 +518,7 @@ func TestUsers_Search_WithFilters(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/users/search", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &UsersSearchOption{
+	opt := &UsersSearchOptions{
 		Deactivated: true,
 		Query:       "test",
 		PaginationArgs: PaginationArgs{
@@ -536,7 +536,7 @@ func TestUsers_Search_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Invalid page size should fail validation.
-	opt := &UsersSearchOption{
+	opt := &UsersSearchOptions{
 		PaginationArgs: PaginationArgs{PageSize: 1000},
 	}
 	_, _, err := client.Users.Search(opt)
@@ -547,7 +547,7 @@ func TestUsers_SetHomepage(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/users/set_homepage", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &UsersSetHomepageOption{
+	opt := &UsersSetHomepageOptions{
 		Type:      "PROJECT",
 		Component: "my-project",
 	}
@@ -562,7 +562,7 @@ func TestUsers_SetHomepage_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *UsersSetHomepageOption
+		opt  *UsersSetHomepageOptions
 	}{
 		{
 			name: "nil option",
@@ -570,11 +570,11 @@ func TestUsers_SetHomepage_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing type",
-			opt:  &UsersSetHomepageOption{},
+			opt:  &UsersSetHomepageOptions{},
 		},
 		{
 			name: "invalid type",
-			opt:  &UsersSetHomepageOption{Type: "INVALID"},
+			opt:  &UsersSetHomepageOptions{Type: "INVALID"},
 		},
 	}
 
@@ -601,7 +601,7 @@ func TestUsers_Update(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/users/update", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &UsersUpdateOption{
+	opt := &UsersUpdateOptions{
 		Login: "myuser",
 		Name:  "Updated Name",
 		Email: "updated@example.com",
@@ -622,7 +622,7 @@ func TestUsers_Update_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing Login should fail validation.
-	_, _, err = client.Users.Update(&UsersUpdateOption{})
+	_, _, err = client.Users.Update(&UsersUpdateOptions{})
 	assert.Error(t, err)
 }
 
@@ -630,7 +630,7 @@ func TestUsers_UpdateIdentityProvider(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/users/update_identity_provider", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &UsersUpdateIdentityProviderOption{
+	opt := &UsersUpdateIdentityProviderOptions{
 		Login:               "myuser",
 		NewExternalProvider: "github",
 		NewExternalIdentity: "github-user",
@@ -646,7 +646,7 @@ func TestUsers_UpdateIdentityProvider_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *UsersUpdateIdentityProviderOption
+		opt  *UsersUpdateIdentityProviderOptions
 	}{
 		{
 			name: "nil option",
@@ -654,11 +654,11 @@ func TestUsers_UpdateIdentityProvider_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing login",
-			opt:  &UsersUpdateIdentityProviderOption{NewExternalProvider: "github"},
+			opt:  &UsersUpdateIdentityProviderOptions{NewExternalProvider: "github"},
 		},
 		{
 			name: "missing newExternalProvider",
-			opt:  &UsersUpdateIdentityProviderOption{Login: "myuser"},
+			opt:  &UsersUpdateIdentityProviderOptions{Login: "myuser"},
 		},
 	}
 
@@ -674,7 +674,7 @@ func TestUsers_UpdateLogin(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/users/update_login", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &UsersUpdateLoginOption{
+	opt := &UsersUpdateLoginOptions{
 		Login:    "oldlogin",
 		NewLogin: "newlogin",
 	}
@@ -689,7 +689,7 @@ func TestUsers_UpdateLogin_ValidationError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		opt  *UsersUpdateLoginOption
+		opt  *UsersUpdateLoginOptions
 	}{
 		{
 			name: "nil option",
@@ -697,15 +697,15 @@ func TestUsers_UpdateLogin_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing login",
-			opt:  &UsersUpdateLoginOption{NewLogin: "newlogin"},
+			opt:  &UsersUpdateLoginOptions{NewLogin: "newlogin"},
 		},
 		{
 			name: "missing newLogin",
-			opt:  &UsersUpdateLoginOption{Login: "oldlogin"},
+			opt:  &UsersUpdateLoginOptions{Login: "oldlogin"},
 		},
 		{
 			name: "newLogin too short",
-			opt:  &UsersUpdateLoginOption{Login: "oldlogin", NewLogin: "x"},
+			opt:  &UsersUpdateLoginOptions{Login: "oldlogin", NewLogin: "x"},
 		},
 	}
 

--- a/sonar/webhooks_service.go
+++ b/sonar/webhooks_service.go
@@ -100,8 +100,8 @@ type WebhooksList struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// WebhooksCreateOption represents options for creating a webhook.
-type WebhooksCreateOption struct {
+// WebhooksCreateOptions represents options for creating a webhook.
+type WebhooksCreateOptions struct {
 	// Name is the display name of the webhook (required).
 	// Maximum length: 100 characters.
 	Name string `url:"name,omitempty"`
@@ -120,17 +120,17 @@ type WebhooksCreateOption struct {
 	URL string `url:"url,omitempty"`
 }
 
-// WebhooksDeleteOption represents options for deleting a webhook.
-type WebhooksDeleteOption struct {
+// WebhooksDeleteOptions represents options for deleting a webhook.
+type WebhooksDeleteOptions struct {
 	// Webhook is the key of the webhook to delete (required).
 	// Maximum length: 40 characters.
 	Webhook string `url:"webhook,omitempty"`
 }
 
-// WebhooksDeliveriesOption represents options for listing webhook deliveries.
+// WebhooksDeliveriesOptions represents options for listing webhook deliveries.
 //
 //nolint:govet // Embedded PaginationArgs makes optimal alignment impractical
-type WebhooksDeliveriesOption struct {
+type WebhooksDeliveriesOptions struct {
 	PaginationArgs
 
 	// CeTaskID filters deliveries by Compute Engine task ID.
@@ -145,21 +145,21 @@ type WebhooksDeliveriesOption struct {
 	Webhook string `url:"webhook,omitempty"`
 }
 
-// WebhooksDeliveryOption represents options for getting a single delivery.
-type WebhooksDeliveryOption struct {
+// WebhooksDeliveryOptions represents options for getting a single delivery.
+type WebhooksDeliveryOptions struct {
 	// DeliveryID is the unique identifier of the delivery (required).
 	DeliveryID string `url:"deliveryId,omitempty"`
 }
 
-// WebhooksListOption represents options for listing webhooks.
-type WebhooksListOption struct {
+// WebhooksListOptions represents options for listing webhooks.
+type WebhooksListOptions struct {
 	// Project filters webhooks by project key (optional).
 	// If not provided, returns global webhooks.
 	Project string `url:"project,omitempty"`
 }
 
-// WebhooksUpdateOption represents options for updating a webhook.
-type WebhooksUpdateOption struct {
+// WebhooksUpdateOptions represents options for updating a webhook.
+type WebhooksUpdateOptions struct {
 	// Name is the new name for the webhook (required).
 	// Maximum length: 100 characters.
 	Name string `url:"name,omitempty"`
@@ -195,7 +195,7 @@ func validateWebhookSecret(secret string) error {
 }
 
 // ValidateCreateOpt validates the options for Create.
-func (s *WebhooksService) ValidateCreateOpt(opt *WebhooksCreateOption) error {
+func (s *WebhooksService) ValidateCreateOpt(opt *WebhooksCreateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -231,7 +231,7 @@ func (s *WebhooksService) ValidateCreateOpt(opt *WebhooksCreateOption) error {
 }
 
 // ValidateDeleteOpt validates the options for Delete.
-func (s *WebhooksService) ValidateDeleteOpt(opt *WebhooksDeleteOption) error {
+func (s *WebhooksService) ValidateDeleteOpt(opt *WebhooksDeleteOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -245,7 +245,7 @@ func (s *WebhooksService) ValidateDeleteOpt(opt *WebhooksDeleteOption) error {
 }
 
 // ValidateDeliveriesOpt validates the options for Deliveries.
-func (s *WebhooksService) ValidateDeliveriesOpt(opt *WebhooksDeliveriesOption) error {
+func (s *WebhooksService) ValidateDeliveriesOpt(opt *WebhooksDeliveriesOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -254,7 +254,7 @@ func (s *WebhooksService) ValidateDeliveriesOpt(opt *WebhooksDeliveriesOption) e
 }
 
 // ValidateDeliveryOpt validates the options for Delivery.
-func (s *WebhooksService) ValidateDeliveryOpt(opt *WebhooksDeliveryOption) error {
+func (s *WebhooksService) ValidateDeliveryOpt(opt *WebhooksDeliveryOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -263,7 +263,7 @@ func (s *WebhooksService) ValidateDeliveryOpt(opt *WebhooksDeliveryOption) error
 }
 
 // ValidateListOpt validates the options for List.
-func (s *WebhooksService) ValidateListOpt(opt *WebhooksListOption) error {
+func (s *WebhooksService) ValidateListOpt(opt *WebhooksListOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -272,7 +272,7 @@ func (s *WebhooksService) ValidateListOpt(opt *WebhooksListOption) error {
 }
 
 // ValidateUpdateOpt validates the options for Update.
-func (s *WebhooksService) ValidateUpdateOpt(opt *WebhooksUpdateOption) error {
+func (s *WebhooksService) ValidateUpdateOpt(opt *WebhooksUpdateOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -325,7 +325,7 @@ func (s *WebhooksService) ValidateUpdateOpt(opt *WebhooksUpdateOption) error {
 // Requires 'Administer' permission on the specified project, or global 'Administer' permission.
 //
 // Since: 7.1.
-func (s *WebhooksService) Create(opt *WebhooksCreateOption) (*WebhooksCreate, *http.Response, error) {
+func (s *WebhooksService) Create(opt *WebhooksCreateOptions) (*WebhooksCreate, *http.Response, error) {
 	err := s.ValidateCreateOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -350,7 +350,7 @@ func (s *WebhooksService) Create(opt *WebhooksCreateOption) (*WebhooksCreate, *h
 // Requires 'Administer' permission on the specified project, or global 'Administer' permission.
 //
 // Since: 7.1.
-func (s *WebhooksService) Delete(opt *WebhooksDeleteOption) (*http.Response, error) {
+func (s *WebhooksService) Delete(opt *WebhooksDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
@@ -374,7 +374,7 @@ func (s *WebhooksService) Delete(opt *WebhooksDeleteOption) (*http.Response, err
 // Note that additional information is returned by api/webhooks/delivery.
 //
 // Since: 6.2.
-func (s *WebhooksService) Deliveries(opt *WebhooksDeliveriesOption) (*WebhooksDeliveries, *http.Response, error) {
+func (s *WebhooksService) Deliveries(opt *WebhooksDeliveriesOptions) (*WebhooksDeliveries, *http.Response, error) {
 	err := s.ValidateDeliveriesOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -399,7 +399,7 @@ func (s *WebhooksService) Deliveries(opt *WebhooksDeliveriesOption) (*WebhooksDe
 // Requires 'Administer System' permission.
 //
 // Since: 6.2.
-func (s *WebhooksService) Delivery(opt *WebhooksDeliveryOption) (*WebhooksDelivery, *http.Response, error) {
+func (s *WebhooksService) Delivery(opt *WebhooksDeliveryOptions) (*WebhooksDelivery, *http.Response, error) {
 	err := s.ValidateDeliveryOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -425,7 +425,7 @@ func (s *WebhooksService) Delivery(opt *WebhooksDeliveryOption) (*WebhooksDelive
 // Requires 'Administer' permission on the specified project, or global 'Administer' permission.
 //
 // Since: 7.1.
-func (s *WebhooksService) List(opt *WebhooksListOption) (*WebhooksList, *http.Response, error) {
+func (s *WebhooksService) List(opt *WebhooksListOptions) (*WebhooksList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -450,7 +450,7 @@ func (s *WebhooksService) List(opt *WebhooksListOption) (*WebhooksList, *http.Re
 // Requires 'Administer' permission on the specified project, or global 'Administer' permission.
 //
 // Since: 7.1.
-func (s *WebhooksService) Update(opt *WebhooksUpdateOption) (*http.Response, error) {
+func (s *WebhooksService) Update(opt *WebhooksUpdateOptions) (*http.Response, error) {
 	err := s.ValidateUpdateOpt(opt)
 	if err != nil {
 		return nil, err

--- a/sonar/webhooks_service_test.go
+++ b/sonar/webhooks_service_test.go
@@ -22,7 +22,7 @@ func TestWebhooks_Create(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/webhooks/create", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &WebhooksCreateOption{
+	opt := &WebhooksCreateOptions{
 		Name:   "My Webhook",
 		URL:    "https://example.com/webhook",
 		Secret: "my-secret-at-least-16",
@@ -42,33 +42,33 @@ func TestWebhooks_Create_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, _, err = client.Webhooks.Create(&WebhooksCreateOption{
+	_, _, err = client.Webhooks.Create(&WebhooksCreateOptions{
 		URL: "https://example.com",
 	})
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, _, err = client.Webhooks.Create(&WebhooksCreateOption{
+	_, _, err = client.Webhooks.Create(&WebhooksCreateOptions{
 		Name: "My Webhook",
 	})
 	assert.Error(t, err)
 
 	// Test Name too long
-	_, _, err = client.Webhooks.Create(&WebhooksCreateOption{
+	_, _, err = client.Webhooks.Create(&WebhooksCreateOptions{
 		Name: strings.Repeat("a", MaxWebhookNameLength+1),
 		URL:  "https://example.com",
 	})
 	assert.Error(t, err)
 
 	// Test URL too long
-	_, _, err = client.Webhooks.Create(&WebhooksCreateOption{
+	_, _, err = client.Webhooks.Create(&WebhooksCreateOptions{
 		Name: "My Webhook",
 		URL:  strings.Repeat("a", MaxWebhookURLLength+1),
 	})
 	assert.Error(t, err)
 
 	// Test Secret too short
-	_, _, err = client.Webhooks.Create(&WebhooksCreateOption{
+	_, _, err = client.Webhooks.Create(&WebhooksCreateOptions{
 		Name:   "My Webhook",
 		URL:    "https://example.com",
 		Secret: "short",
@@ -80,7 +80,7 @@ func TestWebhooks_Delete(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/webhooks/delete", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &WebhooksDeleteOption{
+	opt := &WebhooksDeleteOptions{
 		Webhook: "my-webhook-key",
 	}
 
@@ -97,7 +97,7 @@ func TestWebhooks_Delete_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Webhook
-	_, err = client.Webhooks.Delete(&WebhooksDeleteOption{})
+	_, err = client.Webhooks.Delete(&WebhooksDeleteOptions{})
 	assert.Error(t, err)
 }
 
@@ -122,7 +122,7 @@ func TestWebhooks_Deliveries(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/webhooks/deliveries", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &WebhooksDeliveriesOption{
+	opt := &WebhooksDeliveriesOptions{
 		Webhook: "webhook-key",
 	}
 
@@ -155,7 +155,7 @@ func TestWebhooks_Delivery(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/webhooks/delivery", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &WebhooksDeliveryOption{
+	opt := &WebhooksDeliveryOptions{
 		DeliveryID: "delivery-1",
 	}
 
@@ -173,7 +173,7 @@ func TestWebhooks_Delivery_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing DeliveryID
-	_, _, err = client.Webhooks.Delivery(&WebhooksDeliveryOption{})
+	_, _, err = client.Webhooks.Delivery(&WebhooksDeliveryOptions{})
 	assert.Error(t, err)
 }
 
@@ -192,7 +192,7 @@ func TestWebhooks_List(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/webhooks/list", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	opt := &WebhooksListOption{}
+	opt := &WebhooksListOptions{}
 
 	result, resp, err := client.Webhooks.List(opt)
 	require.NoError(t, err)
@@ -212,7 +212,7 @@ func TestWebhooks_Update(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/webhooks/update", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &WebhooksUpdateOption{
+	opt := &WebhooksUpdateOptions{
 		Webhook: "webhook-1",
 		Name:    "Updated Webhook",
 		URL:     "https://example.com/updated",
@@ -231,21 +231,21 @@ func TestWebhooks_Update_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, err = client.Webhooks.Update(&WebhooksUpdateOption{
+	_, err = client.Webhooks.Update(&WebhooksUpdateOptions{
 		URL:     "https://example.com",
 		Webhook: "webhook-1",
 	})
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.Webhooks.Update(&WebhooksUpdateOption{
+	_, err = client.Webhooks.Update(&WebhooksUpdateOptions{
 		Name:    "My Webhook",
 		Webhook: "webhook-1",
 	})
 	assert.Error(t, err)
 
 	// Test missing Webhook
-	_, err = client.Webhooks.Update(&WebhooksUpdateOption{
+	_, err = client.Webhooks.Update(&WebhooksUpdateOptions{
 		Name: "My Webhook",
 		URL:  "https://example.com",
 	})

--- a/sonar/webservices_service.go
+++ b/sonar/webservices_service.go
@@ -110,15 +110,15 @@ type WebserviceParam struct {
 // Option Types
 // -----------------------------------------------------------------------------
 
-// WebservicesListOption represents options for listing webservices.
-type WebservicesListOption struct {
+// WebservicesListOptions represents options for listing webservices.
+type WebservicesListOptions struct {
 	// IncludeInternals includes internal actions and parameters.
 	// Default: false.
 	IncludeInternals bool `url:"include_internals,omitempty"`
 }
 
-// WebservicesResponseExampleOption represents options for getting a response example.
-type WebservicesResponseExampleOption struct {
+// WebservicesResponseExampleOptions represents options for getting a response example.
+type WebservicesResponseExampleOptions struct {
 	// Action is the action key (required).
 	Action string `url:"action,omitempty"`
 	// Controller is the controller key (required).
@@ -130,13 +130,13 @@ type WebservicesResponseExampleOption struct {
 // -----------------------------------------------------------------------------
 
 // ValidateListOpt validates the options for the List method.
-func (s *WebservicesService) ValidateListOpt(_ *WebservicesListOption) error {
+func (s *WebservicesService) ValidateListOpt(_ *WebservicesListOptions) error {
 	// No required fields, all options are optional
 	return nil
 }
 
 // ValidateResponseExampleOpt validates the options for the ResponseExample method.
-func (s *WebservicesService) ValidateResponseExampleOpt(opt *WebservicesResponseExampleOption) error {
+func (s *WebservicesService) ValidateResponseExampleOpt(opt *WebservicesResponseExampleOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -158,7 +158,7 @@ func (s *WebservicesService) ValidateResponseExampleOpt(opt *WebservicesResponse
 //
 // API endpoint: GET /api/webservices/list.
 // Since: 4.2.
-func (s *WebservicesService) List(opt *WebservicesListOption) (*WebservicesList, *http.Response, error) {
+func (s *WebservicesService) List(opt *WebservicesListOptions) (*WebservicesList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -184,7 +184,7 @@ func (s *WebservicesService) List(opt *WebservicesListOption) (*WebservicesList,
 //
 // API endpoint: GET /api/webservices/response_example.
 // Since: 4.4.
-func (s *WebservicesService) ResponseExample(opt *WebservicesResponseExampleOption) (*string, *http.Response, error) {
+func (s *WebservicesService) ResponseExample(opt *WebservicesResponseExampleOptions) (*string, *http.Response, error) {
 	err := s.ValidateResponseExampleOpt(opt)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/webservices_service_test.go
+++ b/sonar/webservices_service_test.go
@@ -59,7 +59,7 @@ func TestWebservicesService_List(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Webservices.List(&WebservicesListOption{
+		_, _, err := client.Webservices.List(&WebservicesListOptions{
 			IncludeInternals: true,
 		})
 
@@ -71,7 +71,7 @@ func TestWebservicesService_List(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Webservices.List(&WebservicesListOption{})
+		_, _, err := client.Webservices.List(&WebservicesListOptions{})
 
 		require.NoError(t, err)
 	})
@@ -90,7 +90,7 @@ func TestWebservicesService_ResponseExample(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Webservices.ResponseExample(&WebservicesResponseExampleOption{
+		result, resp, err := client.Webservices.ResponseExample(&WebservicesResponseExampleOptions{
 			Action:     "search",
 			Controller: "api/issues",
 		})
@@ -111,7 +111,7 @@ func TestWebservicesService_ResponseExample(t *testing.T) {
 	t.Run("missing action fails validation", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.Webservices.ResponseExample(&WebservicesResponseExampleOption{
+		_, _, err := client.Webservices.ResponseExample(&WebservicesResponseExampleOptions{
 			Controller: "api/issues",
 		})
 
@@ -121,7 +121,7 @@ func TestWebservicesService_ResponseExample(t *testing.T) {
 	t.Run("missing controller fails validation", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.Webservices.ResponseExample(&WebservicesResponseExampleOption{
+		_, _, err := client.Webservices.ResponseExample(&WebservicesResponseExampleOptions{
 			Action: "search",
 		})
 
@@ -134,12 +134,12 @@ func TestWebservicesService_ValidateListOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *WebservicesListOption
+		opt     *WebservicesListOptions
 		wantErr bool
 	}{
 		{"nil option", nil, false},
-		{"empty option", &WebservicesListOption{}, false},
-		{"with include internals", &WebservicesListOption{IncludeInternals: true}, false},
+		{"empty option", &WebservicesListOptions{}, false},
+		{"with include internals", &WebservicesListOptions{IncludeInternals: true}, false},
 	}
 
 	for _, tt := range tests {
@@ -159,14 +159,14 @@ func TestWebservicesService_ValidateResponseExampleOpt(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		opt     *WebservicesResponseExampleOption
+		opt     *WebservicesResponseExampleOptions
 		wantErr bool
 	}{
-		{"valid", &WebservicesResponseExampleOption{Action: "search", Controller: "api/issues"}, false},
+		{"valid", &WebservicesResponseExampleOptions{Action: "search", Controller: "api/issues"}, false},
 		{"nil option", nil, true},
-		{"missing action", &WebservicesResponseExampleOption{Controller: "api/issues"}, true},
-		{"missing controller", &WebservicesResponseExampleOption{Action: "search"}, true},
-		{"empty both", &WebservicesResponseExampleOption{}, true},
+		{"missing action", &WebservicesResponseExampleOptions{Controller: "api/issues"}, true},
+		{"missing controller", &WebservicesResponseExampleOptions{Action: "search"}, true},
+		{"empty both", &WebservicesResponseExampleOptions{}, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Description of your changes

This PR standardizes the "Option" structures (the types that are passed to API requests), all of them are now ending with "Options", instead of having both naming coexisting.

BREAKING CHANGE: all structures that ended with `Option` now end with `Options`

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.