### PR TITLE
feat(enterprise): support portfolios endpoints

### DIFF
--- a/integration_testing/views_test.go
+++ b/integration_testing/views_test.go
@@ -1,0 +1,464 @@
+package integration_testing_test
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Views Service", Ordered, func() {
+	var (
+		client  *sonar.Client
+		cleanup *helpers.CleanupManager
+	)
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+		cleanup = helpers.NewCleanupManager(client)
+	})
+
+	AfterAll(func() {
+		cleanup.Cleanup()
+	})
+
+	// =========================================================================
+	// Create
+	// =========================================================================
+	Describe("Create", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Views.Create(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required name", func() {
+				resp, err := client.Views.Create(&sonar.ViewsCreateOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Name"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail with invalid visibility", func() {
+				resp, err := client.Views.Create(&sonar.ViewsCreateOptions{
+					Name:       "Test View",
+					Visibility: "invalid",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should create or return an enterprise-only error", func() {
+				viewKey := helpers.UniqueResourceName("view")
+				resp, err := client.Views.Create(&sonar.ViewsCreateOptions{
+					Name: viewKey,
+					Key:  viewKey,
+				})
+				if err != nil {
+					// Community edition returns 404 for enterprise-only endpoints.
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					cleanup.RegisterCleanup("view", viewKey, func() error {
+						_, cleanupErr := client.Views.Delete(&sonar.ViewsDeleteOptions{
+							Key: viewKey,
+						})
+						return cleanupErr
+					})
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// List
+	// =========================================================================
+	Describe("List", func() {
+		Context("Functional Tests", func() {
+			It("should return a list or an enterprise-only error", func() {
+				result, resp, err := client.Views.List()
+				if err != nil {
+					// Community edition does not expose views endpoints.
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp).NotTo(BeNil())
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Search
+	// =========================================================================
+	Describe("Search", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with invalid pagination", func() {
+				_, _, err := client.Views.Search(&sonar.ViewsSearchOptions{
+					PaginationArgs: sonar.PaginationArgs{Page: -1},
+				})
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should return results or an enterprise-only error", func() {
+				result, resp, err := client.Views.Search(nil)
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp).NotTo(BeNil())
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Show
+	// =========================================================================
+	Describe("Show", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				_, _, err := client.Views.Show(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+			})
+
+			It("should fail without key", func() {
+				_, _, err := client.Views.Show(&sonar.ViewsShowOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Key"))
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should fail for a non-existent view", func() {
+				result, resp, err := client.Views.Show(&sonar.ViewsShowOptions{
+					Key: "non-existent-view-key",
+				})
+				Expect(err).To(HaveOccurred())
+				// Either 404 (not found) or 404 (enterprise endpoint not available).
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// Update
+	// =========================================================================
+	Describe("Update", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Views.Update(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required key", func() {
+				resp, err := client.Views.Update(&sonar.ViewsUpdateOptions{
+					Name: "New Name",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Key"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required name", func() {
+				resp, err := client.Views.Update(&sonar.ViewsUpdateOptions{
+					Key: "my-view",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Name"))
+				Expect(resp).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// Delete
+	// =========================================================================
+	Describe("Delete", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Views.Delete(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without key", func() {
+				resp, err := client.Views.Delete(&sonar.ViewsDeleteOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Key"))
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should fail for a non-existent view", func() {
+				resp, err := client.Views.Delete(&sonar.ViewsDeleteOptions{
+					Key: "non-existent-view",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// AddProject / RemoveProject
+	// =========================================================================
+	Describe("AddProject", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Views.AddProject(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without key", func() {
+				resp, err := client.Views.AddProject(&sonar.ViewsAddProjectOptions{
+					Project: "my-project",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Key"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without project key", func() {
+				resp, err := client.Views.AddProject(&sonar.ViewsAddProjectOptions{
+					Key: "my-view",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Project"))
+				Expect(resp).To(BeNil())
+			})
+		})
+	})
+
+	Describe("RemoveProject", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Views.RemoveProject(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without key", func() {
+				resp, err := client.Views.RemoveProject(&sonar.ViewsRemoveProjectOptions{
+					Project: "my-project",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Key"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without project key", func() {
+				resp, err := client.Views.RemoveProject(&sonar.ViewsRemoveProjectOptions{
+					Key: "my-view",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Project"))
+				Expect(resp).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// MoveOptions
+	// =========================================================================
+	Describe("MoveOptions", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				_, _, err := client.Views.MoveOptions(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+			})
+
+			It("should fail without key", func() {
+				_, _, err := client.Views.MoveOptions(&sonar.ViewsMoveOptionsOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Key"))
+			})
+		})
+	})
+
+	// =========================================================================
+	// Move
+	// =========================================================================
+	Describe("Move", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Views.Move(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without key", func() {
+				resp, err := client.Views.Move(&sonar.ViewsMoveOptions{
+					Destination: "dest",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Key"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without destination", func() {
+				resp, err := client.Views.Move(&sonar.ViewsMoveOptions{
+					Key: "my-view",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Destination"))
+				Expect(resp).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// Projects
+	// =========================================================================
+	Describe("Projects", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				_, _, err := client.Views.Projects(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+			})
+
+			It("should fail without key", func() {
+				_, _, err := client.Views.Projects(&sonar.ViewsProjectsOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Key"))
+			})
+
+			It("should fail with invalid selected value", func() {
+				_, _, err := client.Views.Projects(&sonar.ViewsProjectsOptions{
+					Key:      "my-view",
+					Selected: "invalid",
+				})
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	// =========================================================================
+	// AddApplication / RemoveApplication
+	// =========================================================================
+	Describe("AddApplication", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Views.AddApplication(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without portfolio key", func() {
+				resp, err := client.Views.AddApplication(&sonar.ViewsAddApplicationOptions{
+					Application: "my-app",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Portfolio"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without application key", func() {
+				resp, err := client.Views.AddApplication(&sonar.ViewsAddApplicationOptions{
+					Portfolio: "my-portfolio",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Application"))
+				Expect(resp).To(BeNil())
+			})
+		})
+	})
+
+	Describe("RemoveApplication", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Views.RemoveApplication(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without portfolio key", func() {
+				resp, err := client.Views.RemoveApplication(&sonar.ViewsRemoveApplicationOptions{
+					Application: "my-app",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Portfolio"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without application key", func() {
+				resp, err := client.Views.RemoveApplication(&sonar.ViewsRemoveApplicationOptions{
+					Portfolio: "my-portfolio",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Application"))
+				Expect(resp).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// AddPortfolio / RemovePortfolio
+	// =========================================================================
+	Describe("AddPortfolio", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Views.AddPortfolio(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without portfolio", func() {
+				resp, err := client.Views.AddPortfolio(&sonar.ViewsAddPortfolioOptions{
+					Reference: "ref-portfolio",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Portfolio"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without reference", func() {
+				resp, err := client.Views.AddPortfolio(&sonar.ViewsAddPortfolioOptions{
+					Portfolio: "parent-portfolio",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Reference"))
+				Expect(resp).To(BeNil())
+			})
+		})
+	})
+
+	Describe("RemovePortfolio", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Views.RemovePortfolio(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+		})
+	})
+})

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -51,6 +51,7 @@ type Client struct {
 	Editions           *EditionsService
 	Languages          *LanguagesService
 	Measures           *MeasuresService
+	Views              *ViewsService
 	Metrics            *MetricsService
 	Monitoring         *MonitoringService
 	Navigation         *NavigationService
@@ -351,6 +352,7 @@ func initServices(client *Client) {
 	client.Editions = &EditionsService{client: client}
 	client.Languages = &LanguagesService{client: client}
 	client.Measures = &MeasuresService{client: client}
+	client.Views = &ViewsService{client: client}
 	client.Metrics = &MetricsService{client: client}
 	client.Monitoring = &MonitoringService{client: client}
 	client.Navigation = &NavigationService{client: client}

--- a/sonar/views_service.go
+++ b/sonar/views_service.go
@@ -1,0 +1,1348 @@
+package sonar
+
+import "net/http"
+
+// ViewsService handles communication with the portfolio related methods of
+// the SonarQube API. This service is only available in Enterprise Edition.
+type ViewsService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Response Types
+// -----------------------------------------------------------------------------
+
+// View represents a SonarQube portfolio/view.
+type View struct {
+	// Description is the portfolio description.
+	Description string `json:"description,omitempty"`
+	// Key is the portfolio key.
+	Key string `json:"key,omitempty"`
+	// Name is the portfolio name.
+	Name string `json:"name,omitempty"`
+	// Qualifier is the qualifier of the component (VW for portfolio, SVW for sub-portfolio).
+	Qualifier string `json:"qualifier,omitempty"`
+	// Visibility is the visibility of the portfolio (public or private).
+	Visibility string `json:"visibility,omitempty"`
+}
+
+// ViewDetails is an extended portfolio with sub-portfolios and selection modes.
+type ViewDetails struct {
+	// Description is the portfolio description.
+	Description string `json:"description,omitempty"`
+	// Key is the portfolio key.
+	Key string `json:"key,omitempty"`
+	// Name is the portfolio name.
+	Name string `json:"name,omitempty"`
+	// Qualifier is the qualifier (VW or SVW).
+	Qualifier string `json:"qualifier,omitempty"`
+	// Visibility is the visibility (public or private).
+	Visibility string `json:"visibility,omitempty"`
+	// SelectionMode describes how projects are selected for the portfolio.
+	SelectionMode string `json:"selectionMode,omitempty"`
+	// SubViews is the list of sub-portfolios.
+	SubViews []View `json:"subViews,omitempty"`
+}
+
+// ViewProject represents a project entry in a portfolio.
+type ViewProject struct {
+	// Key is the project key.
+	Key string `json:"key,omitempty"`
+	// Name is the project name.
+	Name string `json:"name,omitempty"`
+	// Selected indicates whether the project is selected in the portfolio.
+	Selected bool `json:"selected,omitempty"`
+}
+
+// ViewProjectStatus represents a project with its quality gate status in a portfolio.
+type ViewProjectStatus struct {
+	// Key is the project key.
+	Key string `json:"key,omitempty"`
+	// Name is the project name.
+	Name string `json:"name,omitempty"`
+	// Status is the quality gate status of the project.
+	Status string `json:"status,omitempty"`
+	// BranchKey is the branch key used for the analysis.
+	BranchKey string `json:"branchKey,omitempty"`
+}
+
+// ViewApplication represents an application entry in a portfolio.
+type ViewApplication struct {
+	// Key is the application key.
+	Key string `json:"key,omitempty"`
+	// Name is the application name.
+	Name string `json:"name,omitempty"`
+}
+
+// ViewDestination represents a possible destination for moving a portfolio.
+type ViewDestination struct {
+	// Key is the destination portfolio key.
+	Key string `json:"key,omitempty"`
+	// Name is the destination portfolio name.
+	Name string `json:"name,omitempty"`
+}
+
+// ViewsList represents the response from the list endpoint.
+type ViewsList struct {
+	// Views is the list of root portfolios.
+	Views []View `json:"views,omitempty"`
+}
+
+// ViewsSearch represents the response from the search endpoint.
+type ViewsSearch struct {
+	// Components is the list of portfolios matching the search.
+	Components []View `json:"components,omitempty"`
+	// Paging contains pagination information.
+	Paging Paging `json:"paging,omitzero"`
+}
+
+// ViewsShow represents the response from the show endpoint.
+type ViewsShow struct {
+	// Portfolio contains the portfolio details.
+	Portfolio ViewDetails `json:"portfolio,omitzero"`
+}
+
+// ViewsProjects represents the response from the projects endpoint.
+type ViewsProjects struct {
+	// Projects is the list of projects in the portfolio.
+	Projects []ViewProject `json:"projects,omitempty"`
+	// Paging contains pagination information.
+	Paging Paging `json:"paging,omitzero"`
+}
+
+// ViewsProjectsStatus represents the response from the projects_status endpoint.
+type ViewsProjectsStatus struct {
+	// Projects is the list of projects with their quality gate status.
+	Projects []ViewProjectStatus `json:"projects,omitempty"`
+	// Paging contains pagination information.
+	Paging Paging `json:"paging,omitzero"`
+}
+
+// ViewsApplications represents the response from the applications endpoint.
+type ViewsApplications struct {
+	// Applications is the list of applications in the portfolio.
+	Applications []ViewApplication `json:"applications,omitempty"`
+}
+
+// ViewsSubViews represents the response from the portfolios endpoint.
+type ViewsSubViews struct {
+	// SubViews is the list of sub-portfolios.
+	SubViews []View `json:"subViews,omitempty"`
+}
+
+// ViewsMoveDestinations represents the response from the move_options endpoint.
+type ViewsMoveDestinations struct {
+	// Views is the list of possible destination portfolios.
+	Views []ViewDestination `json:"views,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// ViewsCreateOptions contains parameters for the Create method.
+type ViewsCreateOptions struct {
+	// Description is an optional portfolio description.
+	Description string `url:"description,omitempty"`
+	// Key is the portfolio key. If not provided, it will be generated from the name.
+	Key string `url:"key,omitempty"`
+	// Name is the portfolio name. This field is required.
+	Name string `url:"name"`
+	// Parent is the key of the parent portfolio, when creating a sub-portfolio.
+	Parent string `url:"parent,omitempty"`
+	// Visibility is the portfolio visibility (public or private).
+	Visibility string `url:"visibility,omitempty"`
+}
+
+// ViewsDeleteOptions contains parameters for the Delete method.
+type ViewsDeleteOptions struct {
+	// Key is the portfolio key. This field is required.
+	Key string `url:"key"`
+}
+
+// ViewsSearchOptions contains parameters for the Search method.
+//
+//nolint:govet // Field alignment is less important than logical grouping
+type ViewsSearchOptions struct {
+	PaginationArgs
+
+	// Q limits search to portfolios whose name or key contains this value.
+	Q string `url:"q,omitempty"`
+	// Qualifiers filters by component qualifier (VW for portfolio, SVW for sub-portfolio).
+	Qualifiers string `url:"qualifiers,omitempty"`
+	// OnlyFavorites if true restricts results to favorite portfolios only.
+	OnlyFavorites bool `url:"onlyFavorites,omitempty"`
+}
+
+// ViewsShowOptions contains parameters for the Show method.
+type ViewsShowOptions struct {
+	// Key is the portfolio key. This field is required.
+	Key string `url:"key"`
+}
+
+// ViewsUpdateOptions contains parameters for the Update method.
+type ViewsUpdateOptions struct {
+	// Description is the new description for the portfolio.
+	Description string `url:"description,omitempty"`
+	// Key is the portfolio key. This field is required.
+	Key string `url:"key"`
+	// Name is the new name for the portfolio. This field is required.
+	Name string `url:"name"`
+}
+
+// ViewsAddProjectOptions contains parameters for the AddProject method.
+type ViewsAddProjectOptions struct {
+	// Key is the portfolio key. This field is required.
+	Key string `url:"key"`
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+}
+
+// ViewsRemoveProjectOptions contains parameters for the RemoveProject method.
+type ViewsRemoveProjectOptions struct {
+	// Key is the portfolio key. This field is required.
+	Key string `url:"key"`
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+}
+
+// ViewsAddProjectBranchOptions contains parameters for the AddProjectBranch method.
+type ViewsAddProjectBranchOptions struct {
+	// Branch is the branch key. This field is required.
+	Branch string `url:"branch"`
+	// Key is the portfolio key. This field is required.
+	Key string `url:"key"`
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+}
+
+// ViewsRemoveProjectBranchOptions contains parameters for the RemoveProjectBranch method.
+type ViewsRemoveProjectBranchOptions struct {
+	// Branch is the branch key. This field is required.
+	Branch string `url:"branch"`
+	// Key is the portfolio key. This field is required.
+	Key string `url:"key"`
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+}
+
+// ViewsAddPortfolioOptions contains parameters for the AddPortfolio method
+// (adding a reference portfolio as a sub-portfolio).
+type ViewsAddPortfolioOptions struct {
+	// Portfolio is the parent portfolio key. This field is required.
+	Portfolio string `url:"portfolio"`
+	// Reference is the key of the portfolio to add as a sub-portfolio. This field is required.
+	Reference string `url:"reference"`
+}
+
+// ViewsRemovePortfolioOptions contains parameters for the RemovePortfolio method.
+type ViewsRemovePortfolioOptions struct {
+	// Portfolio is the parent portfolio key. This field is required.
+	Portfolio string `url:"portfolio"`
+	// Reference is the key of the sub-portfolio to remove. This field is required.
+	Reference string `url:"reference"`
+}
+
+// ViewsMoveOptions contains parameters for the Move method.
+type ViewsMoveOptions struct {
+	// Destination is the key of the destination (new parent) portfolio. This field is required.
+	Destination string `url:"destination"`
+	// Key is the portfolio key to move. This field is required.
+	Key string `url:"key"`
+}
+
+// ViewsMoveOptionsOptions contains parameters for the MoveOptions method.
+type ViewsMoveOptionsOptions struct {
+	// Key is the portfolio key. This field is required.
+	Key string `url:"key"`
+}
+
+// ViewsProjectsOptions contains parameters for the Projects method.
+//
+//nolint:govet // Field alignment is less important than logical grouping
+type ViewsProjectsOptions struct {
+	PaginationArgs
+
+	// Key is the portfolio key. This field is required.
+	Key string `url:"key"`
+	// Query limits results to projects whose key contains this value.
+	Query string `url:"query,omitempty"`
+	// Selected filters on selected, deselected or all projects.
+	Selected string `url:"selected,omitempty"`
+}
+
+// ViewsApplicationsOptions contains parameters for the Applications method.
+type ViewsApplicationsOptions struct {
+	// Portfolio is the portfolio key. This field is required.
+	Portfolio string `url:"portfolio"`
+}
+
+// ViewsSubViewsOptions contains parameters for the SubPortfolios method.
+type ViewsSubViewsOptions struct {
+	// Portfolio is the portfolio key. This field is required.
+	Portfolio string `url:"portfolio"`
+}
+
+// ViewsProjectsStatusOptions contains parameters for the ProjectsStatus method.
+//
+//nolint:govet // Field alignment is less important than logical grouping
+type ViewsProjectsStatusOptions struct {
+	PaginationArgs
+
+	// Portfolio is the portfolio key. This field is required.
+	Portfolio string `url:"portfolio"`
+	// Status filters projects by quality gate status.
+	Status string `url:"status,omitempty"`
+}
+
+// ViewsRefreshOptions contains parameters for the Refresh method.
+type ViewsRefreshOptions struct {
+	// Key is the root portfolio key. If not specified, all portfolios are refreshed.
+	Key string `url:"key,omitempty"`
+}
+
+// ViewsAddApplicationOptions contains parameters for the AddApplication method.
+type ViewsAddApplicationOptions struct {
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+	// Portfolio is the portfolio key. This field is required.
+	Portfolio string `url:"portfolio"`
+}
+
+// ViewsRemoveApplicationOptions contains parameters for the RemoveApplication method.
+type ViewsRemoveApplicationOptions struct {
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+	// Portfolio is the portfolio key. This field is required.
+	Portfolio string `url:"portfolio"`
+}
+
+// ViewsAddApplicationBranchOptions contains parameters for the AddApplicationBranch method.
+type ViewsAddApplicationBranchOptions struct {
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+	// Branch is the branch key. This field is required.
+	Branch string `url:"branch"`
+	// Key is the portfolio key. This field is required.
+	Key string `url:"key"`
+}
+
+// ViewsRemoveApplicationBranchOptions contains parameters for the RemoveApplicationBranch method.
+type ViewsRemoveApplicationBranchOptions struct {
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+	// Branch is the branch key. This field is required.
+	Branch string `url:"branch"`
+	// Key is the portfolio key. This field is required.
+	Key string `url:"key"`
+}
+
+// ViewsSetManualModeOptions contains parameters for the SetManualMode method.
+type ViewsSetManualModeOptions struct {
+	// Portfolio is the portfolio key. This field is required.
+	Portfolio string `url:"portfolio"`
+}
+
+// ViewsSetNoneModeOptions contains parameters for the SetNoneMode method.
+type ViewsSetNoneModeOptions struct {
+	// Portfolio is the portfolio key. This field is required.
+	Portfolio string `url:"portfolio"`
+}
+
+// ViewsSetRegexpModeOptions contains parameters for the SetRegexpMode method.
+type ViewsSetRegexpModeOptions struct {
+	// Branch selects a branch in all matched projects instead of using main branches.
+	Branch string `url:"branch,omitempty"`
+	// Portfolio is the portfolio key. This field is required.
+	Portfolio string `url:"portfolio"`
+	// Regexp is a valid Java regular expression for project key matching. This field is required.
+	Regexp string `url:"regexp"`
+}
+
+// ViewsSetRemainingProjectsModeOptions contains parameters for the SetRemainingProjectsMode method.
+type ViewsSetRemainingProjectsModeOptions struct {
+	// Branch selects a branch in all matched projects instead of using main branches.
+	Branch string `url:"branch,omitempty"`
+	// Portfolio is the portfolio key. This field is required.
+	Portfolio string `url:"portfolio"`
+}
+
+// ViewsSetTagsModeOptions contains parameters for the SetTagsMode method.
+type ViewsSetTagsModeOptions struct {
+	// Branch selects a branch in all matched projects instead of using main branches.
+	Branch string `url:"branch,omitempty"`
+	// Portfolio is the portfolio key. This field is required.
+	Portfolio string `url:"portfolio"`
+	// Tags is a comma-separated list of project tags. This field is required.
+	Tags string `url:"tags"`
+}
+
+// -----------------------------------------------------------------------------
+// Allowed Value Sets
+// -----------------------------------------------------------------------------
+
+//nolint:gochecknoglobals // constant set of allowed values
+var allowedViewVisibilities = map[string]struct{}{
+	"private": {},
+	"public":  {},
+}
+
+//nolint:gochecknoglobals // constant set of allowed values
+var allowedViewProjectSelections = map[string]struct{}{
+	SelectionFilterAll:        {},
+	SelectionFilterSelected:   {},
+	SelectionFilterDeselected: {},
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateCreateOpt validates the options for the Create method.
+func (s *ViewsService) ValidateCreateOpt(opt *ViewsCreateOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Name, "Name")
+	if err != nil {
+		return err
+	}
+
+	return IsValueAuthorized(opt.Visibility, allowedViewVisibilities, "Visibility")
+}
+
+// ValidateDeleteOpt validates the options for the Delete method.
+func (s *ViewsService) ValidateDeleteOpt(opt *ViewsDeleteOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Key, "Key")
+}
+
+// ValidateShowOpt validates the options for the Show method.
+func (s *ViewsService) ValidateShowOpt(opt *ViewsShowOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Key, "Key")
+}
+
+// ValidateUpdateOpt validates the options for the Update method.
+func (s *ViewsService) ValidateUpdateOpt(opt *ViewsUpdateOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Key, "Key")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Name, "Name")
+}
+
+// ValidateAddProjectOpt validates the options for the AddProject method.
+func (s *ViewsService) ValidateAddProjectOpt(opt *ViewsAddProjectOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Key, "Key")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Project, "Project")
+}
+
+// ValidateRemoveProjectOpt validates the options for the RemoveProject method.
+func (s *ViewsService) ValidateRemoveProjectOpt(opt *ViewsRemoveProjectOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Key, "Key")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Project, "Project")
+}
+
+// ValidateAddProjectBranchOpt validates the options for the AddProjectBranch method.
+func (s *ViewsService) ValidateAddProjectBranchOpt(opt *ViewsAddProjectBranchOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Branch, "Branch")
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequired(opt.Key, "Key")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Project, "Project")
+}
+
+// ValidateRemoveProjectBranchOpt validates the options for the RemoveProjectBranch method.
+func (s *ViewsService) ValidateRemoveProjectBranchOpt(opt *ViewsRemoveProjectBranchOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Branch, "Branch")
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequired(opt.Key, "Key")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Project, "Project")
+}
+
+// ValidateAddPortfolioOpt validates the options for the AddPortfolio method.
+func (s *ViewsService) ValidateAddPortfolioOpt(opt *ViewsAddPortfolioOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Portfolio, "Portfolio")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Reference, "Reference")
+}
+
+// ValidateRemovePortfolioOpt validates the options for the RemovePortfolio method.
+func (s *ViewsService) ValidateRemovePortfolioOpt(opt *ViewsRemovePortfolioOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Portfolio, "Portfolio")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Reference, "Reference")
+}
+
+// ValidateMoveOpt validates the options for the Move method.
+func (s *ViewsService) ValidateMoveOpt(opt *ViewsMoveOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Key, "Key")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Destination, "Destination")
+}
+
+// ValidateMoveOptionsOpt validates the options for the MoveOptions method.
+func (s *ViewsService) ValidateMoveOptionsOpt(opt *ViewsMoveOptionsOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Key, "Key")
+}
+
+// ValidateProjectsOpt validates the options for the Projects method.
+func (s *ViewsService) ValidateProjectsOpt(opt *ViewsProjectsOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Key, "Key")
+	if err != nil {
+		return err
+	}
+
+	err = opt.Validate()
+	if err != nil {
+		return err
+	}
+
+	return IsValueAuthorized(opt.Selected, allowedViewProjectSelections, "Selected")
+}
+
+// ValidateApplicationsOpt validates the options for the Applications method.
+func (s *ViewsService) ValidateApplicationsOpt(opt *ViewsApplicationsOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Portfolio, "Portfolio")
+}
+
+// ValidateSubPortfoliosOpt validates the options for the SubPortfolios method.
+func (s *ViewsService) ValidateSubPortfoliosOpt(opt *ViewsSubViewsOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Portfolio, "Portfolio")
+}
+
+// ValidateProjectsStatusOpt validates the options for the ProjectsStatus method.
+func (s *ViewsService) ValidateProjectsStatusOpt(opt *ViewsProjectsStatusOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Portfolio, "Portfolio")
+	if err != nil {
+		return err
+	}
+
+	return opt.Validate()
+}
+
+// ValidateAddApplicationOpt validates the options for the AddApplication method.
+func (s *ViewsService) ValidateAddApplicationOpt(opt *ViewsAddApplicationOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Portfolio, "Portfolio")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Application, "Application")
+}
+
+// ValidateRemoveApplicationOpt validates the options for the RemoveApplication method.
+func (s *ViewsService) ValidateRemoveApplicationOpt(opt *ViewsRemoveApplicationOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Portfolio, "Portfolio")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Application, "Application")
+}
+
+// ValidateAddApplicationBranchOpt validates the options for the AddApplicationBranch method.
+func (s *ViewsService) ValidateAddApplicationBranchOpt(opt *ViewsAddApplicationBranchOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Application, "Application")
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequired(opt.Branch, "Branch")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Key, "Key")
+}
+
+// ValidateRemoveApplicationBranchOpt validates the options for the RemoveApplicationBranch method.
+func (s *ViewsService) ValidateRemoveApplicationBranchOpt(opt *ViewsRemoveApplicationBranchOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Application, "Application")
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequired(opt.Branch, "Branch")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Key, "Key")
+}
+
+// ValidateSetManualModeOpt validates the options for the SetManualMode method.
+func (s *ViewsService) ValidateSetManualModeOpt(opt *ViewsSetManualModeOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Portfolio, "Portfolio")
+}
+
+// ValidateSetNoneModeOpt validates the options for the SetNoneMode method.
+func (s *ViewsService) ValidateSetNoneModeOpt(opt *ViewsSetNoneModeOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Portfolio, "Portfolio")
+}
+
+// ValidateSetRegexpModeOpt validates the options for the SetRegexpMode method.
+func (s *ViewsService) ValidateSetRegexpModeOpt(opt *ViewsSetRegexpModeOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Portfolio, "Portfolio")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Regexp, "Regexp")
+}
+
+// ValidateSetRemainingProjectsModeOpt validates the options for the SetRemainingProjectsMode method.
+func (s *ViewsService) ValidateSetRemainingProjectsModeOpt(opt *ViewsSetRemainingProjectsModeOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Portfolio, "Portfolio")
+}
+
+// ValidateSetTagsModeOpt validates the options for the SetTagsMode method.
+func (s *ViewsService) ValidateSetTagsModeOpt(opt *ViewsSetTagsModeOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Portfolio, "Portfolio")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Tags, "Tags")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// AddApplication adds an application to a portfolio.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/add_application.
+// Since: 7.1.
+// Enterprise Edition only.
+func (s *ViewsService) AddApplication(opt *ViewsAddApplicationOptions) (*http.Response, error) {
+	err := s.ValidateAddApplicationOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/add_application", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// AddApplicationBranch adds a specific application branch to a portfolio.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/add_application_branch.
+// Since: 7.1.
+// Enterprise Edition only.
+func (s *ViewsService) AddApplicationBranch(opt *ViewsAddApplicationBranchOptions) (*http.Response, error) {
+	err := s.ValidateAddApplicationBranchOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/add_application_branch", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// AddPortfolio adds an existing portfolio as a sub-portfolio (reference) to a parent portfolio.
+// Requires 'Administer' permission on the parent portfolio.
+//
+// API endpoint: POST /api/views/add_portfolio.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) AddPortfolio(opt *ViewsAddPortfolioOptions) (*http.Response, error) {
+	err := s.ValidateAddPortfolioOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/add_portfolio", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// AddProject adds a project to a portfolio.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/add_project.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) AddProject(opt *ViewsAddProjectOptions) (*http.Response, error) {
+	err := s.ValidateAddProjectOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/add_project", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// AddProjectBranch adds a specific project branch to a portfolio.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/add_project_branch.
+// Since: 7.1.
+// Enterprise Edition only.
+func (s *ViewsService) AddProjectBranch(opt *ViewsAddProjectBranchOptions) (*http.Response, error) {
+	err := s.ValidateAddProjectBranchOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/add_project_branch", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Applications returns the applications in a portfolio.
+// Requires 'Browse' permission on the portfolio.
+//
+// API endpoint: GET /api/views/applications.
+// Since: 7.1.
+// Enterprise Edition only.
+func (s *ViewsService) Applications(opt *ViewsApplicationsOptions) (*ViewsApplications, *http.Response, error) {
+	err := s.ValidateApplicationsOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/applications", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(ViewsApplications)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// Create creates a new root portfolio or sub-portfolio.
+// Requires 'Administer System' permission (root) or 'Administer' permission on the parent.
+//
+// API endpoint: POST /api/views/create.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) Create(opt *ViewsCreateOptions) (*http.Response, error) {
+	err := s.ValidateCreateOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/create", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Delete deletes a portfolio.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/delete.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) Delete(opt *ViewsDeleteOptions) (*http.Response, error) {
+	err := s.ValidateDeleteOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/delete", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// List returns the list of root portfolios.
+// Requires authentication.
+//
+// API endpoint: GET /api/views/list.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) List() (*ViewsList, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/list", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(ViewsList)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// Move moves a portfolio to a new parent portfolio.
+// Requires 'Administer' permission on both portfolios.
+//
+// API endpoint: POST /api/views/move.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) Move(opt *ViewsMoveOptions) (*http.Response, error) {
+	err := s.ValidateMoveOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/move", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// MoveOptions returns the list of possible destination portfolios for a move operation.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: GET /api/views/move_options.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) MoveOptions(opt *ViewsMoveOptionsOptions) (*ViewsMoveDestinations, *http.Response, error) {
+	err := s.ValidateMoveOptionsOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/move_options", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(ViewsMoveDestinations)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// SubPortfolios returns the sub-portfolios of a portfolio.
+// Requires 'Browse' permission on the portfolio.
+//
+// API endpoint: GET /api/views/portfolios.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) SubPortfolios(opt *ViewsSubViewsOptions) (*ViewsSubViews, *http.Response, error) {
+	err := s.ValidateSubPortfoliosOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/portfolios", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(ViewsSubViews)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// Projects lists the projects in a portfolio.
+// Requires 'Browse' permission on the portfolio.
+//
+// API endpoint: GET /api/views/projects.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) Projects(opt *ViewsProjectsOptions) (*ViewsProjects, *http.Response, error) {
+	err := s.ValidateProjectsOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/projects", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(ViewsProjects)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// ProjectsStatus returns the quality gate status of projects in a portfolio.
+// Requires 'Browse' permission on the portfolio.
+//
+// API endpoint: GET /api/views/projects_status.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) ProjectsStatus(opt *ViewsProjectsStatusOptions) (*ViewsProjectsStatus, *http.Response, error) {
+	err := s.ValidateProjectsStatusOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/projects_status", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(ViewsProjectsStatus)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// Refresh triggers a computation of portfolio measures. If no key is provided,
+// all portfolios are refreshed.
+// Requires 'Administer System' permission.
+//
+// API endpoint: POST /api/views/refresh.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) Refresh(opt *ViewsRefreshOptions) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/refresh", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// RemoveApplication removes an application from a portfolio.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/remove_application.
+// Since: 7.1.
+// Enterprise Edition only.
+func (s *ViewsService) RemoveApplication(opt *ViewsRemoveApplicationOptions) (*http.Response, error) {
+	err := s.ValidateRemoveApplicationOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/remove_application", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// RemoveApplicationBranch removes a specific application branch from a portfolio.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/remove_application_branch.
+// Since: 7.1.
+// Enterprise Edition only.
+func (s *ViewsService) RemoveApplicationBranch(opt *ViewsRemoveApplicationBranchOptions) (*http.Response, error) {
+	err := s.ValidateRemoveApplicationBranchOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/remove_application_branch", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// RemovePortfolio removes a sub-portfolio from a parent portfolio.
+// Requires 'Administer' permission on the parent portfolio.
+//
+// API endpoint: POST /api/views/remove_portfolio.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) RemovePortfolio(opt *ViewsRemovePortfolioOptions) (*http.Response, error) {
+	err := s.ValidateRemovePortfolioOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/remove_portfolio", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// RemoveProject removes a project from a portfolio.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/remove_project.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) RemoveProject(opt *ViewsRemoveProjectOptions) (*http.Response, error) {
+	err := s.ValidateRemoveProjectOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/remove_project", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// RemoveProjectBranch removes a specific project branch from a portfolio.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/remove_project_branch.
+// Since: 7.1.
+// Enterprise Edition only.
+func (s *ViewsService) RemoveProjectBranch(opt *ViewsRemoveProjectBranchOptions) (*http.Response, error) {
+	err := s.ValidateRemoveProjectBranchOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/remove_project_branch", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Search searches portfolios by name, key, or description.
+// Requires authentication.
+//
+// API endpoint: GET /api/views/search.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) Search(opt *ViewsSearchOptions) (*ViewsSearch, *http.Response, error) {
+	if opt != nil {
+		err := opt.Validate()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/search", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(ViewsSearch)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// SetManualMode sets a portfolio to manual project selection mode.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/set_manual_mode.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) SetManualMode(opt *ViewsSetManualModeOptions) (*http.Response, error) {
+	err := s.ValidateSetManualModeOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/set_manual_mode", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// SetNoneMode sets a portfolio to no project selection (empty).
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/set_none_mode.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) SetNoneMode(opt *ViewsSetNoneModeOptions) (*http.Response, error) {
+	err := s.ValidateSetNoneModeOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/set_none_mode", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// SetRegexpMode sets a portfolio to regexp-based project selection mode.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/set_regexp_mode.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) SetRegexpMode(opt *ViewsSetRegexpModeOptions) (*http.Response, error) {
+	err := s.ValidateSetRegexpModeOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/set_regexp_mode", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// SetRemainingProjectsMode sets a portfolio to include all remaining (unclassified) projects.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/set_remaining_projects_mode.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) SetRemainingProjectsMode(opt *ViewsSetRemainingProjectsModeOptions) (*http.Response, error) {
+	err := s.ValidateSetRemainingProjectsModeOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/set_remaining_projects_mode", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// SetTagsMode sets a portfolio to tag-based project selection mode.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/set_tags_mode.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) SetTagsMode(opt *ViewsSetTagsModeOptions) (*http.Response, error) {
+	err := s.ValidateSetTagsModeOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/set_tags_mode", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Show returns the details of a portfolio, including sub-portfolios.
+// Requires 'Browse' permission on the portfolio.
+//
+// API endpoint: GET /api/views/show.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) Show(opt *ViewsShowOptions) (*ViewsShow, *http.Response, error) {
+	err := s.ValidateShowOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/show", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(ViewsShow)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// Update updates a portfolio's name and/or description.
+// Requires 'Administer' permission on the portfolio.
+//
+// API endpoint: POST /api/views/update.
+// Since: 6.6.
+// Enterprise Edition only.
+func (s *ViewsService) Update(opt *ViewsUpdateOptions) (*http.Response, error) {
+	err := s.ValidateUpdateOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/update", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/sonar/views_service_test.go
+++ b/sonar/views_service_test.go
@@ -1,0 +1,890 @@
+package sonar
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// AddApplication / RemoveApplication
+// -----------------------------------------------------------------------------
+
+func TestViewsService_AddApplication(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/add_application", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.AddApplication(&ViewsAddApplicationOptions{
+		Portfolio:   "my-portfolio",
+		Application: "my-application",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_AddApplication_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.AddApplication(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.AddApplication(&ViewsAddApplicationOptions{Application: "my-app"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.AddApplication(&ViewsAddApplicationOptions{Portfolio: "my-portfolio"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestViewsService_RemoveApplication(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/remove_application", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.RemoveApplication(&ViewsRemoveApplicationOptions{
+		Portfolio:   "my-portfolio",
+		Application: "my-application",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_RemoveApplication_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.RemoveApplication(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.RemoveApplication(&ViewsRemoveApplicationOptions{Application: "my-app"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.RemoveApplication(&ViewsRemoveApplicationOptions{Portfolio: "my-portfolio"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// AddApplicationBranch / RemoveApplicationBranch
+// -----------------------------------------------------------------------------
+
+func TestViewsService_AddApplicationBranch(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/add_application_branch", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.AddApplicationBranch(&ViewsAddApplicationBranchOptions{
+		Application: "my-app",
+		Branch:      "main",
+		Key:         "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_AddApplicationBranch_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.AddApplicationBranch(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.AddApplicationBranch(&ViewsAddApplicationBranchOptions{Branch: "main", Key: "pf"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.AddApplicationBranch(&ViewsAddApplicationBranchOptions{Application: "app", Key: "pf"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.AddApplicationBranch(&ViewsAddApplicationBranchOptions{Application: "app", Branch: "main"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestViewsService_RemoveApplicationBranch(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/remove_application_branch", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.RemoveApplicationBranch(&ViewsRemoveApplicationBranchOptions{
+		Application: "my-app",
+		Branch:      "main",
+		Key:         "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_RemoveApplicationBranch_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.RemoveApplicationBranch(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// AddPortfolio / RemovePortfolio
+// -----------------------------------------------------------------------------
+
+func TestViewsService_AddPortfolio(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/add_portfolio", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.AddPortfolio(&ViewsAddPortfolioOptions{
+		Portfolio: "parent-portfolio",
+		Reference: "ref-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_AddPortfolio_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.AddPortfolio(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.AddPortfolio(&ViewsAddPortfolioOptions{Reference: "ref"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.AddPortfolio(&ViewsAddPortfolioOptions{Portfolio: "parent"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestViewsService_RemovePortfolio(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/remove_portfolio", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.RemovePortfolio(&ViewsRemovePortfolioOptions{
+		Portfolio: "parent-portfolio",
+		Reference: "sub-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_RemovePortfolio_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.RemovePortfolio(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.RemovePortfolio(&ViewsRemovePortfolioOptions{Reference: "sub"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.RemovePortfolio(&ViewsRemovePortfolioOptions{Portfolio: "parent"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// AddProject / RemoveProject
+// -----------------------------------------------------------------------------
+
+func TestViewsService_AddProject(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/add_project", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.AddProject(&ViewsAddProjectOptions{
+		Key:     "my-portfolio",
+		Project: "my-project",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_AddProject_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.AddProject(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.AddProject(&ViewsAddProjectOptions{Project: "my-project"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.AddProject(&ViewsAddProjectOptions{Key: "my-portfolio"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestViewsService_RemoveProject(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/remove_project", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.RemoveProject(&ViewsRemoveProjectOptions{
+		Key:     "my-portfolio",
+		Project: "my-project",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_RemoveProject_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.RemoveProject(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.RemoveProject(&ViewsRemoveProjectOptions{Project: "my-project"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.RemoveProject(&ViewsRemoveProjectOptions{Key: "my-portfolio"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// AddProjectBranch / RemoveProjectBranch
+// -----------------------------------------------------------------------------
+
+func TestViewsService_AddProjectBranch(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/add_project_branch", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.AddProjectBranch(&ViewsAddProjectBranchOptions{
+		Branch:  "main",
+		Key:     "my-portfolio",
+		Project: "my-project",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_AddProjectBranch_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.AddProjectBranch(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.AddProjectBranch(&ViewsAddProjectBranchOptions{Key: "pf", Project: "proj"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestViewsService_RemoveProjectBranch(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/remove_project_branch", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.RemoveProjectBranch(&ViewsRemoveProjectBranchOptions{
+		Branch:  "main",
+		Key:     "my-portfolio",
+		Project: "my-project",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_RemoveProjectBranch_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.RemoveProjectBranch(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// Applications / SubPortfolios
+// -----------------------------------------------------------------------------
+
+func TestViewsService_Applications(t *testing.T) {
+	response := ViewsApplications{
+		Applications: []ViewApplication{
+			{Key: "app-1", Name: "Application 1"},
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/applications", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Views.Applications(&ViewsApplicationsOptions{
+		Portfolio: "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+	assert.Len(t, result.Applications, 1)
+	assert.Equal(t, "app-1", result.Applications[0].Key)
+}
+
+func TestViewsService_Applications_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	_, _, err := client.Views.Applications(nil)
+	assert.Error(t, err)
+
+	_, _, err = client.Views.Applications(&ViewsApplicationsOptions{})
+	assert.Error(t, err)
+}
+
+func TestViewsService_SubPortfolios(t *testing.T) {
+	response := ViewsSubViews{
+		SubViews: []View{
+			{Key: "sub-1", Name: "Sub Portfolio 1", Qualifier: "SVW"},
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/portfolios", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Views.SubPortfolios(&ViewsSubViewsOptions{
+		Portfolio: "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+	assert.Len(t, result.SubViews, 1)
+}
+
+func TestViewsService_SubPortfolios_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	_, _, err := client.Views.SubPortfolios(nil)
+	assert.Error(t, err)
+
+	_, _, err = client.Views.SubPortfolios(&ViewsSubViewsOptions{})
+	assert.Error(t, err)
+}
+
+// -----------------------------------------------------------------------------
+// Create
+// -----------------------------------------------------------------------------
+
+func TestViewsService_Create(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/create", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.Create(&ViewsCreateOptions{
+		Name: "My Portfolio",
+		Key:  "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_Create_WithParent(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/create", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.Create(&ViewsCreateOptions{
+		Name:   "Sub Portfolio",
+		Parent: "parent-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_Create_WithVisibility(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/create", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.Create(&ViewsCreateOptions{
+		Name:        "My Portfolio",
+		Description: "A test portfolio",
+		Visibility:  "private",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_Create_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.Create(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.Create(&ViewsCreateOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.Create(&ViewsCreateOptions{Name: "My Portfolio", Visibility: "invalid"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// Delete
+// -----------------------------------------------------------------------------
+
+func TestViewsService_Delete(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/delete", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.Delete(&ViewsDeleteOptions{
+		Key: "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_Delete_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.Delete(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.Delete(&ViewsDeleteOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// List
+// -----------------------------------------------------------------------------
+
+func TestViewsService_List(t *testing.T) {
+	response := ViewsList{
+		Views: []View{
+			{Key: "pf-1", Name: "Portfolio 1", Qualifier: "VW"},
+			{Key: "pf-2", Name: "Portfolio 2", Qualifier: "VW"},
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/list", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Views.List()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+	assert.Len(t, result.Views, 2)
+	assert.Equal(t, "pf-1", result.Views[0].Key)
+	assert.Equal(t, "Portfolio 1", result.Views[0].Name)
+}
+
+func TestViewsService_List_Empty(t *testing.T) {
+	response := ViewsList{}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/list", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Views.List()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Views)
+}
+
+// -----------------------------------------------------------------------------
+// Move
+// -----------------------------------------------------------------------------
+
+func TestViewsService_Move(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/move", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.Move(&ViewsMoveOptions{
+		Key:         "my-portfolio",
+		Destination: "destination-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_Move_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.Move(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.Move(&ViewsMoveOptions{Destination: "dest"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.Move(&ViewsMoveOptions{Key: "my-portfolio"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// MoveOptions
+// -----------------------------------------------------------------------------
+
+func TestViewsService_MoveOptions(t *testing.T) {
+	response := ViewsMoveDestinations{
+		Views: []ViewDestination{
+			{Key: "dest-1", Name: "Destination 1"},
+			{Key: "dest-2", Name: "Destination 2"},
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/move_options", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Views.MoveOptions(&ViewsMoveOptionsOptions{
+		Key: "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+	assert.Len(t, result.Views, 2)
+	assert.Equal(t, "dest-1", result.Views[0].Key)
+}
+
+func TestViewsService_MoveOptions_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	_, _, err := client.Views.MoveOptions(nil)
+	assert.Error(t, err)
+
+	_, _, err = client.Views.MoveOptions(&ViewsMoveOptionsOptions{})
+	assert.Error(t, err)
+}
+
+// -----------------------------------------------------------------------------
+// Projects / ProjectsStatus
+// -----------------------------------------------------------------------------
+
+func TestViewsService_Projects(t *testing.T) {
+	response := ViewsProjects{
+		Projects: []ViewProject{
+			{Key: "proj-1", Name: "Project 1", Selected: true},
+			{Key: "proj-2", Name: "Project 2", Selected: false},
+		},
+		Paging: Paging{PageIndex: 1, PageSize: 100, Total: 2},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/projects", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Views.Projects(&ViewsProjectsOptions{
+		Key:      "my-portfolio",
+		Selected: "all",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+	assert.Len(t, result.Projects, 2)
+	assert.Equal(t, int64(2), result.Paging.Total)
+}
+
+func TestViewsService_Projects_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	_, _, err := client.Views.Projects(nil)
+	assert.Error(t, err)
+
+	_, _, err = client.Views.Projects(&ViewsProjectsOptions{})
+	assert.Error(t, err)
+
+	_, _, err = client.Views.Projects(&ViewsProjectsOptions{Key: "pf", Selected: "invalid"})
+	assert.Error(t, err)
+}
+
+func TestViewsService_ProjectsStatus(t *testing.T) {
+	response := ViewsProjectsStatus{
+		Projects: []ViewProjectStatus{
+			{Key: "proj-1", Name: "Project 1", Status: "OK"},
+		},
+		Paging: Paging{PageIndex: 1, PageSize: 100, Total: 1},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/projects_status", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Views.ProjectsStatus(&ViewsProjectsStatusOptions{
+		Portfolio: "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+	assert.Len(t, result.Projects, 1)
+	assert.Equal(t, "OK", result.Projects[0].Status)
+}
+
+func TestViewsService_ProjectsStatus_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	_, _, err := client.Views.ProjectsStatus(nil)
+	assert.Error(t, err)
+
+	_, _, err = client.Views.ProjectsStatus(&ViewsProjectsStatusOptions{})
+	assert.Error(t, err)
+}
+
+// -----------------------------------------------------------------------------
+// Refresh
+// -----------------------------------------------------------------------------
+
+func TestViewsService_Refresh(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/refresh", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.Refresh(nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_Refresh_WithKey(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/refresh", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.Refresh(&ViewsRefreshOptions{Key: "my-portfolio"})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+// -----------------------------------------------------------------------------
+// Search
+// -----------------------------------------------------------------------------
+
+func TestViewsService_Search(t *testing.T) {
+	response := ViewsSearch{
+		Components: []View{
+			{Key: "pf-1", Name: "Portfolio 1"},
+		},
+		Paging: Paging{PageIndex: 1, PageSize: 100, Total: 1},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/search", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Views.Search(&ViewsSearchOptions{Q: "Portfolio"})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+	assert.Len(t, result.Components, 1)
+	assert.Equal(t, int64(1), result.Paging.Total)
+}
+
+func TestViewsService_Search_Nil(t *testing.T) {
+	response := ViewsSearch{}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/search", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Views.Search(nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+}
+
+func TestViewsService_Search_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	_, _, err := client.Views.Search(&ViewsSearchOptions{PaginationArgs: PaginationArgs{Page: -1}})
+	assert.Error(t, err)
+}
+
+// -----------------------------------------------------------------------------
+// SetManualMode / SetNoneMode / SetRegexpMode / SetRemainingProjectsMode / SetTagsMode
+// -----------------------------------------------------------------------------
+
+func TestViewsService_SetManualMode(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/set_manual_mode", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.SetManualMode(&ViewsSetManualModeOptions{Portfolio: "my-portfolio"})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_SetManualMode_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.SetManualMode(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.SetManualMode(&ViewsSetManualModeOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestViewsService_SetNoneMode(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/set_none_mode", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.SetNoneMode(&ViewsSetNoneModeOptions{Portfolio: "my-portfolio"})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_SetNoneMode_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.SetNoneMode(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestViewsService_SetRegexpMode(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/set_regexp_mode", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.SetRegexpMode(&ViewsSetRegexpModeOptions{
+		Portfolio: "my-portfolio",
+		Regexp:    ".*my-project.*",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_SetRegexpMode_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.SetRegexpMode(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.SetRegexpMode(&ViewsSetRegexpModeOptions{Portfolio: "pf"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.SetRegexpMode(&ViewsSetRegexpModeOptions{Regexp: ".*"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestViewsService_SetRemainingProjectsMode(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/set_remaining_projects_mode", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.SetRemainingProjectsMode(&ViewsSetRemainingProjectsModeOptions{
+		Portfolio: "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_SetRemainingProjectsMode_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.SetRemainingProjectsMode(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestViewsService_SetTagsMode(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/set_tags_mode", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.SetTagsMode(&ViewsSetTagsModeOptions{
+		Portfolio: "my-portfolio",
+		Tags:      "java,security",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_SetTagsMode_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.SetTagsMode(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.SetTagsMode(&ViewsSetTagsModeOptions{Portfolio: "pf"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// Show
+// -----------------------------------------------------------------------------
+
+func TestViewsService_Show(t *testing.T) {
+	response := ViewsShow{
+		Portfolio: ViewDetails{
+			Key:           "pf-1",
+			Name:          "Portfolio 1",
+			Qualifier:     "VW",
+			SelectionMode: "MANUAL",
+			SubViews: []View{
+				{Key: "sub-pf-1", Name: "Sub Portfolio 1", Qualifier: "SVW"},
+			},
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/show", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Views.Show(&ViewsShowOptions{Key: "pf-1"})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+	assert.Equal(t, "pf-1", result.Portfolio.Key)
+	assert.Equal(t, "Portfolio 1", result.Portfolio.Name)
+	assert.Len(t, result.Portfolio.SubViews, 1)
+}
+
+func TestViewsService_Show_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	_, _, err := client.Views.Show(nil)
+	assert.Error(t, err)
+
+	_, _, err = client.Views.Show(&ViewsShowOptions{})
+	assert.Error(t, err)
+}
+
+// -----------------------------------------------------------------------------
+// Update
+// -----------------------------------------------------------------------------
+
+func TestViewsService_Update(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/update", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Views.Update(&ViewsUpdateOptions{
+		Key:  "my-portfolio",
+		Name: "My Renamed Portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestViewsService_Update_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Views.Update(nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.Update(&ViewsUpdateOptions{Name: "New Name"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Views.Update(&ViewsUpdateOptions{Key: "my-portfolio"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// Validation method tests
+// -----------------------------------------------------------------------------
+
+func TestViewsService_ValidateCreateOpt(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	err := client.Views.ValidateCreateOpt(&ViewsCreateOptions{Name: "My Portfolio"})
+	assert.NoError(t, err)
+
+	err = client.Views.ValidateCreateOpt(nil)
+	assert.Error(t, err)
+
+	err = client.Views.ValidateCreateOpt(&ViewsCreateOptions{})
+	assert.Error(t, err)
+
+	err = client.Views.ValidateCreateOpt(&ViewsCreateOptions{Name: "X", Visibility: "bad"})
+	assert.Error(t, err)
+}
+
+func TestViewsService_ValidateProjectsOpt(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	err := client.Views.ValidateProjectsOpt(&ViewsProjectsOptions{Key: "pf", Selected: "selected"})
+	assert.NoError(t, err)
+
+	err = client.Views.ValidateProjectsOpt(nil)
+	assert.Error(t, err)
+
+	err = client.Views.ValidateProjectsOpt(&ViewsProjectsOptions{Key: "pf", Selected: "bad-value"})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
### Description of your changes

This PR adds the support of Portfolios (views) related endpoints

This comes packaged with corresponding unit tests and integration (dummy) tests

Closes #197 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
