### PR TITLE
feat: create usage constants

### DIFF
--- a/integration_testing/alm_integrations_test.go
+++ b/integration_testing/alm_integrations_test.go
@@ -118,7 +118,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOptions{
 					ProjectName:            "test-project",
 					RepositoryName:         "test-repo",
-					NewCodeDefinitionType:  "NUMBER_OF_DAYS",
+					NewCodeDefinitionType:  sonar.NewCodePeriodTypeNumberOfDays,
 					NewCodeDefinitionValue: 0,
 				})
 				Expect(err).To(HaveOccurred())
@@ -130,7 +130,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOptions{
 					ProjectName:            "test-project",
 					RepositoryName:         "test-repo",
-					NewCodeDefinitionType:  "NUMBER_OF_DAYS",
+					NewCodeDefinitionType:  sonar.NewCodePeriodTypeNumberOfDays,
 					NewCodeDefinitionValue: 100,
 				})
 				Expect(err).To(HaveOccurred())

--- a/integration_testing/ce_test.go
+++ b/integration_testing/ce_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 			It("should list CE tasks filtered by status", func() {
 				result, resp, err := client.Ce.Activity(&sonar.CeActivityOptions{
-					Statuses: []string{"SUCCESS"},
+					Statuses: []string{sonar.TaskStatusSuccess},
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -92,7 +92,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 			It("should list CE tasks filtered by type", func() {
 				result, resp, err := client.Ce.Activity(&sonar.CeActivityOptions{
-					Type: "REPORT",
+					Type: sonar.TaskTypeReport,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))

--- a/integration_testing/components_test.go
+++ b/integration_testing/components_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Components Service", Ordered, func() {
 	Describe("Search", func() {
 		It("should search for projects", func() {
 			result, resp, err := client.Components.Search(&sonar.ComponentsSearchOptions{
-				Qualifiers: []string{"TRK"},
+				Qualifiers: []string{sonar.ProjectQualifierTRK},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -47,7 +47,7 @@ var _ = Describe("Components Service", Ordered, func() {
 
 		It("should search projects with pagination", func() {
 			result, resp, err := client.Components.Search(&sonar.ComponentsSearchOptions{
-				Qualifiers: []string{"TRK"},
+				Qualifiers: []string{sonar.ProjectQualifierTRK},
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 5,
 				},
@@ -81,7 +81,7 @@ var _ = Describe("Components Service", Ordered, func() {
 
 			// Search for it
 			result, resp, err := client.Components.Search(&sonar.ComponentsSearchOptions{
-				Qualifiers: []string{"TRK"},
+				Qualifiers: []string{sonar.ProjectQualifierTRK},
 				Query:      query,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -216,7 +216,7 @@ var _ = Describe("Components Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
 			Expect(result.Component.Key).To(Equal(projectKey))
-			Expect(result.Component.Qualifier).To(Equal("TRK"))
+			Expect(result.Component.Qualifier).To(Equal(sonar.ProjectQualifierTRK))
 		})
 
 		It("should return ancestors for project", func() {
@@ -288,7 +288,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		It("should get tree with all strategy", func() {
 			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
 				Component: projectKey,
-				Strategy:  "all",
+				Strategy:  sonar.MeasureStrategyAll,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -298,7 +298,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		It("should get tree with children strategy", func() {
 			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
 				Component: projectKey,
-				Strategy:  "children",
+				Strategy:  sonar.MeasureStrategyChildren,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -308,7 +308,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		It("should get tree with leaves strategy", func() {
 			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
 				Component: projectKey,
-				Strategy:  "leaves",
+				Strategy:  sonar.MeasureStrategyLeaves,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -416,7 +416,7 @@ var _ = Describe("Components Service", Ordered, func() {
 
 		It("should get more suggestions for TRK qualifier", func() {
 			result, resp, err := client.Components.Suggestions(&sonar.ComponentsSuggestionsOptions{
-				More: "TRK",
+				More: sonar.ProjectQualifierTRK,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -480,7 +480,7 @@ var _ = Describe("Components Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result.Name).NotTo(BeEmpty())
-			Expect(result.Query).To(Equal("TRK"))
+			Expect(result.Query).To(Equal(sonar.ProjectQualifierTRK))
 		})
 
 		Context("parameter validation", func() {

--- a/integration_testing/hotspots_test.go
+++ b/integration_testing/hotspots_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			It("should search hotspots with status filter", func() {
 				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOptions{
 					Project: projectKey,
-					Status:  "TO_REVIEW",
+					Status:  sonar.HotspotStatusToReview,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -174,7 +174,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			It("should list hotspots with status filter", func() {
 				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOptions{
 					Project: projectKey,
-					Status:  "TO_REVIEW",
+					Status:  sonar.HotspotStatusToReview,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -376,7 +376,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 			It("should fail without required hotspot key", func() {
 				resp, err := client.Hotspots.ChangeStatus(&sonar.HotspotsChangeStatusOptions{
-					Status: "REVIEWED",
+					Status: sonar.HotspotStatusReviewed,
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Hotspot"))
@@ -397,8 +397,8 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			It("should fail with non-existent hotspot key", func() {
 				resp, err := client.Hotspots.ChangeStatus(&sonar.HotspotsChangeStatusOptions{
 					Hotspot:    "AXxxxxxxxxxxxxxxxxxx",
-					Status:     "REVIEWED",
-					Resolution: "SAFE",
+					Status:     sonar.HotspotStatusReviewed,
+					Resolution: sonar.HotspotResolutionSafe,
 				})
 				Expect(err).To(HaveOccurred())
 				if resp != nil {

--- a/integration_testing/issues_test.go
+++ b/integration_testing/issues_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			It("should search issues with impact severities filter", func() {
 				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
 					Projects:         []string{projectKey},
-					ImpactSeverities: []string{"HIGH", "MEDIUM"},
+					ImpactSeverities: []string{sonar.RuleImpactSeverityHigh, sonar.RuleImpactSeverityMedium},
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -99,7 +99,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			It("should search issues with issue statuses filter", func() {
 				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
 					Projects:      []string{projectKey},
-					IssueStatuses: []string{"OPEN", "CONFIRMED"},
+					IssueStatuses: []string{sonar.IssueStatusOpen, sonar.IssueStatusConfirmed},
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -109,7 +109,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			It("should search issues with clean code categories filter", func() {
 				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
 					Projects:                     []string{projectKey},
-					CleanCodeAttributeCategories: []string{"INTENTIONAL", "CONSISTENT"},
+					CleanCodeAttributeCategories: []string{sonar.CleanCodeAttributeCategoryIntentional, sonar.CleanCodeAttributeCategoryConsistent},
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -408,7 +408,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 			It("should fail without required issue key", func() {
 				result, resp, err := client.Issues.DoTransition(&sonar.IssuesDoTransitionOptions{
-					Transition: "confirm",
+					Transition: sonar.IssueTransitionConfirm,
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Issue"))
@@ -431,7 +431,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			It("should fail with non-existent issue key", func() {
 				result, resp, err := client.Issues.DoTransition(&sonar.IssuesDoTransitionOptions{
 					Issue:      nonExistentIssueKey,
-					Transition: "confirm",
+					Transition: sonar.IssueTransitionConfirm,
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
@@ -498,7 +498,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 			It("should fail without required issue key", func() {
 				result, resp, err := client.Issues.SetSeverity(&sonar.IssuesSetSeverityOptions{
-					Severity: "MAJOR",
+					Severity: sonar.RuleSeverityMajor,
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Issue"))
@@ -511,7 +511,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			It("should fail with non-existent issue key", func() {
 				result, resp, err := client.Issues.SetSeverity(&sonar.IssuesSetSeverityOptions{
 					Issue:    nonExistentIssueKey,
-					Severity: "MAJOR",
+					Severity: sonar.RuleSeverityMajor,
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
@@ -576,7 +576,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 			It("should fail without required issue key", func() {
 				result, resp, err := client.Issues.SetType(&sonar.IssuesSetTypeOptions{
-					Type: "BUG",
+					Type: sonar.RuleTypeBug,
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Issue"))
@@ -599,7 +599,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			It("should fail with non-existent issue key", func() {
 				result, resp, err := client.Issues.SetType(&sonar.IssuesSetTypeOptions{
 					Issue: nonExistentIssueKey,
-					Type:  "BUG",
+					Type:  sonar.RuleTypeBug,
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())

--- a/integration_testing/measures_test.go
+++ b/integration_testing/measures_test.go
@@ -235,7 +235,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
-					Strategy:   "children",
+					Strategy:   sonar.MeasureStrategyChildren,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -246,7 +246,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
-					Strategy:   "leaves",
+					Strategy:   sonar.MeasureStrategyLeaves,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -257,7 +257,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
-					Strategy:   "all",
+					Strategy:   sonar.MeasureStrategyAll,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -268,7 +268,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
 					Component:        projectKey,
 					MetricKeys:       []string{"ncloc"},
-					MetricSortFilter: "withMeasuresOnly",
+					MetricSortFilter: sonar.MeasuresMetricSortFilterWithMeasuresOnly,
 					MetricSort:       "ncloc",
 					Sort:             []string{"metric"},
 				})

--- a/integration_testing/new_code_periods_test.go
+++ b/integration_testing/new_code_periods_test.go
@@ -198,7 +198,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 
 			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
-				Type:    "PREVIOUS_VERSION",
+				Type:    sonar.NewCodePeriodTypePreviousVersion,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -227,7 +227,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 
 			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
-				Type:    "NUMBER_OF_DAYS",
+				Type:    sonar.NewCodePeriodTypeNumberOfDays,
 				Value:   "30",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -257,7 +257,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 
 			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
-				Type:    "REFERENCE_BRANCH",
+				Type:    sonar.NewCodePeriodTypeReferenceBranch,
 				Value:   "main",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -288,7 +288,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Branch:  "main",
-				Type:    "NUMBER_OF_DAYS",
+				Type:    sonar.NewCodePeriodTypeNumberOfDays,
 				Value:   "15",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -331,7 +331,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			It("should fail with NUMBER_OF_DAYS and invalid value", func() {
 				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
-					Type:    "NUMBER_OF_DAYS",
+					Type:    sonar.NewCodePeriodTypeNumberOfDays,
 					Value:   "invalid",
 				})
 				Expect(err).To(HaveOccurred())
@@ -341,7 +341,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			It("should fail with NUMBER_OF_DAYS exceeding max value", func() {
 				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
-					Type:    "NUMBER_OF_DAYS",
+					Type:    sonar.NewCodePeriodTypeNumberOfDays,
 					Value:   "100",
 				})
 				Expect(err).To(HaveOccurred())
@@ -351,7 +351,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			It("should fail with NUMBER_OF_DAYS without value", func() {
 				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
-					Type:    "NUMBER_OF_DAYS",
+					Type:    sonar.NewCodePeriodTypeNumberOfDays,
 					Value:   "",
 				})
 				Expect(err).To(HaveOccurred())
@@ -361,7 +361,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			It("should fail with NUMBER_OF_DAYS with zero value", func() {
 				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
-					Type:    "NUMBER_OF_DAYS",
+					Type:    sonar.NewCodePeriodTypeNumberOfDays,
 					Value:   "0",
 				})
 				Expect(err).To(HaveOccurred())
@@ -371,7 +371,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			It("should fail with NUMBER_OF_DAYS with negative value", func() {
 				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
-					Type:    "NUMBER_OF_DAYS",
+					Type:    sonar.NewCodePeriodTypeNumberOfDays,
 					Value:   "-5",
 				})
 				Expect(err).To(HaveOccurred())
@@ -396,7 +396,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 
 				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: projectKey,
-					Type:    "NUMBER_OF_DAYS",
+					Type:    sonar.NewCodePeriodTypeNumberOfDays,
 					Value:   "1",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -421,7 +421,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 
 				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: projectKey,
-					Type:    "NUMBER_OF_DAYS",
+					Type:    sonar.NewCodePeriodTypeNumberOfDays,
 					Value:   "90",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -430,7 +430,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 
 			It("should fail with REFERENCE_BRANCH missing project", func() {
 				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
-					Type:  "REFERENCE_BRANCH",
+					Type:  sonar.NewCodePeriodTypeReferenceBranch,
 					Value: "main",
 				})
 				Expect(err).To(HaveOccurred())
@@ -440,7 +440,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			It("should fail with SPECIFIC_ANALYSIS missing branch", func() {
 				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
-					Type:    "SPECIFIC_ANALYSIS",
+					Type:    sonar.NewCodePeriodTypeSpecificAnalysis,
 					Value:   "some-analysis-id",
 				})
 				Expect(err).To(HaveOccurred())
@@ -472,7 +472,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			// First, set a new code period
 			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
-				Type:    "PREVIOUS_VERSION",
+				Type:    sonar.NewCodePeriodTypePreviousVersion,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -505,7 +505,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Branch:  "main",
-				Type:    "NUMBER_OF_DAYS",
+				Type:    sonar.NewCodePeriodTypeNumberOfDays,
 				Value:   "45",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -559,7 +559,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			// Step 3: Set project-level new code period
 			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
-				Type:    "NUMBER_OF_DAYS",
+				Type:    sonar.NewCodePeriodTypeNumberOfDays,
 				Value:   "30",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -568,7 +568,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Branch:  "main",
-				Type:    "PREVIOUS_VERSION",
+				Type:    sonar.NewCodePeriodTypePreviousVersion,
 			})
 			Expect(err).NotTo(HaveOccurred())
 

--- a/integration_testing/permissions_test.go
+++ b/integration_testing/permissions_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Permission Test Project",
 				Project:    testProjectKey,
-				Visibility: "private",
+				Visibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -173,7 +173,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Remove User Permission Test",
 				Project:    testProjectKey,
-				Visibility: "private",
+				Visibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -274,7 +274,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Group Permission Test Project",
 				Project:    testProjectKey,
-				Visibility: "private",
+				Visibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -401,7 +401,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Remove Group Permission Test",
 				Project:    testProjectKey,
-				Visibility: "private",
+				Visibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1471,7 +1471,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Apply Template Test",
 				Project:    testProjectKey,
-				Visibility: "private",
+				Visibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1697,7 +1697,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			var originalDefaultID string
 			for _, dt := range searchResult.DefaultTemplates {
-				if dt.Qualifier == "TRK" {
+				if dt.Qualifier == sonar.ProjectQualifierTRK {
 					originalDefaultID = dt.TemplateID
 					break
 				}
@@ -1706,7 +1706,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			// Set our template as default
 			resp, err := client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOptions{
 				TemplateName: testTemplateName,
-				Qualifier:    "TRK",
+				Qualifier:    sonar.ProjectQualifierTRK,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
@@ -1718,7 +1718,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			for _, t := range searchResult.PermissionTemplates {
 				if t.Name == testTemplateName {
 					for _, dt := range searchResult.DefaultTemplates {
-						if dt.TemplateID == t.ID && dt.Qualifier == "TRK" {
+						if dt.TemplateID == t.ID && dt.Qualifier == sonar.ProjectQualifierTRK {
 							found = true
 							break
 						}
@@ -1732,7 +1732,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			if originalDefaultID != "" {
 				_, _ = client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOptions{
 					TemplateID: originalDefaultID,
-					Qualifier:  "TRK",
+					Qualifier:  sonar.ProjectQualifierTRK,
 				})
 			}
 		})
@@ -1746,7 +1746,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			It("should fail with missing template identifier", func() {
 				resp, err := client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOptions{
-					Qualifier: "TRK",
+					Qualifier: sonar.ProjectQualifierTRK,
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
@@ -1775,7 +1775,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Lifecycle Test Project",
 				Project:    projectKey,
-				Visibility: "private",
+				Visibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1879,7 +1879,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Template Lifecycle Project",
 				Project:    projectKey,
-				Visibility: "private",
+				Visibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
 

--- a/integration_testing/projects_test.go
+++ b/integration_testing/projects_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			result, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Full Config Project",
 				Project:    projectKey,
-				Visibility: "private",
+				Visibility: sonar.ProjectVisibilityPrivate,
 				MainBranch: "main",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -80,7 +80,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
 			Expect(result.Project.Key).To(Equal(projectKey))
-			Expect(result.Project.Visibility).To(Equal("private"))
+			Expect(result.Project.Visibility).To(Equal(sonar.ProjectVisibilityPrivate))
 		})
 
 		It("should create a public project", func() {
@@ -89,7 +89,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			result, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Public Project",
 				Project:    projectKey,
-				Visibility: "public",
+				Visibility: sonar.ProjectVisibilityPublic,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -103,7 +103,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
-			Expect(result.Project.Visibility).To(Equal("public"))
+			Expect(result.Project.Visibility).To(Equal(sonar.ProjectVisibilityPublic))
 		})
 
 		Context("parameter validation", func() {
@@ -183,7 +183,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Search Test Project",
 				Project:    testProjectKey,
-				Visibility: "private",
+				Visibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -235,25 +235,25 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		It("should search projects by visibility", func() {
 			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
-				Visibility: "private",
+				Visibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
 			for _, c := range result.Components {
-				Expect(c.Visibility).To(Equal("private"))
+				Expect(c.Visibility).To(Equal(sonar.ProjectVisibilityPrivate))
 			}
 		})
 
 		It("should search projects by qualifier", func() {
 			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
-				Qualifiers: []string{"TRK"},
+				Qualifiers: []string{sonar.ProjectQualifierTRK},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
 			for _, c := range result.Components {
-				Expect(c.Qualifier).To(Equal("TRK"))
+				Expect(c.Qualifier).To(Equal(sonar.ProjectQualifierTRK))
 			}
 		})
 
@@ -444,7 +444,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Visibility Test Project",
 				Project:    projectKey,
-				Visibility: "public",
+				Visibility: sonar.ProjectVisibilityPublic,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -457,7 +457,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
 				Project:    projectKey,
-				Visibility: "private",
+				Visibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
@@ -471,7 +471,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			for _, c := range result.Components {
 				if c.Key == projectKey {
 					found = true
-					Expect(c.Visibility).To(Equal("private"))
+					Expect(c.Visibility).To(Equal(sonar.ProjectVisibilityPrivate))
 					break
 				}
 			}
@@ -484,7 +484,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Visibility Test Project 2",
 				Project:    projectKey,
-				Visibility: "private",
+				Visibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -497,7 +497,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
 				Project:    projectKey,
-				Visibility: "public",
+				Visibility: sonar.ProjectVisibilityPublic,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
@@ -511,7 +511,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			for _, c := range result.Components {
 				if c.Key == projectKey {
 					found = true
-					Expect(c.Visibility).To(Equal("public"))
+					Expect(c.Visibility).To(Equal(sonar.ProjectVisibilityPublic))
 					break
 				}
 			}
@@ -527,7 +527,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			It("should fail with missing project key", func() {
 				resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
-					Visibility: "private",
+					Visibility: sonar.ProjectVisibilityPrivate,
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
@@ -767,7 +767,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		It("should update default visibility to private", func() {
 			resp, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOptions{
-				ProjectVisibility: "private",
+				ProjectVisibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
@@ -775,7 +775,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		It("should update default visibility to public", func() {
 			resp, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOptions{
-				ProjectVisibility: "public",
+				ProjectVisibility: sonar.ProjectVisibilityPublic,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
@@ -816,7 +816,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			result, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
 				Name:       "Lifecycle Test",
 				Project:    projectKey,
-				Visibility: "public",
+				Visibility: sonar.ProjectVisibilityPublic,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -835,7 +835,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			Expect(result.Project.Key).To(Equal(projectKey))
-			Expect(result.Project.Visibility).To(Equal("public"))
+			Expect(result.Project.Visibility).To(Equal(sonar.ProjectVisibilityPublic))
 
 			// Step 2: Search for project
 			searchResult, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
@@ -854,7 +854,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			// Step 3: Update visibility
 			_, err = client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
 				Project:    projectKey,
-				Visibility: "private",
+				Visibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -874,7 +874,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			for _, c := range searchResult.Components {
 				if c.Key == newProjectKey {
 					found = true
-					Expect(c.Visibility).To(Equal("private"))
+					Expect(c.Visibility).To(Equal(sonar.ProjectVisibilityPrivate))
 					break
 				}
 			}

--- a/integration_testing/qualitygates_test.go
+++ b/integration_testing/qualitygates_test.go
@@ -873,7 +873,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 			result, resp, err := client.Qualitygates.Search(&sonar.QualitygatesSearchOptions{
 				GateName: gateName,
-				Selected: "all",
+				Selected: sonar.SelectionFilterAll,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -973,7 +973,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			// Verify the group was actually added
 			groupsResult, _, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOptions{
 				GateName: gateName,
-				Selected: "selected",
+				Selected: sonar.SelectionFilterSelected,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			foundGroup := false
@@ -1029,7 +1029,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 			result, resp, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOptions{
 				GateName: gateName,
-				Selected: "all",
+				Selected: sonar.SelectionFilterAll,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -1087,7 +1087,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			// Verify the group was actually removed
 			groupsResult, _, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOptions{
 				GateName: gateName,
-				Selected: "selected",
+				Selected: sonar.SelectionFilterSelected,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			for _, group := range groupsResult.Groups {
@@ -1190,7 +1190,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 			result, resp, err := client.Qualitygates.SearchUsers(&sonar.QualitygatesSearchUsersOptions{
 				GateName: gateName,
-				Selected: "all",
+				Selected: sonar.SelectionFilterAll,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -1357,7 +1357,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			// Step 7: Search users
 			usersResult, _, err := client.Qualitygates.SearchUsers(&sonar.QualitygatesSearchUsersOptions{
 				GateName: gateName,
-				Selected: "selected",
+				Selected: sonar.SelectionFilterSelected,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(usersResult.Users).To(HaveLen(1))

--- a/integration_testing/qualityprofiles_test.go
+++ b/integration_testing/qualityprofiles_test.go
@@ -1333,7 +1333,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			result, resp, err := client.Qualityprofiles.SearchGroups(&sonar.QualityprofilesSearchGroupsOptions{
 				QualityProfile: profileName,
 				Language:       "java",
-				Selected:       "all",
+				Selected:       sonar.SelectionFilterAll,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -1509,7 +1509,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			result, resp, err := client.Qualityprofiles.SearchUsers(&sonar.QualityprofilesSearchUsersOptions{
 				QualityProfile: profileName,
 				Language:       "java",
-				Selected:       "all",
+				Selected:       sonar.SelectionFilterAll,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -1692,7 +1692,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			usersResult, _, err := client.Qualityprofiles.SearchUsers(&sonar.QualityprofilesSearchUsersOptions{
 				QualityProfile: profileName,
 				Language:       "java",
-				Selected:       "selected",
+				Selected:       sonar.SelectionFilterSelected,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			foundAdmin := false

--- a/integration_testing/rules_test.go
+++ b/integration_testing/rules_test.go
@@ -203,34 +203,34 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 		It("should filter by severity", func() {
 			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
-				Severities: []string{"CRITICAL"},
+				Severities: []string{sonar.RuleSeverityCritical},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			for _, rule := range result.Rules {
-				Expect(rule.Severity).To(Equal("CRITICAL"))
+				Expect(rule.Severity).To(Equal(sonar.RuleSeverityCritical))
 			}
 		})
 
 		It("should filter by type", func() {
 			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
-				Types: []string{"BUG"},
+				Types: []string{sonar.RuleTypeBug},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			for _, rule := range result.Rules {
-				Expect(rule.Type).To(Equal("BUG"))
+				Expect(rule.Type).To(Equal(sonar.RuleTypeBug))
 			}
 		})
 
 		It("should filter by status", func() {
 			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
-				Statuses: []string{"READY"},
+				Statuses: []string{sonar.RuleStatusReady},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			for _, rule := range result.Rules {
-				Expect(rule.Status).To(Equal("READY"))
+				Expect(rule.Status).To(Equal(sonar.RuleStatusReady))
 			}
 		})
 
@@ -474,11 +474,11 @@ var _ = Describe("Rules Service", Ordered, func() {
 					Name:                "E2E Severity Rule " + customKey,
 					MarkdownDescription: "Rule with custom severity",
 					TemplateKey:         templateRule.Key,
-					Severity:            "CRITICAL",
+					Severity:            sonar.RuleSeverityCritical,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
-				Expect(result.Rule.Severity).To(Equal("CRITICAL"))
+				Expect(result.Rule.Severity).To(Equal(sonar.RuleSeverityCritical))
 
 				cleanup.RegisterCleanup("rule", result.Rule.Key, func() error {
 					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
@@ -496,11 +496,11 @@ var _ = Describe("Rules Service", Ordered, func() {
 					Name:                "E2E Status Rule " + customKey,
 					MarkdownDescription: "Rule with custom status",
 					TemplateKey:         templateRule.Key,
-					Status:              "BETA",
+					Status:              sonar.RuleStatusBeta,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
-				Expect(result.Rule.Status).To(Equal("BETA"))
+				Expect(result.Rule.Status).To(Equal(sonar.RuleStatusBeta))
 
 				cleanup.RegisterCleanup("rule", result.Rule.Key, func() error {
 					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
@@ -626,7 +626,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 					Name:                "Severity Update Rule",
 					MarkdownDescription: "Testing severity update",
 					TemplateKey:         templateRule.Key,
-					Severity:            "MINOR",
+					Severity:            sonar.RuleSeverityMinor,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -639,11 +639,11 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
 					Key:      createResult.Rule.Key,
-					Severity: "BLOCKER",
+					Severity: sonar.RuleSeverityBlocker,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
-				Expect(updateResult.Rule.Severity).To(Equal("BLOCKER"))
+				Expect(updateResult.Rule.Severity).To(Equal(sonar.RuleSeverityBlocker))
 			})
 
 			It("should update a custom rule status", func() {
@@ -654,7 +654,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 					Name:                "Status Update Rule",
 					MarkdownDescription: "Testing status update",
 					TemplateKey:         templateRule.Key,
-					Status:              "READY",
+					Status:              sonar.RuleStatusReady,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -667,11 +667,11 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
 					Key:    createResult.Rule.Key,
-					Status: "DEPRECATED",
+					Status: sonar.RuleStatusDeprecated,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
-				Expect(updateResult.Rule.Status).To(Equal("DEPRECATED"))
+				Expect(updateResult.Rule.Status).To(Equal(sonar.RuleStatusDeprecated))
 			})
 
 			It("should update tags on a rule", func() {
@@ -804,7 +804,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 					Key: createResult.Rule.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(showResult.Rule.Status).To(Equal("REMOVED"))
+				Expect(showResult.Rule.Status).To(Equal(sonar.RuleStatusRemoved))
 			})
 
 			Context("parameter validation", func() {

--- a/integration_testing/user_groups_test.go
+++ b/integration_testing/user_groups_test.go
@@ -513,7 +513,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
 			result, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
-				Selected: "selected",
+				Selected: sonar.SelectionFilterSelected,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			found := false
@@ -642,7 +642,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
 			result, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
-				Selected: "selected",
+				Selected: sonar.SelectionFilterSelected,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			for _, u := range result.Users {
@@ -737,7 +737,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
 			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
-				Selected: "selected",
+				Selected: sonar.SelectionFilterSelected,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -760,7 +760,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
 			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
-				Selected: "all",
+				Selected: sonar.SelectionFilterAll,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -773,7 +773,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
 			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
-				Selected: "deselected",
+				Selected: sonar.SelectionFilterDeselected,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -789,7 +789,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
 				Query:    testUserLogin,
-				Selected: "all",
+				Selected: sonar.SelectionFilterAll,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -894,7 +894,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
 			usersResult, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     groupName,
-				Selected: "selected",
+				Selected: sonar.SelectionFilterSelected,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			found := false
@@ -926,7 +926,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
 			usersResult, _, err = client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
 				Name:     groupName,
-				Selected: "selected",
+				Selected: sonar.SelectionFilterSelected,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			for _, u := range usersResult.Users {

--- a/integration_testing/v2_clean_code_policy_test.go
+++ b/integration_testing/v2_clean_code_policy_test.go
@@ -48,7 +48,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					TemplateKey:         "java:S100",
 					Name:                "Test Rule",
 					MarkdownDescription: "Test description",
-					Impacts:             []sonar.RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+					Impacts:             []sonar.RuleImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
@@ -60,7 +60,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					Key:                 "custom:test_rule",
 					Name:                "Test Rule",
 					MarkdownDescription: "Test description",
-					Impacts:             []sonar.RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+					Impacts:             []sonar.RuleImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
@@ -72,7 +72,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					Key:                 "custom:test_rule",
 					TemplateKey:         "java:S100",
 					MarkdownDescription: "Test description",
-					Impacts:             []sonar.RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+					Impacts:             []sonar.RuleImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
@@ -84,7 +84,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					Key:         "custom:test_rule",
 					TemplateKey: "java:S100",
 					Name:        "Test Rule",
-					Impacts:     []sonar.RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+					Impacts:     []sonar.RuleImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
@@ -110,7 +110,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					TemplateKey:         "java:S100",
 					Name:                "Test Rule",
 					MarkdownDescription: "Test description",
-					Impacts:             []sonar.RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+					Impacts:             []sonar.RuleImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
 					CleanCodeAttribute:  "INVALID",
 				})
 				Expect(err).To(HaveOccurred())
@@ -124,7 +124,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					TemplateKey:         "java:S100",
 					Name:                "Test Rule",
 					MarkdownDescription: "Test description",
-					Impacts:             []sonar.RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "INVALID"}},
+					Impacts:             []sonar.RuleImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: "INVALID"}},
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
@@ -158,17 +158,17 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					TemplateKey:         templateRule.Key,
 					Name:                "E2E V2 Test Rule " + customKey,
 					MarkdownDescription: "This is a test rule created by V2 e2e tests",
-					Impacts:             []sonar.RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
-					Status:              "READY",
-					CleanCodeAttribute:  "CONVENTIONAL",
+					Impacts:             []sonar.RuleImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
+					Status:              sonar.RuleStatusReady,
+					CleanCodeAttribute:  sonar.CleanCodeAttributeConventional,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
 				Expect(result.Name).To(Equal("E2E V2 Test Rule " + customKey))
 				Expect(result.Key).To(Equal(ruleKey))
-				Expect(result.Status).To(Equal("READY"))
-				Expect(result.CleanCodeAttribute).To(Equal("CONVENTIONAL"))
+				Expect(result.Status).To(Equal(sonar.RuleStatusReady))
+				Expect(result.CleanCodeAttribute).To(Equal(sonar.CleanCodeAttributeConventional))
 				Expect(result.Impacts).NotTo(BeEmpty())
 
 				// Register cleanup using V1 Rules.Delete.

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -80,7 +81,7 @@ func TestBindFlags_SliceField(t *testing.T) {
 	assert.NotContains(t, f.Usage, "required")
 
 	require.NoError(t, cmd.Flags().Set("severities", "CRITICAL,MAJOR"))
-	assert.Equal(t, []string{"CRITICAL", "MAJOR"}, opt.Severities)
+	assert.Equal(t, []string{sonar.RuleSeverityCritical, sonar.RuleSeverityMajor}, opt.Severities)
 }
 
 // TestBindFlags_PointerBoolField tests binding of a *bool field (tri-state).

--- a/sonar/alm_integrations_service.go
+++ b/sonar/alm_integrations_service.go
@@ -26,9 +26,9 @@ const (
 var (
 	// allowedNewCodeDefinitionTypes is the set of allowed new code definition types.
 	allowedNewCodeDefinitionTypes = map[string]struct{}{
-		"PREVIOUS_VERSION": {},
-		"NUMBER_OF_DAYS":   {},
-		"REFERENCE_BRANCH": {},
+		NewCodePeriodTypePreviousVersion: {},
+		NewCodePeriodTypeNumberOfDays:    {},
+		NewCodePeriodTypeReferenceBranch: {},
 	}
 )
 

--- a/sonar/alm_integrations_service_test.go
+++ b/sonar/alm_integrations_service_test.go
@@ -127,7 +127,7 @@ func TestAlmIntegrations_ImportAzureProject_ValidationError(t *testing.T) {
 	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOptions{
 		ProjectName:           "project",
 		RepositoryName:        "repo",
-		NewCodeDefinitionType: "NUMBER_OF_DAYS",
+		NewCodeDefinitionType: NewCodePeriodTypeNumberOfDays,
 	})
 	assert.Error(t, err)
 
@@ -135,7 +135,7 @@ func TestAlmIntegrations_ImportAzureProject_ValidationError(t *testing.T) {
 	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOptions{
 		ProjectName:            "project",
 		RepositoryName:         "repo",
-		NewCodeDefinitionType:  "PREVIOUS_VERSION",
+		NewCodeDefinitionType:  NewCodePeriodTypePreviousVersion,
 		NewCodeDefinitionValue: 30,
 	})
 	assert.Error(t, err)
@@ -150,7 +150,7 @@ func TestAlmIntegrations_ImportAzureProject_WithNewCodeDefinition(t *testing.T) 
 	opt := &AlmIntegrationsImportAzureProjectOptions{
 		ProjectName:           "project",
 		RepositoryName:        "repo",
-		NewCodeDefinitionType: "PREVIOUS_VERSION",
+		NewCodeDefinitionType: NewCodePeriodTypePreviousVersion,
 	}
 
 	resp, err := client.AlmIntegrations.ImportAzureProject(opt)
@@ -161,7 +161,7 @@ func TestAlmIntegrations_ImportAzureProject_WithNewCodeDefinition(t *testing.T) 
 	opt = &AlmIntegrationsImportAzureProjectOptions{
 		ProjectName:            "project",
 		RepositoryName:         "repo",
-		NewCodeDefinitionType:  "NUMBER_OF_DAYS",
+		NewCodeDefinitionType:  NewCodePeriodTypeNumberOfDays,
 		NewCodeDefinitionValue: 30,
 	}
 
@@ -735,37 +735,37 @@ func TestValidateNewCodeDefinition(t *testing.T) {
 		},
 		{
 			name:            "PREVIOUS_VERSION without value",
-			definitionType:  "PREVIOUS_VERSION",
+			definitionType:  NewCodePeriodTypePreviousVersion,
 			definitionValue: 0,
 			wantErr:         false,
 		},
 		{
 			name:            "PREVIOUS_VERSION with value is invalid",
-			definitionType:  "PREVIOUS_VERSION",
+			definitionType:  NewCodePeriodTypePreviousVersion,
 			definitionValue: 30,
 			wantErr:         true,
 		},
 		{
 			name:            "REFERENCE_BRANCH without value",
-			definitionType:  "REFERENCE_BRANCH",
+			definitionType:  NewCodePeriodTypeReferenceBranch,
 			definitionValue: 0,
 			wantErr:         false,
 		},
 		{
 			name:            "REFERENCE_BRANCH with value is invalid",
-			definitionType:  "REFERENCE_BRANCH",
+			definitionType:  NewCodePeriodTypeReferenceBranch,
 			definitionValue: 30,
 			wantErr:         true,
 		},
 		{
 			name:            "NUMBER_OF_DAYS with value",
-			definitionType:  "NUMBER_OF_DAYS",
+			definitionType:  NewCodePeriodTypeNumberOfDays,
 			definitionValue: 30,
 			wantErr:         false,
 		},
 		{
 			name:            "NUMBER_OF_DAYS without value is invalid",
-			definitionType:  "NUMBER_OF_DAYS",
+			definitionType:  NewCodePeriodTypeNumberOfDays,
 			definitionValue: 0,
 			wantErr:         true,
 		},

--- a/sonar/analysis_v2_service_test.go
+++ b/sonar/analysis_v2_service_test.go
@@ -183,11 +183,11 @@ func TestAnalysisV2_GetActiveRules(t *testing.T) {
 		{
 			RuleKey:     AnalysisRuleKey{Repository: "java", Rule: "S1234"},
 			Name:        "Some Rule",
-			Severity:    "MAJOR",
+			Severity:    RuleSeverityMajor,
 			Language:    "java",
 			QProfileKey: "qp-1",
 			Params:      []AnalysisParam{{Key: "max", Value: "10"}},
-			Impacts:     map[string]string{"MAINTAINABILITY": "HIGH"},
+			Impacts:     map[string]string{SoftwareQualityMaintainability: RuleImpactSeverityHigh},
 		},
 	}
 	server := newTestServer(t, mockHandlerWithParams(t, http.MethodGet, "/v2/analysis/active_rules", http.StatusOK,
@@ -203,7 +203,7 @@ func TestAnalysisV2_GetActiveRules(t *testing.T) {
 	assert.Len(t, result, 1)
 	assert.Equal(t, "java", result[0].RuleKey.Repository)
 	assert.Equal(t, "S1234", result[0].RuleKey.Rule)
-	assert.Equal(t, "MAJOR", result[0].Severity)
+	assert.Equal(t, RuleSeverityMajor, result[0].Severity)
 }
 
 func TestAnalysisV2_GetActiveRules_Validation(t *testing.T) {

--- a/sonar/ce_service.go
+++ b/sonar/ce_service.go
@@ -9,6 +9,33 @@ const (
 	MaxProjectKeyLength = 400
 	// MaxProjectNameLength is the maximum length for a project name (truncated if longer).
 	MaxProjectNameLength = 500
+
+	// TaskStatusSuccess represents a successful task status.
+	TaskStatusSuccess = "SUCCESS"
+	// TaskStatusFailed represents a failed task status.
+	TaskStatusFailed = "FAILED"
+	// TaskStatusCanceled represents a canceled task status.
+	TaskStatusCanceled = "CANCELED"
+	// TaskStatusPending represents a pending task status.
+	TaskStatusPending = "PENDING"
+	// TaskStatusInProgress represents an in-progress task status.
+	TaskStatusInProgress = "IN_PROGRESS"
+
+	// TaskTypeReport represents a report task type.
+	TaskTypeReport = "REPORT"
+	// TaskTypeIssueSync represents an issue synchronization task type.
+	TaskTypeIssueSync = "ISSUE_SYNC"
+	// TaskTypeAuditPurge represents an audit purge task type.
+	TaskTypeAuditPurge = "AUDIT_PURGE"
+	// TaskTypeProjectExport represents a project export task type.
+	TaskTypeProjectExport = "PROJECT_EXPORT"
+
+	// TaskFieldStacktrace represents the "stacktrace" additional field for task details.
+	TaskFieldStacktrace = "stacktrace"
+	// TaskFieldScannerContext represents the "scannerContext" additional field for task details.
+	TaskFieldScannerContext = "scannerContext"
+	// TaskFieldWarnings represents the "warnings" additional field for task details.
+	TaskFieldWarnings = "warnings"
 )
 
 // CeService handles communication with the Compute Engine related methods
@@ -24,26 +51,26 @@ type CeService struct {
 var (
 	// allowedTaskStatuses is the set of supported task statuses.
 	allowedTaskStatuses = map[string]struct{}{
-		"SUCCESS":     {},
-		"FAILED":      {},
-		"CANCELED":    {},
-		"PENDING":     {},
-		"IN_PROGRESS": {},
+		TaskStatusSuccess:    {},
+		TaskStatusFailed:     {},
+		TaskStatusCanceled:   {},
+		TaskStatusPending:    {},
+		TaskStatusInProgress: {},
 	}
 
 	// allowedTaskTypes is the set of supported task types.
 	allowedTaskTypes = map[string]struct{}{
-		"REPORT":         {},
-		"ISSUE_SYNC":     {},
-		"AUDIT_PURGE":    {},
-		"PROJECT_EXPORT": {},
+		TaskTypeReport:        {},
+		TaskTypeIssueSync:     {},
+		TaskTypeAuditPurge:    {},
+		TaskTypeProjectExport: {},
 	}
 
 	// allowedAdditionalFields is the set of supported additional fields for task queries.
 	allowedAdditionalFields = map[string]struct{}{
-		"stacktrace":     {},
-		"scannerContext": {},
-		"warnings":       {},
+		TaskFieldStacktrace:     {},
+		TaskFieldScannerContext: {},
+		TaskFieldWarnings:       {},
 	}
 )
 

--- a/sonar/ce_service_test.go
+++ b/sonar/ce_service_test.go
@@ -13,7 +13,7 @@ func TestCe_Activity(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/ce/activity", r.URL.Path)
 		assert.Equal(t, "my-project", r.URL.Query().Get("component"))
-		assert.Equal(t, "SUCCESS", r.URL.Query().Get("status"))
+		assert.Equal(t, TaskStatusSuccess, r.URL.Query().Get("status"))
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -51,7 +51,7 @@ func TestCe_Activity(t *testing.T) {
 
 	opt := &CeActivityOptions{
 		Component: "my-project",
-		Statuses:  []string{"SUCCESS"},
+		Statuses:  []string{TaskStatusSuccess},
 	}
 
 	result, resp, err := client.Ce.Activity(opt)
@@ -61,7 +61,7 @@ func TestCe_Activity(t *testing.T) {
 	assert.Equal(t, int64(2), result.Paging.Total)
 	assert.Len(t, result.Tasks, 2)
 	assert.Equal(t, "task-1", result.Tasks[0].ID)
-	assert.Equal(t, "SUCCESS", result.Tasks[0].Status)
+	assert.Equal(t, TaskStatusSuccess, result.Tasks[0].Status)
 	assert.Equal(t, int64(1234), result.Tasks[0].ExecutionTimeMs)
 }
 
@@ -331,10 +331,10 @@ func TestCe_Component(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
 	assert.Equal(t, "current-task", result.Current.ID)
-	assert.Equal(t, "SUCCESS", result.Current.Status)
+	assert.Equal(t, TaskStatusSuccess, result.Current.Status)
 	assert.Len(t, result.Queue, 1)
 	assert.Equal(t, "queued-task-1", result.Queue[0].ID)
-	assert.Equal(t, "PENDING", result.Queue[0].Status)
+	assert.Equal(t, TaskStatusPending, result.Queue[0].Status)
 }
 
 func TestCe_Component_ValidationError(t *testing.T) {
@@ -527,7 +527,7 @@ func TestCe_Task(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/ce/task", r.URL.Path)
 		assert.Equal(t, "task-123", r.URL.Query().Get("id"))
-		assert.Equal(t, "stacktrace", r.URL.Query().Get("additionalFields"))
+		assert.Equal(t, TaskFieldStacktrace, r.URL.Query().Get("additionalFields"))
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -552,7 +552,7 @@ func TestCe_Task(t *testing.T) {
 
 	opt := &CeTaskOptions{
 		ID:               "task-123",
-		AdditionalFields: []string{"stacktrace"},
+		AdditionalFields: []string{TaskFieldStacktrace},
 	}
 
 	result, resp, err := client.Ce.Task(opt)
@@ -560,7 +560,7 @@ func TestCe_Task(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
 	assert.Equal(t, "task-123", result.Task.ID)
-	assert.Equal(t, "FAILED", result.Task.Status)
+	assert.Equal(t, TaskStatusFailed, result.Task.Status)
 	assert.Equal(t, "Analysis failed", result.Task.ErrorMessage)
 	assert.True(t, result.Task.HasErrorStacktrace)
 	assert.Equal(t, int64(3), result.Task.WarningCount)
@@ -609,7 +609,7 @@ func TestCe_TaskTypes(t *testing.T) {
 	require.NotNil(t, result)
 	assert.Len(t, result.TaskTypes, 4)
 
-	expectedTypes := []string{"REPORT", "ISSUE_SYNC", "AUDIT_PURGE", "PROJECT_EXPORT"}
+	expectedTypes := []string{TaskTypeReport, TaskTypeIssueSync, TaskTypeAuditPurge, TaskTypeProjectExport}
 	assert.Equal(t, expectedTypes, result.TaskTypes)
 }
 
@@ -702,21 +702,21 @@ func TestCe_ValidateActivityOpt(t *testing.T) {
 		{
 			name: "valid statuses",
 			opt: &CeActivityOptions{
-				Statuses: []string{"SUCCESS", "FAILED"},
+				Statuses: []string{TaskStatusSuccess, TaskStatusFailed},
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalid status",
 			opt: &CeActivityOptions{
-				Statuses: []string{"SUCCESS", "INVALID"},
+				Statuses: []string{TaskStatusSuccess, "INVALID"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "valid type",
 			opt: &CeActivityOptions{
-				Type: "REPORT",
+				Type: TaskTypeReport,
 			},
 			wantErr: false,
 		},
@@ -731,8 +731,8 @@ func TestCe_ValidateActivityOpt(t *testing.T) {
 			name: "valid all fields",
 			opt: &CeActivityOptions{
 				Component:    "my-project",
-				Statuses:     []string{"SUCCESS", "FAILED", "PENDING"},
-				Type:         "REPORT",
+				Statuses:     []string{TaskStatusSuccess, TaskStatusFailed, TaskStatusPending},
+				Type:         TaskTypeReport,
 				OnlyCurrents: true,
 				CePaginationArgs: CePaginationArgs{
 					Page:     1,
@@ -784,7 +784,7 @@ func TestCe_ValidateTaskOpt(t *testing.T) {
 			name: "valid with all additional fields",
 			opt: &CeTaskOptions{
 				ID:               "task-123",
-				AdditionalFields: []string{"stacktrace", "scannerContext", "warnings"},
+				AdditionalFields: []string{TaskFieldStacktrace, TaskFieldScannerContext, TaskFieldWarnings},
 			},
 			wantErr: false,
 		},

--- a/sonar/clean_code_policy_v2_service.go
+++ b/sonar/clean_code_policy_v2_service.go
@@ -170,7 +170,7 @@ func validateRuleImpacts(impacts []RuleImpact) error {
 			return err
 		}
 
-		err = IsValueAuthorized(impact.Severity, allowedImpactSeverities, fmt.Sprintf("Impacts[%d].Severity", impactIdx))
+		err = IsValueAuthorized(impact.Severity, allowedRuleImpactSeverities, fmt.Sprintf("Impacts[%d].Severity", impactIdx))
 		if err != nil {
 			return err
 		}
@@ -230,7 +230,7 @@ func (s *CleanCodePolicyService) ValidateCreateRuleRequest(opt *CleanCodePolicyC
 		return err
 	}
 
-	err = IsValueAuthorized(opt.Severity, allowedSeverities, "Severity")
+	err = IsValueAuthorized(opt.Severity, allowedRuleSeverities, "Severity")
 	if err != nil {
 		return err
 	}

--- a/sonar/clean_code_policy_v2_service_test.go
+++ b/sonar/clean_code_policy_v2_service_test.go
@@ -20,22 +20,22 @@ func TestCleanCodePolicyV2_CreateRule(t *testing.T) {
 		Name:                "My Custom Rule",
 		MarkdownDescription: "This is a custom rule",
 		Impacts: []RuleImpact{
-			{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"},
+			{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh},
 		},
-		Status:             "READY",
-		CleanCodeAttribute: "CLEAR",
-		Type:               "CODE_SMELL",
+		Status:             RuleStatusReady,
+		CleanCodeAttribute: CleanCodeAttributeClear,
+		Type:               RuleTypeCodeSmell,
 	}
 	response := RuleV2{
 		Id:                 "rule-1",
 		Key:                "custom:my_rule",
 		RepositoryKey:      "custom",
 		Name:               "My Custom Rule",
-		Status:             "READY",
-		CleanCodeAttribute: "CLEAR",
-		Type:               "CODE_SMELL",
+		Status:             RuleStatusReady,
+		CleanCodeAttribute: CleanCodeAttributeClear,
+		Type:               RuleTypeCodeSmell,
 		Impacts: []RuleImpact{
-			{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"},
+			{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh},
 		},
 		MarkdownDescription: "This is a custom rule",
 		Template:            false,
@@ -51,11 +51,11 @@ func TestCleanCodePolicyV2_CreateRule(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "custom:my_rule", result.Key)
 	assert.Equal(t, "My Custom Rule", result.Name)
-	assert.Equal(t, "CLEAR", result.CleanCodeAttribute)
-	assert.Equal(t, "CODE_SMELL", result.Type)
+	assert.Equal(t, CleanCodeAttributeClear, result.CleanCodeAttribute)
+	assert.Equal(t, RuleTypeCodeSmell, result.Type)
 	assert.Len(t, result.Impacts, 1)
-	assert.Equal(t, "MAINTAINABILITY", result.Impacts[0].SoftwareQuality)
-	assert.Equal(t, "HIGH", result.Impacts[0].Severity)
+	assert.Equal(t, SoftwareQualityMaintainability, result.Impacts[0].SoftwareQuality)
+	assert.Equal(t, RuleImpactSeverityHigh, result.Impacts[0].Severity)
 	assert.Equal(t, "java", result.LanguageKey)
 }
 
@@ -66,7 +66,7 @@ func TestCleanCodePolicyV2_CreateRule_MinimalRequest(t *testing.T) {
 		Name:                "Minimal Rule",
 		MarkdownDescription: "Minimal description",
 		Impacts: []RuleImpact{
-			{SoftwareQuality: "SECURITY", Severity: "LOW"},
+			{SoftwareQuality: SoftwareQualitySecurity, Severity: RuleImpactSeverityLow},
 		},
 	}
 	response := RuleV2{
@@ -74,7 +74,7 @@ func TestCleanCodePolicyV2_CreateRule_MinimalRequest(t *testing.T) {
 		Key:  "custom:min_rule",
 		Name: "Minimal Rule",
 		Impacts: []RuleImpact{
-			{SoftwareQuality: "SECURITY", Severity: "LOW"},
+			{SoftwareQuality: SoftwareQualitySecurity, Severity: RuleImpactSeverityLow},
 		},
 	}
 	server := newTestServer(t, mockJSONBodyHandler(t, http.MethodPost, "/v2/clean-code-policy/rules", http.StatusOK, request, response))
@@ -94,18 +94,18 @@ func TestCleanCodePolicyV2_CreateRule_MultipleImpacts(t *testing.T) {
 		Name:                "Multi Impact Rule",
 		MarkdownDescription: "Rule with multiple impacts",
 		Impacts: []RuleImpact{
-			{SoftwareQuality: "MAINTAINABILITY", Severity: "MEDIUM"},
-			{SoftwareQuality: "RELIABILITY", Severity: "HIGH"},
-			{SoftwareQuality: "SECURITY", Severity: "BLOCKER"},
+			{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityMedium},
+			{SoftwareQuality: SoftwareQualityReliability, Severity: RuleImpactSeverityHigh},
+			{SoftwareQuality: SoftwareQualitySecurity, Severity: RuleSeverityBlocker},
 		},
 	}
 	response := RuleV2{
 		Id:  "rule-3",
 		Key: "custom:multi_impact",
 		Impacts: []RuleImpact{
-			{SoftwareQuality: "MAINTAINABILITY", Severity: "MEDIUM"},
-			{SoftwareQuality: "RELIABILITY", Severity: "HIGH"},
-			{SoftwareQuality: "SECURITY", Severity: "BLOCKER"},
+			{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityMedium},
+			{SoftwareQuality: SoftwareQualityReliability, Severity: RuleImpactSeverityHigh},
+			{SoftwareQuality: SoftwareQualitySecurity, Severity: RuleSeverityBlocker},
 		},
 	}
 	server := newTestServer(t, mockJSONBodyHandler(t, http.MethodPost, "/v2/clean-code-policy/rules", http.StatusOK, request, response))
@@ -124,7 +124,7 @@ func TestCleanCodePolicyV2_CreateRule_WithParameters(t *testing.T) {
 		Name:                "Parameterized Rule",
 		MarkdownDescription: "Rule with parameters",
 		Impacts: []RuleImpact{
-			{SoftwareQuality: "MAINTAINABILITY", Severity: "LOW"},
+			{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityLow},
 		},
 		Parameters: []RuleParameterV2{
 			{Key: "maxLines", DefaultValue: "100"},
@@ -166,25 +166,25 @@ func TestCleanCodePolicyV2_CreateRule_Validation(t *testing.T) {
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 		}},
 		{"missing template key", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 		}},
 		{"missing name", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			TemplateKey:         "java:S100",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 		}},
 		{"missing markdown description", &CleanCodePolicyCreateRuleOptions{
 			Key:         "custom:test",
 			TemplateKey: "java:S100",
 			Name:        "Test",
-			Impacts:     []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+			Impacts:     []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 		}},
 		{"missing impacts", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
@@ -204,28 +204,28 @@ func TestCleanCodePolicyV2_CreateRule_Validation(t *testing.T) {
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 		}},
 		{"template key too long", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			TemplateKey:         strings.Repeat("a", MaxTemplateKeyLengthV2+1),
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 		}},
 		{"name too long", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			TemplateKey:         "java:S100",
 			Name:                strings.Repeat("a", MaxRuleNameLengthV2+1),
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 		}},
 		{"invalid status", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 			Status:              "INVALID",
 		}},
 		{"invalid clean code attribute", &CleanCodePolicyCreateRuleOptions{
@@ -233,7 +233,7 @@ func TestCleanCodePolicyV2_CreateRule_Validation(t *testing.T) {
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 			CleanCodeAttribute:  "INVALID",
 		}},
 		{"invalid type", &CleanCodePolicyCreateRuleOptions{
@@ -241,7 +241,7 @@ func TestCleanCodePolicyV2_CreateRule_Validation(t *testing.T) {
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 			Type:                "INVALID",
 		}},
 		{"invalid impact software quality", &CleanCodePolicyCreateRuleOptions{
@@ -249,28 +249,28 @@ func TestCleanCodePolicyV2_CreateRule_Validation(t *testing.T) {
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: "INVALID", Severity: "HIGH"}},
+			Impacts:             []RuleImpact{{SoftwareQuality: "INVALID", Severity: RuleImpactSeverityHigh}},
 		}},
 		{"invalid impact severity", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "INVALID"}},
+			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: "INVALID"}},
 		}},
 		{"missing impact software quality", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{Severity: "HIGH"}},
+			Impacts:             []RuleImpact{{Severity: RuleImpactSeverityHigh}},
 		}},
 		{"missing impact severity", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY"}},
+			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability}},
 		}},
 	}
 
@@ -290,9 +290,9 @@ func TestCleanCodePolicyV2_CreateRule_AllCleanCodeAttributes(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	validAttributes := []string{
-		"CONVENTIONAL", "FORMATTED", "IDENTIFIABLE", "CLEAR", "COMPLETE",
-		"EFFICIENT", "LOGICAL", "DISTINCT", "FOCUSED", "MODULAR",
-		"TESTED", "LAWFUL", "RESPECTFUL", "TRUSTWORTHY",
+		CleanCodeAttributeConventional, CleanCodeAttributeFormatted, CleanCodeAttributeIdentifiable, CleanCodeAttributeClear, CleanCodeAttributeComplete,
+		CleanCodeAttributeEfficient, CleanCodeAttributeLogical, CleanCodeAttributeDistinct, CleanCodeAttributeFocused, CleanCodeAttributeModular,
+		CleanCodeAttributeTested, CleanCodeAttributeLawful, CleanCodeAttributeRespectful, CleanCodeAttributeTrustworthy,
 	}
 
 	for _, attr := range validAttributes {
@@ -302,7 +302,7 @@ func TestCleanCodePolicyV2_CreateRule_AllCleanCodeAttributes(t *testing.T) {
 				TemplateKey:         "java:S100",
 				Name:                "Test",
 				MarkdownDescription: "desc",
-				Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+				Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 				CleanCodeAttribute:  attr,
 			})
 			assert.NoError(t, err)
@@ -313,7 +313,7 @@ func TestCleanCodePolicyV2_CreateRule_AllCleanCodeAttributes(t *testing.T) {
 func TestCleanCodePolicyV2_CreateRule_AllImpactSeverities(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	validSeverities := []string{"INFO", "LOW", "MEDIUM", "HIGH", "BLOCKER"}
+	validSeverities := []string{RuleSeverityInfo, RuleImpactSeverityLow, RuleImpactSeverityMedium, RuleImpactSeverityHigh, RuleSeverityBlocker}
 
 	for _, sev := range validSeverities {
 		t.Run(sev, func(t *testing.T) {
@@ -322,7 +322,7 @@ func TestCleanCodePolicyV2_CreateRule_AllImpactSeverities(t *testing.T) {
 				TemplateKey:         "java:S100",
 				Name:                "Test",
 				MarkdownDescription: "desc",
-				Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: sev}},
+				Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: sev}},
 			})
 			assert.NoError(t, err)
 		})
@@ -332,7 +332,7 @@ func TestCleanCodePolicyV2_CreateRule_AllImpactSeverities(t *testing.T) {
 func TestCleanCodePolicyV2_CreateRule_AllRuleStatuses(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	validStatuses := []string{"BETA", "DEPRECATED", "READY", "REMOVED"}
+	validStatuses := []string{RuleStatusBeta, RuleStatusDeprecated, RuleStatusReady, RuleStatusRemoved}
 
 	for _, status := range validStatuses {
 		t.Run(status, func(t *testing.T) {
@@ -341,7 +341,7 @@ func TestCleanCodePolicyV2_CreateRule_AllRuleStatuses(t *testing.T) {
 				TemplateKey:         "java:S100",
 				Name:                "Test",
 				MarkdownDescription: "desc",
-				Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+				Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 				Status:              status,
 			})
 			assert.NoError(t, err)
@@ -352,7 +352,7 @@ func TestCleanCodePolicyV2_CreateRule_AllRuleStatuses(t *testing.T) {
 func TestCleanCodePolicyV2_CreateRule_AllRuleTypes(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	validTypes := []string{"CODE_SMELL", "BUG", "VULNERABILITY", "SECURITY_HOTSPOT"}
+	validTypes := []string{RuleTypeCodeSmell, RuleTypeBug, RuleTypeVulnerability, RuleTypeSecurityHotspot}
 
 	for _, ruleType := range validTypes {
 		t.Run(ruleType, func(t *testing.T) {
@@ -361,7 +361,7 @@ func TestCleanCodePolicyV2_CreateRule_AllRuleTypes(t *testing.T) {
 				TemplateKey:         "java:S100",
 				Name:                "Test",
 				MarkdownDescription: "desc",
-				Impacts:             []RuleImpact{{SoftwareQuality: "MAINTAINABILITY", Severity: "HIGH"}},
+				Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 				Type:                ruleType,
 			})
 			assert.NoError(t, err)
@@ -372,7 +372,7 @@ func TestCleanCodePolicyV2_CreateRule_AllRuleTypes(t *testing.T) {
 func TestCleanCodePolicyV2_CreateRule_AllSoftwareQualities(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	validQualities := []string{"MAINTAINABILITY", "RELIABILITY", "SECURITY"}
+	validQualities := []string{SoftwareQualityMaintainability, SoftwareQualityReliability, SoftwareQualitySecurity}
 
 	for _, quality := range validQualities {
 		t.Run(quality, func(t *testing.T) {
@@ -381,7 +381,7 @@ func TestCleanCodePolicyV2_CreateRule_AllSoftwareQualities(t *testing.T) {
 				TemplateKey:         "java:S100",
 				Name:                "Test",
 				MarkdownDescription: "desc",
-				Impacts:             []RuleImpact{{SoftwareQuality: quality, Severity: "HIGH"}},
+				Impacts:             []RuleImpact{{SoftwareQuality: quality, Severity: RuleImpactSeverityHigh}},
 			})
 			assert.NoError(t, err)
 		})

--- a/sonar/clean_code_policy_v2_service_test.go
+++ b/sonar/clean_code_policy_v2_service_test.go
@@ -313,7 +313,7 @@ func TestCleanCodePolicyV2_CreateRule_AllCleanCodeAttributes(t *testing.T) {
 func TestCleanCodePolicyV2_CreateRule_AllImpactSeverities(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	validSeverities := []string{RuleSeverityInfo, RuleImpactSeverityLow, RuleImpactSeverityMedium, RuleImpactSeverityHigh, RuleSeverityBlocker}
+	validSeverities := []string{RuleImpactSeverityInfo, RuleImpactSeverityLow, RuleImpactSeverityMedium, RuleImpactSeverityHigh, RuleImpactSeverityBlocker}
 
 	for _, sev := range validSeverities {
 		t.Run(sev, func(t *testing.T) {

--- a/sonar/clean_code_policy_v2_service_test.go
+++ b/sonar/clean_code_policy_v2_service_test.go
@@ -96,7 +96,7 @@ func TestCleanCodePolicyV2_CreateRule_MultipleImpacts(t *testing.T) {
 		Impacts: []RuleImpact{
 			{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityMedium},
 			{SoftwareQuality: SoftwareQualityReliability, Severity: RuleImpactSeverityHigh},
-			{SoftwareQuality: SoftwareQualitySecurity, Severity: RuleSeverityBlocker},
+			{SoftwareQuality: SoftwareQualitySecurity, Severity: RuleImpactSeverityBlocker},
 		},
 	}
 	response := RuleV2{
@@ -105,7 +105,7 @@ func TestCleanCodePolicyV2_CreateRule_MultipleImpacts(t *testing.T) {
 		Impacts: []RuleImpact{
 			{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityMedium},
 			{SoftwareQuality: SoftwareQualityReliability, Severity: RuleImpactSeverityHigh},
-			{SoftwareQuality: SoftwareQualitySecurity, Severity: RuleSeverityBlocker},
+			{SoftwareQuality: SoftwareQualitySecurity, Severity: RuleImpactSeverityBlocker},
 		},
 	}
 	server := newTestServer(t, mockJSONBodyHandler(t, http.MethodPost, "/v2/clean-code-policy/rules", http.StatusOK, request, response))

--- a/sonar/common.go
+++ b/sonar/common.go
@@ -24,6 +24,169 @@ const (
 	MaxTokenNameLength = 100
 	// MaxBranchNameLength is the maximum length for a branch name.
 	MaxBranchNameLength = 255
+
+	// LanguageAzureResourceManager is the language key for Azure Resource Manager.
+	LanguageAzureResourceManager = "azureresourcemanager"
+	// LanguageCloudFormation is the language key for CloudFormation.
+	LanguageCloudFormation = "cloudformation"
+	// LanguageCS is the language key for C#.
+	LanguageCS = "cs"
+	// LanguageCSS is the language key for CSS.
+	LanguageCSS = "css"
+	// LanguageDocker is the language key for Docker.
+	LanguageDocker = "docker"
+	// LanguageFlex is the language key for Flex.
+	LanguageFlex = "flex"
+	// LanguageGo is the language key for Go.
+	LanguageGo = "go"
+	// LanguageIPYNB is the language key for Jupyter Notebooks.
+	LanguageIPYNB = "ipynb"
+	// LanguageJava is the language key for Java.
+	LanguageJava = "java"
+	// LanguageJS is the language key for JavaScript.
+	LanguageJS = "js"
+	// LanguageJSON is the language key for JSON.
+	LanguageJSON = "json"
+	// LanguageJSP is the language key for JSP.
+	LanguageJSP = "jsp"
+	// LanguageKotlin is the language key for Kotlin.
+	LanguageKotlin = "kotlin"
+	// LanguageKubernetes is the language key for Kubernetes.
+	LanguageKubernetes = "kubernetes"
+	// LanguagePHP is the language key for PHP.
+	LanguagePHP = "php"
+	// LanguagePython is the language key for Python.
+	LanguagePython = "py"
+	// LanguageRuby is the language key for Ruby On Rails.
+	LanguageRuby = "ruby"
+	// LanguageRust is the language key for Rust.
+	LanguageRust = "rust"
+	// LanguageScala is the language key for Scala.
+	LanguageScala = "scala"
+	// LanguageSecrets is the language key for Secrets.
+	LanguageSecrets = "secrets"
+	// LanguageTerraform is the language key for Terraform.
+	LanguageTerraform = "terraform"
+	// LanguageText is the language key for Text files.
+	LanguageText = "text"
+	// LanguageTypeScript is the language key for TypeScript.
+	LanguageTypeScript = "ts"
+	// LanguageVBNet is the language key for Visual Basic .NET.
+	LanguageVBNet = "vbnet"
+	// LanguageWeb is the language key for Web files.
+	LanguageWeb = "web"
+	// LanguageXML is the language key for XML.
+	LanguageXML = "xml"
+	// LanguageYAML is the language key for YAML.
+	LanguageYAML = "yaml"
+
+	// CleanCodeAttributeCategoryAdaptable is the Clean Code attribute category for adaptability.
+	CleanCodeAttributeCategoryAdaptable = "ADAPTABLE"
+	// CleanCodeAttributeCategoryConsistent is the Clean Code attribute category for consistency.
+	CleanCodeAttributeCategoryConsistent = "CONSISTENT"
+	// CleanCodeAttributeCategoryIntentional is the Clean Code attribute category for intentionality.
+	CleanCodeAttributeCategoryIntentional = "INTENTIONAL"
+	// CleanCodeAttributeCategoryResponsible is the Clean Code attribute category for responsibility.
+	CleanCodeAttributeCategoryResponsible = "RESPONSIBLE"
+
+	// CleanCodeAttributeConventional is the Clean Code attribute for conventional code.
+	CleanCodeAttributeConventional = "CONVENTIONAL"
+	// CleanCodeAttributeFormatted is the Clean Code attribute for formatted code.
+	CleanCodeAttributeFormatted = "FORMATTED"
+	// CleanCodeAttributeIdentifiable is the Clean Code attribute for identifiable code.
+	CleanCodeAttributeIdentifiable = "IDENTIFIABLE"
+	// CleanCodeAttributeClear is the Clean Code attribute for clear code.
+	CleanCodeAttributeClear = "CLEAR"
+	// CleanCodeAttributeComplete is the Clean Code attribute for complete code.
+	CleanCodeAttributeComplete = "COMPLETE"
+	// CleanCodeAttributeEfficient is the Clean Code attribute for efficient code.
+	CleanCodeAttributeEfficient = "EFFICIENT"
+	// CleanCodeAttributeLogical is the Clean Code attribute for logical code.
+	CleanCodeAttributeLogical = "LOGICAL"
+	// CleanCodeAttributeDistinct is the Clean Code attribute for distinct code.
+	CleanCodeAttributeDistinct = "DISTINCT"
+	// CleanCodeAttributeFocused is the Clean Code attribute for focused code.
+	CleanCodeAttributeFocused = "FOCUSED"
+	// CleanCodeAttributeModular is the Clean Code attribute for modular code.
+	CleanCodeAttributeModular = "MODULAR"
+	// CleanCodeAttributeTested is the Clean Code attribute for tested code.
+	CleanCodeAttributeTested = "TESTED"
+	// CleanCodeAttributeLawful is the Clean Code attribute for lawful code.
+	CleanCodeAttributeLawful = "LAWFUL"
+	// CleanCodeAttributeRespectful is the Clean Code attribute for respectful code.
+	CleanCodeAttributeRespectful = "RESPECTFUL"
+	// CleanCodeAttributeTrustworthy is the Clean Code attribute for trustworthy code.
+	CleanCodeAttributeTrustworthy = "TRUSTWORTHY"
+
+	// OwaspCategoryA1 is the OWASP category for Injection.
+	OwaspCategoryA1 = "a1"
+	// OwaspCategoryA2 is the OWASP category for Broken Authentication.
+	OwaspCategoryA2 = "a2"
+	// OwaspCategoryA3 is the OWASP category for Sensitive Data Exposure.
+	OwaspCategoryA3 = "a3"
+	// OwaspCategoryA4 is the OWASP category for XML External Entities (XXE).
+	OwaspCategoryA4 = "a4"
+	// OwaspCategoryA5 is the OWASP category for Broken Access Control.
+	OwaspCategoryA5 = "a5"
+	// OwaspCategoryA6 is the OWASP category for Security Misconfiguration.
+	OwaspCategoryA6 = "a6"
+	// OwaspCategoryA7 is the OWASP category for Cross-Site Scripting (XSS).
+	OwaspCategoryA7 = "a7"
+	// OwaspCategoryA8 is the OWASP category for Insecure Deserialization.
+	OwaspCategoryA8 = "a8"
+	// OwaspCategoryA9 is the OWASP category for Using Components with Known Vulnerabilities.
+	OwaspCategoryA9 = "a9"
+	// OwaspCategoryA10 is the OWASP category for Insufficient Logging & Monitoring.
+	OwaspCategoryA10 = "a10"
+
+	// OwaspMobileCategoryM1 is the OWASP Mobile category for Improper Platform Usage.
+	OwaspMobileCategoryM1 = "m1"
+	// OwaspMobileCategoryM2 is the OWASP Mobile category for Insecure Data Storage.
+	OwaspMobileCategoryM2 = "m2"
+	// OwaspMobileCategoryM3 is the OWASP Mobile category for Insecure Communication.
+	OwaspMobileCategoryM3 = "m3"
+	// OwaspMobileCategoryM4 is the OWASP Mobile category for Insecure Authentication.
+	OwaspMobileCategoryM4 = "m4"
+	// OwaspMobileCategoryM5 is the OWASP Mobile category for Insufficient Cryptography.
+	OwaspMobileCategoryM5 = "m5"
+	// OwaspMobileCategoryM6 is the OWASP Mobile category for Insecure Authorization.
+	OwaspMobileCategoryM6 = "m6"
+	// OwaspMobileCategoryM7 is the OWASP Mobile category for Client Code Quality.
+	OwaspMobileCategoryM7 = "m7"
+	// OwaspMobileCategoryM8 is the OWASP Mobile category for Code Tampering.
+	OwaspMobileCategoryM8 = "m8"
+	// OwaspMobileCategoryM9 is the OWASP Mobile category for Reverse Engineering.
+	OwaspMobileCategoryM9 = "m9"
+	// OwaspMobileCategoryM10 is the OWASP Mobile category for Extraneous Functionality.
+	OwaspMobileCategoryM10 = "m10"
+
+	// SansTop25CategoryInsecureInteraction is the SANS Top 25 category for Insecure Interaction.
+	SansTop25CategoryInsecureInteraction = "insecure-interaction"
+	// SansTop25CategoryRiskyResource is the SANS Top 25 category for Risky Resource.
+	SansTop25CategoryRiskyResource = "risky-resource"
+	// SansTop25CategoryPorousDefenses is the SANS Top 25 category for Porous Defenses.
+	SansTop25CategoryPorousDefenses = "porous-defenses"
+
+	// SoftwareQualityMaintainability is the software quality characteristic for maintainability.
+	SoftwareQualityMaintainability = "MAINTAINABILITY"
+	// SoftwareQualityReliability is the software quality characteristic for reliability.
+	SoftwareQualityReliability = "RELIABILITY"
+	// SoftwareQualitySecurity is the software quality characteristic for security.
+	SoftwareQualitySecurity = "SECURITY"
+
+	// InheritanceTypeNone represents no inheritance.
+	InheritanceTypeNone = "NONE"
+	// InheritanceTypeInherited represents inherited.
+	InheritanceTypeInherited = "INHERITED"
+	// InheritanceTypeOverrides represents overrides.
+	InheritanceTypeOverrides = "OVERRIDES"
+
+	// SelectionFilterAll represents the "all" selection filter.
+	SelectionFilterAll = "all"
+	// SelectionFilterSelected represents the "selected" selection filter.
+	SelectionFilterSelected = "selected"
+	// SelectionFilterDeselected represents the "deselected" selection filter.
+	SelectionFilterDeselected = "deselected"
 )
 
 type authType int
@@ -38,202 +201,202 @@ const (
 var (
 	// allowedLanguages is the set of supported programming languages.
 	allowedLanguages = map[string]struct{}{
-		"azureresourcemanager": {},
-		"cloudformation":       {},
-		"cs":                   {},
-		"css":                  {},
-		"docker":               {},
-		"flex":                 {},
-		"go":                   {},
-		"ipynb":                {},
-		"java":                 {},
-		"js":                   {},
-		"json":                 {},
-		"jsp":                  {},
-		"kotlin":               {},
-		"kubernetes":           {},
-		"php":                  {},
-		"py":                   {},
-		"ruby":                 {},
-		"rust":                 {},
-		"scala":                {},
-		"secrets":              {},
-		"terraform":            {},
-		"text":                 {},
-		"ts":                   {},
-		"vbnet":                {},
-		"web":                  {},
-		"xml":                  {},
-		"yaml":                 {},
+		LanguageAzureResourceManager: {},
+		LanguageCloudFormation:       {},
+		LanguageCS:                   {},
+		LanguageCSS:                  {},
+		LanguageDocker:               {},
+		LanguageFlex:                 {},
+		LanguageGo:                   {},
+		LanguageIPYNB:                {},
+		LanguageJava:                 {},
+		LanguageJS:                   {},
+		LanguageJSON:                 {},
+		LanguageJSP:                  {},
+		LanguageKotlin:               {},
+		LanguageKubernetes:           {},
+		LanguagePHP:                  {},
+		LanguagePython:               {},
+		LanguageRuby:                 {},
+		LanguageRust:                 {},
+		LanguageScala:                {},
+		LanguageSecrets:              {},
+		LanguageTerraform:            {},
+		LanguageText:                 {},
+		LanguageTypeScript:           {},
+		LanguageVBNet:                {},
+		LanguageWeb:                  {},
+		LanguageXML:                  {},
+		LanguageYAML:                 {},
 	}
 
-	// allowedSeverities is the set of supported severity levels.
-	allowedSeverities = map[string]struct{}{
-		"BLOCKER":  {},
-		"CRITICAL": {},
-		"MAJOR":    {},
-		"MINOR":    {},
-		"INFO":     {},
+	// allowedRuleSeverities is the set of supported severity levels.
+	allowedRuleSeverities = map[string]struct{}{
+		RuleSeverityBlocker:  {},
+		RuleSeverityCritical: {},
+		RuleSeverityMajor:    {},
+		RuleSeverityMinor:    {},
+		RuleSeverityInfo:     {},
 	}
 
-	// allowedImpactSeverities is the set of supported impact severity levels.
-	allowedImpactSeverities = map[string]struct{}{
-		"BLOCKER": {},
-		"HIGH":    {},
-		"MEDIUM":  {},
-		"LOW":     {},
-		"INFO":    {},
+	// allowedRuleImpactSeverities is the set of supported impact severity levels.
+	allowedRuleImpactSeverities = map[string]struct{}{
+		RuleImpactSeverityBlocker: {},
+		RuleImpactSeverityHigh:    {},
+		RuleImpactSeverityMedium:  {},
+		RuleImpactSeverityLow:     {},
+		RuleImpactSeverityInfo:    {},
 	}
 
 	// allowedCleanCodeAttributesCategories is the set of supported Clean Code attribute categories.
 	allowedCleanCodeAttributesCategories = map[string]struct{}{
-		"ADAPTABLE":   {},
-		"CONSISTENT":  {},
-		"INTENTIONAL": {},
-		"RESPONSIBLE": {},
+		CleanCodeAttributeCategoryAdaptable:   {},
+		CleanCodeAttributeCategoryConsistent:  {},
+		CleanCodeAttributeCategoryIntentional: {},
+		CleanCodeAttributeCategoryResponsible: {},
 	}
 
 	// allowedCleanCodeAttributes is the set of supported Clean Code attributes.
 	allowedCleanCodeAttributes = map[string]struct{}{
-		"CONVENTIONAL": {},
-		"FORMATTED":    {},
-		"IDENTIFIABLE": {},
-		"CLEAR":        {},
-		"COMPLETE":     {},
-		"EFFICIENT":    {},
-		"LOGICAL":      {},
-		"DISTINCT":     {},
-		"FOCUSED":      {},
-		"MODULAR":      {},
-		"TESTED":       {},
-		"LAWFUL":       {},
-		"RESPECTFUL":   {},
-		"TRUSTWORTHY":  {},
+		CleanCodeAttributeConventional: {},
+		CleanCodeAttributeFormatted:    {},
+		CleanCodeAttributeIdentifiable: {},
+		CleanCodeAttributeClear:        {},
+		CleanCodeAttributeComplete:     {},
+		CleanCodeAttributeEfficient:    {},
+		CleanCodeAttributeLogical:      {},
+		CleanCodeAttributeDistinct:     {},
+		CleanCodeAttributeFocused:      {},
+		CleanCodeAttributeModular:      {},
+		CleanCodeAttributeTested:       {},
+		CleanCodeAttributeLawful:       {},
+		CleanCodeAttributeRespectful:   {},
+		CleanCodeAttributeTrustworthy:  {},
 	}
 
 	// allowedImpactSoftwareQualities is the set of supported impact software qualities.
 	allowedImpactSoftwareQualities = map[string]struct{}{
-		"MAINTAINABILITY": {},
-		"RELIABILITY":     {},
-		"SECURITY":        {},
+		SoftwareQualityMaintainability: {},
+		SoftwareQualityReliability:     {},
+		SoftwareQualitySecurity:        {},
 	}
 
 	// allowedInheritanceTypes is the set of supported inheritance types.
 	allowedInheritanceTypes = map[string]struct{}{
-		"NONE":       {},
-		"INHERITED":  {},
-		"OVERRIDDES": {},
+		InheritanceTypeNone:      {},
+		InheritanceTypeInherited: {},
+		InheritanceTypeOverrides: {},
 	}
 
 	// allowedOwaspCategories is the set of supported OWASP categories.
 	allowedOwaspCategories = map[string]struct{}{
-		"a1":  {},
-		"a2":  {},
-		"a3":  {},
-		"a4":  {},
-		"a5":  {},
-		"a6":  {},
-		"a7":  {},
-		"a8":  {},
-		"a9":  {},
-		"a10": {},
+		OwaspCategoryA1:  {},
+		OwaspCategoryA2:  {},
+		OwaspCategoryA3:  {},
+		OwaspCategoryA4:  {},
+		OwaspCategoryA5:  {},
+		OwaspCategoryA6:  {},
+		OwaspCategoryA7:  {},
+		OwaspCategoryA8:  {},
+		OwaspCategoryA9:  {},
+		OwaspCategoryA10: {},
 	}
 
 	// allowedOwaspMobileCategories is the set of supported OWASP Mobile categories.
 	allowedOwaspMobileCategories = map[string]struct{}{
-		"m1":  {},
-		"m2":  {},
-		"m3":  {},
-		"m4":  {},
-		"m5":  {},
-		"m6":  {},
-		"m7":  {},
-		"m8":  {},
-		"m9":  {},
-		"m10": {},
+		OwaspMobileCategoryM1:  {},
+		OwaspMobileCategoryM2:  {},
+		OwaspMobileCategoryM3:  {},
+		OwaspMobileCategoryM4:  {},
+		OwaspMobileCategoryM5:  {},
+		OwaspMobileCategoryM6:  {},
+		OwaspMobileCategoryM7:  {},
+		OwaspMobileCategoryM8:  {},
+		OwaspMobileCategoryM9:  {},
+		OwaspMobileCategoryM10: {},
 	}
 
 	// allowedRulesStatuses is the set of supported statuses.
 	allowedRulesStatuses = map[string]struct{}{
-		"READY":      {},
-		"DEPRECATED": {},
-		"REMOVED":    {},
-		"BETA":       {},
+		RuleStatusReady:      {},
+		RuleStatusDeprecated: {},
+		RuleStatusRemoved:    {},
+		RuleStatusBeta:       {},
 	}
 
 	// allowedRulesExistingStatuses is the set of supported existing statuses.
 	allowedRulesExistingStatuses = map[string]struct{}{
-		"READY":      {},
-		"DEPRECATED": {},
-		"BETA":       {},
+		RuleStatusReady:      {},
+		RuleStatusDeprecated: {},
+		RuleStatusBeta:       {},
 	}
 
 	// allowedRulesTypes is the set of supported rule types.
 	allowedRulesTypes = map[string]struct{}{
-		"CODE_SMELL":       {},
-		"BUG":              {},
-		"VULNERABILITY":    {},
-		"SECURITY_HOTSPOT": {},
+		RuleTypeCodeSmell:       {},
+		RuleTypeBug:             {},
+		RuleTypeVulnerability:   {},
+		RuleTypeSecurityHotspot: {},
 	}
 
 	// allowedSansTop25Categories is the set of supported SANS Top 25 categories.
 	allowedSansTop25Categories = map[string]struct{}{
-		"insecure-interaction": {},
-		"risky-resource":       {},
-		"porous-defenses":      {},
+		SansTop25CategoryInsecureInteraction: {},
+		SansTop25CategoryRiskyResource:       {},
+		SansTop25CategoryPorousDefenses:      {},
 	}
 
 	// allowedSelectedFilters is the set of supported selected filters.
 	allowedSelectedFilters = map[string]struct{}{
-		"all":        {},
-		"selected":   {},
-		"deselected": {},
+		SelectionFilterAll:        {},
+		SelectionFilterSelected:   {},
+		SelectionFilterDeselected: {},
 	}
 
 	// allowedIssueTypes is the set of supported issue types.
 	allowedIssueTypes = map[string]struct{}{
-		"CODE_SMELL":       {},
-		"BUG":              {},
-		"VULNERABILITY":    {},
-		"SECURITY_HOTSPOT": {},
+		RuleTypeCodeSmell:       {},
+		RuleTypeBug:             {},
+		RuleTypeVulnerability:   {},
+		RuleTypeSecurityHotspot: {},
 	}
 
 	// allowedIssueTransitions is the set of supported issue transitions.
 	allowedIssueTransitions = map[string]struct{}{
-		"confirm":           {},
-		"unconfirm":         {},
-		"reopen":            {},
-		"resolve":           {},
-		"falsepositive":     {},
-		"wontfix":           {},
-		"accept":            {},
-		"close":             {},
-		"resolveasreviewed": {},
-		"resetastoreview":   {},
+		IssueTransitionConfirm:           {},
+		IssueTransitionUnconfirm:         {},
+		IssueTransitionReopen:            {},
+		IssueTransitionResolve:           {},
+		IssueTransitionFalsePositive:     {},
+		IssueTransitionWontFix:           {},
+		IssueTransitionAccept:            {},
+		IssueTransitionClose:             {},
+		IssueTransitionResolveAsReviewed: {},
+		IssueTransitionResetAsReviewed:   {},
 	}
 
 	// allowedIssueStatuses is the set of supported issue statuses.
 	allowedIssueStatuses = map[string]struct{}{
-		"OPEN":           {},
-		"CONFIRMED":      {},
-		"FALSE_POSITIVE": {},
-		"ACCEPTED":       {},
-		"FIXED":          {},
-		"IN_SANDBOX":     {},
+		IssueStatusOpen:          {},
+		IssueStatusConfirmed:     {},
+		IssueStatusFalsePositive: {},
+		IssueStatusAccepted:      {},
+		IssueStatusFixed:         {},
+		IssueStatusInSandbox:     {},
 	}
 
 	// allowedIssueResolutions is the set of supported issue resolutions.
 	allowedIssueResolutions = map[string]struct{}{
-		"FIXED":          {},
-		"REMOVED":        {},
-		"FALSE-POSITIVE": {},
-		"WONTFIX":        {},
+		IssueResolutionFixed:         {},
+		IssueResolutionRemoved:       {},
+		IssueResolutionFalsePositive: {},
+		IssueResolutionWontFix:       {},
 	}
 
 	// allowedIssueScopes is the set of supported issue scopes.
 	allowedIssueScopes = map[string]struct{}{
-		"MAIN": {},
-		"TEST": {},
+		IssueScopeMain: {},
+		IssueScopeTest: {},
 	}
 )
 

--- a/sonar/components_service_test.go
+++ b/sonar/components_service_test.go
@@ -112,7 +112,7 @@ func TestComponents_Search(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	result, resp, err := client.Components.Search(&ComponentsSearchOptions{
-		Qualifiers: []string{"TRK"},
+		Qualifiers: []string{ProjectQualifierTRK},
 		Query:      "sonar",
 	})
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestComponents_Search_ValidationError(t *testing.T) {
 		{
 			name: "query too short",
 			opt: &ComponentsSearchOptions{
-				Qualifiers: []string{"TRK"},
+				Qualifiers: []string{ProjectQualifierTRK},
 				Query:      "a",
 			},
 		},
@@ -407,7 +407,7 @@ func TestComponents_Tree(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/components/tree", r.URL.Path)
 		assert.Equal(t, "my_project", r.URL.Query().Get("component"))
-		assert.Equal(t, "children", r.URL.Query().Get("strategy"))
+		assert.Equal(t, MeasureStrategyChildren, r.URL.Query().Get("strategy"))
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -444,7 +444,7 @@ func TestComponents_Tree(t *testing.T) {
 
 	result, resp, err := client.Components.Tree(&ComponentsTreeOptions{
 		Component: "my_project",
-		Strategy:  "children",
+		Strategy:  MeasureStrategyChildren,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -492,7 +492,7 @@ func TestComponents_Tree_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing component",
-			opt:  &ComponentsTreeOptions{Strategy: "all"},
+			opt:  &ComponentsTreeOptions{Strategy: MeasureStrategyAll},
 		},
 		{
 			name: "query too short",
@@ -552,7 +552,7 @@ func TestComponents_Search_WithPagination(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	result, _, err := client.Components.Search(&ComponentsSearchOptions{
-		Qualifiers: []string{"TRK"},
+		Qualifiers: []string{ProjectQualifierTRK},
 		PaginationArgs: PaginationArgs{
 			Page:     2,
 			PageSize: 50,
@@ -583,7 +583,7 @@ func TestComponents_Tree_AllowedQualifiers(t *testing.T) {
 func TestComponents_Tree_AllowedStrategies(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	validStrategies := []string{"all", "children", "leaves"}
+	validStrategies := []string{MeasureStrategyAll, MeasureStrategyChildren, MeasureStrategyLeaves}
 	for _, s := range validStrategies {
 		opt := &ComponentsTreeOptions{
 			Component: "my_project",

--- a/sonar/favorites_service_test.go
+++ b/sonar/favorites_service_test.go
@@ -61,8 +61,8 @@ func TestFavorites_Remove_ValidationError(t *testing.T) {
 func TestFavorites_Search(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/favorites/search", http.StatusOK, &FavoritesSearch{
 		Favorites: []Favorite{
-			{Key: "project-1", Name: "Project One", Qualifier: "TRK"},
-			{Key: "project-2", Name: "Project Two", Qualifier: "TRK"},
+			{Key: "project-1", Name: "Project One", Qualifier: ProjectQualifierTRK},
+			{Key: "project-2", Name: "Project Two", Qualifier: ProjectQualifierTRK},
 		},
 		Paging: Paging{
 			PageIndex: 1,

--- a/sonar/hotspots_service.go
+++ b/sonar/hotspots_service.go
@@ -7,6 +7,18 @@ const (
 	MaxHotspotCommentLength = 1000
 	// MaxHotspotListPageSize is the maximum page size for the List endpoint.
 	MaxHotspotListPageSize = 500
+
+	// HotspotStatusToReview represents the "TO_REVIEW" status for a hotspot.
+	HotspotStatusToReview = "TO_REVIEW"
+	// HotspotStatusReviewed represents the "REVIEWED" status for a hotspot.
+	HotspotStatusReviewed = "REVIEWED"
+
+	// HotspotResolutionFixed represents the "FIXED" resolution for a hotspot.
+	HotspotResolutionFixed = "FIXED"
+	// HotspotResolutionSafe represents the "SAFE" resolution for a hotspot.
+	HotspotResolutionSafe = "SAFE"
+	// HotspotResolutionAcknowledged represents the "ACKNOWLEDGED" resolution for a hotspot.
+	HotspotResolutionAcknowledged = "ACKNOWLEDGED"
 )
 
 // HotspotsService handles communication with the Security Hotspots related methods
@@ -26,15 +38,15 @@ type HotspotsService struct {
 var (
 	// allowedHotspotStatuses is the set of allowed hotspot statuses.
 	allowedHotspotStatuses = map[string]struct{}{
-		"TO_REVIEW": {},
-		"REVIEWED":  {},
+		HotspotStatusToReview: {},
+		HotspotStatusReviewed: {},
 	}
 
 	// allowedHotspotResolutions is the set of allowed hotspot resolutions.
 	allowedHotspotResolutions = map[string]struct{}{
-		"FIXED":        {},
-		"SAFE":         {},
-		"ACKNOWLEDGED": {},
+		HotspotResolutionFixed:        {},
+		HotspotResolutionSafe:         {},
+		HotspotResolutionAcknowledged: {},
 	}
 
 	// allowedOwaspAsvsLevels is the set of allowed OWASP ASVS levels.

--- a/sonar/hotspots_service_test.go
+++ b/sonar/hotspots_service_test.go
@@ -126,8 +126,8 @@ func TestHotspots_ChangeStatus(t *testing.T) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/hotspots/change_status", r.URL.Path)
 		assert.Equal(t, "hotspot123", r.URL.Query().Get("hotspot"))
-		assert.Equal(t, "REVIEWED", r.URL.Query().Get("status"))
-		assert.Equal(t, "SAFE", r.URL.Query().Get("resolution"))
+		assert.Equal(t, HotspotStatusReviewed, r.URL.Query().Get("status"))
+		assert.Equal(t, HotspotResolutionSafe, r.URL.Query().Get("resolution"))
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -136,8 +136,8 @@ func TestHotspots_ChangeStatus(t *testing.T) {
 
 	resp, err := client.Hotspots.ChangeStatus(&HotspotsChangeStatusOptions{
 		Hotspot:    "hotspot123",
-		Status:     "REVIEWED",
-		Resolution: "SAFE",
+		Status:     HotspotStatusReviewed,
+		Resolution: HotspotResolutionSafe,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
@@ -156,7 +156,7 @@ func TestHotspots_ChangeStatus_ValidationError(t *testing.T) {
 		},
 		{
 			name: "missing hotspot",
-			opt:  &HotspotsChangeStatusOptions{Status: "REVIEWED"},
+			opt:  &HotspotsChangeStatusOptions{Status: HotspotStatusReviewed},
 		},
 		{
 			name: "missing status",
@@ -168,7 +168,7 @@ func TestHotspots_ChangeStatus_ValidationError(t *testing.T) {
 		},
 		{
 			name: "invalid resolution",
-			opt:  &HotspotsChangeStatusOptions{Hotspot: "hotspot123", Status: "REVIEWED", Resolution: "INVALID"},
+			opt:  &HotspotsChangeStatusOptions{Hotspot: "hotspot123", Status: HotspotStatusReviewed, Resolution: "INVALID"},
 		},
 	}
 
@@ -486,8 +486,8 @@ func TestHotspots_Search_WithFilters(t *testing.T) {
 	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "my-project", r.URL.Query().Get("project"))
-		assert.Equal(t, "REVIEWED", r.URL.Query().Get("status"))
-		assert.Equal(t, "SAFE", r.URL.Query().Get("resolution"))
+		assert.Equal(t, HotspotStatusReviewed, r.URL.Query().Get("status"))
+		assert.Equal(t, HotspotResolutionSafe, r.URL.Query().Get("resolution"))
 		assert.Equal(t, "true", r.URL.Query().Get("inNewCodePeriod"))
 		assert.Equal(t, "true", r.URL.Query().Get("onlyMine"))
 
@@ -500,8 +500,8 @@ func TestHotspots_Search_WithFilters(t *testing.T) {
 
 	_, resp, err := client.Hotspots.Search(&HotspotsSearchOptions{
 		Project:         "my-project",
-		Status:          "REVIEWED",
-		Resolution:      "SAFE",
+		Status:          HotspotStatusReviewed,
+		Resolution:      HotspotResolutionSafe,
 		InNewCodePeriod: true,
 		OnlyMine:        true,
 	})
@@ -538,11 +538,11 @@ func TestHotspots_Search_ValidationError(t *testing.T) {
 		},
 		{
 			name: "invalid owasp top 10",
-			opt:  &HotspotsSearchOptions{Project: "my-project", OwaspTop10: []string{"a1", "invalid"}},
+			opt:  &HotspotsSearchOptions{Project: "my-project", OwaspTop10: []string{OwaspCategoryA1, "invalid"}},
 		},
 		{
 			name: "invalid sans top 25",
-			opt:  &HotspotsSearchOptions{Project: "my-project", SansTop25: []string{"insecure-interaction", "invalid"}},
+			opt:  &HotspotsSearchOptions{Project: "my-project", SansTop25: []string{SansTop25CategoryInsecureInteraction, "invalid"}},
 		},
 	}
 
@@ -614,7 +614,7 @@ func TestHotspots_Show(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
 	assert.Equal(t, "hotspot123", result.Key)
-	assert.Equal(t, "TO_REVIEW", result.Status)
+	assert.Equal(t, HotspotStatusToReview, result.Status)
 	assert.True(t, result.CanChangeStatus)
 	assert.Len(t, result.Users, 1)
 	assert.Equal(t, "john.doe", result.Users[0].Login)
@@ -714,7 +714,7 @@ func TestHotspots_ValidateChangeStatusOpt(t *testing.T) {
 			name: "valid TO_REVIEW status",
 			opt: &HotspotsChangeStatusOptions{
 				Hotspot: "hotspot123",
-				Status:  "TO_REVIEW",
+				Status:  HotspotStatusToReview,
 			},
 			wantErr: false,
 		},
@@ -722,8 +722,8 @@ func TestHotspots_ValidateChangeStatusOpt(t *testing.T) {
 			name: "valid REVIEWED with SAFE resolution",
 			opt: &HotspotsChangeStatusOptions{
 				Hotspot:    "hotspot123",
-				Status:     "REVIEWED",
-				Resolution: "SAFE",
+				Status:     HotspotStatusReviewed,
+				Resolution: HotspotResolutionSafe,
 			},
 			wantErr: false,
 		},
@@ -731,8 +731,8 @@ func TestHotspots_ValidateChangeStatusOpt(t *testing.T) {
 			name: "valid REVIEWED with FIXED resolution",
 			opt: &HotspotsChangeStatusOptions{
 				Hotspot:    "hotspot123",
-				Status:     "REVIEWED",
-				Resolution: "FIXED",
+				Status:     HotspotStatusReviewed,
+				Resolution: HotspotResolutionFixed,
 			},
 			wantErr: false,
 		},
@@ -740,8 +740,8 @@ func TestHotspots_ValidateChangeStatusOpt(t *testing.T) {
 			name: "valid REVIEWED with ACKNOWLEDGED resolution",
 			opt: &HotspotsChangeStatusOptions{
 				Hotspot:    "hotspot123",
-				Status:     "REVIEWED",
-				Resolution: "ACKNOWLEDGED",
+				Status:     HotspotStatusReviewed,
+				Resolution: HotspotResolutionAcknowledged,
 			},
 			wantErr: false,
 		},
@@ -762,7 +762,7 @@ func TestHotspots_ValidateChangeStatusOpt(t *testing.T) {
 			name: "invalid resolution",
 			opt: &HotspotsChangeStatusOptions{
 				Hotspot:    "hotspot123",
-				Status:     "REVIEWED",
+				Status:     HotspotStatusReviewed,
 				Resolution: "INVALID",
 			},
 			wantErr: true,
@@ -807,8 +807,8 @@ func TestHotspots_ValidateSearchOpt(t *testing.T) {
 			name: "valid with all OWASP filters",
 			opt: &HotspotsSearchOptions{
 				Project:        "my-project",
-				OwaspTop10:     []string{"a1", "a2"},
-				OwaspTop102021: []string{"a3", "a4"},
+				OwaspTop10:     []string{OwaspCategoryA1, OwaspCategoryA2},
+				OwaspTop102021: []string{OwaspCategoryA3, OwaspCategoryA4},
 				OwaspAsvsLevel: "2",
 			},
 			wantErr: false,
@@ -817,7 +817,7 @@ func TestHotspots_ValidateSearchOpt(t *testing.T) {
 			name: "valid with SANS filter",
 			opt: &HotspotsSearchOptions{
 				Project:   "my-project",
-				SansTop25: []string{"insecure-interaction", "porous-defenses"},
+				SansTop25: []string{SansTop25CategoryInsecureInteraction, SansTop25CategoryPorousDefenses},
 			},
 			wantErr: false,
 		},
@@ -890,8 +890,8 @@ func TestHotspots_ValidateListOpt(t *testing.T) {
 				Project:         "my-project",
 				Branch:          "main",
 				InNewCodePeriod: true,
-				Status:          "TO_REVIEW",
-				Resolution:      "SAFE",
+				Status:          HotspotStatusToReview,
+				Resolution:      HotspotResolutionSafe,
 				PaginationArgs:  PaginationArgs{PageSize: 100},
 			},
 			wantErr: false,

--- a/sonar/issues_service.go
+++ b/sonar/issues_service.go
@@ -4,6 +4,56 @@ import (
 	"net/http"
 )
 
+const (
+	// IssueTransitionConfirm represents the "confirm" transition for issues.
+	IssueTransitionConfirm = "confirm"
+	// IssueTransitionUnconfirm represents the "unconfirm" transition for issues.
+	IssueTransitionUnconfirm = "unconfirm"
+	// IssueTransitionReopen represents the "reopen" transition for issues.
+	IssueTransitionReopen = "reopen"
+	// IssueTransitionResolve represents the "resolve" transition for issues.
+	IssueTransitionResolve = "resolve"
+	// IssueTransitionFalsePositive represents the "falsepositive" transition for issues.
+	IssueTransitionFalsePositive = "falsepositive"
+	// IssueTransitionWontFix represents the "wontfix" transition for issues.
+	IssueTransitionWontFix = "wontfix"
+	// IssueTransitionAccept represents the "accept" transition for issues.
+	IssueTransitionAccept = "accept"
+	// IssueTransitionClose represents the "close" transition for issues.
+	IssueTransitionClose = "close"
+	// IssueTransitionResolveAsReviewed represents the "resolveasreviewed" transition for issues.
+	IssueTransitionResolveAsReviewed = "resolveasreviewed"
+	// IssueTransitionResetAsReviewed represents the "resetastoreview" transition for issues.
+	IssueTransitionResetAsReviewed = "resetastoreview"
+
+	// IssueStatusOpen represents the "OPEN" status for issues.
+	IssueStatusOpen = "OPEN"
+	// IssueStatusConfirmed represents the "CONFIRMED" status for issues.
+	IssueStatusConfirmed = "CONFIRMED"
+	// IssueStatusFalsePositive represents the "FALSE_POSITIVE" status for issues.
+	IssueStatusFalsePositive = "FALSE_POSITIVE"
+	// IssueStatusAccepted represents the "ACCEPTED" status for issues.
+	IssueStatusAccepted = "ACCEPTED"
+	// IssueStatusFixed represents the "FIXED" status for issues.
+	IssueStatusFixed = "FIXED"
+	// IssueStatusInSandbox represents the "IN_SANDBOX" status for issues.
+	IssueStatusInSandbox = "IN_SANDBOX"
+
+	// IssueResolutionFixed represents the "FIXED" resolution for issues.
+	IssueResolutionFixed = "FIXED"
+	// IssueResolutionRemoved represents the "REMOVED" resolution for issues.
+	IssueResolutionRemoved = "REMOVED"
+	// IssueResolutionFalsePositive represents the "FALSE-POSITIVE" resolution for issues.
+	IssueResolutionFalsePositive = "FALSE-POSITIVE"
+	// IssueResolutionWontFix represents the "WONTFIX" resolution for issues.
+	IssueResolutionWontFix = "WONTFIX"
+
+	// IssueScopeMain represents the "MAIN" scope for issues.
+	IssueScopeMain = "MAIN"
+	// IssueScopeTest represents the "TEST" scope for issues.
+	IssueScopeTest = "TEST"
+)
+
 // IssuesService handles communication with the Issues related methods of the SonarQube API.
 // Issues represent code problems detected by SonarQube during analysis.
 type IssuesService struct {
@@ -1252,7 +1302,7 @@ func (s *IssuesService) ValidateBulkChangeOpt(opt *IssuesBulkChangeOptions) erro
 
 	// Validate severity if set
 	if opt.SetSeverity != "" {
-		err := IsValueAuthorized(opt.SetSeverity, allowedSeverities, "SetSeverity")
+		err := IsValueAuthorized(opt.SetSeverity, allowedRuleSeverities, "SetSeverity")
 		if err != nil {
 			return err
 		}
@@ -1464,7 +1514,7 @@ func (s *IssuesService) ValidateSearchOpt(opt *IssuesSearchOptions) error {
 
 	// Validate impact severities
 	if len(opt.ImpactSeverities) > 0 {
-		err := AreValuesAuthorized(opt.ImpactSeverities, allowedImpactSeverities, "ImpactSeverities")
+		err := AreValuesAuthorized(opt.ImpactSeverities, allowedRuleImpactSeverities, "ImpactSeverities")
 		if err != nil {
 			return err
 		}
@@ -1488,7 +1538,7 @@ func (s *IssuesService) ValidateSearchOpt(opt *IssuesSearchOptions) error {
 
 	// Validate severities
 	if len(opt.Severities) > 0 {
-		err := AreValuesAuthorized(opt.Severities, allowedSeverities, "Severities")
+		err := AreValuesAuthorized(opt.Severities, allowedRuleSeverities, "Severities")
 		if err != nil {
 			return err
 		}
@@ -1590,7 +1640,7 @@ func (s *IssuesService) ValidateSetSeverityOpt(opt *IssuesSetSeverityOptions) er
 
 	// Validate severity if set
 	if opt.Severity != "" {
-		err := IsValueAuthorized(opt.Severity, allowedSeverities, "Severity")
+		err := IsValueAuthorized(opt.Severity, allowedRuleSeverities, "Severity")
 		if err != nil {
 			return err
 		}

--- a/sonar/issues_service_test.go
+++ b/sonar/issues_service_test.go
@@ -150,7 +150,7 @@ func TestIssues_BulkChange(t *testing.T) {
 
 	opt := &IssuesBulkChangeOptions{
 		Issues:      []string{"issue1", "issue2"},
-		SetSeverity: "MAJOR",
+		SetSeverity: RuleSeverityMajor,
 		AddTags:     []string{"tag1", "tag2"},
 	}
 	result, resp, err := client.Issues.BulkChange(opt)
@@ -303,7 +303,7 @@ func TestIssues_DoTransition(t *testing.T) {
 
 	opt := &IssuesDoTransitionOptions{
 		Issue:      "test-key",
-		Transition: "confirm",
+		Transition: IssueTransitionConfirm,
 	}
 	result, resp, err := client.Issues.DoTransition(opt)
 	require.NoError(t, err)
@@ -433,9 +433,9 @@ func TestIssues_Search(t *testing.T) {
 
 	opt := &IssuesSearchOptions{
 		Projects:         []string{"my-project"},
-		Severities:       []string{"BLOCKER", "CRITICAL"},
-		Types:            []string{"BUG"},
-		ImpactSeverities: []string{"HIGH"},
+		Severities:       []string{RuleSeverityBlocker, RuleSeverityCritical},
+		Types:            []string{RuleTypeBug},
+		ImpactSeverities: []string{RuleImpactSeverityHigh},
 	}
 	result, resp, err := client.Issues.Search(opt)
 	require.NoError(t, err)
@@ -508,12 +508,12 @@ func TestIssues_SetSeverity(t *testing.T) {
 
 	opt := &IssuesSetSeverityOptions{
 		Issue:    "test-key",
-		Severity: "BLOCKER",
+		Severity: RuleSeverityBlocker,
 	}
 	result, resp, err := client.Issues.SetSeverity(opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "BLOCKER", result.Issue.Severity)
+	assert.Equal(t, RuleSeverityBlocker, result.Issue.Severity)
 }
 
 func TestIssues_SetSeverity_ValidationError(t *testing.T) {
@@ -570,12 +570,12 @@ func TestIssues_SetType(t *testing.T) {
 
 	opt := &IssuesSetTypeOptions{
 		Issue: "test-key",
-		Type:  "BUG",
+		Type:  RuleTypeBug,
 	}
 	result, resp, err := client.Issues.SetType(opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "BUG", result.Issue.Type)
+	assert.Equal(t, RuleTypeBug, result.Issue.Type)
 }
 
 func TestIssues_SetType_ValidationError(t *testing.T) {
@@ -587,7 +587,7 @@ func TestIssues_SetType_ValidationError(t *testing.T) {
 	}{
 		{
 			name: "missing issue",
-			opt:  &IssuesSetTypeOptions{Type: "BUG"},
+			opt:  &IssuesSetTypeOptions{Type: RuleTypeBug},
 		},
 		{
 			name: "missing type",

--- a/sonar/measures_service.go
+++ b/sonar/measures_service.go
@@ -4,6 +4,20 @@ import (
 	"net/http"
 )
 
+const (
+	// MeasureStrategyAll represents the "all" strategy for measures component tree.
+	MeasureStrategyAll = "all"
+	// MeasureStrategyChildren represents the "children" strategy for measures component tree.
+	MeasureStrategyChildren = "children"
+	// MeasureStrategyLeaves represents the "leaves" strategy for measures component tree.
+	MeasureStrategyLeaves = "leaves"
+
+	// MeasuresMetricSortFilterAll represents the "all" metric sort filter.
+	MeasuresMetricSortFilterAll = "all"
+	// MeasuresMetricSortFilterWithMeasuresOnly represents the "withMeasuresOnly" metric sort filter.
+	MeasuresMetricSortFilterWithMeasuresOnly = "withMeasuresOnly"
+)
+
 // MeasuresService handles communication with the Measures related methods of the SonarQube API.
 // Get components or children with specified measures.
 //
@@ -16,15 +30,15 @@ type MeasuresService struct {
 var (
 	// allowedMeasuresMetricSortFilter is the set of allowed values for metric sort filtering.
 	allowedMeasuresMetricSortFilter = map[string]struct{}{
-		"all":              {},
-		"withMeasuresOnly": {},
+		MeasuresMetricSortFilterAll:              {},
+		MeasuresMetricSortFilterWithMeasuresOnly: {},
 	}
 
 	// allowedMeasuresStrategy is the set of allowed values for strategy.
 	allowedMeasuresStrategy = map[string]struct{}{
-		"all":      {},
-		"children": {},
-		"leaves":   {},
+		MeasureStrategyAll:      {},
+		MeasureStrategyChildren: {},
+		MeasureStrategyLeaves:   {},
 	}
 )
 

--- a/sonar/measures_service_test.go
+++ b/sonar/measures_service_test.go
@@ -96,7 +96,7 @@ func TestMeasuresService_ComponentTree(t *testing.T) {
 	opt := &MeasuresComponentTreeOptions{
 		Component:  "my-project",
 		MetricKeys: []string{"coverage"},
-		Strategy:   "all",
+		Strategy:   MeasureStrategyAll,
 	}
 
 	result, resp, err := client.Measures.ComponentTree(opt)

--- a/sonar/navigation_service_test.go
+++ b/sonar/navigation_service_test.go
@@ -17,7 +17,7 @@ func TestNavigationService_Component(t *testing.T) {
 			AnalysisDate: "2023-05-01T12:00:00+0000",
 			IsFavorite:   true,
 			Breadcrumbs: []NavigationBreadcrumb{
-				{Key: "my-project", Name: "My Project", Qualifier: "TRK"},
+				{Key: "my-project", Name: "My Project", Qualifier: ProjectQualifierTRK},
 			},
 			QualityGate: NavigationQualityGate{
 				Key:       "1",
@@ -82,7 +82,7 @@ func TestNavigationService_Global(t *testing.T) {
 			CanAdmin:           true,
 			Standalone:         true,
 			ProductionDatabase: true,
-			Qualifiers:         []string{"TRK", "VW", "APP"},
+			Qualifiers:         []string{ProjectQualifierTRK, ProjectQualifierVW, ProjectQualifierAPP},
 			GlobalPages: []NavigationExtension{
 				{Key: "page1", Name: "Page 1"},
 			},

--- a/sonar/new_code_periods_service.go
+++ b/sonar/new_code_periods_service.go
@@ -5,6 +5,17 @@ import (
 	"strconv"
 )
 
+const (
+	// NewCodePeriodTypeSpecificAnalysis represents the "SPECIFIC_ANALYSIS" new code period type.
+	NewCodePeriodTypeSpecificAnalysis = "SPECIFIC_ANALYSIS"
+	// NewCodePeriodTypePreviousVersion represents the "PREVIOUS_VERSION" new code period type.
+	NewCodePeriodTypePreviousVersion = "PREVIOUS_VERSION"
+	// NewCodePeriodTypeNumberOfDays represents the "NUMBER_OF_DAYS" new code period type.
+	NewCodePeriodTypeNumberOfDays = "NUMBER_OF_DAYS"
+	// NewCodePeriodTypeReferenceBranch represents the "REFERENCE_BRANCH" new code period type.
+	NewCodePeriodTypeReferenceBranch = "REFERENCE_BRANCH"
+)
+
 // NewCodePeriodsService handles communication with the new code periods related methods
 // of the SonarQube API.
 // This service manages new code definitions.
@@ -17,10 +28,10 @@ type NewCodePeriodsService struct {
 var (
 	// allowedNewCodePeriodTypes is the set of supported new code period types.
 	allowedNewCodePeriodTypes = map[string]struct{}{
-		"SPECIFIC_ANALYSIS": {},
-		"PREVIOUS_VERSION":  {},
-		"NUMBER_OF_DAYS":    {},
-		"REFERENCE_BRANCH":  {},
+		NewCodePeriodTypeSpecificAnalysis: {},
+		NewCodePeriodTypePreviousVersion:  {},
+		NewCodePeriodTypeNumberOfDays:     {},
+		NewCodePeriodTypeReferenceBranch:  {},
 	}
 )
 

--- a/sonar/new_code_periods_service_test.go
+++ b/sonar/new_code_periods_service_test.go
@@ -48,7 +48,7 @@ func TestNewCodePeriods_List(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
 	assert.Len(t, result.NewCodePeriods, 2)
-	assert.Equal(t, "PREVIOUS_VERSION", result.NewCodePeriods[0].Type)
+	assert.Equal(t, NewCodePeriodTypePreviousVersion, result.NewCodePeriods[0].Type)
 	assert.Equal(t, "30", result.NewCodePeriods[1].Value)
 }
 
@@ -68,7 +68,7 @@ func TestNewCodePeriods_Set(t *testing.T) {
 	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/new_code_periods/set", r.URL.Path)
-		assert.Equal(t, "NUMBER_OF_DAYS", r.URL.Query().Get("type"))
+		assert.Equal(t, NewCodePeriodTypeNumberOfDays, r.URL.Query().Get("type"))
 		assert.Equal(t, "30", r.URL.Query().Get("value"))
 
 		w.WriteHeader(http.StatusOK)
@@ -77,7 +77,7 @@ func TestNewCodePeriods_Set(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	opt := &NewCodePeriodsSetOptions{
-		Type:  "NUMBER_OF_DAYS",
+		Type:  NewCodePeriodTypeNumberOfDays,
 		Value: "30",
 	}
 
@@ -105,13 +105,13 @@ func TestNewCodePeriods_Set_ValidationError(t *testing.T) {
 
 	// SPECIFIC_ANALYSIS without Branch should fail validation.
 	_, err = client.NewCodePeriods.Set(&NewCodePeriodsSetOptions{
-		Type: "SPECIFIC_ANALYSIS",
+		Type: NewCodePeriodTypeSpecificAnalysis,
 	})
 	assert.Error(t, err)
 
 	// REFERENCE_BRANCH without Project should fail validation.
 	_, err = client.NewCodePeriods.Set(&NewCodePeriodsSetOptions{
-		Type: "REFERENCE_BRANCH",
+		Type: NewCodePeriodTypeReferenceBranch,
 	})
 	assert.Error(t, err)
 }
@@ -130,7 +130,7 @@ func TestNewCodePeriods_Show(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
-	assert.Equal(t, "NUMBER_OF_DAYS", result.Type)
+	assert.Equal(t, NewCodePeriodTypeNumberOfDays, result.Type)
 	assert.Equal(t, "30", result.Value)
 }
 
@@ -164,7 +164,7 @@ func TestNewCodePeriods_Show_WithOptions(t *testing.T) {
 	result, _, err := client.NewCodePeriods.Show(opt)
 	require.NoError(t, err)
 	assert.Equal(t, "my-project", result.ProjectKey)
-	assert.Equal(t, "REFERENCE_BRANCH", result.Type)
+	assert.Equal(t, NewCodePeriodTypeReferenceBranch, result.Type)
 	assert.Equal(t, "main", result.Value)
 }
 
@@ -201,7 +201,7 @@ func TestNewCodePeriods_ValidateSetOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// All valid types without special requirements should pass.
-	validTypes := []string{"PREVIOUS_VERSION"}
+	validTypes := []string{NewCodePeriodTypePreviousVersion}
 	for _, periodType := range validTypes {
 		err := client.NewCodePeriods.ValidateSetOpt(&NewCodePeriodsSetOptions{
 			Type: periodType,
@@ -211,21 +211,21 @@ func TestNewCodePeriods_ValidateSetOpt(t *testing.T) {
 
 	// NUMBER_OF_DAYS with valid Value should pass.
 	err := client.NewCodePeriods.ValidateSetOpt(&NewCodePeriodsSetOptions{
-		Type:  "NUMBER_OF_DAYS",
+		Type:  NewCodePeriodTypeNumberOfDays,
 		Value: "30",
 	})
 	assert.NoError(t, err)
 
 	// SPECIFIC_ANALYSIS with Branch should pass.
 	err = client.NewCodePeriods.ValidateSetOpt(&NewCodePeriodsSetOptions{
-		Type:   "SPECIFIC_ANALYSIS",
+		Type:   NewCodePeriodTypeSpecificAnalysis,
 		Branch: "main",
 	})
 	assert.NoError(t, err)
 
 	// REFERENCE_BRANCH with Project should pass.
 	err = client.NewCodePeriods.ValidateSetOpt(&NewCodePeriodsSetOptions{
-		Type:    "REFERENCE_BRANCH",
+		Type:    NewCodePeriodTypeReferenceBranch,
 		Project: "my-project",
 	})
 	assert.NoError(t, err)

--- a/sonar/permissions_service.go
+++ b/sonar/permissions_service.go
@@ -5,6 +5,34 @@ import "net/http"
 const (
 	// MinPermissionQueryLength is the minimum required length for permission query strings.
 	MinPermissionQueryLength = 3
+
+	// PermissionGlobalAdmin is the global admin permission.
+	PermissionGlobalAdmin = "admin"
+	// PermissionGlobalGateAdmin is the global gate admin permission.
+	PermissionGlobalGateAdmin = "gateadmin"
+	// PermissionGlobalProfileAdmin is the global profile admin permission.
+	PermissionGlobalProfileAdmin = "profileadmin"
+	// PermissionGlobalProvisioning is the global provisioning permission.
+	PermissionGlobalProvisioning = "provisioning"
+	// PermissionGlobalScan is the global scan permission.
+	PermissionGlobalScan = "scan"
+	// PermissionGlobalApplicationCreator is the global application creator permission.
+	PermissionGlobalApplicationCreator = "applicationcreator"
+	// PermissionGlobalPortfolioCreator is the global portfolio creator permission.
+	PermissionGlobalPortfolioCreator = "portfoliocreator"
+
+	// PermissionProjectAdmin is the project admin permission.
+	PermissionProjectAdmin = "admin"
+	// PermissionProjectCodeViewer is the project code viewer permission.
+	PermissionProjectCodeViewer = "codeviewer"
+	// PermissionProjectIssueAdmin is the project issue admin permission.
+	PermissionProjectIssueAdmin = "issueadmin"
+	// PermissionProjectSecurityHotspotAdmin is the project security hotspot admin permission.
+	PermissionProjectSecurityHotspotAdmin = "securityhotspotadmin"
+	// PermissionProjectScan is the project scan permission.
+	PermissionProjectScan = "scan"
+	// PermissionProjectUser is the project user permission.
+	PermissionProjectUser = "user"
 )
 
 // PermissionsService handles communication with the permissions related methods
@@ -20,23 +48,23 @@ type PermissionsService struct {
 var (
 	// allowedGlobalPermissions is the set of supported global permissions.
 	allowedGlobalPermissions = map[string]struct{}{
-		"admin":              {},
-		"gateadmin":          {},
-		"profileadmin":       {},
-		"provisioning":       {},
-		"scan":               {},
-		"applicationcreator": {},
-		"portfoliocreator":   {},
+		PermissionGlobalAdmin:              {},
+		PermissionGlobalGateAdmin:          {},
+		PermissionGlobalProfileAdmin:       {},
+		PermissionGlobalProvisioning:       {},
+		PermissionGlobalScan:               {},
+		PermissionGlobalApplicationCreator: {},
+		PermissionGlobalPortfolioCreator:   {},
 	}
 
 	// allowedProjectPermissions is the set of supported project permissions.
 	allowedProjectPermissions = map[string]struct{}{
-		"admin":                {},
-		"codeviewer":           {},
-		"issueadmin":           {},
-		"securityhotspotadmin": {},
-		"scan":                 {},
-		"user":                 {},
+		PermissionProjectAdmin:                {},
+		PermissionProjectCodeViewer:           {},
+		PermissionProjectIssueAdmin:           {},
+		PermissionProjectSecurityHotspotAdmin: {},
+		PermissionProjectScan:                 {},
+		PermissionProjectUser:                 {},
 	}
 
 	// allowedQualifiers is the set of supported qualifiers for permissions.

--- a/sonar/permissions_service_test.go
+++ b/sonar/permissions_service_test.go
@@ -731,7 +731,7 @@ func TestPermissions_SearchTemplates(t *testing.T) {
 			},
 		},
 		DefaultTemplates: []DefaultTemplate{
-			{Qualifier: "TRK", TemplateID: "template-1"},
+			{Qualifier: ProjectQualifierTRK, TemplateID: "template-1"},
 		},
 	}
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/permissions/search_templates", http.StatusOK, response))

--- a/sonar/project_badges_service.go
+++ b/sonar/project_badges_service.go
@@ -2,6 +2,47 @@ package sonar
 
 import "net/http"
 
+const (
+	// BadgeMetricCoverage represents the coverage metric for badges.
+	BadgeMetricCoverage = "coverage"
+	// BadgeMetricDuplicatedLinesDensity represents the duplicated lines density metric for badges.
+	BadgeMetricDuplicatedLinesDensity = "duplicated_lines_density"
+	// BadgeMetricNcloc represents the ncloc metric for badges.
+	BadgeMetricNcloc = "ncloc"
+	// BadgeMetricAlertStatus represents the alert status metric for badges.
+	BadgeMetricAlertStatus = "alert_status"
+	// BadgeMetricSecurityHotspots represents the security hotspots metric for badges.
+	BadgeMetricSecurityHotspots = "security_hotspots"
+	// BadgeMetricBugs represents the bugs metric for badges.
+	BadgeMetricBugs = "bugs"
+	// BadgeMetricCodeSmells represents the code smells metric for badges.
+	BadgeMetricCodeSmells = "code_smells"
+	// BadgeMetricVulnerabilities represents the vulnerabilities metric for badges.
+	BadgeMetricVulnerabilities = "vulnerabilities"
+	// BadgeMetricSqaleRating represents the sqale rating metric for badges.
+	BadgeMetricSqaleRating = "sqale_rating"
+	// BadgeMetricReliabilityRating represents the reliability rating metric for badges.
+	BadgeMetricReliabilityRating = "reliability_rating"
+	// BadgeMetricSecurityRating represents the security rating metric for badges.
+	BadgeMetricSecurityRating = "security_rating"
+	// BadgeMetricSqaleIndex represents the sqale index metric for badges.
+	BadgeMetricSqaleIndex = "sqale_index"
+	// BadgeMetricSoftwareQualityReliabilityIssues represents the software quality reliability issues metric for badges.
+	BadgeMetricSoftwareQualityReliabilityIssues = "software_quality_reliability_issues"
+	// BadgeMetricSoftwareQualityMaintainabilityIssues represents the software quality maintainability issues metric for badges.
+	BadgeMetricSoftwareQualityMaintainabilityIssues = "software_quality_maintainability_issues"
+	// BadgeMetricSoftwareQualitySecurityIssues represents the software quality security issues metric for badges.
+	BadgeMetricSoftwareQualitySecurityIssues = "software_quality_security_issues"
+	// BadgeMetricSoftwareQualityMaintainabilityRating represents the software quality maintainability rating metric for badges.
+	BadgeMetricSoftwareQualityMaintainabilityRating = "software_quality_maintainability_rating"
+	// BadgeMetricSoftwareQualityReliabilityRating represents the software quality reliability rating metric for badges.
+	BadgeMetricSoftwareQualityReliabilityRating = "software_quality_reliability_rating"
+	// BadgeMetricSoftwareQualitySecurityRating represents the software quality security rating metric for badges.
+	BadgeMetricSoftwareQualitySecurityRating = "software_quality_security_rating"
+	// BadgeMetricSoftwareQualityMaintainabilityRemediationEffort represents the software quality maintainability remediation effort metric for badges.
+	BadgeMetricSoftwareQualityMaintainabilityRemediationEffort = "software_quality_maintainability_remediation_effort"
+)
+
 // ProjectBadgesService handles communication with the project badges related methods
 // of the SonarQube API.
 // This service generates badges based on quality gates or measures.
@@ -14,25 +55,25 @@ type ProjectBadgesService struct {
 var (
 	// allowedBadgeMetrics is the set of supported metrics for badges.
 	allowedBadgeMetrics = map[string]struct{}{
-		"coverage":                            {},
-		"duplicated_lines_density":            {},
-		"ncloc":                               {},
-		"alert_status":                        {},
-		"security_hotspots":                   {},
-		"bugs":                                {},
-		"code_smells":                         {},
-		"vulnerabilities":                     {},
-		"sqale_rating":                        {},
-		"reliability_rating":                  {},
-		"security_rating":                     {},
-		"sqale_index":                         {},
-		"software_quality_reliability_issues": {},
-		"software_quality_maintainability_issues":             {},
-		"software_quality_security_issues":                    {},
-		"software_quality_maintainability_rating":             {},
-		"software_quality_reliability_rating":                 {},
-		"software_quality_security_rating":                    {},
-		"software_quality_maintainability_remediation_effort": {},
+		BadgeMetricCoverage:                                        {},
+		BadgeMetricDuplicatedLinesDensity:                          {},
+		BadgeMetricNcloc:                                           {},
+		BadgeMetricAlertStatus:                                     {},
+		BadgeMetricSecurityHotspots:                                {},
+		BadgeMetricBugs:                                            {},
+		BadgeMetricCodeSmells:                                      {},
+		BadgeMetricVulnerabilities:                                 {},
+		BadgeMetricSqaleRating:                                     {},
+		BadgeMetricReliabilityRating:                               {},
+		BadgeMetricSecurityRating:                                  {},
+		BadgeMetricSqaleIndex:                                      {},
+		BadgeMetricSoftwareQualityReliabilityIssues:                {},
+		BadgeMetricSoftwareQualityMaintainabilityIssues:            {},
+		BadgeMetricSoftwareQualitySecurityIssues:                   {},
+		BadgeMetricSoftwareQualityMaintainabilityRating:            {},
+		BadgeMetricSoftwareQualityReliabilityRating:                {},
+		BadgeMetricSoftwareQualitySecurityRating:                   {},
+		BadgeMetricSoftwareQualityMaintainabilityRemediationEffort: {},
 	}
 )
 

--- a/sonar/projects_service.go
+++ b/sonar/projects_service.go
@@ -4,19 +4,33 @@ import (
 	"net/http"
 )
 
+const (
+	// ProjectVisibilityPrivate represents private project visibility.
+	ProjectVisibilityPrivate = "private"
+	// ProjectVisibilityPublic represents public project visibility.
+	ProjectVisibilityPublic = "public"
+
+	// ProjectQualifierTRK represents the TRK project qualifier.
+	ProjectQualifierTRK = "TRK"
+	// ProjectQualifierVW represents the VW project qualifier.
+	ProjectQualifierVW = "VW"
+	// ProjectQualifierAPP represents the APP project qualifier.
+	ProjectQualifierAPP = "APP"
+)
+
 //nolint:gochecknoglobals // these are constant sets of allowed values
 var (
 	// allowedProjectQualifiers is the set of allowed values for project qualifiers.
 	allowedProjectQualifiers = map[string]struct{}{
-		"TRK": {},
-		"VW":  {},
-		"APP": {},
+		ProjectQualifierTRK: {},
+		ProjectQualifierVW:  {},
+		ProjectQualifierAPP: {},
 	}
 
 	// allowedProjectVisibility is the set of allowed values for project visibility.
 	allowedProjectVisibility = map[string]struct{}{
-		"private": {},
-		"public":  {},
+		ProjectVisibilityPrivate: {},
+		ProjectVisibilityPublic:  {},
 	}
 )
 

--- a/sonar/projects_service_test.go
+++ b/sonar/projects_service_test.go
@@ -53,8 +53,8 @@ func TestProjectsService_Create(t *testing.T) {
 		Project: Project{
 			Key:        "my-project",
 			Name:       "My Project",
-			Qualifier:  "TRK",
-			Visibility: "private",
+			Qualifier:  ProjectQualifierTRK,
+			Visibility: ProjectVisibilityPrivate,
 		},
 	}))
 	defer server.Close()
@@ -64,7 +64,7 @@ func TestProjectsService_Create(t *testing.T) {
 	opt := &ProjectsCreateOptions{
 		Name:       "My Project",
 		Project:    "my-project",
-		Visibility: "private",
+		Visibility: ProjectVisibilityPrivate,
 	}
 
 	result, resp, err := client.Projects.Create(opt)
@@ -152,15 +152,15 @@ func TestProjectsService_Search(t *testing.T) {
 			{
 				Key:              "project1",
 				Name:             "Project One",
-				Qualifier:        "TRK",
-				Visibility:       "public",
+				Qualifier:        ProjectQualifierTRK,
+				Visibility:       ProjectVisibilityPublic,
 				LastAnalysisDate: "2024-01-15T10:30:00+0000",
 			},
 			{
 				Key:        "project2",
 				Name:       "Project Two",
-				Qualifier:  "TRK",
-				Visibility: "private",
+				Qualifier:  ProjectQualifierTRK,
+				Visibility: ProjectVisibilityPrivate,
 				Managed:    true,
 			},
 		},
@@ -171,7 +171,7 @@ func TestProjectsService_Search(t *testing.T) {
 
 	opt := &ProjectsSearchOptions{
 		Query:      "project",
-		Qualifiers: []string{"TRK"},
+		Qualifiers: []string{ProjectQualifierTRK},
 	}
 
 	result, resp, err := client.Projects.Search(opt)
@@ -244,7 +244,7 @@ func TestProjectsService_UpdateDefaultVisibility(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	opt := &ProjectsUpdateDefaultVisibilityOptions{
-		ProjectVisibility: "private",
+		ProjectVisibility: ProjectVisibilityPrivate,
 	}
 
 	resp, err := client.Projects.UpdateDefaultVisibility(opt)
@@ -314,7 +314,7 @@ func TestProjectsService_UpdateVisibility(t *testing.T) {
 
 	opt := &ProjectsUpdateVisibilityOptions{
 		Project:    "my-project",
-		Visibility: "public",
+		Visibility: ProjectVisibilityPublic,
 	}
 
 	resp, err := client.Projects.UpdateVisibility(opt)
@@ -328,7 +328,7 @@ func TestProjectsService_UpdateVisibility_ValidationError(t *testing.T) {
 
 	// Test missing Project
 	opt := &ProjectsUpdateVisibilityOptions{
-		Visibility: "public",
+		Visibility: ProjectVisibilityPublic,
 	}
 	_, err := client.Projects.UpdateVisibility(opt)
 	assert.Error(t, err)

--- a/sonar/qualityprofiles_service.go
+++ b/sonar/qualityprofiles_service.go
@@ -1628,7 +1628,7 @@ func (s *QualityprofilesService) ValidateActivateRuleOpt(opt *QualityprofilesAct
 	}
 
 	// Validate Severity if provided
-	err = IsValueAuthorized(opt.Severity, allowedSeverities, "Severity")
+	err = IsValueAuthorized(opt.Severity, allowedRuleSeverities, "Severity")
 	if err != nil {
 		return err
 	}
@@ -1639,7 +1639,7 @@ func (s *QualityprofilesService) ValidateActivateRuleOpt(opt *QualityprofilesAct
 		return err
 	}
 
-	err = ValidateMapValues(opt.Impacts, allowedImpactSeverities, "Impacts")
+	err = ValidateMapValues(opt.Impacts, allowedRuleImpactSeverities, "Impacts")
 	if err != nil {
 		return err
 	}
@@ -1661,27 +1661,27 @@ func (s *QualityprofilesService) ValidateActivateRulesOpt(opt *QualityprofilesAc
 	}
 
 	// Validate severity values
-	err = AreValuesAuthorized(opt.ActiveImpactSeverities, allowedImpactSeverities, "ActiveImpactSeverities")
+	err = AreValuesAuthorized(opt.ActiveImpactSeverities, allowedRuleImpactSeverities, "ActiveImpactSeverities")
 	if err != nil {
 		return err
 	}
 
-	err = AreValuesAuthorized(opt.ActiveSeverities, allowedSeverities, "ActiveSeverities")
+	err = AreValuesAuthorized(opt.ActiveSeverities, allowedRuleSeverities, "ActiveSeverities")
 	if err != nil {
 		return err
 	}
 
-	err = AreValuesAuthorized(opt.Severities, allowedSeverities, "Severities")
+	err = AreValuesAuthorized(opt.Severities, allowedRuleSeverities, "Severities")
 	if err != nil {
 		return err
 	}
 
-	err = AreValuesAuthorized(opt.ImpactSeverities, allowedImpactSeverities, "ImpactSeverities")
+	err = AreValuesAuthorized(opt.ImpactSeverities, allowedRuleImpactSeverities, "ImpactSeverities")
 	if err != nil {
 		return err
 	}
 
-	err = IsValueAuthorized(opt.TargetSeverity, allowedSeverities, "TargetSeverity")
+	err = IsValueAuthorized(opt.TargetSeverity, allowedRuleSeverities, "TargetSeverity")
 	if err != nil {
 		return err
 	}

--- a/sonar/qualityprofiles_service_test.go
+++ b/sonar/qualityprofiles_service_test.go
@@ -46,8 +46,8 @@ func TestQualityprofiles_ActivateRule_ValidationError(t *testing.T) {
 	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
 		Key:      "AU-TpxcA-iU5OvuD2FL0",
 		Rule:     "squid:AvoidCycles",
-		Impacts:  map[string]string{"MAINTAINABILITY": "HIGH"},
-		Severity: "MAJOR",
+		Impacts:  map[string]string{SoftwareQualityMaintainability: RuleImpactSeverityHigh},
+		Severity: RuleSeverityMajor,
 	})
 	assert.Error(t, err)
 
@@ -63,7 +63,7 @@ func TestQualityprofiles_ActivateRule_ValidationError(t *testing.T) {
 	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
 		Key:     "AU-TpxcA-iU5OvuD2FL0",
 		Rule:    "squid:AvoidCycles",
-		Impacts: map[string]string{"INVALID_QUALITY": "HIGH"},
+		Impacts: map[string]string{"INVALID_QUALITY": RuleImpactSeverityHigh},
 	})
 	assert.Error(t, err)
 
@@ -71,7 +71,7 @@ func TestQualityprofiles_ActivateRule_ValidationError(t *testing.T) {
 	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
 		Key:     "AU-TpxcA-iU5OvuD2FL0",
 		Rule:    "squid:AvoidCycles",
-		Impacts: map[string]string{"MAINTAINABILITY": "INVALID_SEVERITY"},
+		Impacts: map[string]string{SoftwareQualityMaintainability: "INVALID_SEVERITY"},
 	})
 	assert.Error(t, err)
 }
@@ -1210,7 +1210,7 @@ func TestQualityprofiles_ConvertActivateRuleOptForURL(t *testing.T) {
 	opt := &QualityprofilesActivateRuleOptions{
 		Key:             "AU-TpxcA-iU5OvuD2FL0",
 		Rule:            "squid:AvoidCycles",
-		Impacts:         map[string]string{"MAINTAINABILITY": "HIGH", "SECURITY": "MEDIUM"},
+		Impacts:         map[string]string{SoftwareQualityMaintainability: RuleImpactSeverityHigh, SoftwareQualitySecurity: RuleImpactSeverityMedium},
 		Params:          map[string]string{"max": "10", "threshold": "5"},
 		PrioritizedRule: true,
 		Reset:           false,

--- a/sonar/rules_service.go
+++ b/sonar/rules_service.go
@@ -10,6 +10,53 @@ const (
 	MaxRuleKeyLength = 200
 	// MinSearchQueryLength is the minimum required length for search queries.
 	MinSearchQueryLength = 2
+
+	// RuleRemediationFnTypeConstant represents a constant remediation function type.
+	RuleRemediationFnTypeConstant = "CONSTANT_ISSUE"
+	// RuleRemediationFnTypeLinear represents a linear remediation function type.
+	RuleRemediationFnTypeLinear = "LINEAR"
+	// RuleRemediationFnTypeLinearOffset represents a linear offset remediation function type.
+	RuleRemediationFnTypeLinearOffset = "LINEAR_OFFSET"
+
+	// RuleSeverityInfo represents the INFO severity level for rules.
+	RuleSeverityInfo = "INFO"
+	// RuleSeverityMinor represents the MINOR severity level for rules.
+	RuleSeverityMinor = "MINOR"
+	// RuleSeverityMajor represents the MAJOR severity level for rules.
+	RuleSeverityMajor = "MAJOR"
+	// RuleSeverityCritical represents the CRITICAL severity level for rules.
+	RuleSeverityCritical = "CRITICAL"
+	// RuleSeverityBlocker represents the BLOCKER severity level for rules.
+	RuleSeverityBlocker = "BLOCKER"
+
+	// RuleImpactSeverityInfo represents the INFO severity level for rule impacts.
+	RuleImpactSeverityInfo = "INFO"
+	// RuleImpactSeverityLow represents the LOW severity level for rule impacts.
+	RuleImpactSeverityLow = "LOW"
+	// RuleImpactSeverityMedium represents the MEDIUM severity level for rule impacts.
+	RuleImpactSeverityMedium = "MEDIUM"
+	// RuleImpactSeverityHigh represents the HIGH severity level for rule impacts.
+	RuleImpactSeverityHigh = "HIGH"
+	// RuleImpactSeverityBlocker represents the BLOCKER severity level for rule impacts.
+	RuleImpactSeverityBlocker = "BLOCKER"
+
+	// RuleTypeCodeSmell represents the CODE_SMELL type for rules.
+	RuleTypeCodeSmell = "CODE_SMELL"
+	// RuleTypeBug represents the BUG type for rules.
+	RuleTypeBug = "BUG"
+	// RuleTypeVulnerability represents the VULNERABILITY type for rules.
+	RuleTypeVulnerability = "VULNERABILITY"
+	// RuleTypeSecurityHotspot represents the SECURITY_HOTSPOT type for rules.
+	RuleTypeSecurityHotspot = "SECURITY_HOTSPOT"
+
+	// RuleStatusReady represents the READY status for rules.
+	RuleStatusReady = "READY"
+	// RuleStatusDeprecated represents the DEPRECATED status for rules.
+	RuleStatusDeprecated = "DEPRECATED"
+	// RuleStatusBeta represents the BETA status for rules.
+	RuleStatusBeta = "BETA"
+	// RuleStatusRemoved represents the REMOVED status for rules.
+	RuleStatusRemoved = "REMOVED"
 )
 
 // RulesService handles communication with the Rules related methods of the SonarQube API.
@@ -502,7 +549,7 @@ type RulesUpdateOptions struct {
 	// RemediationFnBaseEffort is the base effort of the remediation function (e.g., '1d').
 	RemediationFnBaseEffort string `url:"remediation_fn_base_effort,omitempty"`
 	// RemediationFnType is the type of the remediation function.
-	// Allowed values: LINEAR, CONSTANT, LINEAR_OFFSET
+	// Allowed values: CONSTANT_ISSUE, LINEAR, LINEAR_OFFSET
 	RemediationFnType string `url:"remediation_fn_type,omitempty"`
 	// RemediationFyGapMultiplier is the gap multiplier of the remediation function (e.g., '2min').
 	RemediationFyGapMultiplier string `url:"remediation_fy_gap_multiplier,omitempty"`
@@ -781,7 +828,7 @@ func (s *RulesService) ValidateCreateOpt(opt *RulesCreateOptions) error {
 	}
 
 	if opt.Severity != "" {
-		err := IsValueAuthorized(opt.Severity, allowedSeverities, "Severity")
+		err := IsValueAuthorized(opt.Severity, allowedRuleSeverities, "Severity")
 		if err != nil {
 			return err
 		}
@@ -808,7 +855,7 @@ func (s *RulesService) ValidateCreateOpt(opt *RulesCreateOptions) error {
 			return err
 		}
 
-		err = ValidateMapValues(opt.Impacts, allowedImpactSeverities, "Impacts")
+		err = ValidateMapValues(opt.Impacts, allowedRuleImpactSeverities, "Impacts")
 		if err != nil {
 			return err
 		}
@@ -881,22 +928,22 @@ func (s *RulesService) ValidateSearchOpt(opt *RulesSearchOptions) error {
 	}
 
 	// Validate severity values
-	err = AreValuesAuthorized(opt.ActiveImpactSeverities, allowedImpactSeverities, "ActiveImpactSeverities")
+	err = AreValuesAuthorized(opt.ActiveImpactSeverities, allowedRuleImpactSeverities, "ActiveImpactSeverities")
 	if err != nil {
 		return err
 	}
 
-	err = AreValuesAuthorized(opt.ActiveSeverities, allowedSeverities, "ActiveSeverities")
+	err = AreValuesAuthorized(opt.ActiveSeverities, allowedRuleSeverities, "ActiveSeverities")
 	if err != nil {
 		return err
 	}
 
-	err = AreValuesAuthorized(opt.Severities, allowedSeverities, "Severities")
+	err = AreValuesAuthorized(opt.Severities, allowedRuleSeverities, "Severities")
 	if err != nil {
 		return err
 	}
 
-	err = AreValuesAuthorized(opt.ImpactSeverities, allowedImpactSeverities, "ImpactSeverities")
+	err = AreValuesAuthorized(opt.ImpactSeverities, allowedRuleImpactSeverities, "ImpactSeverities")
 	if err != nil {
 		return err
 	}
@@ -1021,7 +1068,7 @@ func (s *RulesService) ValidateUpdateOpt(opt *RulesUpdateOptions) error {
 	}
 
 	// Value validations
-	err = IsValueAuthorized(opt.Severity, allowedSeverities, "Severity")
+	err = IsValueAuthorized(opt.Severity, allowedRuleSeverities, "Severity")
 	if err != nil {
 		return err
 	}
@@ -1034,7 +1081,7 @@ func (s *RulesService) ValidateUpdateOpt(opt *RulesUpdateOptions) error {
 	}
 
 	if opt.RemediationFnType != "" {
-		allowed := map[string]struct{}{"LINEAR": {}, "CONSTANT": {}, "LINEAR_OFFSET": {}}
+		allowed := map[string]struct{}{RuleRemediationFnTypeConstant: {}, RuleRemediationFnTypeLinear: {}, RuleRemediationFnTypeLinearOffset: {}}
 
 		err = IsValueAuthorized(opt.RemediationFnType, allowed, "RemediationFnType")
 		if err != nil {
@@ -1049,7 +1096,7 @@ func (s *RulesService) ValidateUpdateOpt(opt *RulesUpdateOptions) error {
 			return err
 		}
 
-		err = ValidateMapValues(opt.Impacts, allowedImpactSeverities, "Impacts")
+		err = ValidateMapValues(opt.Impacts, allowedRuleImpactSeverities, "Impacts")
 		if err != nil {
 			return err
 		}

--- a/sonar/rules_service_test.go
+++ b/sonar/rules_service_test.go
@@ -287,7 +287,7 @@ func TestValidateCreateOpt(t *testing.T) {
 				MarkdownDescription: "Test",
 				TemplateKey:         "java:Template",
 				Impacts: map[string]string{
-					"INVALID": "HIGH",
+					"INVALID": RuleImpactSeverityHigh,
 				},
 			},
 			wantErr: true,
@@ -314,12 +314,12 @@ func TestValidateCreateOpt(t *testing.T) {
 				Name:                "Test Rule",
 				MarkdownDescription: "Test description",
 				TemplateKey:         "java:Template",
-				Severity:            "MAJOR",
-				Status:              "READY",
-				Type:                "BUG",
+				Severity:            RuleSeverityMajor,
+				Status:              RuleStatusReady,
+				Type:                RuleTypeBug,
 				Impacts: map[string]string{
-					"MAINTAINABILITY": "HIGH",
-					"SECURITY":        "LOW",
+					SoftwareQualityMaintainability: RuleImpactSeverityHigh,
+					SoftwareQualitySecurity:        RuleImpactSeverityLow,
 				},
 			},
 			wantErr: false,
@@ -449,9 +449,9 @@ func TestValidateSearchOpt(t *testing.T) {
 				PaginationArgs: PaginationArgs{Page: 1, PageSize: 50},
 				Query:          "test",
 				Languages:      []string{"java", "go"},
-				Severities:     []string{"MAJOR", "CRITICAL"},
-				Statuses:       []string{"READY", "DEPRECATED"},
-				Types:          []string{"BUG", "CODE_SMELL"},
+				Severities:     []string{RuleSeverityMajor, RuleSeverityCritical},
+				Statuses:       []string{RuleStatusReady, RuleStatusDeprecated},
+				Types:          []string{RuleTypeBug, RuleTypeCodeSmell},
 				Sort:           "name",
 			},
 			wantErr: false,
@@ -534,7 +534,7 @@ func TestValidateUpdateOpt(t *testing.T) {
 			opt: &RulesUpdateOptions{
 				Key: "java:MyRule",
 				Impacts: map[string]string{
-					"INVALID": "HIGH",
+					"INVALID": RuleImpactSeverityHigh,
 				},
 			},
 			wantErr: true,
@@ -545,10 +545,10 @@ func TestValidateUpdateOpt(t *testing.T) {
 			opt: &RulesUpdateOptions{
 				Key:      "java:MyRule",
 				Name:     "Updated Rule",
-				Severity: "CRITICAL",
-				Status:   "READY",
+				Severity: RuleSeverityCritical,
+				Status:   RuleStatusReady,
 				Impacts: map[string]string{
-					"SECURITY": "HIGH",
+					SoftwareQualitySecurity: RuleImpactSeverityHigh,
 				},
 				Tags: []string{"security", "bug"},
 			},
@@ -728,8 +728,8 @@ func TestConvertCreateOptForURL(t *testing.T) {
 		MarkdownDescription: "Description",
 		TemplateKey:         "java:Template",
 		Impacts: map[string]string{
-			"MAINTAINABILITY": "HIGH",
-			"SECURITY":        "LOW",
+			SoftwareQualityMaintainability: RuleImpactSeverityHigh,
+			SoftwareQualitySecurity:        RuleImpactSeverityLow,
 		},
 		Params: map[string]string{
 			"param1": "value1",
@@ -757,7 +757,7 @@ func TestConvertSearchOptForURL(t *testing.T) {
 	opt := &RulesSearchOptions{
 		PaginationArgs: PaginationArgs{Page: 1, PageSize: 50},
 		Languages:      []string{"java", "go"},
-		Severities:     []string{"MAJOR", "CRITICAL"},
+		Severities:     []string{RuleSeverityMajor, RuleSeverityCritical},
 		Tags:           []string{"security", "bug"},
 	}
 
@@ -780,7 +780,7 @@ func TestConvertUpdateOptForURL(t *testing.T) {
 		Key:  "java:MyRule",
 		Name: "Updated",
 		Impacts: map[string]string{
-			"SECURITY": "HIGH",
+			SoftwareQualitySecurity: RuleImpactSeverityHigh,
 		},
 		Params: map[string]string{
 			"key1": "val1",

--- a/sonar/system_service.go
+++ b/sonar/system_service.go
@@ -8,25 +8,47 @@ import (
 // Constants
 // -----------------------------------------------------------------------------
 
+const (
+	// LogLevelTrace represents the TRACE log level.
+	LogLevelTrace = "TRACE"
+	// LogLevelDebug represents the DEBUG log level.
+	LogLevelDebug = "DEBUG"
+	// LogLevelInfo represents the INFO log level.
+	LogLevelInfo = "INFO"
+
+	// LogNameAccess represents the access log name.
+	LogNameAccess = "access"
+	// LogNameApp represents the app log name.
+	LogNameApp = "app"
+	// LogNameCE represents the Compute Engine log name.
+	LogNameCE = "ce"
+	// LogNameDeprecation represents the deprecation log name.
+	LogNameDeprecation = "deprecation"
+	// LogNameES represents the Elasticsearch log name.
+	LogNameES = "es"
+	// LogNameWeb represents the web log name.
+	LogNameWeb = "web"
+)
+
 // Allowed log levels for the ChangeLogLevel method.
 //
 //nolint:gochecknoglobals // these are constant sets of allowed values
 var (
 	// allowedLogLevels is the set of allowed log levels for system logging.
 	allowedLogLevels = map[string]struct{}{
-		"TRACE": {},
-		"DEBUG": {},
-		"INFO":  {},
+		LogLevelTrace: {},
+		LogLevelDebug: {},
+		LogLevelInfo:  {},
 	}
 
 	// allowedLogNames is the set of allowed log names for the Logs method.
 	allowedLogNames = map[string]struct{}{
-		"access":      {},
-		"app":         {},
-		"ce":          {},
-		"deprecation": {},
-		"es":          {},
-		"web":         {},
+		LogNameAccess:      {},
+		LogNameApp:         {},
+		LogNameCE:          {},
+		LogNameDeprecation: {},
+		LogNameES:          {},
+		LogNameWeb:         {},
 	}
 )
 

--- a/sonar/user_groups_service.go
+++ b/sonar/user_groups_service.go
@@ -9,23 +9,32 @@ const (
 	MaxGroupNameLength = 255
 	// MaxGroupDescriptionLength is the maximum allowed length for group descriptions.
 	MaxGroupDescriptionLength = 200
+
+	// UserGroupFieldName represents the "name" field for user groups.
+	UserGroupFieldName = "name"
+	// UserGroupFieldDescription represents the "description" field for user groups.
+	UserGroupFieldDescription = "description"
+	// UserGroupFieldMembersCount represents the "membersCount" field for user groups.
+	UserGroupFieldMembersCount = "membersCount"
+	// UserGroupFieldManaged represents the "managed" field for user groups.
+	UserGroupFieldManaged = "managed"
 )
 
 //nolint:gochecknoglobals // these are constant sets of allowed values
 var (
 	// allowedUserGroupSearchFields is the set of fields that can be returned in search response.
 	allowedUserGroupSearchFields = map[string]struct{}{
-		"name":         {},
-		"description":  {},
-		"membersCount": {},
-		"managed":      {},
+		UserGroupFieldName:         {},
+		UserGroupFieldDescription:  {},
+		UserGroupFieldMembersCount: {},
+		UserGroupFieldManaged:      {},
 	}
 
 	// allowedUserGroupsUsersSelected is the set of allowed values for user selection filter.
 	allowedUserGroupsUsersSelected = map[string]struct{}{
-		"all":        {},
-		"deselected": {},
-		"selected":   {},
+		SelectionFilterAll:        {},
+		SelectionFilterDeselected: {},
+		SelectionFilterSelected:   {},
 	}
 )
 

--- a/sonar/user_groups_service_test.go
+++ b/sonar/user_groups_service_test.go
@@ -225,7 +225,7 @@ func TestUserGroups_Users(t *testing.T) {
 
 	opt := &UserGroupsUsersOptions{
 		Name:     "sonar-administrators",
-		Selected: "selected",
+		Selected: SelectionFilterSelected,
 	}
 
 	result, resp, err := client.UserGroups.Users(opt)

--- a/sonar/user_tokens_service.go
+++ b/sonar/user_tokens_service.go
@@ -2,6 +2,15 @@ package sonar
 
 import "net/http"
 
+const (
+	// TokenTypeUserToken represents a user token that can be used for authentication and project analysis.
+	TokenTypeUserToken = "USER_TOKEN"
+	// TokenTypeGlobalAnalysisToken represents a global analysis token.
+	TokenTypeGlobalAnalysisToken = "GLOBAL_ANALYSIS_TOKEN"
+	// TokenTypeProjectAnalysisToken represents a project analysis token.
+	TokenTypeProjectAnalysisToken = "PROJECT_ANALYSIS_TOKEN"
+)
+
 // UserTokensService handles communication with the user tokens related methods
 // of the SonarQube API.
 // This service lists, creates, and deletes a user's access tokens.
@@ -14,9 +23,9 @@ type UserTokensService struct {
 var (
 	// allowedTokenTypes is the set of supported token types.
 	allowedTokenTypes = map[string]struct{}{
-		"USER_TOKEN":             {},
-		"GLOBAL_ANALYSIS_TOKEN":  {},
-		"PROJECT_ANALYSIS_TOKEN": {},
+		TokenTypeUserToken:            {},
+		TokenTypeGlobalAnalysisToken:  {},
+		TokenTypeProjectAnalysisToken: {},
 	}
 )
 

--- a/sonar/users_service.go
+++ b/sonar/users_service.go
@@ -13,6 +13,42 @@ const (
 	MaxEmailLength = 100
 	// MaxNameLength is the maximum length for a user name.
 	MaxNameLength = 200
+
+	// HomepageTypeProject represents the project homepage type.
+	HomepageTypeProject = "PROJECT"
+	// HomepageTypeProjects represents the projects homepage type.
+	HomepageTypeProjects = "PROJECTS"
+	// HomepageTypeIssues represents the issues homepage type.
+	HomepageTypeIssues = "ISSUES"
+	// HomepageTypePortfolios represents the portfolios homepage type.
+	HomepageTypePortfolios = "PORTFOLIOS"
+	// HomepageTypePortfolio represents the portfolio homepage type.
+	HomepageTypePortfolio = "PORTFOLIO"
+	// HomepageTypeApplication represents the application homepage type.
+	HomepageTypeApplication = "APPLICATION"
+
+	// NoticeTypeEducationPrinciples represents the education principles notice type.
+	NoticeTypeEducationPrinciples = "educationPrinciples"
+	// NoticeTypeSonarlintAd represents the SonarLint ad notice type.
+	NoticeTypeSonarlintAd = "sonarlintAd"
+	// NoticeTypeShowDesignAndArchitectureBanner represents the show design and architecture banner notice type.
+	NoticeTypeShowDesignAndArchitectureBanner = "showDesignAndArchitectureBanner"
+	// NoticeTypeShowNewModesBanner represents the show new modes banner notice type.
+	NoticeTypeShowNewModesBanner = "showNewModesBanner"
+	// NoticeTypeShowSandboxedIssuesIntro represents the show sandboxed issues intro notice type.
+	NoticeTypeShowSandboxedIssuesIntro = "showSandboxedIssuesIntro"
+	// NoticeTypeIssueCleanCodeGuide represents the issue clean code guide notice type.
+	NoticeTypeIssueCleanCodeGuide = "issueCleanCodeGuide"
+	// NoticeTypeIssueNewIssueStatusAndTransitionGuide represents the issue new issue status and transition guide notice type.
+	NoticeTypeIssueNewIssueStatusAndTransitionGuide = "issueNewIssueStatusAndTransitionGuide"
+	// NoticeTypeShowDesignAndArchitectureOptInBanner represents the show design and architecture opt-in banner notice type.
+	NoticeTypeShowDesignAndArchitectureOptInBanner = "showDesignAndArchitectureOptInBanner"
+	// NoticeTypeOverviewZeroNewIssuesSimplification represents the overview zero new issues simplification notice type.
+	NoticeTypeOverviewZeroNewIssuesSimplification = "overviewZeroNewIssuesSimplification"
+	// NoticeTypeShowDesignAndArchitectureTour represents the show design and architecture tour notice type.
+	NoticeTypeShowDesignAndArchitectureTour = "showDesignAndArchitectureTour"
+	// NoticeTypeShowEnableSca represents the show enable SCA notice type.
+	NoticeTypeShowEnableSca = "showEnableSca"
 )
 
 // UsersService handles communication with the user management related methods
@@ -27,27 +63,27 @@ type UsersService struct {
 var (
 	// allowedHomepageTypes is the set of supported homepage types.
 	allowedHomepageTypes = map[string]struct{}{
-		"PROJECT":     {},
-		"PROJECTS":    {},
-		"ISSUES":      {},
-		"PORTFOLIOS":  {},
-		"PORTFOLIO":   {},
-		"APPLICATION": {},
+		HomepageTypeProject:     {},
+		HomepageTypeProjects:    {},
+		HomepageTypeIssues:      {},
+		HomepageTypePortfolios:  {},
+		HomepageTypePortfolio:   {},
+		HomepageTypeApplication: {},
 	}
 
 	// allowedNoticeTypes is the set of supported notice types.
 	allowedNoticeTypes = map[string]struct{}{
-		"educationPrinciples":                   {},
-		"sonarlintAd":                           {},
-		"showDesignAndArchitectureBanner":       {},
-		"showNewModesBanner":                    {},
-		"showSandboxedIssuesIntro":              {},
-		"issueCleanCodeGuide":                   {},
-		"issueNewIssueStatusAndTransitionGuide": {},
-		"showDesignAndArchitectureOptInBanner":  {},
-		"overviewZeroNewIssuesSimplification":   {},
-		"showDesignAndArchitectureTour":         {},
-		"showEnableSca":                         {},
+		NoticeTypeEducationPrinciples:                   {},
+		NoticeTypeSonarlintAd:                           {},
+		NoticeTypeShowDesignAndArchitectureBanner:       {},
+		NoticeTypeShowNewModesBanner:                    {},
+		NoticeTypeShowSandboxedIssuesIntro:              {},
+		NoticeTypeIssueCleanCodeGuide:                   {},
+		NoticeTypeIssueNewIssueStatusAndTransitionGuide: {},
+		NoticeTypeShowDesignAndArchitectureOptInBanner:  {},
+		NoticeTypeOverviewZeroNewIssuesSimplification:   {},
+		NoticeTypeShowDesignAndArchitectureTour:         {},
+		NoticeTypeShowEnableSca:                         {},
 	}
 )
 

--- a/sonar/users_service_test.go
+++ b/sonar/users_service_test.go
@@ -385,7 +385,7 @@ func TestUsers_Groups_WithFilter(t *testing.T) {
 	opt := &UsersGroupsOptions{
 		Login:    "myuser",
 		Query:    "admin",
-		Selected: "selected",
+		Selected: SelectionFilterSelected,
 	}
 
 	_, resp, err := client.Users.Groups(opt)


### PR DESCRIPTION
### Description of your changes

This PR introduces constants to help the users use preconfigured "valid" values and reduce hardcoding in their codebase.

It also uses them directly in the unit tests & e2e tests to ensure they are working as intended.

Closes #173 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
