### PR TITLE
feat(enterprise): support editions endpoints

### DIFF
--- a/integration_testing/editions_test.go
+++ b/integration_testing/editions_test.go
@@ -1,0 +1,135 @@
+package integration_testing_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("License Service", Ordered, func() {
+	var (
+		client  *sonar.Client
+		cleanup *helpers.CleanupManager
+	)
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+		cleanup = helpers.NewCleanupManager(client)
+	})
+
+	AfterAll(func() {
+		cleanup.Cleanup()
+	})
+
+	// =========================================================================
+	// ActivateGracePeriod
+	// =========================================================================
+	Describe("ActivateGracePeriod", func() {
+		Context("Functional Tests", func() {
+			It("should activate grace period or return an error on community edition", func() {
+				resp, err := client.License.ActivateGracePeriod()
+				if err != nil {
+					// Community edition does not expose this endpoint;
+					// a 404 or 403 is acceptable.
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Get
+	// =========================================================================
+	Describe("Get", func() {
+		Context("Functional Tests", func() {
+			It("should return license information or an error on community edition", func() {
+				result, resp, err := client.License.Get()
+				if err != nil {
+					// Community edition does not expose the license endpoint;
+					// a 404 or 403 is acceptable.
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp).NotTo(BeNil())
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// IsValidLicense
+	// =========================================================================
+	Describe("IsValidLicense", func() {
+		Context("Functional Tests", func() {
+			It("should return license validity or an error on community edition", func() {
+				result, resp, err := client.License.IsValidLicense()
+				if err != nil {
+					// Community edition does not expose this endpoint;
+					// a 404 or 403 is acceptable.
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp).NotTo(BeNil())
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Set
+	// =========================================================================
+	Describe("Set", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.License.Set(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without license key", func() {
+				resp, err := client.License.Set(&sonar.LicenseSetOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("License"))
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should fail with an invalid license key", func() {
+				resp, err := client.License.Set(&sonar.LicenseSetOptions{
+					License: "invalid-license-key",
+				})
+				// Expect an error because the license key is invalid.
+				// On community edition this may return 404 (endpoint not found).
+				Expect(err).To(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// UnsetLicense
+	// =========================================================================
+	Describe("UnsetLicense", func() {
+		Context("Functional Tests", func() {
+			It("should unset the license or return an error on community edition", func() {
+				resp, err := client.License.UnsetLicense()
+				if err != nil {
+					// Community edition does not expose this endpoint;
+					// a 404 or 403 is acceptable.
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp).NotTo(BeNil())
+				}
+			})
+		})
+	})
+})

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -48,6 +48,7 @@ type Client struct {
 	Hotspots           *HotspotsService
 	Issues             *IssuesService
 	L10N               *L10NService
+	License            *EditionsService
 	Languages          *LanguagesService
 	Measures           *MeasuresService
 	Metrics            *MetricsService
@@ -347,6 +348,7 @@ func initServices(client *Client) {
 	client.Hotspots = &HotspotsService{client: client}
 	client.Issues = &IssuesService{client: client}
 	client.L10N = &L10NService{client: client}
+	client.License = &EditionsService{client: client}
 	client.Languages = &LanguagesService{client: client}
 	client.Measures = &MeasuresService{client: client}
 	client.Metrics = &MetricsService{client: client}

--- a/sonar/editions_service.go
+++ b/sonar/editions_service.go
@@ -1,0 +1,182 @@
+package sonar
+
+import "net/http"
+
+// EditionsService handles communication with the editions related methods of the
+// SonarQube API. This service is only available in Enterprise Edition.
+type EditionsService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Response Types
+// -----------------------------------------------------------------------------
+
+// License represents a SonarQube Enterprise Edition license.
+//
+//nolint:govet // Field alignment is less important than logical grouping
+type License struct {
+	// ContactEmail is the contact email associated with the license.
+	ContactEmail string `json:"contactEmail,omitempty"`
+	// ExpiresAt is the license expiration date (ISO 8601 format).
+	ExpiresAt string `json:"expiresAt,omitempty"`
+	// IsExpired indicates whether the license has expired.
+	IsExpired bool `json:"isExpired,omitempty"`
+	// IsOfficialDistribution indicates whether the SonarQube instance is an
+	// official distribution.
+	IsOfficialDistribution bool `json:"isOfficialDistribution,omitempty"`
+	// IsSupported indicates whether the license is currently valid and supported.
+	IsSupported bool `json:"isSupported,omitempty"`
+	// IsValidEdition indicates whether the license edition matches the running
+	// SonarQube edition.
+	IsValidEdition bool `json:"isValidEdition,omitempty"`
+	// IsValidServerId indicates whether the license server ID matches the current
+	// instance.
+	IsValidServerId bool `json:"isValidServerId,omitempty"`
+	// LOCsMax is the maximum number of lines of code allowed by the license.
+	LOCsMax int64 `json:"locsMax,omitempty"`
+	// LOCsRemaining is the number of lines of code remaining before the limit
+	// is reached.
+	LOCsRemaining int64 `json:"locsRemaining,omitempty"`
+	// Organization is the name of the organization the license was issued to.
+	Organization string `json:"organization,omitempty"`
+	// ProductEdition is the SonarQube edition the license is for.
+	ProductEdition string `json:"productEdition,omitempty"`
+	// ServerId is the server ID the license is bound to.
+	ServerId string `json:"serverId,omitempty"`
+	// Type is the license type (e.g. PRODUCTION, EVALUATION).
+	Type string `json:"type,omitempty"`
+}
+
+// LicenseGet wraps the License response from the show_license endpoint.
+type LicenseGet struct {
+	// License contains the license details.
+	License License `json:"license,omitzero"`
+}
+
+// LicenseIsValid wraps the response from the is_valid_license endpoint.
+type LicenseIsValid struct {
+	// IsValid indicates whether the current license is valid.
+	IsValid bool `json:"isValid,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// LicenseSetOptions contains parameters for the Set method.
+type LicenseSetOptions struct {
+	// License is the license key to activate. This field is required.
+	License string `url:"license"`
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateSetOpt validates the options for the Set method.
+func (s *EditionsService) ValidateSetOpt(opt *LicenseSetOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.License, "License")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// ActivateGracePeriod enables a 7-day license grace period when the Server ID
+// is invalid. Requires 'Administer System' permission.
+//
+// API endpoint: POST /api/editions/activate_grace_period.
+// Since: 10.3.
+// Enterprise Edition only.
+func (s *EditionsService) ActivateGracePeriod() (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "editions/activate_grace_period", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Get returns the details of the current SonarQube Enterprise Edition license.
+// Requires 'Administer System' permission.
+//
+// API endpoint: GET /api/editions/show_license.
+// Since: 7.2.
+// Enterprise Edition only.
+func (s *EditionsService) Get() (*LicenseGet, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "editions/show_license", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(LicenseGet)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// IsValidLicense returns the validity of the current license.
+//
+// API endpoint: GET /api/editions/is_valid_license.
+// Since: 7.3.
+// Enterprise Edition only.
+func (s *EditionsService) IsValidLicense() (*LicenseIsValid, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "editions/is_valid_license", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(LicenseIsValid)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// Set activates a new SonarQube Enterprise Edition license.
+// Requires 'Administer System' permission.
+//
+// API endpoint: POST /api/editions/set_license.
+// Since: 7.2.
+// Enterprise Edition only.
+func (s *EditionsService) Set(opt *LicenseSetOptions) (*http.Response, error) {
+	err := s.ValidateSetOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "editions/set_license", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// UnsetLicense removes the current license.
+// Requires 'Administer System' permission.
+//
+// API endpoint: POST /api/editions/unset_license.
+// Since: 7.2.
+// Enterprise Edition only.
+func (s *EditionsService) UnsetLicense() (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "editions/unset_license", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/sonar/editions_service_test.go
+++ b/sonar/editions_service_test.go
@@ -1,0 +1,145 @@
+package sonar
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEditionsService_ActivateGracePeriod(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/editions/activate_grace_period", http.StatusNoContent))
+
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.License.ActivateGracePeriod()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestEditionsService_Get(t *testing.T) {
+	response := LicenseGet{
+		License: License{
+			ContactEmail:           "admin@example.com",
+			ExpiresAt:              "2030-01-01",
+			IsExpired:              false,
+			IsOfficialDistribution: true,
+			IsSupported:            true,
+			IsValidEdition:         true,
+			IsValidServerId:        true,
+			LOCsMax:                1000000,
+			LOCsRemaining:          750000,
+			Organization:           "Example Corp",
+			ProductEdition:         "ENTERPRISE",
+			ServerId:               "server-id-123",
+			Type:                   "PRODUCTION",
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/editions/show_license", http.StatusOK, response))
+
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.License.Get()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+	assert.Equal(t, "admin@example.com", result.License.ContactEmail)
+	assert.Equal(t, "Example Corp", result.License.Organization)
+	assert.Equal(t, "ENTERPRISE", result.License.ProductEdition)
+	assert.True(t, result.License.IsSupported)
+	assert.Equal(t, int64(1000000), result.License.LOCsMax)
+	assert.Equal(t, int64(750000), result.License.LOCsRemaining)
+}
+
+func TestEditionsService_Get_Empty(t *testing.T) {
+	response := LicenseGet{}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/editions/show_license", http.StatusOK, response))
+
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.License.Get()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+}
+
+func TestEditionsService_IsValidLicense(t *testing.T) {
+	response := LicenseIsValid{IsValid: true}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/editions/is_valid_license", http.StatusOK, response))
+
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.License.IsValidLicense()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+	assert.True(t, result.IsValid)
+}
+
+func TestEditionsService_IsValidLicense_Invalid(t *testing.T) {
+	response := LicenseIsValid{IsValid: false}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/editions/is_valid_license", http.StatusOK, response))
+
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.License.IsValidLicense()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+	assert.False(t, result.IsValid)
+}
+
+func TestEditionsService_Set(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/editions/set_license", http.StatusNoContent))
+
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.License.Set(&LicenseSetOptions{
+		License: "my-license-key",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestEditionsService_Set_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	// Nil option should fail validation.
+	resp, err := client.License.Set(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	// Missing License key should fail validation.
+	resp, err = client.License.Set(&LicenseSetOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestEditionsService_UnsetLicense(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/editions/unset_license", http.StatusNoContent))
+
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.License.UnsetLicense()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestEditionsService_ValidateSetOpt(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	// Valid option should pass.
+	err := client.License.ValidateSetOpt(&LicenseSetOptions{
+		License: "my-license-key",
+	})
+	assert.NoError(t, err)
+
+	// Nil option should fail.
+	err = client.License.ValidateSetOpt(nil)
+	assert.Error(t, err)
+
+	// Missing License key should fail.
+	err = client.License.ValidateSetOpt(&LicenseSetOptions{})
+	assert.Error(t, err)
+}

--- a/sonar/editions_service_test.go
+++ b/sonar/editions_service_test.go
@@ -91,7 +91,7 @@ func TestEditionsService_IsValidLicense_Invalid(t *testing.T) {
 }
 
 func TestEditionsService_Set(t *testing.T) {
-	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/editions/set_license", http.StatusNoContent))
+	server := newTestServer(t, mockEmptyHandlerWithParams(t, http.MethodPost, "/editions/set_license", http.StatusNoContent, map[string]string{"license": "my-license-key"}))
 
 	client := newTestClient(t, server.URL)
 


### PR DESCRIPTION
### Description of your changes

This PR adds a new service for "Editions" endpoints. This only exists in **non community** editions.

This comes packaged with its full set of unit tests and integration tests.

Closes #196 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:


- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
