### PR TITLE
refactor!: rename unclear / unscoped methods and types

### DIFF
--- a/integration_testing/alm_integrations_test.go
+++ b/integration_testing/alm_integrations_test.go
@@ -51,12 +51,12 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	})
 
 	// =========================================================================
-	// GetGithubClientId
+	// GetGithubClientID
 	// =========================================================================
-	Describe("GetGithubClientId", func() {
+	Describe("GetGithubClientID", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.AlmIntegrations.GetGithubClientId(nil)
+				result, resp, err := client.AlmIntegrations.GetGithubClientID(nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
@@ -64,7 +64,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.GetGithubClientId(&sonar.AlmIntegrationsGetGithubClientIdOptions{})
+				result, resp, err := client.AlmIntegrations.GetGithubClientID(&sonar.AlmIntegrationsGetGithubClientIDOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())

--- a/integration_testing/analysis_reports_test.go
+++ b/integration_testing/analysis_reports_test.go
@@ -23,12 +23,12 @@ var _ = Describe("AnalysisReports Service", Ordered, func() {
 	})
 
 	// =========================================================================
-	// IsQueueEmpty
+	// QueueStatus
 	// =========================================================================
-	Describe("IsQueueEmpty", func() {
+	Describe("QueueStatus", func() {
 		Context("Functional Tests", func() {
 			It("should check if compute engine queue is empty", func() {
-				result, resp, err := client.AnalysisReports.IsQueueEmpty()
+				result, resp, err := client.AnalysisReports.QueueStatus()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -36,12 +36,12 @@ var _ = Describe("AnalysisReports Service", Ordered, func() {
 
 			It("should return consistent results on multiple calls", func() {
 				// Call twice and verify both return valid results
-				result1, resp1, err1 := client.AnalysisReports.IsQueueEmpty()
+				result1, resp1, err1 := client.AnalysisReports.QueueStatus()
 				Expect(err1).NotTo(HaveOccurred())
 				Expect(resp1.StatusCode).To(Equal(http.StatusOK))
 				Expect(result1).NotTo(BeNil())
 
-				result2, resp2, err2 := client.AnalysisReports.IsQueueEmpty()
+				result2, resp2, err2 := client.AnalysisReports.QueueStatus()
 				Expect(err2).NotTo(HaveOccurred())
 				Expect(resp2.StatusCode).To(Equal(http.StatusOK))
 				Expect(result2).NotTo(BeNil())

--- a/integration_testing/batch_test.go
+++ b/integration_testing/batch_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 	Describe("Index", func() {
 		Context("Functional Tests", func() {
 			It("should get batch index", func() {
-				result, resp, err := client.Batch.Index()
+				result, resp, err := client.Batch.GetIndex()
 				// Batch API may not be available in newer SonarQube versions
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("Batch API is not available in this SonarQube version")
@@ -65,7 +65,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 			})
 
 			It("should return JAR file list", func() {
-				result, resp, err := client.Batch.Index()
+				result, resp, err := client.Batch.GetIndex()
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("Batch API is not available in this SonarQube version")
 				}
@@ -82,14 +82,14 @@ var _ = Describe("Batch Service", Ordered, func() {
 			})
 
 			It("should return consistent results on multiple calls", func() {
-				result1, resp1, err := client.Batch.Index()
+				result1, resp1, err := client.Batch.GetIndex()
 				if resp1 != nil && resp1.StatusCode == http.StatusNotFound {
 					Skip("Batch API is not available in this SonarQube version")
 				}
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp1.StatusCode).To(Equal(http.StatusOK))
 
-				result2, resp2, err := client.Batch.Index()
+				result2, resp2, err := client.Batch.GetIndex()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp2.StatusCode).To(Equal(http.StatusOK))
 
@@ -105,7 +105,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 		Context("Functional Tests", func() {
 			It("should download batch file with valid name", func() {
 				// First get the index to find a valid file name
-				index, resp, err := client.Batch.Index()
+				index, resp, err := client.Batch.GetIndex()
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("Batch API is not available in this SonarQube version")
 				}
@@ -116,7 +116,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 					for _, line := range lines {
 						parts := strings.Split(strings.TrimSpace(line), "|")
 						if len(parts) > 0 && strings.HasSuffix(parts[0], ".jar") {
-							result, resp, err := client.Batch.File(&sonar.BatchFileOptions{
+							result, resp, err := client.Batch.GetFile(&sonar.BatchFileOptions{
 								Name: parts[0],
 							})
 							Expect(err).NotTo(HaveOccurred())
@@ -132,7 +132,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should handle nil options", func() {
-				_, resp, err := client.Batch.File(nil)
+				_, resp, err := client.Batch.GetFile(nil)
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("Batch API is not available in this SonarQube version")
 				}
@@ -143,7 +143,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent file", func() {
-				_, resp, err := client.Batch.File(&sonar.BatchFileOptions{
+				_, resp, err := client.Batch.GetFile(&sonar.BatchFileOptions{
 					Name: "non-existent-file.jar",
 				})
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
@@ -165,7 +165,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 	Describe("Project", func() {
 		Context("Functional Tests", func() {
 			It("should get project batch info with valid key", func() {
-				result, resp, err := client.Batch.Project(&sonar.BatchProjectOptions{
+				result, resp, err := client.Batch.GetProject(&sonar.BatchProjectOptions{
 					Key: testProject.Project.Key,
 				})
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
@@ -189,17 +189,17 @@ var _ = Describe("Batch Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				_, _, err := client.Batch.Project(nil)
+				_, _, err := client.Batch.GetProject(nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing key", func() {
-				_, _, err := client.Batch.Project(&sonar.BatchProjectOptions{})
+				_, _, err := client.Batch.GetProject(&sonar.BatchProjectOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with non-existent project", func() {
-				_, resp, err := client.Batch.Project(&sonar.BatchProjectOptions{
+				_, resp, err := client.Batch.GetProject(&sonar.BatchProjectOptions{
 					Key: "non-existent-project-12345",
 				})
 				if resp != nil && resp.StatusCode == http.StatusNotFound {

--- a/integration_testing/l10n_test.go
+++ b/integration_testing/l10n_test.go
@@ -29,7 +29,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 	Describe("Index", func() {
 		Context("Parameter Validation", func() {
 			It("should work with nil options", func() {
-				result, resp, err := client.L10N.Index(nil)
+				result, resp, err := client.L10N.GetIndex(nil)
 				// Skip if API not available
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("L10N API is not available in this SonarQube version")
@@ -42,7 +42,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 
 		Context("Default Locale", func() {
 			It("should get localization messages with default locale", func() {
-				result, resp, err := client.L10N.Index(nil)
+				result, resp, err := client.L10N.GetIndex(nil)
 				// Skip if API not available
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("L10N API is not available in this SonarQube version")
@@ -71,7 +71,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 
 		Context("Specific Locale", func() {
 			It("should get localization messages for specific locale", func() {
-				result, resp, err := client.L10N.Index(&sonar.L10NIndexOptions{
+				result, resp, err := client.L10N.GetIndex(&sonar.L10NIndexOptions{
 					Locale: "en",
 				})
 				// Skip if API not available
@@ -93,7 +93,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 		Context("Compare Different Locales", func() {
 			It("should return different translations for different locales if available", func() {
 				// Get English locale
-				resultEN, respEN, err := client.L10N.Index(&sonar.L10NIndexOptions{
+				resultEN, respEN, err := client.L10N.GetIndex(&sonar.L10NIndexOptions{
 					Locale: "en",
 				})
 				// Skip if API not available
@@ -104,7 +104,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 				Expect(respEN.StatusCode).To(Equal(http.StatusOK))
 
 				// Try to get French locale
-				resultFR, respFR, err := client.L10N.Index(&sonar.L10NIndexOptions{
+				resultFR, respFR, err := client.L10N.GetIndex(&sonar.L10NIndexOptions{
 					Locale: "fr",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -130,7 +130,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 			It("should get localization messages with timestamp", func() {
 				// Use a recent timestamp (1 year ago)
 				oneYearAgo := time.Now().AddDate(-1, 0, 0).Format("2006-01-02T15:04:05-0700")
-				result, resp, err := client.L10N.Index(&sonar.L10NIndexOptions{
+				result, resp, err := client.L10N.GetIndex(&sonar.L10NIndexOptions{
 					Timestamp: oneYearAgo,
 				})
 				// Skip if API not available

--- a/integration_testing/project_branches_test.go
+++ b/integration_testing/project_branches_test.go
@@ -66,7 +66,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			Expect(result.Branches).NotTo(BeEmpty())
 
 			// Find and verify the main branch
-			var mainBranch *sonar.Branch
+			var mainBranch *sonar.ProjectBranch
 			for i := range result.Branches {
 				if result.Branches[i].IsMain {
 					mainBranch = &result.Branches[i]
@@ -142,7 +142,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			var mainBranch *sonar.Branch
+			var mainBranch *sonar.ProjectBranch
 			for i := range result.Branches {
 				if result.Branches[i].IsMain {
 					mainBranch = &result.Branches[i]
@@ -310,7 +310,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			var mainBranch *sonar.Branch
+			var mainBranch *sonar.ProjectBranch
 			for i := range result.Branches {
 				if result.Branches[i].IsMain {
 					mainBranch = &result.Branches[i]
@@ -456,7 +456,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Branches).NotTo(BeEmpty())
 
-			var mainBranch *sonar.Branch
+			var mainBranch *sonar.ProjectBranch
 			for i := range result.Branches {
 				if result.Branches[i].IsMain {
 					mainBranch = &result.Branches[i]

--- a/integration_testing/qualitygates_test.go
+++ b/integration_testing/qualitygates_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(result.Name).To(Equal(gateName))
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -109,7 +109,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-					_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+					_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 						Name: gateName,
 					})
 					return err
@@ -139,7 +139,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -198,7 +198,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", newName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: newName,
 				})
 				return err
@@ -258,7 +258,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", sourceName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: sourceName,
 				})
 				return err
@@ -272,7 +272,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			cleanup.RegisterCleanup("qualitygate", copyName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: copyName,
 				})
 				return err
@@ -312,9 +312,9 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 	})
 
 	// =========================================================================
-	// Destroy
+	// Delete
 	// =========================================================================
-	Describe("Destroy", func() {
+	Describe("Delete", func() {
 		It("should delete a quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-destroy")
 
@@ -323,7 +323,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			resp, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+			resp, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -338,13 +338,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.Destroy(nil)
+				resp, err := client.Qualitygates.Delete(nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with empty name", func() {
-				resp, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{})
+				resp, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -352,7 +352,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent quality gate", func() {
-				resp, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				resp, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: "non-existent-gate-xyz",
 				})
 				Expect(err).To(HaveOccurred())
@@ -363,9 +363,9 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 	})
 
 	// =========================================================================
-	// SetAsDefault
+	// SetDefault
 	// =========================================================================
-	Describe("SetAsDefault", func() {
+	Describe("SetDefault", func() {
 		It("should set a quality gate as default", func() {
 			gateName := helpers.UniqueResourceName("qg-default")
 
@@ -375,13 +375,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			resp, err := client.Qualitygates.SetAsDefault(&sonar.QualitygatesSetAsDefaultOptions{
+			resp, err := client.Qualitygates.SetDefault(&sonar.QualitygatesSetDefaultOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -398,7 +398,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			listResult, _, _ := client.Qualitygates.List()
 			for _, gate := range listResult.Qualitygates {
 				if gate.IsBuiltIn {
-					_, _ = client.Qualitygates.SetAsDefault(&sonar.QualitygatesSetAsDefaultOptions{
+					_, _ = client.Qualitygates.SetDefault(&sonar.QualitygatesSetDefaultOptions{
 						Name: gate.Name,
 					})
 					break
@@ -408,13 +408,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.SetAsDefault(nil)
+				resp, err := client.Qualitygates.SetDefault(nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with empty name", func() {
-				resp, err := client.Qualitygates.SetAsDefault(&sonar.QualitygatesSetAsDefaultOptions{})
+				resp, err := client.Qualitygates.SetDefault(&sonar.QualitygatesSetDefaultOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -434,7 +434,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -463,7 +463,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -533,7 +533,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -606,7 +606,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -656,7 +656,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 	// =========================================================================
 	// Select and Deselect (Project association)
 	// =========================================================================
-	Describe("Select", func() {
+	Describe("Assign", func() {
 		It("should associate a project with a quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-sel")
 			projectKey := helpers.UniqueResourceName("proj-qg")
@@ -667,7 +667,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -686,7 +686,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 				return err
 			})
 
-			resp, err := client.Qualitygates.Select(&sonar.QualitygatesSelectOptions{
+			resp, err := client.Qualitygates.Assign(&sonar.QualitygatesAssignOptions{
 				GateName:   gateName,
 				ProjectKey: projectKey,
 			})
@@ -703,13 +703,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.Select(nil)
+				resp, err := client.Qualitygates.Assign(nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing gate name", func() {
-				resp, err := client.Qualitygates.Select(&sonar.QualitygatesSelectOptions{
+				resp, err := client.Qualitygates.Assign(&sonar.QualitygatesAssignOptions{
 					ProjectKey: "some-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -717,7 +717,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.Qualitygates.Select(&sonar.QualitygatesSelectOptions{
+				resp, err := client.Qualitygates.Assign(&sonar.QualitygatesAssignOptions{
 					GateName: "some-gate",
 				})
 				Expect(err).To(HaveOccurred())
@@ -726,7 +726,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		})
 	})
 
-	Describe("Deselect", func() {
+	Describe("Unassign", func() {
 		It("should remove project association from quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-desel")
 			projectKey := helpers.UniqueResourceName("proj-qgde")
@@ -737,7 +737,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -757,14 +757,14 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			// Associate first
-			_, err = client.Qualitygates.Select(&sonar.QualitygatesSelectOptions{
+			_, err = client.Qualitygates.Assign(&sonar.QualitygatesAssignOptions{
 				GateName:   gateName,
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Deselect
-			resp, err := client.Qualitygates.Deselect(&sonar.QualitygatesDeselectOptions{
+			resp, err := client.Qualitygates.Unassign(&sonar.QualitygatesUnassignOptions{
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -780,13 +780,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.Deselect(nil)
+				resp, err := client.Qualitygates.Unassign(nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.Qualitygates.Deselect(&sonar.QualitygatesDeselectOptions{})
+				resp, err := client.Qualitygates.Unassign(&sonar.QualitygatesUnassignOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -865,7 +865,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -890,7 +890,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -910,7 +910,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			// Associate project with gate
-			_, err = client.Qualitygates.Select(&sonar.QualitygatesSelectOptions{
+			_, err = client.Qualitygates.Assign(&sonar.QualitygatesAssignOptions{
 				GateName:   gateName,
 				ProjectKey: projectKey,
 			})
@@ -957,7 +957,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -1021,7 +1021,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -1063,7 +1063,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -1133,7 +1133,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -1182,7 +1182,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -1224,7 +1224,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -1287,7 +1287,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(createResult.Name).To(Equal(gateName))
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Destroy(&sonar.QualitygatesDestroyOptions{
+				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -1333,7 +1333,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 				return err
 			})
 
-			_, err = client.Qualitygates.Select(&sonar.QualitygatesSelectOptions{
+			_, err = client.Qualitygates.Assign(&sonar.QualitygatesAssignOptions{
 				GateName:   gateName,
 				ProjectKey: projectKey,
 			})
@@ -1345,7 +1345,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(projectStatusResult).NotTo(BeNil())
-			Expect(projectStatusResult.ProjectStatus).NotTo(BeNil())
+			Expect(projectStatusResult.QualityGateProjectStatus).NotTo(BeNil())
 
 			// Step 6: Add user permission
 			_, err = client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOptions{
@@ -1370,7 +1370,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 9: Deselect project
-			_, err = client.Qualitygates.Deselect(&sonar.QualitygatesDeselectOptions{
+			_, err = client.Qualitygates.Unassign(&sonar.QualitygatesUnassignOptions{
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/qualitygates_test.go
+++ b/integration_testing/qualitygates_test.go
@@ -1345,7 +1345,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(projectStatusResult).NotTo(BeNil())
-			Expect(projectStatusResult.QualityGateProjectStatus).NotTo(BeNil())
+			Expect(projectStatusResult.ProjectStatus).NotTo(BeNil())
 
 			// Step 6: Add user permission
 			_, err = client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOptions{

--- a/integration_testing/rules_test.go
+++ b/integration_testing/rules_test.go
@@ -422,7 +422,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 	// Create, Update, Delete (Custom Rule Lifecycle)
 	// =========================================================================
 	Describe("Custom Rule Lifecycle", func() {
-		var templateRule sonar.RuleDetails
+		var templateRule sonar.RulesDetails
 
 		BeforeAll(func() {
 			// Find a template rule to use for creating custom rules

--- a/integration_testing/v2_authorizations_test.go
+++ b/integration_testing/v2_authorizations_test.go
@@ -152,7 +152,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 		})
 	})
 
-	Describe("FetchGroup", func() {
+	Describe("GetGroup", func() {
 		var createdGroup *sonar.AuthorizationsGroup
 
 		BeforeAll(func() {
@@ -174,7 +174,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 
 		Context("with valid group ID", func() {
 			It("should fetch the group by ID", func() {
-				fetched, resp, err := client.V2.Authorizations.FetchGroup(createdGroup.Id)
+				fetched, resp, err := client.V2.Authorizations.GetGroup(createdGroup.Id)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(fetched).NotTo(BeNil())
@@ -186,7 +186,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with empty group ID", func() {
-				group, resp, err := client.V2.Authorizations.FetchGroup("")
+				group, resp, err := client.V2.Authorizations.GetGroup("")
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(group).To(BeNil())

--- a/integration_testing/v2_authorizations_test.go
+++ b/integration_testing/v2_authorizations_test.go
@@ -153,7 +153,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 	})
 
 	Describe("FetchGroup", func() {
-		var createdGroup *sonar.Group
+		var createdGroup *sonar.AuthorizationsGroup
 
 		BeforeAll(func() {
 			groupName := helpers.UniqueResourceName("v2gfetch")
@@ -195,7 +195,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 	})
 
 	Describe("UpdateGroup", func() {
-		var createdGroup *sonar.Group
+		var createdGroup *sonar.AuthorizationsGroup
 
 		BeforeAll(func() {
 			groupName := helpers.UniqueResourceName("v2gupd")
@@ -326,7 +326,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 
 	Describe("CreateGroupMembership", func() {
 		var (
-			createdGroup *sonar.Group
+			createdGroup *sonar.AuthorizationsGroup
 			createdUser  *sonar.UserV2
 		)
 

--- a/integration_testing/v2_clean_code_policy_test.go
+++ b/integration_testing/v2_clean_code_policy_test.go
@@ -48,7 +48,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					TemplateKey:         "java:S100",
 					Name:                "Test Rule",
 					MarkdownDescription: "Test description",
-					Impacts:             []sonar.RuleImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
+					Impacts:             []sonar.RulesImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
@@ -60,7 +60,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					Key:                 "custom:test_rule",
 					Name:                "Test Rule",
 					MarkdownDescription: "Test description",
-					Impacts:             []sonar.RuleImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
+					Impacts:             []sonar.RulesImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
@@ -72,7 +72,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					Key:                 "custom:test_rule",
 					TemplateKey:         "java:S100",
 					MarkdownDescription: "Test description",
-					Impacts:             []sonar.RuleImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
+					Impacts:             []sonar.RulesImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
@@ -84,7 +84,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					Key:         "custom:test_rule",
 					TemplateKey: "java:S100",
 					Name:        "Test Rule",
-					Impacts:     []sonar.RuleImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
+					Impacts:     []sonar.RulesImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
@@ -97,7 +97,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					TemplateKey:         "java:S100",
 					Name:                "Test Rule",
 					MarkdownDescription: "Test description",
-					Impacts:             []sonar.RuleImpact{},
+					Impacts:             []sonar.RulesImpact{},
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
@@ -110,7 +110,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					TemplateKey:         "java:S100",
 					Name:                "Test Rule",
 					MarkdownDescription: "Test description",
-					Impacts:             []sonar.RuleImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
+					Impacts:             []sonar.RulesImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
 					CleanCodeAttribute:  "INVALID",
 				})
 				Expect(err).To(HaveOccurred())
@@ -124,7 +124,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					TemplateKey:         "java:S100",
 					Name:                "Test Rule",
 					MarkdownDescription: "Test description",
-					Impacts:             []sonar.RuleImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: "INVALID"}},
+					Impacts:             []sonar.RulesImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: "INVALID"}},
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
@@ -133,7 +133,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 		})
 
 		Context("successful creation", func() {
-			var templateRule sonar.RuleDetails
+			var templateRule sonar.RulesDetails
 
 			BeforeAll(func() {
 				// Find a template rule to use for creating custom rules.
@@ -158,7 +158,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 					TemplateKey:         templateRule.Key,
 					Name:                "E2E V2 Test Rule " + customKey,
 					MarkdownDescription: "This is a test rule created by V2 e2e tests",
-					Impacts:             []sonar.RuleImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
+					Impacts:             []sonar.RulesImpact{{SoftwareQuality: sonar.SoftwareQualityMaintainability, Severity: sonar.RuleImpactSeverityHigh}},
 					Status:              sonar.RuleStatusReady,
 					CleanCodeAttribute:  sonar.CleanCodeAttributeConventional,
 				})

--- a/integration_testing/v2_dop_translation_test.go
+++ b/integration_testing/v2_dop_translation_test.go
@@ -33,11 +33,11 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 	})
 
 	// =========================================================================
-	// FetchAllDopSettings
+	// GetDopSettings
 	// =========================================================================
-	Describe("FetchAllDopSettings", func() {
+	Describe("GetDopSettings", func() {
 		It("should return DevOps Platform settings", func() {
-			result, resp, err := client.V2.DopTranslation.FetchAllDopSettings()
+			result, resp, err := client.V2.DopTranslation.GetDopSettings()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -99,7 +99,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				settings, _, err := client.V2.DopTranslation.FetchAllDopSettings()
+				settings, _, err := client.V2.DopTranslation.GetDopSettings()
 				Expect(err).NotTo(HaveOccurred())
 
 				if len(settings.DopSettings) == 0 {
@@ -169,7 +169,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				settings, _, err := client.V2.DopTranslation.FetchAllDopSettings()
+				settings, _, err := client.V2.DopTranslation.GetDopSettings()
 				Expect(err).NotTo(HaveOccurred())
 
 				if len(settings.DopSettings) == 0 {

--- a/integration_testing/v2_users_test.go
+++ b/integration_testing/v2_users_test.go
@@ -195,7 +195,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 	// =========================================================================
 	// Fetch
 	// =========================================================================
-	Describe("Fetch", func() {
+	Describe("Get", func() {
 		var createdUser *sonar.UserV2
 
 		BeforeAll(func() {
@@ -221,7 +221,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 
 		Context("with valid user ID", func() {
 			It("should fetch the user by ID", func() {
-				fetched, resp, err := client.V2.UsersManagement.Fetch(createdUser.Id)
+				fetched, resp, err := client.V2.UsersManagement.Get(createdUser.Id)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(fetched).NotTo(BeNil())
@@ -234,7 +234,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with empty user ID", func() {
-				user, resp, err := client.V2.UsersManagement.Fetch("")
+				user, resp, err := client.V2.UsersManagement.Get("")
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(user).To(BeNil())
@@ -353,7 +353,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 				Expect(resp).NotTo(BeNil())
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
-				fetched, resp, err := client.V2.UsersManagement.Fetch(created.Id)
+				fetched, resp, err := client.V2.UsersManagement.Get(created.Id)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(fetched).NotTo(BeNil())

--- a/internal/cli/descriptions.go
+++ b/internal/cli/descriptions.go
@@ -59,7 +59,7 @@ var serviceDescriptions = map[string]string{ //nolint:gosec // G101 false positi
 var methodDescriptions = map[string]string{ //nolint:gosec // G101 false positive: these are API descriptions, not credentials
 	// AlmIntegrations
 	"AlmIntegrations.CheckPat":                     "Checks validity of a Personal Access Token",
-	"AlmIntegrations.GetGithubClientId":            "Gets the client ID of a GitHub integration",
+	"AlmIntegrations.GetGithubClientID":            "Gets the client ID of a GitHub integration",
 	"AlmIntegrations.ImportAzureProject":           "Creates a project from an Azure DevOps project",
 	"AlmIntegrations.ImportBitbucketCloudRepo":     "Creates a project from a Bitbucket Cloud repo",
 	"AlmIntegrations.ImportBitbucketServerProject": "Creates a project from a Bitbucket Server project",
@@ -98,7 +98,7 @@ var methodDescriptions = map[string]string{ //nolint:gosec // G101 false positiv
 	"AnalysisCache.Get":   "Gets scanner cached data for a project",
 
 	// AnalysisReports
-	"AnalysisReports.IsQueueEmpty": "Checks if the CE queue is empty",
+	"AnalysisReports.QueueStatus": "Checks if the CE queue is empty",
 
 	// Authentication
 	"Authentication.Login":    "Authenticates a user with credentials",
@@ -106,9 +106,9 @@ var methodDescriptions = map[string]string{ //nolint:gosec // G101 false positiv
 	"Authentication.Validate": "Checks if current credentials are valid",
 
 	// Batch
-	"Batch.File":    "Downloads a JAR file from the batch index",
-	"Batch.Index":   "Lists JAR files for scanners",
-	"Batch.Project": "Returns project repository info",
+	"Batch.GetFile":    "Downloads a JAR file from the batch index",
+	"Batch.GetIndex":   "Lists JAR files for scanners",
+	"Batch.GetProject": "Returns project repository info",
 
 	// Ce
 	"Ce.Activity":               "Searches CE activity history",
@@ -192,7 +192,7 @@ var methodDescriptions = map[string]string{ //nolint:gosec // G101 false positiv
 	"Issues.Tags":                   "Lists rule tags",
 
 	// L10N
-	"L10N.Index": "Returns localized messages",
+	"L10N.GetIndex": "Returns localized messages",
 
 	// Languages
 	"Languages.List": "Lists supported languages",
@@ -316,8 +316,8 @@ var methodDescriptions = map[string]string{ //nolint:gosec // G101 false positiv
 	"Qualitygates.Create":          "Creates a new quality gate",
 	"Qualitygates.CreateCondition": "Adds a condition to a quality gate",
 	"Qualitygates.DeleteCondition": "Deletes a quality gate condition",
-	"Qualitygates.Deselect":        "Removes quality gate from a project",
-	"Qualitygates.Destroy":         "Deletes a quality gate",
+	"Qualitygates.Unassign":        "Removes quality gate from a project",
+	"Qualitygates.Delete":          "Deletes a quality gate",
 	"Qualitygates.GetByProject":    "Gets a project's quality gate",
 	"Qualitygates.List":            "Lists all quality gates",
 	"Qualitygates.ProjectStatus":   "Gets quality gate status of a project",
@@ -327,8 +327,8 @@ var methodDescriptions = map[string]string{ //nolint:gosec // G101 false positiv
 	"Qualitygates.Search":          "Searches quality gate projects",
 	"Qualitygates.SearchGroups":    "Searches quality gate groups",
 	"Qualitygates.SearchUsers":     "Searches quality gate users",
-	"Qualitygates.Select":          "Associates project with a quality gate",
-	"Qualitygates.SetAsDefault":    "Sets a default quality gate",
+	"Qualitygates.Assign":          "Associates project with a quality gate",
+	"Qualitygates.SetDefault":      "Sets a default quality gate",
 	"Qualitygates.Show":            "Shows quality gate details",
 	"Qualitygates.UpdateCondition": "Updates a quality gate condition",
 

--- a/sonar/alm_integrations_service.go
+++ b/sonar/alm_integrations_service.go
@@ -48,8 +48,8 @@ type AlmIntegrationsService struct {
 // Note: The API does not return a response body, validation is indicated by HTTP status.
 type AlmIntegrationsCheckPat struct{}
 
-// AlmIntegrationsGetGithubClientId represents the response from getting a GitHub client ID.
-type AlmIntegrationsGetGithubClientId struct {
+// AlmIntegrationsGetGithubClientID represents the response from getting a GitHub client ID.
+type AlmIntegrationsGetGithubClientID struct {
 	// ClientID is the GitHub OAuth client ID for the integration.
 	ClientID string `json:"clientId,omitempty"`
 }
@@ -237,8 +237,8 @@ type AlmIntegrationsCheckPatOptions struct {
 	AlmSetting string `url:"almSetting,omitempty"`
 }
 
-// AlmIntegrationsGetGithubClientIdOptions contains options for getting a GitHub client ID.
-type AlmIntegrationsGetGithubClientIdOptions struct {
+// AlmIntegrationsGetGithubClientIDOptions contains options for getting a GitHub client ID.
+type AlmIntegrationsGetGithubClientIDOptions struct {
 	// AlmSetting is the DevOps Platform setting key (required).
 	// Maximum length: 200 characters
 	AlmSetting string `url:"almSetting,omitempty"`
@@ -502,10 +502,10 @@ func (s *AlmIntegrationsService) CheckPat(opt *AlmIntegrationsCheckPatOptions) (
 	return
 }
 
-// GetGithubClientId gets the client ID of a GitHub Integration.
+// GetGithubClientID gets the client ID of a GitHub Integration.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) GetGithubClientId(opt *AlmIntegrationsGetGithubClientIdOptions) (v *AlmIntegrationsGetGithubClientId, resp *http.Response, err error) {
-	err = s.ValidateGetGithubClientIdOpt(opt)
+func (s *AlmIntegrationsService) GetGithubClientID(opt *AlmIntegrationsGetGithubClientIDOptions) (v *AlmIntegrationsGetGithubClientID, resp *http.Response, err error) {
+	err = s.ValidateGetGithubClientIDOpt(opt)
 	if err != nil {
 		return
 	}
@@ -515,7 +515,7 @@ func (s *AlmIntegrationsService) GetGithubClientId(opt *AlmIntegrationsGetGithub
 		return
 	}
 
-	v = new(AlmIntegrationsGetGithubClientId)
+	v = new(AlmIntegrationsGetGithubClientID)
 
 	resp, err = s.client.Do(req, v)
 	if err != nil {
@@ -873,10 +873,10 @@ func (s *AlmIntegrationsService) ValidateCheckPatOpt(opt *AlmIntegrationsCheckPa
 	return nil
 }
 
-// ValidateGetGithubClientIdOpt validates the options for getting a GitHub client ID.
-func (s *AlmIntegrationsService) ValidateGetGithubClientIdOpt(opt *AlmIntegrationsGetGithubClientIdOptions) error {
+// ValidateGetGithubClientIDOpt validates the options for getting a GitHub client ID.
+func (s *AlmIntegrationsService) ValidateGetGithubClientIDOpt(opt *AlmIntegrationsGetGithubClientIDOptions) error {
 	if opt == nil {
-		return NewValidationError("AlmIntegrationsGetGithubClientIdOption", "cannot be nil", ErrMissingRequired)
+		return NewValidationError("AlmIntegrationsGetGithubClientIDOption", "cannot be nil", ErrMissingRequired)
 	}
 
 	err := ValidateRequired(opt.AlmSetting, "AlmSetting")

--- a/sonar/alm_integrations_service_test.go
+++ b/sonar/alm_integrations_service_test.go
@@ -46,34 +46,34 @@ func TestAlmIntegrations_CheckPat_ValidationError(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
-// GetGithubClientId Tests
+// GetGithubClientID Tests
 // -----------------------------------------------------------------------------
 
-func TestAlmIntegrations_GetGithubClientId(t *testing.T) {
+func TestAlmIntegrations_GetGithubClientID(t *testing.T) {
 	handler := mockHandler(t, http.MethodGet, "/alm_integrations/get_github_client_id", http.StatusOK, `{"clientId":"my-client-id"}`)
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	opt := &AlmIntegrationsGetGithubClientIdOptions{
+	opt := &AlmIntegrationsGetGithubClientIDOptions{
 		AlmSetting: "my-github-setting",
 	}
 
-	result, resp, err := client.AlmIntegrations.GetGithubClientId(opt)
+	result, resp, err := client.AlmIntegrations.GetGithubClientID(opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotNil(t, result)
 	assert.Equal(t, "my-client-id", result.ClientID)
 }
 
-func TestAlmIntegrations_GetGithubClientId_ValidationError(t *testing.T) {
+func TestAlmIntegrations_GetGithubClientID_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.AlmIntegrations.GetGithubClientId(nil)
+	_, _, err := client.AlmIntegrations.GetGithubClientID(nil)
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.GetGithubClientId(&AlmIntegrationsGetGithubClientIdOptions{})
+	_, _, err = client.AlmIntegrations.GetGithubClientID(&AlmIntegrationsGetGithubClientIDOptions{})
 	assert.Error(t, err)
 }
 

--- a/sonar/analysis_reports_service.go
+++ b/sonar/analysis_reports_service.go
@@ -24,12 +24,12 @@ type AnalysisReportsQueueStatus struct {
 // Service Methods
 // -----------------------------------------------------------------------------
 
-// IsQueueEmpty checks if the queue of Compute Engine is empty.
-// Returns true if the queue is empty, false otherwise.
+// QueueStatus checks if the queue of Compute Engine is empty.
+// Returns an AnalysisReportsQueueStatus indicating whether the queue is empty.
 //
 // API endpoint: GET /api/analysis_reports/is_queue_empty.
 // WARNING: this is an internal API and may change without notice.
-func (s *AnalysisReportsService) IsQueueEmpty() (*AnalysisReportsQueueStatus, *http.Response, error) {
+func (s *AnalysisReportsService) QueueStatus() (*AnalysisReportsQueueStatus, *http.Response, error) {
 	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "analysis_reports/is_queue_empty", nil)
 	if err != nil {
 		return nil, nil, err

--- a/sonar/analysis_reports_service_test.go
+++ b/sonar/analysis_reports_service_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAnalysisReports_IsQueueEmpty(t *testing.T) {
+func TestAnalysisReports_QueueStatus(t *testing.T) {
 	tests := []struct {
 		name           string
 		serverResponse string
@@ -24,7 +24,7 @@ func TestAnalysisReports_IsQueueEmpty(t *testing.T) {
 			server := newTestServer(t, handler)
 			client := newTestClient(t, server.url())
 
-			result, resp, err := client.AnalysisReports.IsQueueEmpty()
+			result, resp, err := client.AnalysisReports.QueueStatus()
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			require.NotNil(t, result)

--- a/sonar/authorizations_v2_service.go
+++ b/sonar/authorizations_v2_service.go
@@ -16,10 +16,10 @@ type AuthorizationsService struct {
 // Shared Types
 // -----------------------------------------------------------------------------
 
-// Group represents a group returned by V2 API endpoints.
+// AuthorizationsGroup represents a group returned by V2 API endpoints.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type Group struct {
+type AuthorizationsGroup struct {
 	// Default indicates whether this is a default group.
 	Default bool `json:"default,omitempty"`
 	// Description is the group description.
@@ -32,8 +32,8 @@ type Group struct {
 	Name string `json:"name,omitempty"`
 }
 
-// GroupMembership represents a group membership returned by V2 API endpoints.
-type GroupMembership struct {
+// AuthorizationsGroupMembership represents a group membership returned by V2 API endpoints.
+type AuthorizationsGroupMembership struct {
 	// GroupId is the group's unique identifier.
 	GroupId string `json:"groupId,omitempty"`
 	// Id is the membership's unique identifier.
@@ -49,7 +49,7 @@ type GroupMembership struct {
 // AuthorizationsGroupsSearch represents the response from searching groups.
 type AuthorizationsGroupsSearch struct {
 	// Groups is the list of groups.
-	Groups []Group `json:"groups,omitempty"`
+	Groups []AuthorizationsGroup `json:"groups,omitempty"`
 	// Page contains pagination information.
 	Page PageResponseV2 `json:"page,omitzero"`
 }
@@ -57,7 +57,7 @@ type AuthorizationsGroupsSearch struct {
 // AuthorizationsGroupMembershipsSearch represents the response from searching group memberships.
 type AuthorizationsGroupMembershipsSearch struct {
 	// GroupMemberships is the list of group memberships.
-	GroupMemberships []GroupMembership `json:"groupMemberships,omitempty"`
+	GroupMemberships []AuthorizationsGroupMembership `json:"groupMemberships,omitempty"`
 	// Page contains pagination information.
 	Page PageResponseV2 `json:"page,omitzero"`
 }
@@ -248,7 +248,7 @@ func (s *AuthorizationsService) SearchGroups(opt *AuthorizationsSearchGroupsOpti
 }
 
 // CreateGroup creates a new group.
-func (s *AuthorizationsService) CreateGroup(opt *AuthorizationsCreateGroupOptions) (*Group, *http.Response, error) {
+func (s *AuthorizationsService) CreateGroup(opt *AuthorizationsCreateGroupOptions) (*AuthorizationsGroup, *http.Response, error) {
 	err := s.ValidateCreateGroupRequest(opt)
 	if err != nil {
 		return nil, nil, err
@@ -259,7 +259,7 @@ func (s *AuthorizationsService) CreateGroup(opt *AuthorizationsCreateGroupOption
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	result := new(Group)
+	result := new(AuthorizationsGroup)
 
 	resp, err := s.client.Do(req, result)
 	if err != nil {
@@ -270,7 +270,7 @@ func (s *AuthorizationsService) CreateGroup(opt *AuthorizationsCreateGroupOption
 }
 
 // FetchGroup retrieves a single group by ID.
-func (s *AuthorizationsService) FetchGroup(groupID string) (*Group, *http.Response, error) {
+func (s *AuthorizationsService) FetchGroup(groupID string) (*AuthorizationsGroup, *http.Response, error) {
 	err := ValidateRequired(groupID, "Id")
 	if err != nil {
 		return nil, nil, err
@@ -281,7 +281,7 @@ func (s *AuthorizationsService) FetchGroup(groupID string) (*Group, *http.Respon
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	result := new(Group)
+	result := new(AuthorizationsGroup)
 
 	resp, err := s.client.Do(req, result)
 	if err != nil {
@@ -312,7 +312,7 @@ func (s *AuthorizationsService) DeleteGroup(groupID string) (*http.Response, err
 }
 
 // UpdateGroup updates a group's name or description.
-func (s *AuthorizationsService) UpdateGroup(groupID string, opt *AuthorizationsUpdateGroupOptions) (*Group, *http.Response, error) {
+func (s *AuthorizationsService) UpdateGroup(groupID string, opt *AuthorizationsUpdateGroupOptions) (*AuthorizationsGroup, *http.Response, error) {
 	err := s.ValidateUpdateGroupRequest(groupID, opt)
 	if err != nil {
 		return nil, nil, err
@@ -323,7 +323,7 @@ func (s *AuthorizationsService) UpdateGroup(groupID string, opt *AuthorizationsU
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	result := new(Group)
+	result := new(AuthorizationsGroup)
 
 	resp, err := s.client.Do(req, result)
 	if err != nil {
@@ -356,7 +356,7 @@ func (s *AuthorizationsService) SearchGroupMemberships(opt *AuthorizationsSearch
 }
 
 // CreateGroupMembership adds a user to a group.
-func (s *AuthorizationsService) CreateGroupMembership(opt *AuthorizationsCreateGroupMembershipOptions) (*GroupMembership, *http.Response, error) {
+func (s *AuthorizationsService) CreateGroupMembership(opt *AuthorizationsCreateGroupMembershipOptions) (*AuthorizationsGroupMembership, *http.Response, error) {
 	err := s.ValidateCreateGroupMembershipRequest(opt)
 	if err != nil {
 		return nil, nil, err
@@ -367,7 +367,7 @@ func (s *AuthorizationsService) CreateGroupMembership(opt *AuthorizationsCreateG
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	result := new(GroupMembership)
+	result := new(AuthorizationsGroupMembership)
 
 	resp, err := s.client.Do(req, result)
 	if err != nil {

--- a/sonar/authorizations_v2_service.go
+++ b/sonar/authorizations_v2_service.go
@@ -269,8 +269,8 @@ func (s *AuthorizationsService) CreateGroup(opt *AuthorizationsCreateGroupOption
 	return result, resp, nil
 }
 
-// FetchGroup retrieves a single group by ID.
-func (s *AuthorizationsService) FetchGroup(groupID string) (*AuthorizationsGroup, *http.Response, error) {
+// GetGroup retrieves a single group by ID.
+func (s *AuthorizationsService) GetGroup(groupID string) (*AuthorizationsGroup, *http.Response, error) {
 	err := ValidateRequired(groupID, "Id")
 	if err != nil {
 		return nil, nil, err

--- a/sonar/authorizations_v2_service_test.go
+++ b/sonar/authorizations_v2_service_test.go
@@ -120,10 +120,10 @@ func TestAuthorizationsV2_CreateGroup_Validation(t *testing.T) {
 }
 
 // =============================================================================
-// FetchGroup
+// GetGroup
 // =============================================================================
 
-func TestAuthorizationsV2_FetchGroup(t *testing.T) {
+func TestAuthorizationsV2_GetGroup(t *testing.T) {
 	response := AuthorizationsGroup{
 		Id:   "g1",
 		Name: "admins",
@@ -131,16 +131,16 @@ func TestAuthorizationsV2_FetchGroup(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/authorizations/groups/g1", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Authorizations.FetchGroup("g1")
+	result, resp, err := client.V2.Authorizations.GetGroup("g1")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "admins", result.Name)
 }
 
-func TestAuthorizationsV2_FetchGroup_Validation(t *testing.T) {
+func TestAuthorizationsV2_GetGroup_Validation(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.V2.Authorizations.FetchGroup("")
+	_, _, err := client.V2.Authorizations.GetGroup("")
 	assert.Error(t, err)
 }
 

--- a/sonar/authorizations_v2_service_test.go
+++ b/sonar/authorizations_v2_service_test.go
@@ -19,7 +19,7 @@ func stringPtr(v string) *string {
 
 func TestAuthorizationsV2_SearchGroups(t *testing.T) {
 	response := AuthorizationsGroupsSearch{
-		Groups: []Group{
+		Groups: []AuthorizationsGroup{
 			{Id: "g1", Name: "admins", Description: "Administrator group", Managed: false},
 			{Id: "g2", Name: "members", Default: true},
 		},
@@ -38,7 +38,7 @@ func TestAuthorizationsV2_SearchGroups(t *testing.T) {
 func TestAuthorizationsV2_SearchGroups_WithOptions(t *testing.T) {
 	managed := true
 	response := AuthorizationsGroupsSearch{
-		Groups: []Group{{Id: "g1", Name: "admins", Managed: true}},
+		Groups: []AuthorizationsGroup{{Id: "g1", Name: "admins", Managed: true}},
 		Page:   PageResponseV2{PageIndex: 2, PageSize: 10, Total: 1},
 	}
 	server := newTestServer(t, mockHandlerWithParams(t, http.MethodGet, "/v2/authorizations/groups", http.StatusOK,
@@ -77,7 +77,7 @@ func TestAuthorizationsV2_SearchGroups_Validation(t *testing.T) {
 // =============================================================================
 
 func TestAuthorizationsV2_CreateGroup(t *testing.T) {
-	response := Group{
+	response := AuthorizationsGroup{
 		Id:          "g-new",
 		Name:        "new-group",
 		Description: "A new group",
@@ -124,7 +124,7 @@ func TestAuthorizationsV2_CreateGroup_Validation(t *testing.T) {
 // =============================================================================
 
 func TestAuthorizationsV2_FetchGroup(t *testing.T) {
-	response := Group{
+	response := AuthorizationsGroup{
 		Id:   "g1",
 		Name: "admins",
 	}
@@ -169,7 +169,7 @@ func TestAuthorizationsV2_DeleteGroup_Validation(t *testing.T) {
 // =============================================================================
 
 func TestAuthorizationsV2_UpdateGroup(t *testing.T) {
-	response := Group{
+	response := AuthorizationsGroup{
 		Id:          "g1",
 		Name:        "renamed-group",
 		Description: "Updated description",
@@ -218,7 +218,7 @@ func TestAuthorizationsV2_UpdateGroup_Validation(t *testing.T) {
 
 func TestAuthorizationsV2_SearchGroupMemberships(t *testing.T) {
 	response := AuthorizationsGroupMembershipsSearch{
-		GroupMemberships: []GroupMembership{
+		GroupMemberships: []AuthorizationsGroupMembership{
 			{Id: "m1", GroupId: "g1", UserId: "u1"},
 		},
 		Page: PageResponseV2{PageIndex: 1, PageSize: 50, Total: 1},
@@ -235,7 +235,7 @@ func TestAuthorizationsV2_SearchGroupMemberships(t *testing.T) {
 
 func TestAuthorizationsV2_SearchGroupMemberships_WithOptions(t *testing.T) {
 	response := AuthorizationsGroupMembershipsSearch{
-		GroupMemberships: []GroupMembership{{Id: "m1", GroupId: "g1", UserId: "u1"}},
+		GroupMemberships: []AuthorizationsGroupMembership{{Id: "m1", GroupId: "g1", UserId: "u1"}},
 		Page:             PageResponseV2{PageIndex: 2, PageSize: 10, Total: 1},
 	}
 	server := newTestServer(t, mockHandlerWithParams(t, http.MethodGet, "/v2/authorizations/group-memberships", http.StatusOK,
@@ -272,7 +272,7 @@ func TestAuthorizationsV2_SearchGroupMemberships_Validation(t *testing.T) {
 // =============================================================================
 
 func TestAuthorizationsV2_CreateGroupMembership(t *testing.T) {
-	response := GroupMembership{
+	response := AuthorizationsGroupMembership{
 		Id:      "m-new",
 		GroupId: "g1",
 		UserId:  "u1",

--- a/sonar/batch_service.go
+++ b/sonar/batch_service.go
@@ -36,8 +36,8 @@ type BatchFileData struct {
 	Revision string `json:"revision,omitempty"`
 }
 
-// ValidateFileOpt validates the options for the File endpoint.
-func (s *BatchService) ValidateFileOpt(opt *BatchFileOptions) error {
+// ValidateGetFileOpt validates the options for the GetFile endpoint.
+func (s *BatchService) ValidateGetFileOpt(opt *BatchFileOptions) error {
 	if opt == nil {
 		return nil
 	}
@@ -45,8 +45,8 @@ func (s *BatchService) ValidateFileOpt(opt *BatchFileOptions) error {
 	return nil
 }
 
-// ValidateProjectOpt validates the options for the Project endpoint.
-func (s *BatchService) ValidateProjectOpt(opt *BatchProjectOptions) error {
+// ValidateGetProjectOpt validates the options for the GetProject endpoint.
+func (s *BatchService) ValidateGetProjectOpt(opt *BatchProjectOptions) error {
 	if opt == nil {
 		return nil
 	}
@@ -54,10 +54,10 @@ func (s *BatchService) ValidateProjectOpt(opt *BatchProjectOptions) error {
 	return ValidateRequired(opt.Key, "Key")
 }
 
-// File downloads a JAR file listed in the index (see batch/index).
+// GetFile downloads a JAR file listed in the index (see batch/index).
 // This endpoint returns binary data for the requested JAR file.
-func (s *BatchService) File(opt *BatchFileOptions) (v []byte, resp *http.Response, err error) {
-	err = s.ValidateFileOpt(opt)
+func (s *BatchService) GetFile(opt *BatchFileOptions) (v []byte, resp *http.Response, err error) {
+	err = s.ValidateGetFileOpt(opt)
 	if err != nil {
 		return
 	}
@@ -79,9 +79,9 @@ func (s *BatchService) File(opt *BatchFileOptions) (v []byte, resp *http.Respons
 	return
 }
 
-// Index lists the JAR files to be downloaded by scanners.
+// GetIndex lists the JAR files to be downloaded by scanners.
 // Returns a list of JAR file names and their hashes.
-func (s *BatchService) Index() (v *string, resp *http.Response, err error) {
+func (s *BatchService) GetIndex() (v *string, resp *http.Response, err error) {
 	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "batch/index", nil)
 	if err != nil {
 		return
@@ -97,10 +97,10 @@ func (s *BatchService) Index() (v *string, resp *http.Response, err error) {
 	return
 }
 
-// Project returns project repository information including file hashes
+// GetProject returns project repository information including file hashes
 // for incremental analysis.
-func (s *BatchService) Project(opt *BatchProjectOptions) (v *BatchProject, resp *http.Response, err error) {
-	err = s.ValidateProjectOpt(opt)
+func (s *BatchService) GetProject(opt *BatchProjectOptions) (v *BatchProject, resp *http.Response, err error) {
+	err = s.ValidateGetProjectOpt(opt)
 	if err != nil {
 		return
 	}

--- a/sonar/batch_service_test.go
+++ b/sonar/batch_service_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBatchService_File(t *testing.T) {
+func TestBatchService_GetFile(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		handler := mockBinaryHandler(t, http.MethodGet, "/batch/file", http.StatusOK, "application/java-archive", []byte("jar-binary-content"))
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Batch.File(&BatchFileOptions{
+		result, resp, err := client.Batch.GetFile(&BatchFileOptions{
 			Name: "batch-library-2.3.jar",
 		})
 
@@ -28,7 +28,7 @@ func TestBatchService_File(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Batch.File(nil)
+		_, _, err := client.Batch.GetFile(nil)
 
 		require.NoError(t, err)
 	})
@@ -38,19 +38,19 @@ func TestBatchService_File(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Batch.File(&BatchFileOptions{})
+		_, _, err := client.Batch.GetFile(&BatchFileOptions{})
 
 		require.NoError(t, err)
 	})
 }
 
-func TestBatchService_Index(t *testing.T) {
+func TestBatchService_GetIndex(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		handler := mockBinaryHandler(t, http.MethodGet, "/batch/index", http.StatusOK, "text/plain", []byte("batch-library-2.3.jar|abc123def456\nscanner-engine-9.0.jar|789xyz"))
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Batch.Index()
+		result, resp, err := client.Batch.GetIndex()
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -58,7 +58,7 @@ func TestBatchService_Index(t *testing.T) {
 	})
 }
 
-func TestBatchService_Project(t *testing.T) {
+func TestBatchService_GetProject(t *testing.T) {
 	projectJSON := `{
 		"fileDataByModuleAndPath": {
 			"my-project": {
@@ -77,7 +77,7 @@ func TestBatchService_Project(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Batch.Project(&BatchProjectOptions{
+		result, resp, err := client.Batch.GetProject(&BatchProjectOptions{
 			Key: "my-project",
 		})
 
@@ -92,7 +92,7 @@ func TestBatchService_Project(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Batch.Project(&BatchProjectOptions{
+		_, _, err := client.Batch.GetProject(&BatchProjectOptions{
 			Key:    "my-project",
 			Branch: "feature/my-branch",
 		})
@@ -105,7 +105,7 @@ func TestBatchService_Project(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Batch.Project(&BatchProjectOptions{
+		_, _, err := client.Batch.GetProject(&BatchProjectOptions{
 			Key:         "my-project",
 			PullRequest: "5461",
 		})
@@ -118,13 +118,13 @@ func TestBatchService_Project(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Batch.Project(nil)
+		_, _, err := client.Batch.GetProject(nil)
 
 		require.NoError(t, err)
 	})
 }
 
-func TestBatchService_ValidateFileOpt(t *testing.T) {
+func TestBatchService_ValidateGetFileOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	tests := []struct {
@@ -139,7 +139,7 @@ func TestBatchService_ValidateFileOpt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := client.Batch.ValidateFileOpt(tt.opt)
+			err := client.Batch.ValidateGetFileOpt(tt.opt)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -149,7 +149,7 @@ func TestBatchService_ValidateFileOpt(t *testing.T) {
 	}
 }
 
-func TestBatchService_ValidateProjectOpt(t *testing.T) {
+func TestBatchService_ValidateGetProjectOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	tests := []struct {
@@ -166,7 +166,7 @@ func TestBatchService_ValidateProjectOpt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := client.Batch.ValidateProjectOpt(tt.opt)
+			err := client.Batch.ValidateGetProjectOpt(tt.opt)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/sonar/ce_service.go
+++ b/sonar/ce_service.go
@@ -160,8 +160,8 @@ type CeQueuedTask struct {
 	Type string `json:"type,omitempty"`
 }
 
-// CePaging represents pagination information for CE queries.
-type CePaging struct {
+// CeTaskPaging represents pagination information for CE queries.
+type CeTaskPaging struct {
 	// PageIndex is the current page index (1-based).
 	PageIndex int64 `json:"pageIndex,omitempty"`
 	// PageSize is the number of items per page.
@@ -170,10 +170,10 @@ type CePaging struct {
 	Total int64 `json:"total,omitempty"`
 }
 
-// AnalysisWarning represents a warning from analysis.
+// CeAnalysisWarning represents a warning from analysis.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type AnalysisWarning struct {
+type CeAnalysisWarning struct {
 	// Dismissable indicates if the warning can be dismissed.
 	Dismissable bool `json:"dismissable,omitempty"`
 	// Key is the unique key of the warning.
@@ -182,14 +182,14 @@ type AnalysisWarning struct {
 	Message string `json:"message,omitempty"`
 }
 
-// AnalysisComponent represents a component with its analysis warnings.
-type AnalysisComponent struct {
+// CeAnalysisComponent represents a component with its analysis warnings.
+type CeAnalysisComponent struct {
 	// Key is the component key.
 	Key string `json:"key,omitempty"`
 	// Name is the component name.
 	Name string `json:"name,omitempty"`
 	// Warnings is the list of analysis warnings.
-	Warnings []AnalysisWarning `json:"warnings,omitempty"`
+	Warnings []CeAnalysisWarning `json:"warnings,omitempty"`
 }
 
 // -----------------------------------------------------------------------------
@@ -201,7 +201,7 @@ type AnalysisComponent struct {
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
 type CeActivity struct {
 	// Paging contains pagination information.
-	Paging CePaging `json:"paging,omitzero"`
+	Paging CeTaskPaging `json:"paging,omitzero"`
 	// Tasks is the list of tasks.
 	Tasks []CeTask `json:"tasks,omitempty"`
 }
@@ -221,7 +221,7 @@ type CeActivityStatus struct {
 // CeAnalysisStatus represents the analysis status of a component.
 type CeAnalysisStatus struct {
 	// Component contains the component information with warnings.
-	Component AnalysisComponent `json:"component,omitzero"`
+	Component CeAnalysisComponent `json:"component,omitzero"`
 }
 
 // CeComponent represents the pending, in-progress, and last executed tasks for a component.

--- a/sonar/clean_code_policy_v2_service.go
+++ b/sonar/clean_code_policy_v2_service.go
@@ -54,7 +54,7 @@ type RuleV2 struct {
 	// Type is the rule type.
 	Type string `json:"type,omitempty"`
 	// Impacts is the list of software quality impacts.
-	Impacts []RuleImpact `json:"impacts,omitempty"`
+	Impacts []RulesImpact `json:"impacts,omitempty"`
 	// CleanCodeAttribute is the clean code attribute for the rule.
 	CleanCodeAttribute string `json:"cleanCodeAttribute,omitempty"`
 	// CleanCodeAttributeCategory is the clean code attribute category.
@@ -66,7 +66,7 @@ type RuleV2 struct {
 	// CreatedAt is the rule creation timestamp.
 	CreatedAt string `json:"createdAt,omitempty"`
 	// DescriptionSections contains the rule description sections.
-	DescriptionSections []RuleDescriptionSection `json:"descriptionSections,omitempty"`
+	DescriptionSections []RulesDescriptionSection `json:"descriptionSections,omitempty"`
 	// MarkdownDescription is the rule description in markdown format.
 	MarkdownDescription string `json:"markdownDescription,omitempty"`
 	// GapDescription is the gap description for the rule.
@@ -122,7 +122,7 @@ type CleanCodePolicyCreateRuleOptions struct {
 	MarkdownDescription string `json:"markdownDescription"`
 	// Impacts is the list of software quality impacts.
 	// This field is required (at least one impact).
-	Impacts []RuleImpact `json:"impacts"`
+	Impacts []RulesImpact `json:"impacts"`
 	// Status is the rule status. Default is "READY".
 	// Valid values: BETA, DEPRECATED, READY, REMOVED.
 	Status string `json:"status,omitempty"`
@@ -149,7 +149,7 @@ type CleanCodePolicyCreateRuleOptions struct {
 // -----------------------------------------------------------------------------
 
 // validateRuleImpacts validates the impacts list in a create rule request.
-func validateRuleImpacts(impacts []RuleImpact) error {
+func validateRuleImpacts(impacts []RulesImpact) error {
 	if len(impacts) == 0 {
 		return NewValidationError("Impacts", "at least one impact is required", ErrMissingRequired)
 	}

--- a/sonar/clean_code_policy_v2_service_test.go
+++ b/sonar/clean_code_policy_v2_service_test.go
@@ -19,7 +19,7 @@ func TestCleanCodePolicyV2_CreateRule(t *testing.T) {
 		TemplateKey:         "java:S100",
 		Name:                "My Custom Rule",
 		MarkdownDescription: "This is a custom rule",
-		Impacts: []RuleImpact{
+		Impacts: []RulesImpact{
 			{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh},
 		},
 		Status:             RuleStatusReady,
@@ -34,7 +34,7 @@ func TestCleanCodePolicyV2_CreateRule(t *testing.T) {
 		Status:             RuleStatusReady,
 		CleanCodeAttribute: CleanCodeAttributeClear,
 		Type:               RuleTypeCodeSmell,
-		Impacts: []RuleImpact{
+		Impacts: []RulesImpact{
 			{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh},
 		},
 		MarkdownDescription: "This is a custom rule",
@@ -65,7 +65,7 @@ func TestCleanCodePolicyV2_CreateRule_MinimalRequest(t *testing.T) {
 		TemplateKey:         "java:S100",
 		Name:                "Minimal Rule",
 		MarkdownDescription: "Minimal description",
-		Impacts: []RuleImpact{
+		Impacts: []RulesImpact{
 			{SoftwareQuality: SoftwareQualitySecurity, Severity: RuleImpactSeverityLow},
 		},
 	}
@@ -73,7 +73,7 @@ func TestCleanCodePolicyV2_CreateRule_MinimalRequest(t *testing.T) {
 		Id:   "rule-2",
 		Key:  "custom:min_rule",
 		Name: "Minimal Rule",
-		Impacts: []RuleImpact{
+		Impacts: []RulesImpact{
 			{SoftwareQuality: SoftwareQualitySecurity, Severity: RuleImpactSeverityLow},
 		},
 	}
@@ -93,7 +93,7 @@ func TestCleanCodePolicyV2_CreateRule_MultipleImpacts(t *testing.T) {
 		TemplateKey:         "java:S100",
 		Name:                "Multi Impact Rule",
 		MarkdownDescription: "Rule with multiple impacts",
-		Impacts: []RuleImpact{
+		Impacts: []RulesImpact{
 			{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityMedium},
 			{SoftwareQuality: SoftwareQualityReliability, Severity: RuleImpactSeverityHigh},
 			{SoftwareQuality: SoftwareQualitySecurity, Severity: RuleImpactSeverityBlocker},
@@ -102,7 +102,7 @@ func TestCleanCodePolicyV2_CreateRule_MultipleImpacts(t *testing.T) {
 	response := RuleV2{
 		Id:  "rule-3",
 		Key: "custom:multi_impact",
-		Impacts: []RuleImpact{
+		Impacts: []RulesImpact{
 			{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityMedium},
 			{SoftwareQuality: SoftwareQualityReliability, Severity: RuleImpactSeverityHigh},
 			{SoftwareQuality: SoftwareQualitySecurity, Severity: RuleImpactSeverityBlocker},
@@ -123,7 +123,7 @@ func TestCleanCodePolicyV2_CreateRule_WithParameters(t *testing.T) {
 		TemplateKey:         "java:S100",
 		Name:                "Parameterized Rule",
 		MarkdownDescription: "Rule with parameters",
-		Impacts: []RuleImpact{
+		Impacts: []RulesImpact{
 			{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityLow},
 		},
 		Parameters: []RuleParameterV2{
@@ -166,25 +166,25 @@ func TestCleanCodePolicyV2_CreateRule_Validation(t *testing.T) {
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
+			Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 		}},
 		{"missing template key", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
+			Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 		}},
 		{"missing name", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			TemplateKey:         "java:S100",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
+			Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 		}},
 		{"missing markdown description", &CleanCodePolicyCreateRuleOptions{
 			Key:         "custom:test",
 			TemplateKey: "java:S100",
 			Name:        "Test",
-			Impacts:     []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
+			Impacts:     []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 		}},
 		{"missing impacts", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
@@ -197,35 +197,35 @@ func TestCleanCodePolicyV2_CreateRule_Validation(t *testing.T) {
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{},
+			Impacts:             []RulesImpact{},
 		}},
 		{"key too long", &CleanCodePolicyCreateRuleOptions{
 			Key:                 strings.Repeat("a", MaxRuleKeyLengthV2+1),
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
+			Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 		}},
 		{"template key too long", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			TemplateKey:         strings.Repeat("a", MaxTemplateKeyLengthV2+1),
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
+			Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 		}},
 		{"name too long", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			TemplateKey:         "java:S100",
 			Name:                strings.Repeat("a", MaxRuleNameLengthV2+1),
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
+			Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 		}},
 		{"invalid status", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
+			Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 			Status:              "INVALID",
 		}},
 		{"invalid clean code attribute", &CleanCodePolicyCreateRuleOptions{
@@ -233,7 +233,7 @@ func TestCleanCodePolicyV2_CreateRule_Validation(t *testing.T) {
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
+			Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 			CleanCodeAttribute:  "INVALID",
 		}},
 		{"invalid type", &CleanCodePolicyCreateRuleOptions{
@@ -241,7 +241,7 @@ func TestCleanCodePolicyV2_CreateRule_Validation(t *testing.T) {
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
+			Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 			Type:                "INVALID",
 		}},
 		{"invalid impact software quality", &CleanCodePolicyCreateRuleOptions{
@@ -249,28 +249,28 @@ func TestCleanCodePolicyV2_CreateRule_Validation(t *testing.T) {
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: "INVALID", Severity: RuleImpactSeverityHigh}},
+			Impacts:             []RulesImpact{{SoftwareQuality: "INVALID", Severity: RuleImpactSeverityHigh}},
 		}},
 		{"invalid impact severity", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: "INVALID"}},
+			Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: "INVALID"}},
 		}},
 		{"missing impact software quality", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{Severity: RuleImpactSeverityHigh}},
+			Impacts:             []RulesImpact{{Severity: RuleImpactSeverityHigh}},
 		}},
 		{"missing impact severity", &CleanCodePolicyCreateRuleOptions{
 			Key:                 "custom:test",
 			TemplateKey:         "java:S100",
 			Name:                "Test",
 			MarkdownDescription: "desc",
-			Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability}},
+			Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability}},
 		}},
 	}
 
@@ -302,7 +302,7 @@ func TestCleanCodePolicyV2_CreateRule_AllCleanCodeAttributes(t *testing.T) {
 				TemplateKey:         "java:S100",
 				Name:                "Test",
 				MarkdownDescription: "desc",
-				Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
+				Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 				CleanCodeAttribute:  attr,
 			})
 			assert.NoError(t, err)
@@ -322,7 +322,7 @@ func TestCleanCodePolicyV2_CreateRule_AllImpactSeverities(t *testing.T) {
 				TemplateKey:         "java:S100",
 				Name:                "Test",
 				MarkdownDescription: "desc",
-				Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: sev}},
+				Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: sev}},
 			})
 			assert.NoError(t, err)
 		})
@@ -341,7 +341,7 @@ func TestCleanCodePolicyV2_CreateRule_AllRuleStatuses(t *testing.T) {
 				TemplateKey:         "java:S100",
 				Name:                "Test",
 				MarkdownDescription: "desc",
-				Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
+				Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 				Status:              status,
 			})
 			assert.NoError(t, err)
@@ -361,7 +361,7 @@ func TestCleanCodePolicyV2_CreateRule_AllRuleTypes(t *testing.T) {
 				TemplateKey:         "java:S100",
 				Name:                "Test",
 				MarkdownDescription: "desc",
-				Impacts:             []RuleImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
+				Impacts:             []RulesImpact{{SoftwareQuality: SoftwareQualityMaintainability, Severity: RuleImpactSeverityHigh}},
 				Type:                ruleType,
 			})
 			assert.NoError(t, err)
@@ -381,7 +381,7 @@ func TestCleanCodePolicyV2_CreateRule_AllSoftwareQualities(t *testing.T) {
 				TemplateKey:         "java:S100",
 				Name:                "Test",
 				MarkdownDescription: "desc",
-				Impacts:             []RuleImpact{{SoftwareQuality: quality, Severity: RuleImpactSeverityHigh}},
+				Impacts:             []RulesImpact{{SoftwareQuality: quality, Severity: RuleImpactSeverityHigh}},
 			})
 			assert.NoError(t, err)
 		})

--- a/sonar/dop_translation_v2_service.go
+++ b/sonar/dop_translation_v2_service.go
@@ -173,9 +173,9 @@ func (s *DopTranslationService) CreateBoundProject(opt *DopTranslationBoundProje
 	return result, resp, nil
 }
 
-// FetchAllDopSettings lists all DevOps Platform Integration settings.
+// GetDopSettings lists all DevOps Platform Integration settings.
 // Requires the 'Create Projects' permission.
-func (s *DopTranslationService) FetchAllDopSettings() (*DopTranslationDopSettings, *http.Response, error) {
+func (s *DopTranslationService) GetDopSettings() (*DopTranslationDopSettings, *http.Response, error) {
 	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "dop-translation/dop-settings", nil, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)

--- a/sonar/dop_translation_v2_service_test.go
+++ b/sonar/dop_translation_v2_service_test.go
@@ -105,10 +105,10 @@ func TestDopTranslationV2_CreateBoundProject_Validation(t *testing.T) {
 }
 
 // =============================================================================
-// FetchAllDopSettings
+// GetDopSettings
 // =============================================================================
 
-func TestDopTranslationV2_FetchAllDopSettings(t *testing.T) {
+func TestDopTranslationV2_GetDopSettings(t *testing.T) {
 	response := DopTranslationDopSettings{
 		DopSettings: []DopSetting{
 			{Id: "1", Type: "github", Key: "gh-setting", URL: "https://github.com", AppID: "app-1"},
@@ -119,7 +119,7 @@ func TestDopTranslationV2_FetchAllDopSettings(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/dop-translation/dop-settings", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.DopTranslation.FetchAllDopSettings()
+	result, resp, err := client.V2.DopTranslation.GetDopSettings()
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.DopSettings, 2)

--- a/sonar/github_provisioning_service.go
+++ b/sonar/github_provisioning_service.go
@@ -17,39 +17,39 @@ type GithubProvisioningService struct {
 // GithubProvisioningCheck represents the response from checking GitHub provisioning configuration.
 type GithubProvisioningCheck struct {
 	// Application contains provisioning status for the application level.
-	Application ProvisioningApplicationStatus `json:"application,omitzero"`
+	Application GithubProvisioningApplicationStatus `json:"application,omitzero"`
 	// Installations contains provisioning status for each GitHub organization/installation.
-	Installations []ProvisioningInstallation `json:"installations,omitempty"`
+	Installations []GithubProvisioningInstallation `json:"installations,omitempty"`
 }
 
-// ProvisioningApplicationStatus represents the provisioning status at the application level.
-type ProvisioningApplicationStatus struct {
+// GithubProvisioningApplicationStatus represents the provisioning status at the application level.
+type GithubProvisioningApplicationStatus struct {
 	// AutoProvisioning contains the auto-provisioning status.
-	AutoProvisioning ProvisioningStatus `json:"autoProvisioning,omitzero"`
+	AutoProvisioning GithubProvisioningStatus `json:"autoProvisioning,omitzero"`
 	// Jit contains the Just-In-Time provisioning status.
-	Jit JitStatus `json:"jit,omitzero"`
+	Jit GithubProvisioningJitStatus `json:"jit,omitzero"`
 }
 
-// ProvisioningInstallation represents the provisioning status for a GitHub organization/installation.
-type ProvisioningInstallation struct {
+// GithubProvisioningInstallation represents the provisioning status for a GitHub organization/installation.
+type GithubProvisioningInstallation struct {
 	// AutoProvisioning contains the auto-provisioning status for this installation.
-	AutoProvisioning ProvisioningStatus `json:"autoProvisioning,omitzero"`
+	AutoProvisioning GithubProvisioningStatus `json:"autoProvisioning,omitzero"`
 	// Jit contains the Just-In-Time provisioning status for this installation.
-	Jit JitStatus `json:"jit,omitzero"`
+	Jit GithubProvisioningJitStatus `json:"jit,omitzero"`
 	// Organization is the name of the GitHub organization.
 	Organization string `json:"organization,omitempty"`
 }
 
-// ProvisioningStatus represents the status of auto-provisioning.
-type ProvisioningStatus struct {
+// GithubProvisioningStatus represents the status of auto-provisioning.
+type GithubProvisioningStatus struct {
 	// ErrorMessage contains an error message if provisioning failed.
 	ErrorMessage string `json:"errorMessage,omitempty"`
 	// Status is the provisioning status.
 	Status string `json:"status,omitempty"`
 }
 
-// JitStatus represents the status of Just-In-Time provisioning.
-type JitStatus struct {
+// GithubProvisioningJitStatus represents the status of Just-In-Time provisioning.
+type GithubProvisioningJitStatus struct {
 	// Status is the JIT provisioning status.
 	Status string `json:"status,omitempty"`
 }

--- a/sonar/hotspots_service.go
+++ b/sonar/hotspots_service.go
@@ -75,16 +75,6 @@ type HotspotComponent struct {
 	Qualifier string `json:"qualifier,omitempty"`
 }
 
-// HotspotsTaskPaging represents pagination information in a hotspots response.
-type HotspotsTaskPaging struct {
-	// PageIndex is the current page index (1-based).
-	PageIndex int64 `json:"pageIndex,omitempty"`
-	// PageSize is the number of items per page.
-	PageSize int64 `json:"pageSize,omitempty"`
-	// Total is the total number of items.
-	Total int64 `json:"total,omitempty"`
-}
-
 // HotspotSummary represents a hotspot summary in list/search results.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
@@ -236,7 +226,7 @@ type HotspotsList struct {
 	// Hotspots is the list of hotspots.
 	Hotspots []HotspotSummary `json:"hotspots,omitempty"`
 	// Paging contains pagination information.
-	Paging HotspotsTaskPaging `json:"paging"`
+	Paging Paging `json:"paging"`
 }
 
 // HotspotsSearch represents the response from searching hotspots.
@@ -246,7 +236,7 @@ type HotspotsSearch struct {
 	// Hotspots is the list of hotspots.
 	Hotspots []HotspotSummary `json:"hotspots,omitempty"`
 	// Paging contains pagination information.
-	Paging HotspotsTaskPaging `json:"paging"`
+	Paging Paging `json:"paging"`
 }
 
 // HotspotsShow represents the response from showing hotspot details.

--- a/sonar/hotspots_service.go
+++ b/sonar/hotspots_service.go
@@ -75,8 +75,8 @@ type HotspotComponent struct {
 	Qualifier string `json:"qualifier,omitempty"`
 }
 
-// HotspotPaging represents pagination information in a hotspots response.
-type HotspotPaging struct {
+// HotspotsTaskPaging represents pagination information in a hotspots response.
+type HotspotsTaskPaging struct {
 	// PageIndex is the current page index (1-based).
 	PageIndex int64 `json:"pageIndex,omitempty"`
 	// PageSize is the number of items per page.
@@ -236,7 +236,7 @@ type HotspotsList struct {
 	// Hotspots is the list of hotspots.
 	Hotspots []HotspotSummary `json:"hotspots,omitempty"`
 	// Paging contains pagination information.
-	Paging HotspotPaging `json:"paging"`
+	Paging HotspotsTaskPaging `json:"paging"`
 }
 
 // HotspotsSearch represents the response from searching hotspots.
@@ -246,7 +246,7 @@ type HotspotsSearch struct {
 	// Hotspots is the list of hotspots.
 	Hotspots []HotspotSummary `json:"hotspots,omitempty"`
 	// Paging contains pagination information.
-	Paging HotspotPaging `json:"paging"`
+	Paging HotspotsTaskPaging `json:"paging"`
 }
 
 // HotspotsShow represents the response from showing hotspot details.

--- a/sonar/l10n_service.go
+++ b/sonar/l10n_service.go
@@ -40,8 +40,8 @@ type L10NIndexOptions struct {
 // Validation Functions
 // -----------------------------------------------------------------------------
 
-// ValidateIndexOpt validates the options for the Index method.
-func (s *L10NService) ValidateIndexOpt(opt *L10NIndexOptions) error {
+// ValidateGetIndexOpt validates the options for the GetIndex method.
+func (s *L10NService) ValidateGetIndexOpt(opt *L10NIndexOptions) error {
 	// Options are optional; nothing to validate.
 	return nil
 }
@@ -50,12 +50,12 @@ func (s *L10NService) ValidateIndexOpt(opt *L10NIndexOptions) error {
 // Service Methods
 // -----------------------------------------------------------------------------
 
-// Index gets all localization messages for a given locale.
+// GetIndex gets all localization messages for a given locale.
 //
 // API endpoint: GET /api/l10n/index.
 // Warning: This API is internal and may change without notice.
-func (s *L10NService) Index(opt *L10NIndexOptions) (*L10NIndex, *http.Response, error) {
-	err := s.ValidateIndexOpt(opt)
+func (s *L10NService) GetIndex(opt *L10NIndexOptions) (*L10NIndex, *http.Response, error) {
+	err := s.ValidateGetIndexOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/l10n_service_test.go
+++ b/sonar/l10n_service_test.go
@@ -22,7 +22,7 @@ func TestL10N_Index(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.L10N.Index(nil)
+	result, resp, err := client.L10N.GetIndex(nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -44,7 +44,7 @@ func TestL10N_Index_WithLocale(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.L10N.Index(&L10NIndexOptions{Locale: "fr"})
+	result, resp, err := client.L10N.GetIndex(&L10NIndexOptions{Locale: "fr"})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "fr", result.Locale)
@@ -56,7 +56,7 @@ func TestL10N_Index_WithTimestamp(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	_, _, err := client.L10N.Index(&L10NIndexOptions{Timestamp: "2024-01-01T00:00:00+0000"})
+	_, _, err := client.L10N.GetIndex(&L10NIndexOptions{Timestamp: "2024-01-01T00:00:00+0000"})
 	require.NoError(t, err)
 }
 
@@ -65,13 +65,13 @@ func TestL10N_Index_EmptyMessages(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, _, err := client.L10N.Index(nil)
+	result, _, err := client.L10N.GetIndex(nil)
 	require.NoError(t, err)
 	require.NotNil(t, result.Messages)
 	assert.Empty(t, result.Messages)
 }
 
-func TestL10N_ValidateIndexOpt(t *testing.T) {
+func TestL10N_ValidateGetIndexOpt(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	tests := []struct {
@@ -88,7 +88,7 @@ func TestL10N_ValidateIndexOpt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := client.L10N.ValidateIndexOpt(tt.opt)
+			err := client.L10N.ValidateGetIndexOpt(tt.opt)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/sonar/permissions_service.go
+++ b/sonar/permissions_service.go
@@ -113,16 +113,6 @@ type PermissionUser struct {
 	Permissions []string `json:"permissions,omitempty"`
 }
 
-// PermissionsPaging represents pagination information for permission queries.
-type PermissionsPaging struct {
-	// PageIndex is the current page index (1-based).
-	PageIndex int64 `json:"pageIndex,omitempty"`
-	// PageSize is the number of items per page.
-	PageSize int64 `json:"pageSize,omitempty"`
-	// Total is the total number of items.
-	Total int64 `json:"total,omitempty"`
-}
-
 // PermissionTemplate represents a permission template.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
@@ -136,17 +126,17 @@ type PermissionTemplate struct {
 	// Name is the template name.
 	Name string `json:"name,omitempty"`
 	// Permissions is the list of permissions in the template.
-	Permissions []TemplatePermission `json:"permissions,omitempty"`
+	Permissions []PermissionsTemplatePermission `json:"permissions,omitempty"`
 	// ProjectKeyPattern is the regex pattern for matching project keys.
 	ProjectKeyPattern string `json:"projectKeyPattern,omitempty"`
 	// UpdatedAt is the template last update date.
 	UpdatedAt string `json:"updatedAt,omitempty"`
 }
 
-// TemplatePermission represents a permission entry in a template.
+// PermissionsTemplatePermission represents a permission entry in a template.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type TemplatePermission struct {
+type PermissionsTemplatePermission struct {
 	// GroupsCount is the number of groups with this permission.
 	GroupsCount int64 `json:"groupsCount,omitempty"`
 	// Key is the permission key.
@@ -157,16 +147,16 @@ type TemplatePermission struct {
 	WithProjectCreator bool `json:"withProjectCreator,omitempty"`
 }
 
-// DefaultTemplate represents a default template mapping.
-type DefaultTemplate struct {
+// PermissionsDefaultTemplate represents a default template mapping.
+type PermissionsDefaultTemplate struct {
 	// Qualifier is the component qualifier (e.g., TRK for projects).
 	Qualifier string `json:"qualifier,omitempty"`
 	// TemplateID is the ID of the template set as default.
 	TemplateID string `json:"templateId,omitempty"`
 }
 
-// TemplateGroup represents a group in a permission template.
-type TemplateGroup struct {
+// PermissionsTemplateGroup represents a group in a permission template.
+type PermissionsTemplateGroup struct {
 	// Description is the group description.
 	Description string `json:"description,omitempty"`
 	// Name is the group name.
@@ -175,8 +165,8 @@ type TemplateGroup struct {
 	Permissions []string `json:"permissions,omitempty"`
 }
 
-// TemplateUser represents a user in a permission template.
-type TemplateUser struct {
+// PermissionsTemplateUser represents a user in a permission template.
+type PermissionsTemplateUser struct {
 	// Avatar is the user's avatar URL.
 	Avatar string `json:"avatar,omitempty"`
 	// Email is the user's email address.
@@ -196,11 +186,11 @@ type TemplateUser struct {
 // PermissionsCreateTemplate represents the response from creating a permission template.
 type PermissionsCreateTemplate struct {
 	// PermissionTemplate is the created permission template.
-	PermissionTemplate PermissionTemplateBasic `json:"permissionTemplate,omitzero"`
+	PermissionTemplate PermissionsTemplateBasic `json:"permissionTemplate,omitzero"`
 }
 
-// PermissionTemplateBasic represents basic permission template info returned on create.
-type PermissionTemplateBasic struct {
+// PermissionsTemplateBasic represents basic permission template info returned on create.
+type PermissionsTemplateBasic struct {
 	// Description is the template description.
 	Description string `json:"description,omitempty"`
 	// Id is the unique identifier of the template.
@@ -220,13 +210,13 @@ type PermissionsGroups struct {
 	// Groups is the list of groups with their permissions.
 	Groups []PermissionGroup `json:"groups,omitempty"`
 	// Paging contains pagination information.
-	Paging PermissionsPaging `json:"paging,omitzero"`
+	Paging Paging `json:"paging,omitzero"`
 }
 
 // PermissionsSearchTemplates represents the response from searching permission templates.
 type PermissionsSearchTemplates struct {
 	// DefaultTemplates is the list of default template mappings.
-	DefaultTemplates []DefaultTemplate `json:"defaultTemplates,omitempty"`
+	DefaultTemplates []PermissionsDefaultTemplate `json:"defaultTemplates,omitempty"`
 	// PermissionTemplates is the list of permission templates.
 	PermissionTemplates []PermissionTemplate `json:"permissionTemplates,omitempty"`
 }
@@ -234,9 +224,9 @@ type PermissionsSearchTemplates struct {
 // PermissionsTemplateGroups represents the response from listing template groups.
 type PermissionsTemplateGroups struct {
 	// Groups is the list of groups in the template.
-	Groups []TemplateGroup `json:"groups,omitempty"`
+	Groups []PermissionsTemplateGroup `json:"groups,omitempty"`
 	// Paging contains pagination information.
-	Paging PermissionsPaging `json:"paging,omitzero"`
+	Paging Paging `json:"paging,omitzero"`
 }
 
 // PermissionsTemplateUsers represents the response from listing template users.
@@ -244,19 +234,19 @@ type PermissionsTemplateGroups struct {
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
 type PermissionsTemplateUsers struct {
 	// Paging contains pagination information.
-	Paging PermissionsPaging `json:"paging,omitzero"`
+	Paging Paging `json:"paging,omitzero"`
 	// Users is the list of users in the template.
-	Users []TemplateUser `json:"users,omitempty"`
+	Users []PermissionsTemplateUser `json:"users,omitempty"`
 }
 
 // PermissionsUpdateTemplate represents the response from updating a permission template.
 type PermissionsUpdateTemplate struct {
 	// PermissionTemplate is the updated permission template.
-	PermissionTemplate PermissionTemplateUpdated `json:"permissionTemplate,omitzero"`
+	PermissionTemplate PermissionsTemplateUpdated `json:"permissionTemplate,omitzero"`
 }
 
-// PermissionTemplateUpdated represents updated permission template info.
-type PermissionTemplateUpdated struct {
+// PermissionsTemplateUpdated represents updated permission template info.
+type PermissionsTemplateUpdated struct {
 	// CreatedAt is the template creation date.
 	CreatedAt string `json:"createdAt,omitempty"`
 	// Description is the template description.
@@ -276,7 +266,7 @@ type PermissionTemplateUpdated struct {
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
 type PermissionsUsers struct {
 	// Paging contains pagination information.
-	Paging PermissionsPaging `json:"paging,omitzero"`
+	Paging Paging `json:"paging,omitzero"`
 	// Users is the list of users with their permissions.
 	Users []PermissionUser `json:"users,omitempty"`
 }

--- a/sonar/permissions_service_test.go
+++ b/sonar/permissions_service_test.go
@@ -364,7 +364,7 @@ func TestPermissions_BulkApplyTemplate_ValidationError(t *testing.T) {
 
 func TestPermissions_CreateTemplate(t *testing.T) {
 	response := PermissionsCreateTemplate{
-		PermissionTemplate: PermissionTemplateBasic{
+		PermissionTemplate: PermissionsTemplateBasic{
 			Name:              "my-template",
 			Description:       "Template for my projects",
 			ProjectKeyPattern: "my-.*",
@@ -433,7 +433,7 @@ func TestPermissions_DeleteTemplate_ValidationError(t *testing.T) {
 
 func TestPermissions_Groups(t *testing.T) {
 	response := PermissionsGroups{
-		Paging: PermissionsPaging{
+		Paging: Paging{
 			PageIndex: 1,
 			PageSize:  25,
 			Total:     2,
@@ -465,7 +465,7 @@ func TestPermissions_Groups(t *testing.T) {
 
 func TestPermissions_Groups_WithOptions(t *testing.T) {
 	response := PermissionsGroups{
-		Paging: PermissionsPaging{
+		Paging: Paging{
 			PageIndex: 1,
 			PageSize:  25,
 			Total:     0,
@@ -725,7 +725,7 @@ func TestPermissions_SearchTemplates(t *testing.T) {
 				ProjectKeyPattern: "my-.*",
 				CreatedAt:         "2024-01-01T00:00:00+0000",
 				UpdatedAt:         "2024-01-02T00:00:00+0000",
-				Permissions: []TemplatePermission{
+				Permissions: []PermissionsTemplatePermission{
 					{Key: "admin", UsersCount: 1, GroupsCount: 2, WithProjectCreator: true},
 				},
 			},
@@ -812,12 +812,12 @@ func TestPermissions_SetDefaultTemplate_ValidationError(t *testing.T) {
 
 func TestPermissions_TemplateGroups(t *testing.T) {
 	response := PermissionsTemplateGroups{
-		Paging: PermissionsPaging{
+		Paging: Paging{
 			PageIndex: 1,
 			PageSize:  25,
 			Total:     1,
 		},
-		Groups: []TemplateGroup{
+		Groups: []PermissionsTemplateGroup{
 			{
 				Name:        "developers",
 				Description: "Developers group",
@@ -872,12 +872,12 @@ func TestPermissions_TemplateGroups_ValidationError(t *testing.T) {
 
 func TestPermissions_TemplateUsers(t *testing.T) {
 	response := PermissionsTemplateUsers{
-		Paging: PermissionsPaging{
+		Paging: Paging{
 			PageIndex: 1,
 			PageSize:  25,
 			Total:     1,
 		},
-		Users: []TemplateUser{
+		Users: []PermissionsTemplateUser{
 			{
 				Login:       "john.doe",
 				Name:        "John Doe",
@@ -929,7 +929,7 @@ func TestPermissions_TemplateUsers_ValidationError(t *testing.T) {
 
 func TestPermissions_UpdateTemplate(t *testing.T) {
 	response := PermissionsUpdateTemplate{
-		PermissionTemplate: PermissionTemplateUpdated{
+		PermissionTemplate: PermissionsTemplateUpdated{
 			ID:                "template-1",
 			Name:              "new-template-name",
 			Description:       "Updated description",
@@ -975,7 +975,7 @@ func TestPermissions_UpdateTemplate_ValidationError(t *testing.T) {
 
 func TestPermissions_Users(t *testing.T) {
 	response := PermissionsUsers{
-		Paging: PermissionsPaging{
+		Paging: Paging{
 			PageIndex: 1,
 			PageSize:  25,
 			Total:     2,
@@ -1012,7 +1012,7 @@ func TestPermissions_Users(t *testing.T) {
 
 func TestPermissions_Users_WithOptions(t *testing.T) {
 	response := PermissionsUsers{
-		Paging: PermissionsPaging{
+		Paging: Paging{
 			PageIndex: 1,
 			PageSize:  25,
 			Total:     0,

--- a/sonar/project_branches_service.go
+++ b/sonar/project_branches_service.go
@@ -14,16 +14,16 @@ type ProjectBranchesService struct {
 // Shared Types
 // -----------------------------------------------------------------------------
 
-// BranchStatus represents the status of a branch.
-type BranchStatus struct {
+// ProjectBranchStatus represents the status of a branch.
+type ProjectBranchStatus struct {
 	// QualityGateStatus is the quality gate status of the branch.
 	QualityGateStatus string `json:"qualityGateStatus,omitempty"`
 }
 
-// Branch represents a project branch.
+// ProjectBranch represents a project branch.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type Branch struct {
+type ProjectBranch struct {
 	// AnalysisDate is the date of the last analysis.
 	AnalysisDate string `json:"analysisDate,omitempty"`
 	// BranchID is the unique identifier of the branch.
@@ -35,7 +35,7 @@ type Branch struct {
 	// Name is the name of the branch.
 	Name string `json:"name,omitempty"`
 	// Status is the status of the branch.
-	Status BranchStatus `json:"status,omitzero"`
+	Status ProjectBranchStatus `json:"status,omitzero"`
 	// Type is the type of the branch.
 	Type string `json:"type,omitempty"`
 }
@@ -47,7 +47,7 @@ type Branch struct {
 // ProjectBranchesList represents the response from listing branches.
 type ProjectBranchesList struct {
 	// Branches is the list of branches.
-	Branches []Branch `json:"branches,omitempty"`
+	Branches []ProjectBranch `json:"branches,omitempty"`
 }
 
 // -----------------------------------------------------------------------------

--- a/sonar/project_branches_service_test.go
+++ b/sonar/project_branches_service_test.go
@@ -46,12 +46,12 @@ func TestProjectBranches_Delete_ValidationError(t *testing.T) {
 
 func TestProjectBranches_List(t *testing.T) {
 	response := &ProjectBranchesList{
-		Branches: []Branch{
+		Branches: []ProjectBranch{
 			{
 				Name:              "main",
 				IsMain:            true,
 				Type:              "LONG",
-				Status:            BranchStatus{QualityGateStatus: "OK"},
+				Status:            ProjectBranchStatus{QualityGateStatus: "OK"},
 				AnalysisDate:      "2024-01-01T00:00:00+0000",
 				ExcludedFromPurge: true,
 			},
@@ -59,7 +59,7 @@ func TestProjectBranches_List(t *testing.T) {
 				Name:              "feature-1",
 				IsMain:            false,
 				Type:              "BRANCH",
-				Status:            BranchStatus{QualityGateStatus: "ERROR"},
+				Status:            ProjectBranchStatus{QualityGateStatus: "ERROR"},
 				ExcludedFromPurge: false,
 			},
 		},

--- a/sonar/qualitygates_service.go
+++ b/sonar/qualitygates_service.go
@@ -123,28 +123,28 @@ type QualityGateActions struct {
 
 // QualitygatesProjectStatus represents the quality gate status of a project.
 type QualitygatesProjectStatus struct {
-	// ProjectStatus contains the detailed project status information.
-	ProjectStatus ProjectStatus `json:"projectStatus,omitzero"`
+	// QualityGateProjectStatus contains the detailed project status information.
+	QualityGateProjectStatus QualityGateProjectStatus `json:"projectStatus,omitzero"`
 }
 
-// ProjectStatus represents the detailed status of a project's quality gate.
+// QualityGateProjectStatus represents the detailed status of a project's quality gate.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type ProjectStatus struct {
+type QualityGateProjectStatus struct {
 	// Status is the overall quality gate status (OK, WARN, ERROR, NONE).
 	Status string `json:"status,omitempty"`
 	// CaycStatus is the Clean As You Code status.
 	CaycStatus string `json:"caycStatus,omitempty"`
 	// Conditions is the list of condition evaluations.
-	Conditions []ConditionStatus `json:"conditions,omitempty"`
+	Conditions []QualityGateConditionStatus `json:"conditions,omitempty"`
 	// Period contains information about the analysis period.
-	Period AnalysisPeriod `json:"period,omitzero"`
+	Period QualityGateAnalysisPeriod `json:"period,omitzero"`
 	// IgnoredConditions indicates if some conditions were ignored.
 	IgnoredConditions bool `json:"ignoredConditions,omitempty"`
 }
 
-// ConditionStatus represents the evaluation result of a single condition.
-type ConditionStatus struct {
+// QualityGateConditionStatus represents the evaluation result of a single condition.
+type QualityGateConditionStatus struct {
 	// ActualValue is the actual measured value.
 	ActualValue string `json:"actualValue,omitempty"`
 	// Comparator is the comparison operator used.
@@ -157,8 +157,8 @@ type ConditionStatus struct {
 	Status string `json:"status,omitempty"`
 }
 
-// AnalysisPeriod represents information about the analysis period.
-type AnalysisPeriod struct {
+// QualityGateAnalysisPeriod represents information about the analysis period.
+type QualityGateAnalysisPeriod struct {
 	// Date is the date of the period.
 	Date string `json:"date,omitempty"`
 	// Mode is the period mode.
@@ -697,7 +697,7 @@ func (s *QualitygatesService) List() (v *QualitygatesList, resp *http.Response, 
 	return
 }
 
-// ProjectStatus gets the quality gate status of a project or a Compute Engine task.
+// QualityGateProjectStatus gets the quality gate status of a project or a Compute Engine task.
 // Either AnalysisID, ProjectID, or ProjectKey must be provided.
 // Returns status: OK, WARN, ERROR, NONE.
 // NONE is returned when there is no quality gate associated with the analysis.
@@ -706,7 +706,7 @@ func (s *QualitygatesService) List() (v *QualitygatesList, resp *http.Response, 
 //   - 'Administer' rights on the specified project
 //   - 'Browse' on the specified project
 //   - 'Execute Analysis' on the specified project
-func (s *QualitygatesService) ProjectStatus(opt *QualitygatesProjectStatusOptions) (v *QualitygatesProjectStatus, resp *http.Response, err error) {
+func (s *QualitygatesService) QualityGateProjectStatus(opt *QualitygatesProjectStatusOptions) (v *QualitygatesProjectStatus, resp *http.Response, err error) {
 	err = s.ValidateProjectStatusOpt(opt)
 	if err != nil {
 		return

--- a/sonar/qualitygates_service.go
+++ b/sonar/qualitygates_service.go
@@ -124,7 +124,7 @@ type QualityGateActions struct {
 // QualitygatesProjectStatus represents the quality gate status of a project.
 type QualitygatesProjectStatus struct {
 	// QualityGateProjectStatus contains the detailed project status information.
-	QualityGateProjectStatus QualityGateProjectStatus `json:"projectStatus,omitzero"`
+	ProjectStatus QualityGateProjectStatus `json:"projectStatus,omitzero"`
 }
 
 // QualityGateProjectStatus represents the detailed status of a project's quality gate.

--- a/sonar/qualitygates_service.go
+++ b/sonar/qualitygates_service.go
@@ -321,14 +321,14 @@ type QualitygatesDeleteConditionOptions struct {
 	ID string `url:"id,omitempty"`
 }
 
-// QualitygatesDeselectOptions contains options for removing a project association.
-type QualitygatesDeselectOptions struct {
+// QualitygatesUnassignOptions contains options for removing a project association.
+type QualitygatesUnassignOptions struct {
 	// ProjectKey is the project key (required).
 	ProjectKey string `url:"projectKey,omitempty"`
 }
 
-// QualitygatesDestroyOptions contains options for deleting a quality gate.
-type QualitygatesDestroyOptions struct {
+// QualitygatesDeleteOptions contains options for deleting a quality gate.
+type QualitygatesDeleteOptions struct {
 	// Name is the name of the quality gate to delete (required).
 	// Maximum length: 100 characters
 	Name string `url:"name,omitempty"`
@@ -434,8 +434,8 @@ type QualitygatesSearchUsersOptions struct {
 	Selected string `url:"selected,omitempty"`
 }
 
-// QualitygatesSelectOptions contains options for associating a project.
-type QualitygatesSelectOptions struct {
+// QualitygatesAssignOptions contains options for associating a project.
+type QualitygatesAssignOptions struct {
 	// GateName is the name of the quality gate (required).
 	// Maximum length: 100 characters
 	GateName string `url:"gateName,omitempty"`
@@ -443,8 +443,8 @@ type QualitygatesSelectOptions struct {
 	ProjectKey string `url:"projectKey,omitempty"`
 }
 
-// QualitygatesSetAsDefaultOptions contains options for setting the default gate.
-type QualitygatesSetAsDefaultOptions struct {
+// QualitygatesSetDefaultOptions contains options for setting the default gate.
+type QualitygatesSetDefaultOptions struct {
 	// Name is the name of the quality gate to set as default (required).
 	// Maximum length: 100 characters
 	Name string `url:"name,omitempty"`
@@ -610,12 +610,12 @@ func (s *QualitygatesService) DeleteCondition(opt *QualitygatesDeleteConditionOp
 	return
 }
 
-// Deselect removes the association of a project from a quality gate.
+// Unassign removes the association of a project from a quality gate.
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - 'Administer' rights on the project
-func (s *QualitygatesService) Deselect(opt *QualitygatesDeselectOptions) (resp *http.Response, err error) {
-	err = s.ValidateDeselectOpt(opt)
+func (s *QualitygatesService) Unassign(opt *QualitygatesUnassignOptions) (resp *http.Response, err error) {
+	err = s.ValidateUnassignOpt(opt)
 	if err != nil {
 		return
 	}
@@ -633,10 +633,10 @@ func (s *QualitygatesService) Deselect(opt *QualitygatesDeselectOptions) (resp *
 	return
 }
 
-// Destroy deletes a quality gate.
+// Delete deletes a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) Destroy(opt *QualitygatesDestroyOptions) (resp *http.Response, err error) {
-	err = s.ValidateDestroyOpt(opt)
+func (s *QualitygatesService) Delete(opt *QualitygatesDeleteOptions) (resp *http.Response, err error) {
+	err = s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return
 	}
@@ -697,7 +697,7 @@ func (s *QualitygatesService) List() (v *QualitygatesList, resp *http.Response, 
 	return
 }
 
-// QualityGateProjectStatus gets the quality gate status of a project or a Compute Engine task.
+// ProjectStatus gets the quality gate status of a project or a Compute Engine task.
 // Either AnalysisID, ProjectID, or ProjectKey must be provided.
 // Returns status: OK, WARN, ERROR, NONE.
 // NONE is returned when there is no quality gate associated with the analysis.
@@ -706,7 +706,7 @@ func (s *QualitygatesService) List() (v *QualitygatesList, resp *http.Response, 
 //   - 'Administer' rights on the specified project
 //   - 'Browse' on the specified project
 //   - 'Execute Analysis' on the specified project
-func (s *QualitygatesService) QualityGateProjectStatus(opt *QualitygatesProjectStatusOptions) (v *QualitygatesProjectStatus, resp *http.Response, err error) {
+func (s *QualitygatesService) ProjectStatus(opt *QualitygatesProjectStatusOptions) (v *QualitygatesProjectStatus, resp *http.Response, err error) {
 	err = s.ValidateProjectStatusOpt(opt)
 	if err != nil {
 		return
@@ -867,12 +867,12 @@ func (s *QualitygatesService) SearchUsers(opt *QualitygatesSearchUsersOptions) (
 	return
 }
 
-// Select associates a project to a quality gate.
+// Assign associates a project to a quality gate.
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - 'Administer' right on the specified project
-func (s *QualitygatesService) Select(opt *QualitygatesSelectOptions) (resp *http.Response, err error) {
-	err = s.ValidateSelectOpt(opt)
+func (s *QualitygatesService) Assign(opt *QualitygatesAssignOptions) (resp *http.Response, err error) {
+	err = s.ValidateAssignOpt(opt)
 	if err != nil {
 		return
 	}
@@ -890,10 +890,10 @@ func (s *QualitygatesService) Select(opt *QualitygatesSelectOptions) (resp *http
 	return
 }
 
-// SetAsDefault sets a quality gate as the default quality gate.
+// SetDefault sets a quality gate as the default quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) SetAsDefault(opt *QualitygatesSetAsDefaultOptions) (resp *http.Response, err error) {
-	err = s.ValidateSetAsDefaultOpt(opt)
+func (s *QualitygatesService) SetDefault(opt *QualitygatesSetDefaultOptions) (resp *http.Response, err error) {
+	err = s.ValidateSetDefaultOpt(opt)
 	if err != nil {
 		return
 	}
@@ -1102,10 +1102,10 @@ func (s *QualitygatesService) ValidateDeleteConditionOpt(opt *QualitygatesDelete
 	return nil
 }
 
-// ValidateDeselectOpt validates the options for deselecting a project.
-func (s *QualitygatesService) ValidateDeselectOpt(opt *QualitygatesDeselectOptions) error {
+// ValidateUnassignOpt validates the options for unassigning a project.
+func (s *QualitygatesService) ValidateUnassignOpt(opt *QualitygatesUnassignOptions) error {
 	if opt == nil {
-		return NewValidationError("QualitygatesDeselectOption", "cannot be nil", ErrMissingRequired)
+		return NewValidationError("QualitygatesUnassignOption", "cannot be nil", ErrMissingRequired)
 	}
 
 	err := ValidateRequired(opt.ProjectKey, "ProjectKey")
@@ -1116,10 +1116,10 @@ func (s *QualitygatesService) ValidateDeselectOpt(opt *QualitygatesDeselectOptio
 	return nil
 }
 
-// ValidateDestroyOpt validates the options for destroying a quality gate.
-func (s *QualitygatesService) ValidateDestroyOpt(opt *QualitygatesDestroyOptions) error {
+// ValidateDeleteOpt validates the options for deleting a quality gate.
+func (s *QualitygatesService) ValidateDeleteOpt(opt *QualitygatesDeleteOptions) error {
 	if opt == nil {
-		return NewValidationError("QualitygatesDestroyOption", "cannot be nil", ErrMissingRequired)
+		return NewValidationError("QualitygatesDeleteOption", "cannot be nil", ErrMissingRequired)
 	}
 
 	err := ValidateRequired(opt.Name, "Name")
@@ -1315,10 +1315,10 @@ func (s *QualitygatesService) ValidateSearchUsersOpt(opt *QualitygatesSearchUser
 	return nil
 }
 
-// ValidateSelectOpt validates the options for selecting a project.
-func (s *QualitygatesService) ValidateSelectOpt(opt *QualitygatesSelectOptions) error {
+// ValidateAssignOpt validates the options for assigning a project to a quality gate.
+func (s *QualitygatesService) ValidateAssignOpt(opt *QualitygatesAssignOptions) error {
 	if opt == nil {
-		return NewValidationError("QualitygatesSelectOption", "cannot be nil", ErrMissingRequired)
+		return NewValidationError("QualitygatesAssignOption", "cannot be nil", ErrMissingRequired)
 	}
 
 	err := ValidateRequired(opt.GateName, "GateName")
@@ -1339,10 +1339,10 @@ func (s *QualitygatesService) ValidateSelectOpt(opt *QualitygatesSelectOptions) 
 	return nil
 }
 
-// ValidateSetAsDefaultOpt validates the options for setting a default quality gate.
-func (s *QualitygatesService) ValidateSetAsDefaultOpt(opt *QualitygatesSetAsDefaultOptions) error {
+// ValidateSetDefaultOpt validates the options for setting a default quality gate.
+func (s *QualitygatesService) ValidateSetDefaultOpt(opt *QualitygatesSetDefaultOptions) error {
 	if opt == nil {
-		return NewValidationError("QualitygatesSetAsDefaultOption", "cannot be nil", ErrMissingRequired)
+		return NewValidationError("QualitygatesSetDefaultOption", "cannot be nil", ErrMissingRequired)
 	}
 
 	err := ValidateRequired(opt.Name, "Name")

--- a/sonar/qualitygates_service_test.go
+++ b/sonar/qualitygates_service_test.go
@@ -145,28 +145,28 @@ func TestQualityGates_DeleteCondition(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
-func TestQualityGates_Deselect(t *testing.T) {
+func TestQualityGates_Unassign(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/deselect", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesDeselectOptions{
+	opt := &QualitygatesUnassignOptions{
 		ProjectKey: "my_project",
 	}
 
-	resp, err := client.Qualitygates.Deselect(opt)
+	resp, err := client.Qualitygates.Unassign(opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
-func TestQualityGates_Destroy(t *testing.T) {
+func TestQualityGates_Delete(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/destroy", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesDestroyOptions{
+	opt := &QualitygatesDeleteOptions{
 		Name: "My Quality Gate",
 	}
 
-	resp, err := client.Qualitygates.Destroy(opt)
+	resp, err := client.Qualitygates.Delete(opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -225,7 +225,7 @@ func TestQualityGates_ProjectStatus(t *testing.T) {
 		ProjectKey: "my_project",
 	}
 
-	result, resp, err := client.Qualitygates.QualityGateProjectStatus(opt)
+	result, resp, err := client.Qualitygates.ProjectStatus(opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -238,11 +238,11 @@ func TestQualityGates_ProjectStatus_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualitygates.QualityGateProjectStatus(nil)
+	_, _, err := client.Qualitygates.ProjectStatus(nil)
 	assert.Error(t, err)
 
 	// Test missing all required fields
-	_, _, err = client.Qualitygates.QualityGateProjectStatus(&QualitygatesProjectStatusOptions{})
+	_, _, err = client.Qualitygates.ProjectStatus(&QualitygatesProjectStatusOptions{})
 	assert.Error(t, err)
 }
 
@@ -366,29 +366,29 @@ func TestQualityGates_SearchUsers(t *testing.T) {
 	assert.Equal(t, "john.doe", result.Users[0].Login)
 }
 
-func TestQualityGates_Select(t *testing.T) {
+func TestQualityGates_Assign(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/select", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesSelectOptions{
+	opt := &QualitygatesAssignOptions{
 		GateName:   "SonarSource Way",
 		ProjectKey: "my_project",
 	}
 
-	resp, err := client.Qualitygates.Select(opt)
+	resp, err := client.Qualitygates.Assign(opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
-func TestQualityGates_SetAsDefault(t *testing.T) {
+func TestQualityGates_SetDefault(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/qualitygates/set_as_default", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	opt := &QualitygatesSetAsDefaultOptions{
+	opt := &QualitygatesSetDefaultOptions{
 		Name: "SonarSource Way",
 	}
 
-	resp, err := client.Qualitygates.SetAsDefault(opt)
+	resp, err := client.Qualitygates.SetDefault(opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -643,16 +643,16 @@ func TestValidation_EdgeCases(t *testing.T) {
 	err = client.Qualitygates.ValidateRemoveUserOpt(nil)
 	assert.Error(t, err)
 
-	// Test Deselect - nil option
-	err = client.Qualitygates.ValidateDeselectOpt(nil)
+	// Test Unassign - nil option
+	err = client.Qualitygates.ValidateUnassignOpt(nil)
 	assert.Error(t, err)
 
-	// Test Select - nil option
-	err = client.Qualitygates.ValidateSelectOpt(nil)
+	// Test Assign - nil option
+	err = client.Qualitygates.ValidateAssignOpt(nil)
 	assert.Error(t, err)
 
-	// Test SetAsDefault - nil option
-	err = client.Qualitygates.ValidateSetAsDefaultOpt(nil)
+	// Test SetDefault - nil option
+	err = client.Qualitygates.ValidateSetDefaultOpt(nil)
 	assert.Error(t, err)
 
 	// Test Show - nil option

--- a/sonar/qualitygates_service_test.go
+++ b/sonar/qualitygates_service_test.go
@@ -229,9 +229,9 @@ func TestQualityGates_ProjectStatus(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
-	assert.Equal(t, "OK", result.QualityGateProjectStatus.Status)
-	assert.Len(t, result.QualityGateProjectStatus.Conditions, 1)
-	assert.Equal(t, "coverage", result.QualityGateProjectStatus.Conditions[0].MetricKey)
+	assert.Equal(t, "OK", result.ProjectStatus.Status)
+	assert.Len(t, result.ProjectStatus.Conditions, 1)
+	assert.Equal(t, "coverage", result.ProjectStatus.Conditions[0].MetricKey)
 }
 
 func TestQualityGates_ProjectStatus_ValidationError(t *testing.T) {
@@ -544,14 +544,14 @@ func TestQualitygatesProjectStatus_JSONUnmarshal(t *testing.T) {
 
 	err := json.Unmarshal([]byte(jsonData), &response)
 	require.NoError(t, err)
-	assert.Equal(t, "ERROR", response.QualityGateProjectStatus.Status)
-	assert.Equal(t, "non-compliant", response.QualityGateProjectStatus.CaycStatus)
-	require.Len(t, response.QualityGateProjectStatus.Conditions, 2)
+	assert.Equal(t, "ERROR", response.ProjectStatus.Status)
+	assert.Equal(t, "non-compliant", response.ProjectStatus.CaycStatus)
+	require.Len(t, response.ProjectStatus.Conditions, 2)
 
-	cond := response.QualityGateProjectStatus.Conditions[0]
+	cond := response.ProjectStatus.Conditions[0]
 	assert.Equal(t, "new_coverage", cond.MetricKey)
 	assert.Equal(t, "70.5", cond.ActualValue)
-	assert.Equal(t, "PREVIOUS_VERSION", response.QualityGateProjectStatus.Period.Mode)
+	assert.Equal(t, "PREVIOUS_VERSION", response.ProjectStatus.Period.Mode)
 }
 
 // TestQualitygatesShow_JSONUnmarshal verifies the JSON unmarshal for show response.

--- a/sonar/qualitygates_service_test.go
+++ b/sonar/qualitygates_service_test.go
@@ -225,24 +225,24 @@ func TestQualityGates_ProjectStatus(t *testing.T) {
 		ProjectKey: "my_project",
 	}
 
-	result, resp, err := client.Qualitygates.ProjectStatus(opt)
+	result, resp, err := client.Qualitygates.QualityGateProjectStatus(opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
-	assert.Equal(t, "OK", result.ProjectStatus.Status)
-	assert.Len(t, result.ProjectStatus.Conditions, 1)
-	assert.Equal(t, "coverage", result.ProjectStatus.Conditions[0].MetricKey)
+	assert.Equal(t, "OK", result.QualityGateProjectStatus.Status)
+	assert.Len(t, result.QualityGateProjectStatus.Conditions, 1)
+	assert.Equal(t, "coverage", result.QualityGateProjectStatus.Conditions[0].MetricKey)
 }
 
 func TestQualityGates_ProjectStatus_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualitygates.ProjectStatus(nil)
+	_, _, err := client.Qualitygates.QualityGateProjectStatus(nil)
 	assert.Error(t, err)
 
 	// Test missing all required fields
-	_, _, err = client.Qualitygates.ProjectStatus(&QualitygatesProjectStatusOptions{})
+	_, _, err = client.Qualitygates.QualityGateProjectStatus(&QualitygatesProjectStatusOptions{})
 	assert.Error(t, err)
 }
 
@@ -544,14 +544,14 @@ func TestQualitygatesProjectStatus_JSONUnmarshal(t *testing.T) {
 
 	err := json.Unmarshal([]byte(jsonData), &response)
 	require.NoError(t, err)
-	assert.Equal(t, "ERROR", response.ProjectStatus.Status)
-	assert.Equal(t, "non-compliant", response.ProjectStatus.CaycStatus)
-	require.Len(t, response.ProjectStatus.Conditions, 2)
+	assert.Equal(t, "ERROR", response.QualityGateProjectStatus.Status)
+	assert.Equal(t, "non-compliant", response.QualityGateProjectStatus.CaycStatus)
+	require.Len(t, response.QualityGateProjectStatus.Conditions, 2)
 
-	cond := response.ProjectStatus.Conditions[0]
+	cond := response.QualityGateProjectStatus.Conditions[0]
 	assert.Equal(t, "new_coverage", cond.MetricKey)
 	assert.Equal(t, "70.5", cond.ActualValue)
-	assert.Equal(t, "PREVIOUS_VERSION", response.ProjectStatus.Period.Mode)
+	assert.Equal(t, "PREVIOUS_VERSION", response.QualityGateProjectStatus.Period.Mode)
 }
 
 // TestQualitygatesShow_JSONUnmarshal verifies the JSON unmarshal for show response.

--- a/sonar/qualityprofiles_service.go
+++ b/sonar/qualityprofiles_service.go
@@ -91,29 +91,29 @@ type ChangelogImpact struct {
 // QualityprofilesCompare represents the response from comparing two quality profiles.
 type QualityprofilesCompare struct {
 	// Left contains information about the left profile.
-	Left CompareProfile `json:"left,omitzero"`
+	Left QualityprofilesCompareProfile `json:"left,omitzero"`
 	// Right contains information about the right profile.
-	Right CompareProfile `json:"right,omitzero"`
+	Right QualityprofilesCompareProfile `json:"right,omitzero"`
 	// InLeft contains rules only in the left profile.
-	InLeft []CompareRule `json:"inLeft,omitempty"`
+	InLeft []QualityprofilesCompareRule `json:"inLeft,omitempty"`
 	// InRight contains rules only in the right profile.
-	InRight []CompareRule `json:"inRight,omitempty"`
+	InRight []QualityprofilesCompareRule `json:"inRight,omitempty"`
 	// Modified contains rules that differ between profiles.
-	Modified []CompareModifiedRule `json:"modified,omitempty"`
+	Modified []QualityprofilesCompareModifiedRule `json:"modified,omitempty"`
 	// Same contains rules that are the same in both profiles.
-	Same []CompareRule `json:"same,omitempty"`
+	Same []QualityprofilesCompareRule `json:"same,omitempty"`
 }
 
-// CompareProfile represents a profile in a comparison response.
-type CompareProfile struct {
+// QualityprofilesCompareProfile represents a profile in a comparison response.
+type QualityprofilesCompareProfile struct {
 	// Key is the unique key of the profile.
 	Key string `json:"key,omitempty"`
 	// Name is the name of the profile.
 	Name string `json:"name,omitempty"`
 }
 
-// CompareRule represents a rule in a comparison response.
-type CompareRule struct {
+// QualityprofilesCompareRule represents a rule in a comparison response.
+type QualityprofilesCompareRule struct {
 	// Key is the rule key.
 	Key string `json:"key,omitempty"`
 	// Name is the rule name.
@@ -128,10 +128,10 @@ type CompareRule struct {
 	LanguageName string `json:"languageName,omitempty"`
 }
 
-// CompareModifiedRule represents a modified rule in a comparison response.
+// QualityprofilesCompareModifiedRule represents a modified rule in a comparison response.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type CompareModifiedRule struct {
+type QualityprofilesCompareModifiedRule struct {
 	// Key is the rule key.
 	Key string `json:"key,omitempty"`
 	// Name is the rule name.
@@ -145,13 +145,13 @@ type CompareModifiedRule struct {
 	// LanguageName is the language name.
 	LanguageName string `json:"languageName,omitempty"`
 	// Left contains the left profile's settings for this rule.
-	Left RuleSetting `json:"left,omitzero"`
+	Left QualityprofilesRuleSetting `json:"left,omitzero"`
 	// Right contains the right profile's settings for this rule.
-	Right RuleSetting `json:"right,omitzero"`
+	Right QualityprofilesRuleSetting `json:"right,omitzero"`
 }
 
-// RuleSetting represents the settings for a rule in a profile.
-type RuleSetting struct {
+// QualityprofilesRuleSetting represents the settings for a rule in a profile.
+type QualityprofilesRuleSetting struct {
 	// Params contains the rule parameters.
 	Params map[string]string `json:"params,omitempty"`
 }
@@ -177,11 +177,11 @@ type QualityprofilesCopy struct {
 // QualityprofilesCreate represents the response from creating a quality profile.
 type QualityprofilesCreate struct {
 	// Profile contains the created profile details.
-	Profile CreatedProfile `json:"profile,omitzero"`
+	Profile QualityprofilesCreatedProfile `json:"profile,omitzero"`
 }
 
-// CreatedProfile represents a newly created quality profile.
-type CreatedProfile struct {
+// QualityprofilesCreatedProfile represents a newly created quality profile.
+type QualityprofilesCreatedProfile struct {
 	// Key is the unique key of the profile.
 	Key string `json:"key,omitempty"`
 	// Name is the name of the profile.
@@ -201,11 +201,11 @@ type CreatedProfile struct {
 // Deprecated: No more custom profile exporters since SonarQube 25.4.
 type QualityprofilesExporters struct {
 	// Exporters is the list of available exporters.
-	Exporters []ProfileExporter `json:"exporters,omitempty"`
+	Exporters []QualityprofilesExporter `json:"exporters,omitempty"`
 }
 
-// ProfileExporter represents a quality profile exporter.
-type ProfileExporter struct {
+// QualityprofilesExporter represents a quality profile exporter.
+type QualityprofilesExporter struct {
 	// Key is the unique key of the exporter.
 	Key string `json:"key,omitempty"`
 	// Name is the name of the exporter.
@@ -219,11 +219,11 @@ type ProfileExporter struct {
 // Deprecated: Since SonarQube 25.4.
 type QualityprofilesImporters struct {
 	// Importers is the list of available importers.
-	Importers []ProfileImporter `json:"importers,omitempty"`
+	Importers []QualityprofilesImporter `json:"importers,omitempty"`
 }
 
-// ProfileImporter represents a quality profile importer.
-type ProfileImporter struct {
+// QualityprofilesImporter represents a quality profile importer.
+type QualityprofilesImporter struct {
 	// Key is the unique key of the importer.
 	Key string `json:"key,omitempty"`
 	// Name is the name of the importer.
@@ -237,15 +237,15 @@ type ProfileImporter struct {
 //nolint:govet // Field alignment is less important than logical grouping
 type QualityprofilesInheritance struct {
 	// Profile contains the current profile information.
-	Profile InheritanceProfile `json:"profile,omitzero"`
+	Profile QualityprofilesInheritanceProfile `json:"profile,omitzero"`
 	// Ancestors contains the ancestor profiles.
-	Ancestors []InheritanceProfile `json:"ancestors,omitempty"`
+	Ancestors []QualityprofilesInheritanceProfile `json:"ancestors,omitempty"`
 	// Children contains the child profiles.
-	Children []InheritanceProfile `json:"children,omitempty"`
+	Children []QualityprofilesInheritanceProfile `json:"children,omitempty"`
 }
 
-// InheritanceProfile represents a profile in an inheritance hierarchy.
-type InheritanceProfile struct {
+// QualityprofilesInheritanceProfile represents a profile in an inheritance hierarchy.
+type QualityprofilesInheritanceProfile struct {
 	// Key is the unique key of the profile.
 	Key string `json:"key,omitempty"`
 	// Name is the name of the profile.
@@ -267,11 +267,11 @@ type QualityprofilesProjects struct {
 	// Paging contains pagination information.
 	Paging Paging `json:"paging,omitzero"`
 	// Results contains the list of projects.
-	Results []ProfileProject `json:"results,omitempty"`
+	Results []QualityprofilesProfileProject `json:"results,omitempty"`
 }
 
-// ProfileProject represents a project associated with a quality profile.
-type ProfileProject struct {
+// QualityprofilesProfileProject represents a project associated with a quality profile.
+type QualityprofilesProfileProject struct {
 	// Key is the unique key of the project.
 	Key string `json:"key,omitempty"`
 	// Name is the name of the project.
@@ -355,11 +355,11 @@ type QualityprofilesSearchGroups struct {
 	// Paging contains pagination information.
 	Paging Paging `json:"paging,omitzero"`
 	// Groups is the list of groups.
-	Groups []ProfileGroup `json:"groups,omitempty"`
+	Groups []QualityprofilesProfileGroup `json:"groups,omitempty"`
 }
 
-// ProfileGroup represents a group that can edit a quality profile.
-type ProfileGroup struct {
+// QualityprofilesProfileGroup represents a group that can edit a quality profile.
+type QualityprofilesProfileGroup struct {
 	// Name is the name of the group.
 	Name string `json:"name,omitempty"`
 	// Description is the description of the group.
@@ -375,11 +375,11 @@ type QualityprofilesSearchUsers struct {
 	// Paging contains pagination information.
 	Paging Paging `json:"paging,omitzero"`
 	// Users is the list of users.
-	Users []ProfileUser `json:"users,omitempty"`
+	Users []QualityprofilesProfileUser `json:"users,omitempty"`
 }
 
-// ProfileUser represents a user that can edit a quality profile.
-type ProfileUser struct {
+// QualityprofilesProfileUser represents a user that can edit a quality profile.
+type QualityprofilesProfileUser struct {
 	// Login is the login name of the user.
 	Login string `json:"login,omitempty"`
 	// Name is the display name of the user.
@@ -393,11 +393,11 @@ type ProfileUser struct {
 // QualityprofilesShow represents the response from showing a quality profile.
 type QualityprofilesShow struct {
 	// Profile contains the profile details.
-	Profile ShownProfile `json:"profile,omitzero"`
+	Profile QualityprofilesShownProfile `json:"profile,omitzero"`
 }
 
-// ShownProfile represents a quality profile in a show response.
-type ShownProfile struct {
+// QualityprofilesShownProfile represents a quality profile in a show response.
+type QualityprofilesShownProfile struct {
 	// Key is the unique key of the profile.
 	Key string `json:"key,omitempty"`
 	// Name is the name of the profile.

--- a/sonar/qualityprofiles_service_test.go
+++ b/sonar/qualityprofiles_service_test.go
@@ -413,12 +413,12 @@ func TestQualityprofiles_Changelog_ValidationError(t *testing.T) {
 
 func TestQualityprofiles_Compare(t *testing.T) {
 	response := &QualityprofilesCompare{
-		Left:  CompareProfile{Key: "profile1", Name: "Profile 1"},
-		Right: CompareProfile{Key: "profile2", Name: "Profile 2"},
-		InLeft: []CompareRule{
+		Left:  QualityprofilesCompareProfile{Key: "profile1", Name: "Profile 1"},
+		Right: QualityprofilesCompareProfile{Key: "profile2", Name: "Profile 2"},
+		InLeft: []QualityprofilesCompareRule{
 			{Key: "squid:S1234", Name: "Rule in left"},
 		},
-		InRight: []CompareRule{
+		InRight: []QualityprofilesCompareRule{
 			{Key: "squid:S5678", Name: "Rule in right"},
 		},
 	}
@@ -513,7 +513,7 @@ func TestQualityprofiles_Copy_ValidationError(t *testing.T) {
 
 func TestQualityprofiles_Create(t *testing.T) {
 	response := &QualityprofilesCreate{
-		Profile: CreatedProfile{
+		Profile: QualityprofilesCreatedProfile{
 			Key:          "new-profile-key",
 			Name:         "My New Profile",
 			Language:     "java",
@@ -694,7 +694,7 @@ func TestQualityprofiles_Export_ValidationError(t *testing.T) {
 
 func TestQualityprofiles_Exporters(t *testing.T) {
 	response := &QualityprofilesExporters{
-		Exporters: []ProfileExporter{
+		Exporters: []QualityprofilesExporter{
 			{Key: "checkstyle", Name: "Checkstyle", Languages: []string{"java"}},
 		},
 	}
@@ -712,7 +712,7 @@ func TestQualityprofiles_Exporters(t *testing.T) {
 
 func TestQualityprofiles_Importers(t *testing.T) {
 	response := &QualityprofilesImporters{
-		Importers: []ProfileImporter{
+		Importers: []QualityprofilesImporter{
 			{Key: "pmd", Name: "PMD", Languages: []string{"java"}},
 		},
 	}
@@ -730,15 +730,15 @@ func TestQualityprofiles_Importers(t *testing.T) {
 
 func TestQualityprofiles_Inheritance(t *testing.T) {
 	response := &QualityprofilesInheritance{
-		Profile: InheritanceProfile{
+		Profile: QualityprofilesInheritanceProfile{
 			Key:             "my-profile-key",
 			Name:            "My Profile",
 			ActiveRuleCount: 150,
 		},
-		Ancestors: []InheritanceProfile{
+		Ancestors: []QualityprofilesInheritanceProfile{
 			{Key: "parent-key", Name: "Sonar way", ActiveRuleCount: 200},
 		},
-		Children: []InheritanceProfile{},
+		Children: []QualityprofilesInheritanceProfile{},
 	}
 
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualityprofiles/inheritance", http.StatusOK, response))
@@ -781,7 +781,7 @@ func TestQualityprofiles_Inheritance_ValidationError(t *testing.T) {
 func TestQualityprofiles_Projects(t *testing.T) {
 	response := &QualityprofilesProjects{
 		Paging: Paging{PageIndex: 1, PageSize: 25, Total: 2},
-		Results: []ProfileProject{
+		Results: []QualityprofilesProfileProject{
 			{Key: "project1", Name: "Project 1", Selected: true},
 			{Key: "project2", Name: "Project 2", Selected: false},
 		},
@@ -1029,7 +1029,7 @@ func TestQualityprofiles_Search_ValidationError(t *testing.T) {
 func TestQualityprofiles_SearchGroups(t *testing.T) {
 	response := &QualityprofilesSearchGroups{
 		Paging: Paging{PageIndex: 1, PageSize: 25, Total: 1},
-		Groups: []ProfileGroup{
+		Groups: []QualityprofilesProfileGroup{
 			{Name: "sonar-administrators", Description: "Admin group", Selected: true},
 		},
 	}
@@ -1081,7 +1081,7 @@ func TestQualityprofiles_SearchGroups_ValidationError(t *testing.T) {
 func TestQualityprofiles_SearchUsers(t *testing.T) {
 	response := &QualityprofilesSearchUsers{
 		Paging: Paging{PageIndex: 1, PageSize: 25, Total: 1},
-		Users: []ProfileUser{
+		Users: []QualityprofilesProfileUser{
 			{Login: "john.doe", Name: "John Doe", Selected: true},
 		},
 	}
@@ -1166,7 +1166,7 @@ func TestQualityprofiles_SetDefault_ValidationError(t *testing.T) {
 
 func TestQualityprofiles_Show(t *testing.T) {
 	response := &QualityprofilesShow{
-		Profile: ShownProfile{
+		Profile: QualityprofilesShownProfile{
 			Key:             "sonar-way-java",
 			Name:            "Sonar way",
 			Language:        "java",

--- a/sonar/rules_service.go
+++ b/sonar/rules_service.go
@@ -72,15 +72,15 @@ type RulesApp struct {
 	// Statuses is a map of statuses keys and their associated display names.
 	Statuses map[string]string `json:"statuses,omitempty"`
 	// Characteristics is the list of available rule characteristics.
-	Characteristics []RuleCharacteristic `json:"characteristics,omitempty"`
+	Characteristics []RulesCharacteristic `json:"characteristics,omitempty"`
 	// Repositories is the list of available rule repositories.
-	Repositories []RuleRepository `json:"repositories,omitempty"`
+	Repositories []RulesRepository `json:"repositories,omitempty"`
 	// CanWrite indicates if the current user has permission to modify rules.
 	CanWrite bool `json:"canWrite,omitempty"`
 }
 
-// RuleCharacteristic represents a characteristic that can be associated with rules.
-type RuleCharacteristic struct {
+// RulesCharacteristic represents a characteristic that can be associated with rules.
+type RulesCharacteristic struct {
 	// Key is the unique identifier of the characteristic.
 	Key string `json:"key,omitempty"`
 	// Name is the display name of the characteristic.
@@ -89,8 +89,8 @@ type RuleCharacteristic struct {
 	Parent string `json:"parent,omitempty"`
 }
 
-// RuleRepository represents a rules repository.
-type RuleRepository struct {
+// RulesRepository represents a rules repository.
+type RulesRepository struct {
 	// Key is the unique identifier of the repository.
 	Key string `json:"key,omitempty"`
 	// Language is the programming language of the repository.
@@ -101,11 +101,11 @@ type RuleRepository struct {
 
 // RulesCreate represents the response from creating a custom rule.
 type RulesCreate struct {
-	Rule Rule `json:"rule,omitzero"`
+	Rule RulesDefinition `json:"rule,omitzero"`
 }
 
-// Rule represents a SonarQube rule.
-type Rule struct {
+// RulesDefinition represents a SonarQube rule.
+type RulesDefinition struct {
 	// Key is the unique identifier of the rule.
 	Key string `json:"key,omitempty"`
 	// Severity indicates the severity level of the rule.
@@ -147,29 +147,29 @@ type Rule struct {
 	// CleanCodeAttribute is the clean code attribute of the rule.
 	CleanCodeAttribute string `json:"cleanCodeAttribute,omitempty"`
 	// Params is the list of parameters that can be configured for the rule.
-	Params []RuleParam `json:"params,omitempty"`
+	Params []RulesParam `json:"params,omitempty"`
 	// SysTags is the list of system-defined tags.
 	SysTags []string `json:"sysTags,omitempty"`
 	// Tags is the list of user-defined tags.
 	Tags []any `json:"tags,omitempty"`
 	// Impacts is the list of impacts on software quality.
-	Impacts []RuleImpact `json:"impacts,omitempty"`
+	Impacts []RulesImpact `json:"impacts,omitempty"`
 	// IsTemplate indicates if this is a template rule that can be used to create custom rules.
 	IsTemplate bool `json:"isTemplate,omitempty"`
 	// IsExternal indicates if this is an external rule.
 	IsExternal bool `json:"isExternal,omitempty"`
 }
 
-// RuleImpact represents the impact of a rule on software quality.
-type RuleImpact struct {
+// RulesImpact represents the impact of a rule on software quality.
+type RulesImpact struct {
 	// Severity is the severity of the impact (HIGH, MEDIUM, LOW).
 	Severity string `json:"severity,omitempty"`
 	// SoftwareQuality is the software quality characteristic affected (MAINTAINABILITY, RELIABILITY, SECURITY).
 	SoftwareQuality string `json:"softwareQuality,omitempty"`
 }
 
-// RuleParam represents a parameter that can be configured for a rule.
-type RuleParam struct {
+// RulesParam represents a parameter that can be configured for a rule.
+type RulesParam struct {
 	// DefaultValue is the default value of the parameter.
 	DefaultValue string `json:"defaultValue,omitempty"`
 	// HTMLDesc is the HTML-formatted description of the parameter.
@@ -184,20 +184,20 @@ type RuleParam struct {
 
 // RulesRepositories contains the list of available rule repositories.
 type RulesRepositories struct {
-	Repositories []RuleRepository `json:"repositories,omitempty"`
+	Repositories []RulesRepository `json:"repositories,omitempty"`
 }
 
 // RulesSearch represents the response from searching for rules.
 // The Actives field is a map because rule keys are dynamic.
 type RulesSearch struct {
-	Actives map[string][]RuleActivation `json:"actives,omitempty"`
-	Facets  []SearchFacet               `json:"facets,omitempty"`
-	Rules   []RuleDetails               `json:"rules,omitempty"`
-	Paging  Paging                      `json:"paging,omitzero"`
+	Actives map[string][]RulesActivation `json:"actives,omitempty"`
+	Facets  []RulesSearchFacet           `json:"facets,omitempty"`
+	Rules   []RulesDetails               `json:"rules,omitempty"`
+	Paging  Paging                       `json:"paging,omitzero"`
 }
 
-// RuleActivation represents how a rule is activated in a quality profile.
-type RuleActivation struct {
+// RulesActivation represents how a rule is activated in a quality profile.
+type RulesActivation struct {
 	// Inherit indicates how the rule is inherited (NONE, INHERITED, OVERRIDES).
 	Inherit string `json:"inherit,omitempty"`
 	// QProfile is the key of the quality profile where the rule is activated.
@@ -205,92 +205,92 @@ type RuleActivation struct {
 	// Severity is the severity level of the activated rule.
 	Severity string `json:"severity,omitempty"`
 	// Params is the list of parameter values for the activated rule.
-	Params []ParamKV `json:"params,omitempty"`
+	Params []RulesParamKV `json:"params,omitempty"`
 	// CreatedAt is the timestamp when the rule was activated in the profile.
 	CreatedAt string `json:"createdAt,omitempty"`
 	// UpdatedAt is the timestamp when the rule activation was last updated in the profile.
 	UpdatedAt string `json:"updatedAt,omitempty"`
 	// Impacts is the list of impacts on software quality for this activated rule.
-	Impacts []RuleImpact `json:"impacts,omitempty"`
+	Impacts []RulesImpact `json:"impacts,omitempty"`
 	// PrioritizedRule indicates if the rule is prioritized in this profile.
 	PrioritizedRule bool `json:"prioritizedRule,omitempty"`
 }
 
-// ParamKV represents a key-value pair for rule parameters.
-type ParamKV struct {
+// RulesParamKV represents a key-value pair for rule parameters.
+type RulesParamKV struct {
 	// Key is the parameter name.
 	Key string `json:"key,omitempty"`
 	// Value is the parameter value.
 	Value string `json:"value,omitempty"`
 }
 
-// SearchFacet represents a facet in search results.
-type SearchFacet struct {
+// RulesSearchFacet represents a facet in search results.
+type RulesSearchFacet struct {
 	// Name is the facet name (e.g., languages, repositories, tags).
 	Name string `json:"name,omitempty"`
 	// Values is the list of facet values with their counts.
-	Values []FacetItem `json:"values,omitempty"`
+	Values []RulesFacetItem `json:"values,omitempty"`
 }
 
-// FacetItem represents a single facet value with its count.
-type FacetItem struct {
+// RulesFacetItem represents a single facet value with its count.
+type RulesFacetItem struct {
 	// Val is the facet value.
 	Val string `json:"val,omitempty"`
 	// Count is the number of items matching this facet value.
 	Count int64 `json:"count,omitempty"`
 }
 
-// RuleDetails contains comprehensive information about a rule.
-type RuleDetails struct {
-	Name                       string                   `json:"name,omitempty"`
-	Key                        string                   `json:"key,omitempty"`
-	CreatedAt                  string                   `json:"createdAt,omitempty"`
-	UpdatedAt                  string                   `json:"updatedAt,omitempty"`
-	RemFnType                  string                   `json:"remFnType,omitempty"`
-	HTMLDesc                   string                   `json:"htmlDesc,omitempty"`
-	HTMLNote                   string                   `json:"htmlNote,omitempty"`
-	MdNote                     string                   `json:"mdNote,omitempty"`
-	NoteLogin                  string                   `json:"noteLogin,omitempty"`
-	CleanCodeAttribute         string                   `json:"cleanCodeAttribute,omitempty"`
-	InternalKey                string                   `json:"internalKey,omitempty"`
-	RemFnGapMultiplier         string                   `json:"remFnGapMultiplier,omitempty"`
-	RemFnBaseEffort            string                   `json:"remFnBaseEffort,omitempty"`
-	DefaultRemFnBaseEffort     string                   `json:"defaultRemFnBaseEffort,omitempty"`
-	Lang                       string                   `json:"lang,omitempty"`
-	LangName                   string                   `json:"langName,omitempty"`
-	CleanCodeAttributeCategory string                   `json:"cleanCodeAttributeCategory,omitempty"`
-	GapDescription             string                   `json:"gapDescription,omitempty"`
-	Repo                       string                   `json:"repo,omitempty"`
-	Scope                      string                   `json:"scope,omitempty"`
-	Severity                   string                   `json:"severity,omitempty"`
-	Status                     string                   `json:"status,omitempty"`
-	DefaultRemFnType           string                   `json:"defaultRemFnType,omitempty"`
-	DefaultRemFnGapMultiplier  string                   `json:"defaultRemFnGapMultiplier,omitempty"`
-	TemplateKey                string                   `json:"templateKey,omitempty"`
-	Type                       string                   `json:"type,omitempty"`
-	Impacts                    []RuleImpact             `json:"impacts,omitempty"`
-	Tags                       []any                    `json:"tags,omitempty"`
-	SysTags                    []string                 `json:"sysTags,omitempty"`
-	Params                     []RuleParam              `json:"params,omitempty"`
-	DescriptionSections        []RuleDescriptionSection `json:"descriptionSections,omitempty"`
-	IsTemplate                 bool                     `json:"isTemplate,omitempty"`
-	IsExternal                 bool                     `json:"isExternal,omitempty"`
-	RemFnOverloaded            bool                     `json:"remFnOverloaded,omitempty"`
-	Template                   bool                     `json:"template,omitempty"`
+// RulesDetails contains comprehensive information about a rule.
+type RulesDetails struct {
+	Name                       string                    `json:"name,omitempty"`
+	Key                        string                    `json:"key,omitempty"`
+	CreatedAt                  string                    `json:"createdAt,omitempty"`
+	UpdatedAt                  string                    `json:"updatedAt,omitempty"`
+	RemFnType                  string                    `json:"remFnType,omitempty"`
+	HTMLDesc                   string                    `json:"htmlDesc,omitempty"`
+	HTMLNote                   string                    `json:"htmlNote,omitempty"`
+	MdNote                     string                    `json:"mdNote,omitempty"`
+	NoteLogin                  string                    `json:"noteLogin,omitempty"`
+	CleanCodeAttribute         string                    `json:"cleanCodeAttribute,omitempty"`
+	InternalKey                string                    `json:"internalKey,omitempty"`
+	RemFnGapMultiplier         string                    `json:"remFnGapMultiplier,omitempty"`
+	RemFnBaseEffort            string                    `json:"remFnBaseEffort,omitempty"`
+	DefaultRemFnBaseEffort     string                    `json:"defaultRemFnBaseEffort,omitempty"`
+	Lang                       string                    `json:"lang,omitempty"`
+	LangName                   string                    `json:"langName,omitempty"`
+	CleanCodeAttributeCategory string                    `json:"cleanCodeAttributeCategory,omitempty"`
+	GapDescription             string                    `json:"gapDescription,omitempty"`
+	Repo                       string                    `json:"repo,omitempty"`
+	Scope                      string                    `json:"scope,omitempty"`
+	Severity                   string                    `json:"severity,omitempty"`
+	Status                     string                    `json:"status,omitempty"`
+	DefaultRemFnType           string                    `json:"defaultRemFnType,omitempty"`
+	DefaultRemFnGapMultiplier  string                    `json:"defaultRemFnGapMultiplier,omitempty"`
+	TemplateKey                string                    `json:"templateKey,omitempty"`
+	Type                       string                    `json:"type,omitempty"`
+	Impacts                    []RulesImpact             `json:"impacts,omitempty"`
+	Tags                       []any                     `json:"tags,omitempty"`
+	SysTags                    []string                  `json:"sysTags,omitempty"`
+	Params                     []RulesParam              `json:"params,omitempty"`
+	DescriptionSections        []RulesDescriptionSection `json:"descriptionSections,omitempty"`
+	IsTemplate                 bool                      `json:"isTemplate,omitempty"`
+	IsExternal                 bool                      `json:"isExternal,omitempty"`
+	RemFnOverloaded            bool                      `json:"remFnOverloaded,omitempty"`
+	Template                   bool                      `json:"template,omitempty"`
 }
 
-// RuleDescriptionSection represents a section of a rule's description.
-type RuleDescriptionSection struct {
+// RulesDescriptionSection represents a section of a rule's description.
+type RulesDescriptionSection struct {
 	// Content is the HTML content of the section.
 	Content string `json:"content,omitempty"`
 	// Context provides additional context for the section.
-	Context RuleDescriptionSectionContext `json:"context,omitzero"`
+	Context RulesDescriptionSectionContext `json:"context,omitzero"`
 	// Key is the unique identifier of the section.
 	Key string `json:"key,omitempty"`
 }
 
-// RuleDescriptionSectionContext provides context for a description section.
-type RuleDescriptionSectionContext struct {
+// RulesDescriptionSectionContext provides context for a description section.
+type RulesDescriptionSectionContext struct {
 	// DisplayName is the human-readable name of the context.
 	DisplayName string `json:"displayName,omitempty"`
 	// Key is the unique identifier of the context.
@@ -299,12 +299,12 @@ type RuleDescriptionSectionContext struct {
 
 // RulesShow represents the response from showing a specific rule.
 type RulesShow struct {
-	Actives []RuleActivationDetailed `json:"actives,omitempty"`
-	Rule    RuleDetails              `json:"rule,omitzero"`
+	Actives []RulesActivationDetailed `json:"actives,omitempty"`
+	Rule    RulesDetails              `json:"rule,omitzero"`
 }
 
-// RuleActivationDetailed contains detailed information about a rule activation.
-type RuleActivationDetailed struct {
+// RulesActivationDetailed contains detailed information about a rule activation.
+type RulesActivationDetailed struct {
 	// Inherit indicates how the rule is inherited (NONE, INHERITED, OVERRIDES).
 	Inherit string `json:"inherit,omitempty"`
 	// QProfile is the key of the quality profile where the rule is activated.
@@ -312,7 +312,7 @@ type RuleActivationDetailed struct {
 	// Severity is the severity level of the activated rule.
 	Severity string `json:"severity,omitempty"`
 	// Params is the list of parameter values for the activated rule.
-	Params []ParamKV `json:"params,omitempty"`
+	Params []RulesParamKV `json:"params,omitempty"`
 	// PrioritizedRule indicates if the rule is prioritized in this profile.
 	PrioritizedRule bool `json:"prioritizedRule,omitempty"`
 }
@@ -324,7 +324,7 @@ type RulesTags struct {
 
 // RulesUpdate represents the response from updating a rule.
 type RulesUpdate struct {
-	Rule Rule `json:"rule,omitzero"`
+	Rule RulesDefinition `json:"rule,omitzero"`
 }
 
 // RulesCreateOptions contains options for creating a custom rule.

--- a/sonar/rules_service_test.go
+++ b/sonar/rules_service_test.go
@@ -60,7 +60,7 @@ func TestRules_Search(t *testing.T) {
 }
 
 // TestRulesSearchResponse_DynamicActives verifies that the Actives field
-// correctly handles dynamic rule keys as a map[string][]RuleActivation.
+// correctly handles dynamic rule keys as a map[string][]RulesActivation.
 func TestRulesSearchResponse_DynamicActives(t *testing.T) {
 	jsonData := `{
 		"actives": {

--- a/sonar/system_service.go
+++ b/sonar/system_service.go
@@ -82,25 +82,25 @@ type SystemDbMigrationStatus struct {
 // SystemHealth represents the response from checking the health status of SonarQube.
 type SystemHealth struct {
 	// Causes contains the reasons for any health issues.
-	Causes []HealthCause `json:"causes,omitempty"`
+	Causes []SystemHealthCause `json:"causes,omitempty"`
 	// Health is the overall health status: GREEN, YELLOW, or RED.
 	Health string `json:"health,omitempty"`
 	// Nodes contains health information for each node in a cluster.
-	Nodes []HealthNode `json:"nodes,omitempty"`
+	Nodes []SystemHealthNode `json:"nodes,omitempty"`
 }
 
-// HealthCause represents a reason for a health issue.
-type HealthCause struct {
+// SystemHealthCause represents a reason for a health issue.
+type SystemHealthCause struct {
 	// Message describes the cause of the health issue.
 	Message string `json:"message,omitempty"`
 }
 
-// HealthNode represents health information for a single node in a cluster.
+// SystemHealthNode represents health information for a single node in a cluster.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type HealthNode struct {
+type SystemHealthNode struct {
 	// Causes contains the reasons for any health issues on this node.
-	Causes []HealthCause `json:"causes,omitempty"`
+	Causes []SystemHealthCause `json:"causes,omitempty"`
 	// Health is the health status of this node: GREEN, YELLOW, or RED.
 	Health string `json:"health,omitempty"`
 	// Host is the hostname or IP address of this node.
@@ -483,13 +483,13 @@ type SystemUpgrades struct {
 	// UpdateCenterRefresh is the timestamp when Update Center was last refreshed.
 	UpdateCenterRefresh string `json:"updateCenterRefresh,omitempty"`
 	// Upgrades is the list of available upgrades.
-	Upgrades []Upgrade `json:"upgrades,omitempty"`
+	Upgrades []SystemUpgrade `json:"upgrades,omitempty"`
 }
 
-// Upgrade represents an available upgrade.
+// SystemUpgrade represents an available upgrade.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type Upgrade struct {
+type SystemUpgrade struct {
 	// ChangeLogURL is the URL to the release changelog.
 	ChangeLogURL string `json:"changeLogUrl,omitempty"`
 	// Description describes the upgrade.
@@ -497,25 +497,25 @@ type Upgrade struct {
 	// DownloadURL is the URL to download the upgrade.
 	DownloadURL string `json:"downloadUrl,omitempty"`
 	// Plugins contains plugin compatibility information.
-	Plugins UpgradePlugins `json:"plugins,omitzero"`
+	Plugins SystemUpgradePlugins `json:"plugins,omitzero"`
 	// ReleaseDate is the release date of the upgrade.
 	ReleaseDate string `json:"releaseDate,omitempty"`
 	// Version is the version of the upgrade.
 	Version string `json:"version,omitempty"`
 }
 
-// UpgradePlugins contains plugin compatibility information for an upgrade.
-type UpgradePlugins struct {
+// SystemUpgradePlugins contains plugin compatibility information for an upgrade.
+type SystemUpgradePlugins struct {
 	// Incompatible lists plugins that are incompatible with the upgrade.
-	Incompatible []IncompatiblePlugin `json:"incompatible,omitempty"`
+	Incompatible []SystemIncompatiblePlugin `json:"incompatible,omitempty"`
 	// RequireUpdate lists plugins that require updating.
-	RequireUpdate []PluginUpdate `json:"requireUpdate,omitempty"`
+	RequireUpdate []SystemPluginUpdate `json:"requireUpdate,omitempty"`
 }
 
-// IncompatiblePlugin represents a plugin that is incompatible with an upgrade.
+// SystemIncompatiblePlugin represents a plugin that is incompatible with an upgrade.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type IncompatiblePlugin struct {
+type SystemIncompatiblePlugin struct {
 	// Category is the plugin category.
 	Category string `json:"category,omitempty"`
 	// Description is the plugin description.
@@ -534,10 +534,10 @@ type IncompatiblePlugin struct {
 	OrganizationURL string `json:"organizationUrl,omitempty"`
 }
 
-// PluginUpdate represents a plugin that requires updating for an upgrade.
+// SystemPluginUpdate represents a plugin that requires updating for an upgrade.
 //
 //nolint:govet // Field alignment is less important than logical grouping
-type PluginUpdate struct {
+type SystemPluginUpdate struct {
 	// Category is the plugin category.
 	Category string `json:"category,omitempty"`
 	// Description is the plugin description.

--- a/sonar/user_groups_service.go
+++ b/sonar/user_groups_service.go
@@ -48,8 +48,8 @@ type UserGroupsService struct {
 // Response Types
 // -----------------------------------------------------------------------------
 
-// UserGroupDetail represents a user group with its properties from user_groups API.
-type UserGroupDetail struct {
+// UserGroupsDetail represents a user group with its properties from user_groups API.
+type UserGroupsDetail struct {
 	// Description is the description of the group.
 	Description string `json:"description,omitempty"`
 	// ID is the unique identifier of the group.
@@ -69,19 +69,19 @@ type UserGroupDetail struct {
 // UserGroupsCreate represents the response from creating a group.
 type UserGroupsCreate struct {
 	// Group contains the created group details.
-	Group UserGroupDetail `json:"group,omitzero"`
+	Group UserGroupsDetail `json:"group,omitzero"`
 }
 
 // UserGroupsSearch represents the response from searching groups.
 type UserGroupsSearch struct {
 	// Groups is the list of groups.
-	Groups []UserGroupDetail `json:"groups,omitempty"`
+	Groups []UserGroupsDetail `json:"groups,omitempty"`
 	// Paging contains pagination information.
 	Paging Paging `json:"paging,omitzero"`
 }
 
-// UserGroupUser represents a user within a group.
-type UserGroupUser struct {
+// UserGroupsUser represents a user within a group.
+type UserGroupsUser struct {
 	// Login is the user's login.
 	Login string `json:"login,omitempty"`
 	// Name is the user's display name.
@@ -95,7 +95,7 @@ type UserGroupUser struct {
 // UserGroupsUsers represents the response from listing users in a group.
 type UserGroupsUsers struct {
 	// Users is the list of users.
-	Users []UserGroupUser `json:"users,omitempty"`
+	Users []UserGroupsUser `json:"users,omitempty"`
 	// Paging contains pagination information.
 	Paging Paging `json:"paging,omitzero"`
 }

--- a/sonar/user_groups_service_test.go
+++ b/sonar/user_groups_service_test.go
@@ -39,7 +39,7 @@ func TestUserGroups_AddUser_ValidationError(t *testing.T) {
 
 func TestUserGroups_Create(t *testing.T) {
 	response := UserGroupsCreate{
-		Group: UserGroupDetail{
+		Group: UserGroupsDetail{
 			ID:           "uuid-group-1",
 			Name:         "sonar-users",
 			Description:  "Default group",
@@ -130,7 +130,7 @@ func TestUserGroups_RemoveUser(t *testing.T) {
 
 func TestUserGroups_Search(t *testing.T) {
 	response := UserGroupsSearch{
-		Groups: []UserGroupDetail{
+		Groups: []UserGroupsDetail{
 			{
 				Name:         "sonar-administrators",
 				Description:  "Admins",
@@ -205,7 +205,7 @@ func TestUserGroups_Update_ValidationError(t *testing.T) {
 
 func TestUserGroups_Users(t *testing.T) {
 	response := UserGroupsUsers{
-		Users: []UserGroupUser{
+		Users: []UserGroupsUser{
 			{
 				Login:    "john.doe",
 				Name:     "John Doe",

--- a/sonar/users_service.go
+++ b/sonar/users_service.go
@@ -167,8 +167,8 @@ type UsersDeactivateResult struct {
 type UsersCurrentProfile struct {
 	// Avatar is the user's avatar URL.
 	Avatar string `json:"avatar,omitempty"`
-	// UsersDismissedNotices contains the notices dismissed by the user.
-	UsersDismissedNotices UsersDismissedNotices `json:"dismissedNotices,omitzero"`
+	// DismissedNotices contains the notices dismissed by the user.
+	DismissedNotices UsersDismissedNotices `json:"dismissedNotices,omitzero"`
 	// Email is the user's email address.
 	Email string `json:"email,omitempty"`
 	// ExternalIdentity is the user's external identity.
@@ -177,8 +177,8 @@ type UsersCurrentProfile struct {
 	ExternalProvider string `json:"externalProvider,omitempty"`
 	// Groups is the list of groups the user belongs to.
 	Groups []string `json:"groups,omitempty"`
-	// UsersHomepage is the user's homepage configuration.
-	UsersHomepage UsersHomepage `json:"homepage,omitzero"`
+	// Homepage is the user's homepage configuration.
+	Homepage UsersHomepage `json:"homepage,omitzero"`
 	// ID is the user's unique identifier.
 	ID string `json:"id,omitempty"`
 	// IsLoggedIn indicates whether the user is currently logged in.

--- a/sonar/users_service.go
+++ b/sonar/users_service.go
@@ -109,10 +109,10 @@ type User struct {
 	ScmAccounts []string `json:"scmAccounts,omitempty"`
 }
 
-// SearchedUser represents a user returned in search results.
+// UsersSearchResult represents a user returned in search results.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type SearchedUser struct {
+type UsersSearchResult struct {
 	// Active indicates whether the user is active.
 	Active bool `json:"active,omitempty"`
 	// Avatar is the user's avatar URL.
@@ -143,10 +143,10 @@ type SearchedUser struct {
 	TokensCount int64 `json:"tokensCount,omitempty"`
 }
 
-// DeactivatedUser represents a deactivated user.
+// UsersDeactivateResult represents a deactivated user.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type DeactivatedUser struct {
+type UsersDeactivateResult struct {
 	// Active indicates whether the user is active (always false for deactivated users).
 	Active bool `json:"active,omitempty"`
 	// Groups is the list of groups (empty for deactivated users).
@@ -161,14 +161,14 @@ type DeactivatedUser struct {
 	ScmAccounts []any `json:"scmAccounts,omitempty"`
 }
 
-// CurrentUser represents the currently authenticated user.
+// UsersCurrentProfile represents the currently authenticated user.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type CurrentUser struct {
+type UsersCurrentProfile struct {
 	// Avatar is the user's avatar URL.
 	Avatar string `json:"avatar,omitempty"`
-	// DismissedNotices contains the notices dismissed by the user.
-	DismissedNotices DismissedNotices `json:"dismissedNotices,omitzero"`
+	// UsersDismissedNotices contains the notices dismissed by the user.
+	UsersDismissedNotices UsersDismissedNotices `json:"dismissedNotices,omitzero"`
 	// Email is the user's email address.
 	Email string `json:"email,omitempty"`
 	// ExternalIdentity is the user's external identity.
@@ -177,8 +177,8 @@ type CurrentUser struct {
 	ExternalProvider string `json:"externalProvider,omitempty"`
 	// Groups is the list of groups the user belongs to.
 	Groups []string `json:"groups,omitempty"`
-	// Homepage is the user's homepage configuration.
-	Homepage Homepage `json:"homepage,omitzero"`
+	// UsersHomepage is the user's homepage configuration.
+	UsersHomepage UsersHomepage `json:"homepage,omitzero"`
 	// ID is the user's unique identifier.
 	ID string `json:"id,omitempty"`
 	// IsLoggedIn indicates whether the user is currently logged in.
@@ -190,39 +190,39 @@ type CurrentUser struct {
 	// Name is the user's display name.
 	Name string `json:"name,omitempty"`
 	// Permissions contains the user's global permissions.
-	Permissions UserPermissions `json:"permissions,omitzero"`
+	Permissions UsersPermissions `json:"permissions,omitzero"`
 	// ScmAccounts is the list of SCM accounts associated with the user.
 	ScmAccounts []string `json:"scmAccounts,omitempty"`
 	// UsingSonarLintConnectedMode indicates whether the user is using SonarLint connected mode.
 	UsingSonarLintConnectedMode bool `json:"usingSonarLintConnectedMode,omitempty"`
 }
 
-// DismissedNotices represents the notices dismissed by a user.
-type DismissedNotices struct {
+// UsersDismissedNotices represents the notices dismissed by a user.
+type UsersDismissedNotices struct {
 	// EducationPrinciples indicates whether the education principles notice was dismissed.
 	EducationPrinciples bool `json:"educationPrinciples,omitempty"`
 	// SonarlintAd indicates whether the SonarLint ad notice was dismissed.
 	SonarlintAd bool `json:"sonarlintAd,omitempty"`
 }
 
-// Homepage represents a user's homepage configuration.
-type Homepage struct {
+// UsersHomepage represents a user's homepage configuration.
+type UsersHomepage struct {
 	// Component is the project key for project homepages.
 	Component string `json:"component,omitempty"`
 	// Type is the homepage type.
 	Type string `json:"type,omitempty"`
 }
 
-// UserPermissions represents a user's global permissions.
-type UserPermissions struct {
+// UsersPermissions represents a user's global permissions.
+type UsersPermissions struct {
 	// Global is the list of global permissions.
 	Global []string `json:"global,omitempty"`
 }
 
-// UserGroup represents a group that a user belongs to.
+// UsersGroup represents a group that a user belongs to.
 //
 //nolint:govet // Field alignment less important than maintaining consistent field order for readability
-type UserGroup struct {
+type UsersGroup struct {
 	// Default indicates whether this is a default group.
 	Default bool `json:"default,omitempty"`
 	// Description is the group description.
@@ -235,8 +235,8 @@ type UserGroup struct {
 	Selected bool `json:"selected,omitempty"`
 }
 
-// IdentityProvider represents an external identity provider.
-type IdentityProvider struct {
+// UsersIdentityProvider represents an external identity provider.
+type UsersIdentityProvider struct {
 	// BackgroundColor is the background color for the provider icon.
 	BackgroundColor string `json:"backgroundColor,omitempty"`
 	// HelpMessage is a help message for the identity provider.
@@ -247,16 +247,6 @@ type IdentityProvider struct {
 	Key string `json:"key,omitempty"`
 	// Name is the display name of the identity provider.
 	Name string `json:"name,omitempty"`
-}
-
-// UsersPaging represents pagination information for user queries.
-type UsersPaging struct {
-	// PageIndex is the current page index (1-based).
-	PageIndex int64 `json:"pageIndex,omitempty"`
-	// PageSize is the number of items per page.
-	PageSize int64 `json:"pageSize,omitempty"`
-	// Total is the total number of items.
-	Total int64 `json:"total,omitempty"`
 }
 
 // -----------------------------------------------------------------------------
@@ -270,34 +260,34 @@ type UsersCreate struct {
 }
 
 // UsersCurrent represents the response from getting the current user.
-type UsersCurrent = CurrentUser
+type UsersCurrent = UsersCurrentProfile
 
 // UsersDeactivate represents the response from deactivating a user.
 type UsersDeactivate struct {
 	// User is the deactivated user.
-	User DeactivatedUser `json:"user,omitzero"`
+	User UsersDeactivateResult `json:"user,omitzero"`
 }
 
 // UsersGroups represents the response from listing a user's groups.
 type UsersGroups struct {
 	// Groups is the list of groups.
-	Groups []UserGroup `json:"groups,omitempty"`
+	Groups []UsersGroup `json:"groups,omitempty"`
 	// Paging contains pagination information.
-	Paging UsersPaging `json:"paging,omitzero"`
+	Paging Paging `json:"paging,omitzero"`
 }
 
 // UsersIdentityProviders represents the response from listing identity providers.
 type UsersIdentityProviders struct {
 	// IdentityProviders is the list of identity providers.
-	IdentityProviders []IdentityProvider `json:"identityProviders,omitempty"`
+	IdentityProviders []UsersIdentityProvider `json:"identityProviders,omitempty"`
 }
 
 // UsersSearch represents the response from searching users.
 type UsersSearch struct {
 	// Users is the list of users.
-	Users []SearchedUser `json:"users,omitempty"`
+	Users []UsersSearchResult `json:"users,omitempty"`
 	// Paging contains pagination information.
-	Paging UsersPaging `json:"paging,omitzero"`
+	Paging Paging `json:"paging,omitzero"`
 }
 
 // UsersUpdate represents the response from updating a user.

--- a/sonar/users_service_test.go
+++ b/sonar/users_service_test.go
@@ -156,9 +156,9 @@ func TestUsers_Create_ValidationError(t *testing.T) {
 }
 
 func TestUsers_Current(t *testing.T) {
-	response := CurrentUser{
+	response := UsersCurrentProfile{
 		Avatar: "abc123",
-		DismissedNotices: DismissedNotices{
+		UsersDismissedNotices: UsersDismissedNotices{
 			EducationPrinciples: true,
 			SonarlintAd:         false,
 		},
@@ -166,7 +166,7 @@ func TestUsers_Current(t *testing.T) {
 		ExternalIdentity: "admin",
 		ExternalProvider: "sonarqube",
 		Groups:           []string{"sonar-users", "sonar-administrators"},
-		Homepage: Homepage{
+		UsersHomepage: UsersHomepage{
 			Component: "my-project",
 			Type:      "PROJECT",
 		},
@@ -175,7 +175,7 @@ func TestUsers_Current(t *testing.T) {
 		Local:                       true,
 		Login:                       "admin",
 		Name:                        "Administrator",
-		Permissions:                 UserPermissions{Global: []string{"admin", "scan"}},
+		Permissions:                 UsersPermissions{Global: []string{"admin", "scan"}},
 		ScmAccounts:                 []string{"admin@scm.com"},
 		UsingSonarLintConnectedMode: true,
 	}
@@ -189,14 +189,14 @@ func TestUsers_Current(t *testing.T) {
 	require.NotNil(t, result)
 	assert.Equal(t, "admin", result.Login)
 	assert.True(t, result.IsLoggedIn)
-	assert.Equal(t, "PROJECT", result.Homepage.Type)
-	assert.True(t, result.DismissedNotices.EducationPrinciples)
+	assert.Equal(t, "PROJECT", result.UsersHomepage.Type)
+	assert.True(t, result.UsersDismissedNotices.EducationPrinciples)
 	assert.Len(t, result.Permissions.Global, 2)
 }
 
 func TestUsers_Deactivate(t *testing.T) {
 	response := UsersDeactivate{
-		User: DeactivatedUser{
+		User: UsersDeactivateResult{
 			Active: false,
 			Groups: []any{},
 			Local:  true,
@@ -223,7 +223,7 @@ func TestUsers_Deactivate(t *testing.T) {
 
 func TestUsers_Deactivate_WithAnonymize(t *testing.T) {
 	response := UsersDeactivate{
-		User: DeactivatedUser{
+		User: UsersDeactivateResult{
 			Active: false,
 			Groups: []any{},
 			Local:  true,
@@ -302,7 +302,7 @@ func TestUsers_DismissNotice_ValidationError(t *testing.T) {
 
 func TestUsers_Groups(t *testing.T) {
 	response := UsersGroups{
-		Groups: []UserGroup{
+		Groups: []UsersGroup{
 			{
 				Default:     true,
 				Description: "Default group",
@@ -318,7 +318,7 @@ func TestUsers_Groups(t *testing.T) {
 				Selected:    false,
 			},
 		},
-		Paging: UsersPaging{
+		Paging: Paging{
 			PageIndex: 1,
 			PageSize:  25,
 			Total:     2,
@@ -344,8 +344,8 @@ func TestUsers_Groups(t *testing.T) {
 
 func TestUsers_Groups_WithPagination(t *testing.T) {
 	response := UsersGroups{
-		Groups: []UserGroup{},
-		Paging: UsersPaging{
+		Groups: []UsersGroup{},
+		Paging: Paging{
 			PageIndex: 2,
 			PageSize:  10,
 			Total:     2,
@@ -371,8 +371,8 @@ func TestUsers_Groups_WithPagination(t *testing.T) {
 
 func TestUsers_Groups_WithFilter(t *testing.T) {
 	response := UsersGroups{
-		Groups: []UserGroup{},
-		Paging: UsersPaging{
+		Groups: []UsersGroup{},
+		Paging: Paging{
 			PageIndex: 1,
 			PageSize:  25,
 			Total:     0,
@@ -428,7 +428,7 @@ func TestUsers_Groups_ValidationError(t *testing.T) {
 
 func TestUsers_IdentityProviders(t *testing.T) {
 	response := UsersIdentityProviders{
-		IdentityProviders: []IdentityProvider{
+		IdentityProviders: []UsersIdentityProvider{
 			{
 				BackgroundColor: "#444444",
 				HelpMessage:     "Use your LDAP credentials",
@@ -460,12 +460,12 @@ func TestUsers_IdentityProviders(t *testing.T) {
 
 func TestUsers_Search(t *testing.T) {
 	response := UsersSearch{
-		Paging: UsersPaging{
+		Paging: Paging{
 			PageIndex: 1,
 			PageSize:  50,
 			Total:     2,
 		},
-		Users: []SearchedUser{
+		Users: []UsersSearchResult{
 			{
 				Active:                      true,
 				Avatar:                      "abc123",
@@ -507,12 +507,12 @@ func TestUsers_Search(t *testing.T) {
 
 func TestUsers_Search_WithFilters(t *testing.T) {
 	response := UsersSearch{
-		Paging: UsersPaging{
+		Paging: Paging{
 			PageIndex: 1,
 			PageSize:  25,
 			Total:     0,
 		},
-		Users: []SearchedUser{},
+		Users: []UsersSearchResult{},
 	}
 
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/users/search", http.StatusOK, response))

--- a/sonar/users_service_test.go
+++ b/sonar/users_service_test.go
@@ -158,7 +158,7 @@ func TestUsers_Create_ValidationError(t *testing.T) {
 func TestUsers_Current(t *testing.T) {
 	response := UsersCurrentProfile{
 		Avatar: "abc123",
-		UsersDismissedNotices: UsersDismissedNotices{
+		DismissedNotices: UsersDismissedNotices{
 			EducationPrinciples: true,
 			SonarlintAd:         false,
 		},
@@ -166,7 +166,7 @@ func TestUsers_Current(t *testing.T) {
 		ExternalIdentity: "admin",
 		ExternalProvider: "sonarqube",
 		Groups:           []string{"sonar-users", "sonar-administrators"},
-		UsersHomepage: UsersHomepage{
+		Homepage: UsersHomepage{
 			Component: "my-project",
 			Type:      "PROJECT",
 		},
@@ -189,8 +189,8 @@ func TestUsers_Current(t *testing.T) {
 	require.NotNil(t, result)
 	assert.Equal(t, "admin", result.Login)
 	assert.True(t, result.IsLoggedIn)
-	assert.Equal(t, "PROJECT", result.UsersHomepage.Type)
-	assert.True(t, result.UsersDismissedNotices.EducationPrinciples)
+	assert.Equal(t, "PROJECT", result.Homepage.Type)
+	assert.True(t, result.DismissedNotices.EducationPrinciples)
 	assert.Len(t, result.Permissions.Global, 2)
 }
 

--- a/sonar/users_v2_service.go
+++ b/sonar/users_v2_service.go
@@ -347,8 +347,8 @@ func (s *UsersManagementService) Create(opt *UsersCreateOptionsV2) (*UserV2, *ht
 	return result, resp, nil
 }
 
-// Fetch retrieves a single user by ID.
-func (s *UsersManagementService) Fetch(userID string) (*UserV2, *http.Response, error) {
+// Get retrieves a single user by ID.
+func (s *UsersManagementService) Get(userID string) (*UserV2, *http.Response, error) {
 	err := ValidateRequired(userID, "Id")
 	if err != nil {
 		return nil, nil, err

--- a/sonar/users_v2_service_test.go
+++ b/sonar/users_v2_service_test.go
@@ -119,10 +119,10 @@ func TestUsersV2_Create_Validation(t *testing.T) {
 }
 
 // =============================================================================
-// Fetch
+// Get
 // =============================================================================
 
-func TestUsersV2_Fetch(t *testing.T) {
+func TestUsersV2_Get(t *testing.T) {
 	response := UserV2{
 		Id:    "user-1",
 		Login: "jdoe",
@@ -131,16 +131,16 @@ func TestUsersV2_Fetch(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/users-management/users/user-1", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.UsersManagement.Fetch("user-1")
+	result, resp, err := client.V2.UsersManagement.Get("user-1")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "jdoe", result.Login)
 }
 
-func TestUsersV2_Fetch_Validation(t *testing.T) {
+func TestUsersV2_Get_Validation(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.V2.UsersManagement.Fetch("")
+	_, _, err := client.V2.UsersManagement.Get("")
 	assert.Error(t, err)
 }
 

--- a/sonar/webhooks_service.go
+++ b/sonar/webhooks_service.go
@@ -32,8 +32,8 @@ type WebhooksService struct {
 // Response Types
 // -----------------------------------------------------------------------------
 
-// Webhook represents a webhook configuration.
-type Webhook struct {
+// WebhooksDefinition represents a webhook configuration.
+type WebhooksDefinition struct {
 	// Key is the unique identifier of the webhook.
 	Key string `json:"key,omitempty"`
 	// Name is the display name of the webhook.
@@ -47,7 +47,7 @@ type Webhook struct {
 // WebhooksCreate represents the response from creating a webhook.
 type WebhooksCreate struct {
 	// Webhook contains the created webhook details.
-	Webhook Webhook `json:"webhook,omitzero"`
+	Webhook WebhooksDefinition `json:"webhook,omitzero"`
 }
 
 // WebhooksDeliveries represents the response from listing webhook deliveries.
@@ -93,7 +93,7 @@ type WebhooksDelivery struct {
 // WebhooksList represents the response from listing webhooks.
 type WebhooksList struct {
 	// Webhooks is the list of configured webhooks.
-	Webhooks []Webhook `json:"webhooks,omitempty"`
+	Webhooks []WebhooksDefinition `json:"webhooks,omitempty"`
 }
 
 // -----------------------------------------------------------------------------

--- a/sonar/webhooks_service_test.go
+++ b/sonar/webhooks_service_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestWebhooks_Create(t *testing.T) {
 	response := WebhooksCreate{
-		Webhook: Webhook{
+		Webhook: WebhooksDefinition{
 			Key:       "uuid-webhook-1",
 			Name:      "My Webhook",
 			URL:       "https://example.com/webhook",
@@ -179,7 +179,7 @@ func TestWebhooks_Delivery_ValidationError(t *testing.T) {
 
 func TestWebhooks_List(t *testing.T) {
 	response := WebhooksList{
-		Webhooks: []Webhook{
+		Webhooks: []WebhooksDefinition{
 			{
 				Key:       "webhook-1",
 				Name:      "Global Webhook",

--- a/sonar/webservices_service.go
+++ b/sonar/webservices_service.go
@@ -19,15 +19,15 @@ type WebservicesService struct {
 // WebservicesList represents the response from listing webservices.
 type WebservicesList struct {
 	// Webservices is the list of available webservices.
-	Webservices []Webservice `json:"webServices,omitempty"`
+	Webservices []WebservicesDefinition `json:"webServices,omitempty"`
 }
 
-// Webservice represents a webservice controller.
+// WebservicesDefinition represents a webservice controller.
 //
 //nolint:govet // fieldalignment - structure kept for readability
-type Webservice struct {
+type WebservicesDefinition struct {
 	// Actions is the list of actions available in the controller.
-	Actions []WebserviceAction `json:"actions,omitempty"`
+	Actions []WebservicesAction `json:"actions,omitempty"`
 	// Description is the controller description.
 	Description string `json:"description,omitempty"`
 	// Path is the controller path.
@@ -36,12 +36,12 @@ type Webservice struct {
 	Since string `json:"since,omitempty"`
 }
 
-// WebserviceAction represents an action within a webservice.
+// WebservicesAction represents an action within a webservice.
 //
 //nolint:govet // fieldalignment - structure kept for readability
-type WebserviceAction struct {
+type WebservicesAction struct {
 	// Changelog is the list of changes.
-	Changelog []WebserviceChangelog `json:"changelog,omitempty"`
+	Changelog []WebservicesChangelog `json:"changelog,omitempty"`
 	// DeprecatedSince indicates when the action was deprecated.
 	DeprecatedSince string `json:"deprecatedSince,omitempty"`
 	// Description is the action description.
@@ -53,25 +53,25 @@ type WebserviceAction struct {
 	// Key is the action key.
 	Key string `json:"key,omitempty"`
 	// Params is the list of parameters.
-	Params []WebserviceParam `json:"params,omitempty"`
+	Params []WebservicesParam `json:"params,omitempty"`
 	// Post indicates if the action uses POST method.
 	Post bool `json:"post,omitempty"`
 	// Since indicates when the action was introduced.
 	Since string `json:"since,omitempty"`
 }
 
-// WebserviceChangelog represents a changelog entry for an action.
-type WebserviceChangelog struct {
+// WebservicesChangelog represents a changelog entry for an action.
+type WebservicesChangelog struct {
 	// Description is the changelog description.
 	Description string `json:"description,omitempty"`
 	// Version is the version when the change occurred.
 	Version string `json:"version,omitempty"`
 }
 
-// WebserviceParam represents a parameter for an action.
+// WebservicesParam represents a parameter for an action.
 //
 //nolint:govet // fieldalignment - structure kept for readability
-type WebserviceParam struct {
+type WebservicesParam struct {
 	// DefaultValue is the parameter default value.
 	DefaultValue string `json:"defaultValue,omitempty"`
 	// DeprecatedKey is the deprecated key for the parameter.


### PR DESCRIPTION
### Description of your changes

This PR renames unclear/ unscoped resources in the SDK to hold clearer names.
It gets rid of duplicates.

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

#### Type Renames

Closes #200 

```plaintext
BREAKING CHANGE: `Group` renamed to `AuthorizationsGroup` for namespace clarity `AuthorizationsGroup` in `sonar/authorizations_v2_service.go`
BREAKING CHANGE: `GroupMembership` renamed to `AuthorizationsGroupMembership` for namespace clarity `AuthorizationsGroupMembership` in `sonar/authorizations_v2_service.go`
BREAKING CHANGE: `AnalysisWarning` renamed to `CeAnalysisWarning` for namespace clarity `CeAnalysisWarning` in `sonar/ce_service.go`
BREAKING CHANGE: `AnalysisComponent` renamed to `CeAnalysisComponent` for namespace clarity `CeAnalysisComponent` in `sonar/ce_service.go`
BREAKING CHANGE: `CePaging` renamed to `CeTaskPaging` for semantic accuracy `CeTaskPaging` in `sonar/ce_service.go`
BREAKING CHANGE: `ProvisioningApplicationStatus` renamed to `GithubProvisioningApplicationStatus` for namespace clarity `GithubProvisioningApplicationStatus` in `sonar/github_provisioning_service.go`
BREAKING CHANGE: `ProvisioningInstallation` renamed to `GithubProvisioningInstallation` for namespace clarity `GithubProvisioningInstallation` in `sonar/github_provisioning_service.go`
BREAKING CHANGE: `ProvisioningStatus` renamed to `GithubProvisioningStatus` for namespace clarity `GithubProvisioningStatus` in `sonar/github_provisioning_service.go`
BREAKING CHANGE: `JitStatus` renamed to `GithubProvisioningJitStatus` for namespace clarity `GithubProvisioningJitStatus` in `sonar/github_provisioning_service.go`
BREAKING CHANGE: `HotspotPaging` renamed to `HotspotsTaskPaging` for semantic accuracy `HotspotsTaskPaging` in `sonar/hotspots_service.go`
BREAKING CHANGE: `TemplatePermission` renamed to `PermissionsTemplatePermission` for namespace clarity `PermissionsTemplatePermission` in `sonar/permissions_service.go`
BREAKING CHANGE: `DefaultTemplate` renamed to `PermissionsDefaultTemplate` for namespace clarity `PermissionsDefaultTemplate` in `sonar/permissions_service.go`
BREAKING CHANGE: `TemplateGroup` renamed to `PermissionsTemplateGroup` for namespace clarity `PermissionsTemplateGroup` in `sonar/permissions_service.go`
BREAKING CHANGE: `TemplateUser` renamed to `PermissionsTemplateUser` for namespace clarity `PermissionsTemplateUser` in `sonar/permissions_service.go`
BREAKING CHANGE: `PermissionTemplateBasic` renamed to `PermissionsTemplateBasic` for namespace clarity `PermissionsTemplateBasic` in `sonar/permissions_service.go`
BREAKING CHANGE: `PermissionTemplateUpdated` renamed to `PermissionsTemplateUpdated` for namespace clarity `PermissionsTemplateUpdated` in `sonar/permissions_service.go`
BREAKING CHANGE: `PermissionsPaging` replaced with `Paging` type consolidation `Paging` in `sonar/permissions_service.go`
BREAKING CHANGE: `Branch` renamed to `ProjectBranch` for namespace clarity `ProjectBranch` in `sonar/project_branches_service.go`
BREAKING CHANGE: `BranchStatus` renamed to `ProjectBranchStatus` for namespace clarity `ProjectBranchStatus` in `sonar/project_branches_service.go`
BREAKING CHANGE: `ProjectStatus` renamed to `QualityGateProjectStatus` for namespace clarity `QualityGateProjectStatus` in `sonar/qualitygates_service.go`
BREAKING CHANGE: `ConditionStatus` renamed to `QualityGateConditionStatus` for namespace clarity `QualityGateConditionStatus` in `sonar/qualitygates_service.go`
BREAKING CHANGE: `AnalysisPeriod` renamed to `QualityGateAnalysisPeriod` for namespace clarity `QualityGateAnalysisPeriod` in `sonar/qualitygates_service.go`
BREAKING CHANGE: `CompareProfile` renamed to `QualityprofilesCompareProfile` for namespace clarity `QualityprofilesCompareProfile` in `sonar/qualityprofiles_service.go`
BREAKING CHANGE: `CompareRule` renamed to `QualityprofilesCompareRule` for namespace clarity `QualityprofilesCompareRule` in `sonar/qualityprofiles_service.go`
BREAKING CHANGE: `CompareModifiedRule` renamed to `QualityprofilesCompareModifiedRule` for namespace clarity `QualityprofilesCompareModifiedRule` in `sonar/qualityprofiles_service.go`
BREAKING CHANGE: `RuleSetting` renamed to `QualityprofilesRuleSetting` for namespace clarity `QualityprofilesRuleSetting` in `sonar/qualityprofiles_service.go`
BREAKING CHANGE: `CreatedProfile` renamed to `QualityprofilesCreatedProfile` for namespace clarity `QualityprofilesCreatedProfile` in `sonar/qualityprofiles_service.go`
BREAKING CHANGE: `ProfileExporter` renamed to `QualityprofilesExporter` for namespace clarity `QualityprofilesExporter` in `sonar/qualityprofiles_service.go`
BREAKING CHANGE: `ProfileImporter` renamed to `QualityprofilesImporter` for namespace clarity `QualityprofilesImporter` in `sonar/qualityprofiles_service.go`
BREAKING CHANGE: `InheritanceProfile` renamed to `QualityprofilesInheritanceProfile` for namespace clarity `QualityprofilesInheritanceProfile` in `sonar/qualityprofiles_service.go`
BREAKING CHANGE: `ProfileProject` renamed to `QualityprofilesProfileProject` for namespace clarity `QualityprofilesProfileProject` in `sonar/qualityprofiles_service.go`
BREAKING CHANGE: `ProfileGroup` renamed to `QualityprofilesProfileGroup` for namespace clarity `QualityprofilesProfileGroup` in `sonar/qualityprofiles_service.go`
BREAKING CHANGE: `ProfileUser` renamed to `QualityprofilesProfileUser` for namespace clarity `QualityprofilesProfileUser` in `sonar/qualityprofiles_service.go`
BREAKING CHANGE: `ShownProfile` renamed to `QualityprofilesShownProfile` for namespace clarity `QualityprofilesShownProfile` in `sonar/qualityprofiles_service.go`
BREAKING CHANGE: `Rule` renamed to `RulesDefinition` for semantic accuracy `RulesDefinition` in `sonar/rules_service.go`
BREAKING CHANGE: `RuleParam` renamed to `RulesParam` for namespace clarity `RulesParam` in `sonar/rules_service.go`
BREAKING CHANGE: `RuleImpact` renamed to `RulesImpact` for namespace clarity `RulesImpact` in `sonar/rules_service.go`
BREAKING CHANGE: `RuleActivation` renamed to `RulesActivation` for namespace clarity `RulesActivation` in `sonar/rules_service.go`
BREAKING CHANGE: `RuleDescriptionSection` renamed to `RulesDescriptionSection` for namespace clarity `RulesDescriptionSection` in `sonar/rules_service.go`
BREAKING CHANGE: `RuleDescriptionSectionContext` renamed to `RulesDescriptionSectionContext` for namespace clarity `RulesDescriptionSectionContext` in `sonar/rules_service.go`
BREAKING CHANGE: `RuleDetails` renamed to `RulesDetails` for namespace clarity `RulesDetails` in `sonar/rules_service.go`
BREAKING CHANGE: `RuleActivationDetailed` renamed to `RulesActivationDetailed` for namespace clarity `RulesActivationDetailed` in `sonar/rules_service.go`
BREAKING CHANGE: `ParamKV` renamed to `RulesParamKV` for namespace clarity `RulesParamKV` in `sonar/rules_service.go`
BREAKING CHANGE: `SearchFacet` renamed to `RulesSearchFacet` for namespace clarity `RulesSearchFacet` in `sonar/rules_service.go`
BREAKING CHANGE: `FacetItem` renamed to `RulesFacetItem` for namespace clarity `RulesFacetItem` in `sonar/rules_service.go`
BREAKING CHANGE: `RuleCharacteristic` renamed to `RulesCharacteristic` for namespace clarity `RulesCharacteristic` in `sonar/rules_service.go`
BREAKING CHANGE: `RuleRepository` renamed to `RulesRepository` for namespace clarity `RulesRepository` in `sonar/rules_service.go`
BREAKING CHANGE: `Upgrade` renamed to `SystemUpgrade` for namespace clarity `SystemUpgrade` in `sonar/system_service.go`
BREAKING CHANGE: `UpgradePlugins` renamed to `SystemUpgradePlugins` for namespace clarity `SystemUpgradePlugins` in `sonar/system_service.go`
BREAKING CHANGE: `IncompatiblePlugin` renamed to `SystemIncompatiblePlugin` for namespace clarity `SystemIncompatiblePlugin` in `sonar/system_service.go`
BREAKING CHANGE: `PluginUpdate` renamed to `SystemPluginUpdate` for namespace clarity `SystemPluginUpdate` in `sonar/system_service.go`
BREAKING CHANGE: `HealthNode` renamed to `SystemHealthNode` for namespace clarity `SystemHealthNode` in `sonar/system_service.go`
BREAKING CHANGE: `HealthCause` renamed to `SystemHealthCause` for namespace clarity `SystemHealthCause` in `sonar/system_service.go`
BREAKING CHANGE: `SearchedUser` renamed to `UsersSearchResult` for semantic accuracy `UsersSearchResult` in `sonar/users_service.go`
BREAKING CHANGE: `DeactivatedUser` renamed to `UsersDeactivateResult` for semantic accuracy `UsersDeactivateResult` in `sonar/users_service.go`
BREAKING CHANGE: `CurrentUser` renamed to `UsersCurrentProfile` for namespace clarity `UsersCurrentProfile` in `sonar/users_service.go`
BREAKING CHANGE: `UserGroup` renamed to `UsersGroup` for namespace clarity `UsersGroup` in `sonar/users_service.go`
BREAKING CHANGE: `UserPermissions` renamed to `UsersPermissions` for namespace clarity `UsersPermissions` in `sonar/users_service.go`
BREAKING CHANGE: `IdentityProvider` renamed to `UsersIdentityProvider` for namespace clarity `UsersIdentityProvider` in `sonar/users_service.go`
BREAKING CHANGE: `Homepage` renamed to `UsersHomepage` for namespace clarity `UsersHomepage` in `sonar/users_service.go`
BREAKING CHANGE: `DismissedNotices` renamed to `UsersDismissedNotices` for namespace clarity `UsersDismissedNotices` in `sonar/users_service.go`
BREAKING CHANGE: `UsersPaging` replaced with `Paging` type consolidation `Paging` in `sonar/users_service.go`
BREAKING CHANGE: `UserGroupDetail` renamed to `UserGroupsDetail` for namespace clarity `UserGroupsDetail` in `sonar/user_groups_service.go`
BREAKING CHANGE: `UserGroupUser` renamed to `UserGroupsUser` for namespace clarity `UserGroupsUser` in `sonar/user_groups_service.go`
BREAKING CHANGE: `Webhook` renamed to `WebhooksDefinition` for semantic accuracy `WebhooksDefinition` in `sonar/webhooks_service.go`
BREAKING CHANGE: `Webservice` renamed to `WebservicesDefinition` for semantic accuracy `WebservicesDefinition` in `sonar/webservices_service.go`
BREAKING CHANGE: `WebserviceAction` renamed to `WebservicesAction` for namespace clarity `WebservicesAction` in `sonar/webservices_service.go`
BREAKING CHANGE: `WebserviceChangelog` renamed to `WebservicesChangelog` for namespace clarity `WebservicesChangelog` in `sonar/webservices_service.go`
BREAKING CHANGE: `WebserviceParam` renamed to `WebservicesParam` for namespace clarity `WebservicesParam` in `sonar/webservices_service.go`
```

#### Method and Function Renames

Closes #199 

```plaintext
BREAKING CHANGE: `GetGithubClientId` method on `*AlmIntegrationsService` renamed to `GetGithubClientID` following Go acronym convention `GetGithubClientID`
BREAKING CHANGE: `IsQueueEmpty` method on `*AnalysisReportsService` renamed to `QueueStatus` because it returns a struct, not a bool `QueueStatus`
BREAKING CHANGE: `File` method on `*BatchService` renamed to `GetFile` for verb-first read pattern `GetFile`
BREAKING CHANGE: `Index` method on `*BatchService` renamed to `GetIndex` for verb-first read pattern `GetIndex`
BREAKING CHANGE: `Project` method on `*BatchService` renamed to `GetProject` for verb-first read pattern `GetProject`
BREAKING CHANGE: `Index` method on `*L10NService` renamed to `GetIndex` for verb-first read pattern `GetIndex`
BREAKING CHANGE: `Destroy` method on `*QualitygatesService` renamed to `Delete` for consistency across all services `Delete`
BREAKING CHANGE: `Select` method on `*QualitygatesService` renamed to `Assign` to use domain verb for gate assignment `Assign`
BREAKING CHANGE: `Deselect` method on `*QualitygatesService` renamed to `Unassign` paired with Assign `Unassign`
BREAKING CHANGE: `QualityGateProjectStatus` method on `*QualitygatesService` renamed to `ProjectStatus` removing redundant service prefix `ProjectStatus`
BREAKING CHANGE: `SetAsDefault` method on `*QualitygatesService` renamed to `SetDefault` for consistency with QualityprofilesService `SetDefault`
BREAKING CHANGE: `FetchGroup` method on `*AuthorizationsService` renamed to `GetGroup` for consistent SDK verb `GetGroup`
BREAKING CHANGE: `FetchAllDopSettings` method on `*DopTranslationService` renamed to `GetDopSettings` for consistent SDK verb `GetDopSettings`
BREAKING CHANGE: `Fetch` method on `*UsersManagementService` renamed to `Get` for consistent SDK verb `Get`
```

#### Migration Guide

For each type rename, perform a global find-and-replace in your codebase:
- Type names: Replace old type name with new type name
- Method names: Update all method calls to use new method names
- Option structs: Update corresponding `<Service><Method>Options` types


### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
