### PR TITLE
feat!: add context.Context to all service methods

### DIFF
--- a/integration_testing/alm_integrations_test.go
+++ b/integration_testing/alm_integrations_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -25,14 +26,14 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("CheckPat", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.AlmIntegrations.CheckPat(nil)
+				_, resp, err := client.AlmIntegrations.CheckPat(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required almSetting", func() {
-				_, resp, err := client.AlmIntegrations.CheckPat(&sonar.AlmIntegrationsCheckPatOptions{})
+				_, resp, err := client.AlmIntegrations.CheckPat(context.Background(), &sonar.AlmIntegrationsCheckPatOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -40,7 +41,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 
 			It("should fail with almSetting too long", func() {
 				longKey := string(make([]byte, 201))
-				_, resp, err := client.AlmIntegrations.CheckPat(&sonar.AlmIntegrationsCheckPatOptions{
+				_, resp, err := client.AlmIntegrations.CheckPat(context.Background(), &sonar.AlmIntegrationsCheckPatOptions{
 					AlmSetting: longKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -56,7 +57,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("GetGithubClientID", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.AlmIntegrations.GetGithubClientID(nil)
+				result, resp, err := client.AlmIntegrations.GetGithubClientID(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
@@ -64,7 +65,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.GetGithubClientID(&sonar.AlmIntegrationsGetGithubClientIDOptions{})
+				result, resp, err := client.AlmIntegrations.GetGithubClientID(context.Background(), &sonar.AlmIntegrationsGetGithubClientIDOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -79,14 +80,14 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("ImportAzureProject", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmIntegrations.ImportAzureProject(nil)
+				resp, err := client.AlmIntegrations.ImportAzureProject(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required projectName", func() {
-				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOptions{
+				resp, err := client.AlmIntegrations.ImportAzureProject(context.Background(), &sonar.AlmIntegrationsImportAzureProjectOptions{
 					RepositoryName: "test-repo",
 				})
 				Expect(err).To(HaveOccurred())
@@ -95,7 +96,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required repositoryName", func() {
-				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOptions{
+				resp, err := client.AlmIntegrations.ImportAzureProject(context.Background(), &sonar.AlmIntegrationsImportAzureProjectOptions{
 					ProjectName: "test-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -104,7 +105,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail with invalid newCodeDefinitionType", func() {
-				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOptions{
+				resp, err := client.AlmIntegrations.ImportAzureProject(context.Background(), &sonar.AlmIntegrationsImportAzureProjectOptions{
 					ProjectName:           "test-project",
 					RepositoryName:        "test-repo",
 					NewCodeDefinitionType: "INVALID_TYPE",
@@ -115,7 +116,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail with NUMBER_OF_DAYS type and invalid days value", func() {
-				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOptions{
+				resp, err := client.AlmIntegrations.ImportAzureProject(context.Background(), &sonar.AlmIntegrationsImportAzureProjectOptions{
 					ProjectName:            "test-project",
 					RepositoryName:         "test-repo",
 					NewCodeDefinitionType:  sonar.NewCodePeriodTypeNumberOfDays,
@@ -127,7 +128,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail with NUMBER_OF_DAYS type and days value too high", func() {
-				resp, err := client.AlmIntegrations.ImportAzureProject(&sonar.AlmIntegrationsImportAzureProjectOptions{
+				resp, err := client.AlmIntegrations.ImportAzureProject(context.Background(), &sonar.AlmIntegrationsImportAzureProjectOptions{
 					ProjectName:            "test-project",
 					RepositoryName:         "test-repo",
 					NewCodeDefinitionType:  sonar.NewCodePeriodTypeNumberOfDays,
@@ -146,21 +147,21 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("ImportBitbucketCloudRepo", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmIntegrations.ImportBitbucketCloudRepo(nil)
+				resp, err := client.AlmIntegrations.ImportBitbucketCloudRepo(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required repositorySlug", func() {
-				resp, err := client.AlmIntegrations.ImportBitbucketCloudRepo(&sonar.AlmIntegrationsImportBitbucketCloudRepoOptions{})
+				resp, err := client.AlmIntegrations.ImportBitbucketCloudRepo(context.Background(), &sonar.AlmIntegrationsImportBitbucketCloudRepoOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("RepositorySlug"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid newCodeDefinitionType", func() {
-				resp, err := client.AlmIntegrations.ImportBitbucketCloudRepo(&sonar.AlmIntegrationsImportBitbucketCloudRepoOptions{
+				resp, err := client.AlmIntegrations.ImportBitbucketCloudRepo(context.Background(), &sonar.AlmIntegrationsImportBitbucketCloudRepoOptions{
 					RepositorySlug:        "test-slug",
 					NewCodeDefinitionType: "INVALID_TYPE",
 				})
@@ -177,14 +178,14 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("ImportBitbucketServerProject", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmIntegrations.ImportBitbucketServerProject(nil)
+				resp, err := client.AlmIntegrations.ImportBitbucketServerProject(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required projectKey", func() {
-				resp, err := client.AlmIntegrations.ImportBitbucketServerProject(&sonar.AlmIntegrationsImportBitbucketServerProjectOptions{
+				resp, err := client.AlmIntegrations.ImportBitbucketServerProject(context.Background(), &sonar.AlmIntegrationsImportBitbucketServerProjectOptions{
 					RepositorySlug: "test-slug",
 				})
 				Expect(err).To(HaveOccurred())
@@ -193,7 +194,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required repositorySlug", func() {
-				resp, err := client.AlmIntegrations.ImportBitbucketServerProject(&sonar.AlmIntegrationsImportBitbucketServerProjectOptions{
+				resp, err := client.AlmIntegrations.ImportBitbucketServerProject(context.Background(), &sonar.AlmIntegrationsImportBitbucketServerProjectOptions{
 					ProjectKey: "test-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -209,14 +210,14 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("ImportGithubProject", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmIntegrations.ImportGithubProject(nil)
+				resp, err := client.AlmIntegrations.ImportGithubProject(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required repositoryKey", func() {
-				resp, err := client.AlmIntegrations.ImportGithubProject(&sonar.AlmIntegrationsImportGithubProjectOptions{})
+				resp, err := client.AlmIntegrations.ImportGithubProject(context.Background(), &sonar.AlmIntegrationsImportGithubProjectOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("RepositoryKey"))
 				Expect(resp).To(BeNil())
@@ -224,7 +225,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 
 			It("should fail with repositoryKey too long", func() {
 				longKey := string(make([]byte, 257))
-				resp, err := client.AlmIntegrations.ImportGithubProject(&sonar.AlmIntegrationsImportGithubProjectOptions{
+				resp, err := client.AlmIntegrations.ImportGithubProject(context.Background(), &sonar.AlmIntegrationsImportGithubProjectOptions{
 					RepositoryKey: longKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -240,14 +241,14 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("ImportGitlabProject", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmIntegrations.ImportGitlabProject(nil)
+				resp, err := client.AlmIntegrations.ImportGitlabProject(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required gitlabProjectId", func() {
-				resp, err := client.AlmIntegrations.ImportGitlabProject(&sonar.AlmIntegrationsImportGitlabProjectOptions{})
+				resp, err := client.AlmIntegrations.ImportGitlabProject(context.Background(), &sonar.AlmIntegrationsImportGitlabProjectOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("GitlabProjectId"))
 				Expect(resp).To(BeNil())
@@ -261,7 +262,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("ListAzureProjects", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.AlmIntegrations.ListAzureProjects(nil)
+				result, resp, err := client.AlmIntegrations.ListAzureProjects(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
@@ -269,7 +270,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.ListAzureProjects(&sonar.AlmIntegrationsListAzureProjectsOptions{})
+				result, resp, err := client.AlmIntegrations.ListAzureProjects(context.Background(), &sonar.AlmIntegrationsListAzureProjectsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -284,7 +285,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("ListBitbucketServerProjects", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.AlmIntegrations.ListBitbucketServerProjects(nil)
+				result, resp, err := client.AlmIntegrations.ListBitbucketServerProjects(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
@@ -292,7 +293,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.ListBitbucketServerProjects(&sonar.AlmIntegrationsListBitbucketServerProjectsOptions{})
+				result, resp, err := client.AlmIntegrations.ListBitbucketServerProjects(context.Background(), &sonar.AlmIntegrationsListBitbucketServerProjectsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -307,7 +308,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("ListGithubOrganizations", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.AlmIntegrations.ListGithubOrganizations(nil)
+				result, resp, err := client.AlmIntegrations.ListGithubOrganizations(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
@@ -315,7 +316,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.ListGithubOrganizations(&sonar.AlmIntegrationsListGithubOrganizationsOptions{})
+				result, resp, err := client.AlmIntegrations.ListGithubOrganizations(context.Background(), &sonar.AlmIntegrationsListGithubOrganizationsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -330,7 +331,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("ListGithubRepositories", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.AlmIntegrations.ListGithubRepositories(nil)
+				result, resp, err := client.AlmIntegrations.ListGithubRepositories(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
@@ -338,7 +339,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.ListGithubRepositories(&sonar.AlmIntegrationsListGithubRepositoriesOptions{
+				result, resp, err := client.AlmIntegrations.ListGithubRepositories(context.Background(), &sonar.AlmIntegrationsListGithubRepositoriesOptions{
 					Organization: "test-org",
 				})
 				Expect(err).To(HaveOccurred())
@@ -348,7 +349,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required organization", func() {
-				result, resp, err := client.AlmIntegrations.ListGithubRepositories(&sonar.AlmIntegrationsListGithubRepositoriesOptions{
+				result, resp, err := client.AlmIntegrations.ListGithubRepositories(context.Background(), &sonar.AlmIntegrationsListGithubRepositoriesOptions{
 					AlmSetting: "test-github",
 				})
 				Expect(err).To(HaveOccurred())
@@ -365,7 +366,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("SearchAzureRepos", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.AlmIntegrations.SearchAzureRepos(nil)
+				result, resp, err := client.AlmIntegrations.SearchAzureRepos(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
@@ -373,7 +374,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.SearchAzureRepos(&sonar.AlmIntegrationsSearchAzureReposOptions{})
+				result, resp, err := client.AlmIntegrations.SearchAzureRepos(context.Background(), &sonar.AlmIntegrationsSearchAzureReposOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -388,7 +389,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("SearchBitbucketCloudRepos", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.AlmIntegrations.SearchBitbucketCloudRepos(nil)
+				result, resp, err := client.AlmIntegrations.SearchBitbucketCloudRepos(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
@@ -396,7 +397,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.SearchBitbucketCloudRepos(&sonar.AlmIntegrationsSearchBitbucketCloudReposOptions{})
+				result, resp, err := client.AlmIntegrations.SearchBitbucketCloudRepos(context.Background(), &sonar.AlmIntegrationsSearchBitbucketCloudReposOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -411,7 +412,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("SearchBitbucketServerRepos", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.AlmIntegrations.SearchBitbucketServerRepos(nil)
+				result, resp, err := client.AlmIntegrations.SearchBitbucketServerRepos(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
@@ -419,7 +420,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.SearchBitbucketServerRepos(&sonar.AlmIntegrationsSearchBitbucketServerReposOptions{})
+				result, resp, err := client.AlmIntegrations.SearchBitbucketServerRepos(context.Background(), &sonar.AlmIntegrationsSearchBitbucketServerReposOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -434,7 +435,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("SearchGitlabRepos", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.AlmIntegrations.SearchGitlabRepos(nil)
+				result, resp, err := client.AlmIntegrations.SearchGitlabRepos(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
@@ -442,7 +443,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmIntegrations.SearchGitlabRepos(&sonar.AlmIntegrationsSearchGitlabReposOptions{})
+				result, resp, err := client.AlmIntegrations.SearchGitlabRepos(context.Background(), &sonar.AlmIntegrationsSearchGitlabReposOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(resp).To(BeNil())
@@ -457,14 +458,14 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 	Describe("SetPat", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmIntegrations.SetPat(nil)
+				resp, err := client.AlmIntegrations.SetPat(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required pat", func() {
-				resp, err := client.AlmIntegrations.SetPat(&sonar.AlmIntegrationsSetPatOptions{
+				resp, err := client.AlmIntegrations.SetPat(context.Background(), &sonar.AlmIntegrationsSetPatOptions{
 					AlmSetting: "test-alm",
 				})
 				Expect(err).To(HaveOccurred())
@@ -474,7 +475,7 @@ var _ = Describe("AlmIntegrations Service", Ordered, func() {
 
 			It("should fail with pat too long", func() {
 				longPat := string(make([]byte, 2001))
-				resp, err := client.AlmIntegrations.SetPat(&sonar.AlmIntegrationsSetPatOptions{
+				resp, err := client.AlmIntegrations.SetPat(context.Background(), &sonar.AlmIntegrationsSetPatOptions{
 					AlmSetting: "test-alm",
 					Pat:        longPat,
 				})

--- a/integration_testing/alm_settings_test.go
+++ b/integration_testing/alm_settings_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,14 +27,14 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 
 		// Create a test project
 		projectKey = helpers.UniqueResourceName("alm")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    "AlmSettings Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -52,7 +53,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	// =========================================================================
 	Describe("ListDefinitions", func() {
 		It("should list ALM setting definitions", func() {
-			result, resp, err := client.AlmSettings.ListDefinitions()
+			result, resp, err := client.AlmSettings.ListDefinitions(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -65,14 +66,14 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	Describe("List", func() {
 		Context("Valid Requests", func() {
 			It("should list ALM settings with nil options", func() {
-				result, resp, err := client.AlmSettings.List(nil)
+				result, resp, err := client.AlmSettings.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
 			})
 
 			It("should list ALM settings for a project", func() {
-				result, resp, err := client.AlmSettings.List(&sonar.AlmSettingsListOptions{
+				result, resp, err := client.AlmSettings.List(context.Background(), &sonar.AlmSettingsListOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -88,7 +89,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	Describe("GetBinding", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.AlmSettings.GetBinding(nil)
+				result, resp, err := client.AlmSettings.GetBinding(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -96,7 +97,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required project", func() {
-				result, resp, err := client.AlmSettings.GetBinding(&sonar.AlmSettingsGetBindingOptions{})
+				result, resp, err := client.AlmSettings.GetBinding(context.Background(), &sonar.AlmSettingsGetBindingOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Project"))
 				Expect(result).To(BeNil())
@@ -106,7 +107,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 
 		Context("Non-Bound Project", func() {
 			It("should fail for project without ALM binding", func() {
-				result, resp, err := client.AlmSettings.GetBinding(&sonar.AlmSettingsGetBindingOptions{
+				result, resp, err := client.AlmSettings.GetBinding(context.Background(), &sonar.AlmSettingsGetBindingOptions{
 					Project: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -124,7 +125,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	Describe("CountBinding", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.AlmSettings.CountBinding(nil)
+				result, resp, err := client.AlmSettings.CountBinding(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -132,7 +133,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required almSetting", func() {
-				result, resp, err := client.AlmSettings.CountBinding(&sonar.AlmSettingsCountBindingOptions{})
+				result, resp, err := client.AlmSettings.CountBinding(context.Background(), &sonar.AlmSettingsCountBindingOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("AlmSetting"))
 				Expect(result).To(BeNil())
@@ -142,7 +143,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 
 		Context("Non-Existent ALM Setting", func() {
 			It("should fail for non-existent ALM setting", func() {
-				result, resp, err := client.AlmSettings.CountBinding(&sonar.AlmSettingsCountBindingOptions{
+				result, resp, err := client.AlmSettings.CountBinding(context.Background(), &sonar.AlmSettingsCountBindingOptions{
 					AlmSetting: "non-existent-alm-setting",
 				})
 				Expect(err).To(HaveOccurred())
@@ -160,14 +161,14 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	Describe("Delete", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmSettings.Delete(nil)
+				resp, err := client.AlmSettings.Delete(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.Delete(&sonar.AlmSettingsDeleteOptions{})
+				resp, err := client.AlmSettings.Delete(context.Background(), &sonar.AlmSettingsDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(resp).To(BeNil())
@@ -176,7 +177,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 
 		Context("Non-Existent ALM Setting", func() {
 			It("should fail for non-existent ALM setting", func() {
-				resp, err := client.AlmSettings.Delete(&sonar.AlmSettingsDeleteOptions{
+				resp, err := client.AlmSettings.Delete(context.Background(), &sonar.AlmSettingsDeleteOptions{
 					Key: "non-existent-alm-setting",
 				})
 				Expect(err).To(HaveOccurred())
@@ -193,14 +194,14 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	Describe("CreateAzure", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmSettings.CreateAzure(nil)
+				resp, err := client.AlmSettings.CreateAzure(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.CreateAzure(&sonar.AlmSettingsCreateAzureOptions{
+				resp, err := client.AlmSettings.CreateAzure(context.Background(), &sonar.AlmSettingsCreateAzureOptions{
 					PersonalAccessToken: "test-token",
 				})
 				Expect(err).To(HaveOccurred())
@@ -209,7 +210,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required personalAccessToken", func() {
-				resp, err := client.AlmSettings.CreateAzure(&sonar.AlmSettingsCreateAzureOptions{
+				resp, err := client.AlmSettings.CreateAzure(context.Background(), &sonar.AlmSettingsCreateAzureOptions{
 					Key: "test-azure",
 				})
 				Expect(err).To(HaveOccurred())
@@ -225,14 +226,14 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	Describe("CreateGithub", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmSettings.CreateGithub(nil)
+				resp, err := client.AlmSettings.CreateGithub(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.CreateGithub(&sonar.AlmSettingsCreateGithubOptions{
+				resp, err := client.AlmSettings.CreateGithub(context.Background(), &sonar.AlmSettingsCreateGithubOptions{
 					AppID:        "test-app-id",
 					ClientID:     "test-client-id",
 					ClientSecret: "test-client-secret",
@@ -245,7 +246,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required appId", func() {
-				resp, err := client.AlmSettings.CreateGithub(&sonar.AlmSettingsCreateGithubOptions{
+				resp, err := client.AlmSettings.CreateGithub(context.Background(), &sonar.AlmSettingsCreateGithubOptions{
 					Key:          "test-github",
 					ClientID:     "test-client-id",
 					ClientSecret: "test-client-secret",
@@ -258,7 +259,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required privateKey", func() {
-				resp, err := client.AlmSettings.CreateGithub(&sonar.AlmSettingsCreateGithubOptions{
+				resp, err := client.AlmSettings.CreateGithub(context.Background(), &sonar.AlmSettingsCreateGithubOptions{
 					Key:          "test-github",
 					AppID:        "test-app-id",
 					ClientID:     "test-client-id",
@@ -271,7 +272,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required URL", func() {
-				resp, err := client.AlmSettings.CreateGithub(&sonar.AlmSettingsCreateGithubOptions{
+				resp, err := client.AlmSettings.CreateGithub(context.Background(), &sonar.AlmSettingsCreateGithubOptions{
 					Key:          "test-github",
 					AppID:        "test-app-id",
 					ClientID:     "test-client-id",
@@ -291,14 +292,14 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	Describe("CreateGitlab", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmSettings.CreateGitlab(nil)
+				resp, err := client.AlmSettings.CreateGitlab(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.CreateGitlab(&sonar.AlmSettingsCreateGitlabOptions{
+				resp, err := client.AlmSettings.CreateGitlab(context.Background(), &sonar.AlmSettingsCreateGitlabOptions{
 					PersonalAccessToken: "test-token",
 				})
 				Expect(err).To(HaveOccurred())
@@ -307,7 +308,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required personalAccessToken", func() {
-				resp, err := client.AlmSettings.CreateGitlab(&sonar.AlmSettingsCreateGitlabOptions{
+				resp, err := client.AlmSettings.CreateGitlab(context.Background(), &sonar.AlmSettingsCreateGitlabOptions{
 					Key: "test-gitlab",
 				})
 				Expect(err).To(HaveOccurred())
@@ -323,14 +324,14 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	Describe("CreateBitbucket", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmSettings.CreateBitbucket(nil)
+				resp, err := client.AlmSettings.CreateBitbucket(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.CreateBitbucket(&sonar.AlmSettingsCreateBitbucketOptions{
+				resp, err := client.AlmSettings.CreateBitbucket(context.Background(), &sonar.AlmSettingsCreateBitbucketOptions{
 					PersonalAccessToken: "test-token",
 					URL:                 "https://bitbucket.example.com",
 				})
@@ -340,7 +341,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required URL", func() {
-				resp, err := client.AlmSettings.CreateBitbucket(&sonar.AlmSettingsCreateBitbucketOptions{
+				resp, err := client.AlmSettings.CreateBitbucket(context.Background(), &sonar.AlmSettingsCreateBitbucketOptions{
 					Key:                 "test-bitbucket",
 					PersonalAccessToken: "test-token",
 				})
@@ -350,7 +351,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required personalAccessToken", func() {
-				resp, err := client.AlmSettings.CreateBitbucket(&sonar.AlmSettingsCreateBitbucketOptions{
+				resp, err := client.AlmSettings.CreateBitbucket(context.Background(), &sonar.AlmSettingsCreateBitbucketOptions{
 					Key: "test-bitbucket",
 					URL: "https://bitbucket.example.com",
 				})
@@ -367,14 +368,14 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	Describe("CreateBitbucketCloud", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmSettings.CreateBitbucketCloud(nil)
+				resp, err := client.AlmSettings.CreateBitbucketCloud(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.CreateBitbucketCloud(&sonar.AlmSettingsCreateBitbucketCloudOptions{
+				resp, err := client.AlmSettings.CreateBitbucketCloud(context.Background(), &sonar.AlmSettingsCreateBitbucketCloudOptions{
 					ClientID:     "test-client-id",
 					ClientSecret: "test-client-secret",
 					Workspace:    "test-workspace",
@@ -385,7 +386,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required clientId", func() {
-				resp, err := client.AlmSettings.CreateBitbucketCloud(&sonar.AlmSettingsCreateBitbucketCloudOptions{
+				resp, err := client.AlmSettings.CreateBitbucketCloud(context.Background(), &sonar.AlmSettingsCreateBitbucketCloudOptions{
 					Key:          "test-bitbucket-cloud",
 					ClientSecret: "test-client-secret",
 					Workspace:    "test-workspace",
@@ -396,7 +397,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required clientSecret", func() {
-				resp, err := client.AlmSettings.CreateBitbucketCloud(&sonar.AlmSettingsCreateBitbucketCloudOptions{
+				resp, err := client.AlmSettings.CreateBitbucketCloud(context.Background(), &sonar.AlmSettingsCreateBitbucketCloudOptions{
 					Key:       "test-bitbucket-cloud",
 					ClientID:  "test-client-id",
 					Workspace: "test-workspace",
@@ -407,7 +408,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required workspace", func() {
-				resp, err := client.AlmSettings.CreateBitbucketCloud(&sonar.AlmSettingsCreateBitbucketCloudOptions{
+				resp, err := client.AlmSettings.CreateBitbucketCloud(context.Background(), &sonar.AlmSettingsCreateBitbucketCloudOptions{
 					Key:          "test-bitbucket-cloud",
 					ClientID:     "test-client-id",
 					ClientSecret: "test-client-secret",
@@ -425,14 +426,14 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	Describe("UpdateAzure", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmSettings.UpdateAzure(nil)
+				resp, err := client.AlmSettings.UpdateAzure(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.UpdateAzure(&sonar.AlmSettingsUpdateAzureOptions{})
+				resp, err := client.AlmSettings.UpdateAzure(context.Background(), &sonar.AlmSettingsUpdateAzureOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(resp).To(BeNil())
@@ -446,14 +447,14 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	Describe("UpdateGithub", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmSettings.UpdateGithub(nil)
+				resp, err := client.AlmSettings.UpdateGithub(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.UpdateGithub(&sonar.AlmSettingsUpdateGithubOptions{
+				resp, err := client.AlmSettings.UpdateGithub(context.Background(), &sonar.AlmSettingsUpdateGithubOptions{
 					AppID:    "test-app-id",
 					ClientID: "test-client-id",
 					URL:      "https://api.github.com",
@@ -464,7 +465,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required appId", func() {
-				resp, err := client.AlmSettings.UpdateGithub(&sonar.AlmSettingsUpdateGithubOptions{
+				resp, err := client.AlmSettings.UpdateGithub(context.Background(), &sonar.AlmSettingsUpdateGithubOptions{
 					Key:      "test-github",
 					ClientID: "test-client-id",
 					URL:      "https://api.github.com",
@@ -475,7 +476,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required URL", func() {
-				resp, err := client.AlmSettings.UpdateGithub(&sonar.AlmSettingsUpdateGithubOptions{
+				resp, err := client.AlmSettings.UpdateGithub(context.Background(), &sonar.AlmSettingsUpdateGithubOptions{
 					Key:      "test-github",
 					AppID:    "test-app-id",
 					ClientID: "test-client-id",
@@ -493,14 +494,14 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	Describe("UpdateGitlab", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmSettings.UpdateGitlab(nil)
+				resp, err := client.AlmSettings.UpdateGitlab(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.UpdateGitlab(&sonar.AlmSettingsUpdateGitlabOptions{})
+				resp, err := client.AlmSettings.UpdateGitlab(context.Background(), &sonar.AlmSettingsUpdateGitlabOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(resp).To(BeNil())
@@ -514,14 +515,14 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	Describe("UpdateBitbucket", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmSettings.UpdateBitbucket(nil)
+				resp, err := client.AlmSettings.UpdateBitbucket(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.UpdateBitbucket(&sonar.AlmSettingsUpdateBitbucketOptions{
+				resp, err := client.AlmSettings.UpdateBitbucket(context.Background(), &sonar.AlmSettingsUpdateBitbucketOptions{
 					URL: "https://bitbucket.example.com",
 				})
 				Expect(err).To(HaveOccurred())
@@ -530,7 +531,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required URL", func() {
-				resp, err := client.AlmSettings.UpdateBitbucket(&sonar.AlmSettingsUpdateBitbucketOptions{
+				resp, err := client.AlmSettings.UpdateBitbucket(context.Background(), &sonar.AlmSettingsUpdateBitbucketOptions{
 					Key: "test-bitbucket",
 				})
 				Expect(err).To(HaveOccurred())
@@ -546,14 +547,14 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 	Describe("UpdateBitbucketCloud", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.AlmSettings.UpdateBitbucketCloud(nil)
+				resp, err := client.AlmSettings.UpdateBitbucketCloud(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.AlmSettings.UpdateBitbucketCloud(&sonar.AlmSettingsUpdateBitbucketCloudOptions{
+				resp, err := client.AlmSettings.UpdateBitbucketCloud(context.Background(), &sonar.AlmSettingsUpdateBitbucketCloudOptions{
 					ClientID:  "test-client-id",
 					Workspace: "test-workspace",
 				})
@@ -563,7 +564,7 @@ var _ = Describe("AlmSettings Service", Ordered, func() {
 			})
 
 			It("should fail without required workspace", func() {
-				resp, err := client.AlmSettings.UpdateBitbucketCloud(&sonar.AlmSettingsUpdateBitbucketCloudOptions{
+				resp, err := client.AlmSettings.UpdateBitbucketCloud(context.Background(), &sonar.AlmSettingsUpdateBitbucketCloudOptions{
 					Key:      "test-bitbucket-cloud",
 					ClientID: "test-client-id",
 				})

--- a/integration_testing/analysis_cache_test.go
+++ b/integration_testing/analysis_cache_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -27,13 +28,13 @@ var _ = Describe("AnalysisCache Service", Ordered, func() {
 
 		// Create a test project for analysis cache operations
 		projectKey := helpers.UniqueResourceName("analysis-cache")
-		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		testProject, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    projectKey,
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		cleanupManager.RegisterCleanup("project", testProject.Project.Key, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: testProject.Project.Key,
 			})
 			return err
@@ -53,19 +54,19 @@ var _ = Describe("AnalysisCache Service", Ordered, func() {
 	Describe("Clear", func() {
 		Context("Functional Tests", func() {
 			It("should clear all cached data without options", func() {
-				resp, err := client.AnalysisCache.Clear(nil)
+				resp, err := client.AnalysisCache.Clear(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 			})
 
 			It("should clear all cached data with empty options", func() {
-				resp, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOptions{})
+				resp, err := client.AnalysisCache.Clear(context.Background(), &sonar.AnalysisCacheClearOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 			})
 
 			It("should clear cached data for a specific project", func() {
-				resp, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOptions{
+				resp, err := client.AnalysisCache.Clear(context.Background(), &sonar.AnalysisCacheClearOptions{
 					Project: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -73,7 +74,7 @@ var _ = Describe("AnalysisCache Service", Ordered, func() {
 			})
 
 			It("should clear cached data for a specific project branch", func() {
-				resp, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOptions{
+				resp, err := client.AnalysisCache.Clear(context.Background(), &sonar.AnalysisCacheClearOptions{
 					Project: testProject.Project.Key,
 					Branch:  "main",
 				})
@@ -84,14 +85,14 @@ var _ = Describe("AnalysisCache Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail when branch is specified without project", func() {
-				_, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOptions{
+				_, err := client.AnalysisCache.Clear(context.Background(), &sonar.AnalysisCacheClearOptions{
 					Branch: "main",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should succeed with non-existent project (idempotent)", func() {
-				resp, err := client.AnalysisCache.Clear(&sonar.AnalysisCacheClearOptions{
+				resp, err := client.AnalysisCache.Clear(context.Background(), &sonar.AnalysisCacheClearOptions{
 					Project: "non-existent-project-12345",
 				})
 				// Clear is idempotent - should succeed even for non-existent project
@@ -107,7 +108,7 @@ var _ = Describe("AnalysisCache Service", Ordered, func() {
 	Describe("Get", func() {
 		Context("Functional Tests", func() {
 			It("should get cached data for a project", func() {
-				resp, err := client.AnalysisCache.Get(&sonar.AnalysisCacheGetOptions{
+				resp, err := client.AnalysisCache.Get(context.Background(), &sonar.AnalysisCacheGetOptions{
 					Project: testProject.Project.Key,
 				})
 				// May return 404 if no cache exists yet (project not analyzed)
@@ -126,7 +127,7 @@ var _ = Describe("AnalysisCache Service", Ordered, func() {
 			})
 
 			It("should get cached data for a specific branch", func() {
-				resp, err := client.AnalysisCache.Get(&sonar.AnalysisCacheGetOptions{
+				resp, err := client.AnalysisCache.Get(context.Background(), &sonar.AnalysisCacheGetOptions{
 					Project: testProject.Project.Key,
 					Branch:  "main",
 				})
@@ -148,17 +149,17 @@ var _ = Describe("AnalysisCache Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				_, err := client.AnalysisCache.Get(nil)
+				_, err := client.AnalysisCache.Get(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing project", func() {
-				_, err := client.AnalysisCache.Get(&sonar.AnalysisCacheGetOptions{})
+				_, err := client.AnalysisCache.Get(context.Background(), &sonar.AnalysisCacheGetOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with non-existent project", func() {
-				resp, err := client.AnalysisCache.Get(&sonar.AnalysisCacheGetOptions{
+				resp, err := client.AnalysisCache.Get(context.Background(), &sonar.AnalysisCacheGetOptions{
 					Project: "non-existent-project-12345",
 				})
 				Expect(err).To(HaveOccurred())

--- a/integration_testing/analysis_reports_test.go
+++ b/integration_testing/analysis_reports_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,7 +29,7 @@ var _ = Describe("AnalysisReports Service", Ordered, func() {
 	Describe("QueueStatus", func() {
 		Context("Functional Tests", func() {
 			It("should check if compute engine queue is empty", func() {
-				result, resp, err := client.AnalysisReports.QueueStatus()
+				result, resp, err := client.AnalysisReports.QueueStatus(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -36,12 +37,12 @@ var _ = Describe("AnalysisReports Service", Ordered, func() {
 
 			It("should return consistent results on multiple calls", func() {
 				// Call twice and verify both return valid results
-				result1, resp1, err1 := client.AnalysisReports.QueueStatus()
+				result1, resp1, err1 := client.AnalysisReports.QueueStatus(context.Background(), )
 				Expect(err1).NotTo(HaveOccurred())
 				Expect(resp1.StatusCode).To(Equal(http.StatusOK))
 				Expect(result1).NotTo(BeNil())
 
-				result2, resp2, err2 := client.AnalysisReports.QueueStatus()
+				result2, resp2, err2 := client.AnalysisReports.QueueStatus(context.Background(), )
 				Expect(err2).NotTo(HaveOccurred())
 				Expect(resp2.StatusCode).To(Equal(http.StatusOK))
 				Expect(result2).NotTo(BeNil())

--- a/integration_testing/authentication_test.go
+++ b/integration_testing/authentication_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/cookiejar"
 
@@ -28,7 +29,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 	Describe("Validate", func() {
 		Context("with valid credentials", func() {
 			It("should return valid=true for authenticated client", func() {
-				result, resp, err := client.Authentication.Validate()
+				result, resp, err := client.Authentication.Validate(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -46,7 +47,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(basicAuthClient).NotTo(BeNil())
 
-				result, resp, err := basicAuthClient.Authentication.Validate()
+				result, resp, err := basicAuthClient.Authentication.Validate(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -63,7 +64,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(anonClient).NotTo(BeNil())
 
-				result, resp, err := anonClient.Authentication.Validate()
+				result, resp, err := anonClient.Authentication.Validate(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -87,7 +88,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 					Password: cfg.Password,
 				}
 
-				resp, err := loginClient.Authentication.Login(opt)
+				resp, err := loginClient.Authentication.Login(context.Background(), opt)
 				Expect(err).NotTo(HaveOccurred())
 				// SonarQube may return 200 OK or 204 No Content depending on version
 				Expect(resp.StatusCode).To(BeElementOf(http.StatusOK, http.StatusNoContent))
@@ -108,7 +109,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 					Password: "wrongpassword",
 				}
 
-				resp, err := loginClient.Authentication.Login(opt)
+				resp, err := loginClient.Authentication.Login(context.Background(), opt)
 				Expect(err).To(HaveOccurred())
 				// Login failure returns 401 Unauthorized
 				if resp != nil {
@@ -129,7 +130,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 					Password: "somepassword",
 				}
 
-				resp, err := loginClient.Authentication.Login(opt)
+				resp, err := loginClient.Authentication.Login(context.Background(), opt)
 				Expect(err).To(HaveOccurred())
 				// Login failure returns 401 Unauthorized
 				if resp != nil {
@@ -140,7 +141,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Authentication.Login(nil)
+				resp, err := client.Authentication.Login(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -150,7 +151,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 					Password: "somepassword",
 				}
 
-				resp, err := client.Authentication.Login(opt)
+				resp, err := client.Authentication.Login(context.Background(), opt)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -160,7 +161,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 					Login: "someuser",
 				}
 
-				resp, err := client.Authentication.Login(opt)
+				resp, err := client.Authentication.Login(context.Background(), opt)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -171,7 +172,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 					Password: "somepassword",
 				}
 
-				resp, err := client.Authentication.Login(opt)
+				resp, err := client.Authentication.Login(context.Background(), opt)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -182,7 +183,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 					Password: "",
 				}
 
-				resp, err := client.Authentication.Login(opt)
+				resp, err := client.Authentication.Login(context.Background(), opt)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -209,13 +210,13 @@ var _ = Describe("Authentication Service", Ordered, func() {
 					Password: cfg.Password,
 				}
 
-				resp, err := sessionClient.Authentication.Login(loginOpt)
+				resp, err := sessionClient.Authentication.Login(context.Background(), loginOpt)
 				Expect(err).NotTo(HaveOccurred())
 				// SonarQube may return 200 OK or 204 No Content depending on version
 				Expect(resp.StatusCode).To(BeElementOf(http.StatusOK, http.StatusNoContent))
 
 				// Now logout
-				resp, err = sessionClient.Authentication.Logout()
+				resp, err = sessionClient.Authentication.Logout(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				// SonarQube may return 200 OK or 204 No Content depending on version
 				Expect(resp.StatusCode).To(BeElementOf(http.StatusOK, http.StatusNoContent))
@@ -232,7 +233,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 				Expect(anonClient).NotTo(BeNil())
 
 				// Logout should still succeed (no-op for unauthenticated)
-				resp, err := anonClient.Authentication.Logout()
+				resp, err := anonClient.Authentication.Logout(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				// SonarQube may return 200 OK or 204 No Content depending on version
 				Expect(resp.StatusCode).To(BeElementOf(http.StatusOK, http.StatusNoContent))
@@ -254,7 +255,7 @@ var _ = Describe("Authentication Service", Ordered, func() {
 			Expect(sessionClient).NotTo(BeNil())
 
 			// Step 1: Validate should show not authenticated
-			result, resp, err := sessionClient.Authentication.Validate()
+			result, resp, err := sessionClient.Authentication.Validate(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -266,26 +267,26 @@ var _ = Describe("Authentication Service", Ordered, func() {
 				Password: cfg.Password,
 			}
 
-			resp, err = sessionClient.Authentication.Login(loginOpt)
+			resp, err = sessionClient.Authentication.Login(context.Background(), loginOpt)
 			Expect(err).NotTo(HaveOccurred())
 			// SonarQube may return 200 OK or 204 No Content depending on version
 			Expect(resp.StatusCode).To(BeElementOf(http.StatusOK, http.StatusNoContent))
 
 			// Step 3: Validate should now show authenticated
-			result, resp, err = sessionClient.Authentication.Validate()
+			result, resp, err = sessionClient.Authentication.Validate(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
 			Expect(result.Valid).To(BeTrue()) // Session should be established after login
 
 			// Step 4: Logout
-			resp, err = sessionClient.Authentication.Logout()
+			resp, err = sessionClient.Authentication.Logout(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			// SonarQube may return 200 OK or 204 No Content depending on version
 			Expect(resp.StatusCode).To(BeElementOf(http.StatusOK, http.StatusNoContent))
 
 			// Step 5: Validate should show not authenticated after logout
-			result, resp, err = sessionClient.Authentication.Validate()
+			result, resp, err = sessionClient.Authentication.Validate(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())

--- a/integration_testing/batch_test.go
+++ b/integration_testing/batch_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -28,13 +29,13 @@ var _ = Describe("Batch Service", Ordered, func() {
 
 		// Create a test project for batch operations
 		projectKey := helpers.UniqueResourceName("batch")
-		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		testProject, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    "Batch Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		cleanupManager.RegisterCleanup("project", testProject.Project.Key, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: testProject.Project.Key,
 			})
 			return err
@@ -54,7 +55,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 	Describe("Index", func() {
 		Context("Functional Tests", func() {
 			It("should get batch index", func() {
-				result, resp, err := client.Batch.GetIndex()
+				result, resp, err := client.Batch.GetIndex(context.Background(), )
 				// Batch API may not be available in newer SonarQube versions
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("Batch API is not available in this SonarQube version")
@@ -65,7 +66,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 			})
 
 			It("should return JAR file list", func() {
-				result, resp, err := client.Batch.GetIndex()
+				result, resp, err := client.Batch.GetIndex(context.Background(), )
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("Batch API is not available in this SonarQube version")
 				}
@@ -82,14 +83,14 @@ var _ = Describe("Batch Service", Ordered, func() {
 			})
 
 			It("should return consistent results on multiple calls", func() {
-				result1, resp1, err := client.Batch.GetIndex()
+				result1, resp1, err := client.Batch.GetIndex(context.Background(), )
 				if resp1 != nil && resp1.StatusCode == http.StatusNotFound {
 					Skip("Batch API is not available in this SonarQube version")
 				}
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp1.StatusCode).To(Equal(http.StatusOK))
 
-				result2, resp2, err := client.Batch.GetIndex()
+				result2, resp2, err := client.Batch.GetIndex(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp2.StatusCode).To(Equal(http.StatusOK))
 
@@ -105,7 +106,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 		Context("Functional Tests", func() {
 			It("should download batch file with valid name", func() {
 				// First get the index to find a valid file name
-				index, resp, err := client.Batch.GetIndex()
+				index, resp, err := client.Batch.GetIndex(context.Background(), )
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("Batch API is not available in this SonarQube version")
 				}
@@ -116,7 +117,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 					for _, line := range lines {
 						parts := strings.Split(strings.TrimSpace(line), "|")
 						if len(parts) > 0 && strings.HasSuffix(parts[0], ".jar") {
-							result, resp, err := client.Batch.GetFile(&sonar.BatchFileOptions{
+							result, resp, err := client.Batch.GetFile(context.Background(), &sonar.BatchFileOptions{
 								Name: parts[0],
 							})
 							Expect(err).NotTo(HaveOccurred())
@@ -132,7 +133,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should handle nil options", func() {
-				_, resp, err := client.Batch.GetFile(nil)
+				_, resp, err := client.Batch.GetFile(context.Background(), nil)
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("Batch API is not available in this SonarQube version")
 				}
@@ -143,7 +144,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent file", func() {
-				_, resp, err := client.Batch.GetFile(&sonar.BatchFileOptions{
+				_, resp, err := client.Batch.GetFile(context.Background(), &sonar.BatchFileOptions{
 					Name: "non-existent-file.jar",
 				})
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
@@ -165,7 +166,7 @@ var _ = Describe("Batch Service", Ordered, func() {
 	Describe("Project", func() {
 		Context("Functional Tests", func() {
 			It("should get project batch info with valid key", func() {
-				result, resp, err := client.Batch.GetProject(&sonar.BatchProjectOptions{
+				result, resp, err := client.Batch.GetProject(context.Background(), &sonar.BatchProjectOptions{
 					Key: testProject.Project.Key,
 				})
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
@@ -189,17 +190,17 @@ var _ = Describe("Batch Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				_, _, err := client.Batch.GetProject(nil)
+				_, _, err := client.Batch.GetProject(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing key", func() {
-				_, _, err := client.Batch.GetProject(&sonar.BatchProjectOptions{})
+				_, _, err := client.Batch.GetProject(context.Background(), &sonar.BatchProjectOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with non-existent project", func() {
-				_, resp, err := client.Batch.GetProject(&sonar.BatchProjectOptions{
+				_, resp, err := client.Batch.GetProject(context.Background(), &sonar.BatchProjectOptions{
 					Key: "non-existent-project-12345",
 				})
 				if resp != nil && resp.StatusCode == http.StatusNotFound {

--- a/integration_testing/ce_test.go
+++ b/integration_testing/ce_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -27,13 +28,13 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 		// Create a test project for CE operations
 		projectName := helpers.UniqueResourceName("ce-test-project")
-		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		testProject, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    projectName,
 			Project: projectName,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		cleanupManager.RegisterCleanup("project", testProject.Project.Key, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: testProject.Project.Key,
 			})
 			return err
@@ -53,14 +54,14 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("Activity", func() {
 		Context("Functional Tests", func() {
 			It("should list CE tasks with no options", func() {
-				result, resp, err := client.Ce.Activity(nil)
+				result, resp, err := client.Ce.Activity(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
 			})
 
 			It("should list CE tasks with pagination", func() {
-				result, resp, err := client.Ce.Activity(&sonar.CeActivityOptions{
+				result, resp, err := client.Ce.Activity(context.Background(), &sonar.CeActivityOptions{
 					CePaginationArgs: sonar.CePaginationArgs{
 						Page:     1,
 						PageSize: 10,
@@ -73,7 +74,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should list CE tasks filtered by component", func() {
-				result, resp, err := client.Ce.Activity(&sonar.CeActivityOptions{
+				result, resp, err := client.Ce.Activity(context.Background(), &sonar.CeActivityOptions{
 					Component: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -82,7 +83,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should list CE tasks filtered by status", func() {
-				result, resp, err := client.Ce.Activity(&sonar.CeActivityOptions{
+				result, resp, err := client.Ce.Activity(context.Background(), &sonar.CeActivityOptions{
 					Statuses: []string{sonar.TaskStatusSuccess},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -91,7 +92,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should list CE tasks filtered by type", func() {
-				result, resp, err := client.Ce.Activity(&sonar.CeActivityOptions{
+				result, resp, err := client.Ce.Activity(context.Background(), &sonar.CeActivityOptions{
 					Type: sonar.TaskTypeReport,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -100,7 +101,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should list CE tasks with onlyCurrents filter", func() {
-				result, resp, err := client.Ce.Activity(&sonar.CeActivityOptions{
+				result, resp, err := client.Ce.Activity(context.Background(), &sonar.CeActivityOptions{
 					OnlyCurrents: true,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -109,7 +110,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should search CE tasks by query", func() {
-				result, resp, err := client.Ce.Activity(&sonar.CeActivityOptions{
+				result, resp, err := client.Ce.Activity(context.Background(), &sonar.CeActivityOptions{
 					Query: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -120,21 +121,21 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with invalid status", func() {
-				_, _, err := client.Ce.Activity(&sonar.CeActivityOptions{
+				_, _, err := client.Ce.Activity(context.Background(), &sonar.CeActivityOptions{
 					Statuses: []string{"INVALID_STATUS"},
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with invalid type", func() {
-				_, _, err := client.Ce.Activity(&sonar.CeActivityOptions{
+				_, _, err := client.Ce.Activity(context.Background(), &sonar.CeActivityOptions{
 					Type: "INVALID_TYPE",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with invalid page size", func() {
-				_, _, err := client.Ce.Activity(&sonar.CeActivityOptions{
+				_, _, err := client.Ce.Activity(context.Background(), &sonar.CeActivityOptions{
 					CePaginationArgs: sonar.CePaginationArgs{
 						PageSize: 10000,
 					},
@@ -150,14 +151,14 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("ActivityStatus", func() {
 		Context("Functional Tests", func() {
 			It("should get activity status with no options", func() {
-				result, resp, err := client.Ce.ActivityStatus(nil)
+				result, resp, err := client.Ce.ActivityStatus(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
 			})
 
 			It("should get activity status for specific component", func() {
-				result, resp, err := client.Ce.ActivityStatus(&sonar.CeActivityStatusOptions{
+				result, resp, err := client.Ce.ActivityStatus(context.Background(), &sonar.CeActivityStatusOptions{
 					Component: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -173,7 +174,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("AnalysisStatus", func() {
 		Context("Functional Tests", func() {
 			It("should get analysis status for component", func() {
-				result, resp, err := client.Ce.AnalysisStatus(&sonar.CeAnalysisStatusOptions{
+				result, resp, err := client.Ce.AnalysisStatus(context.Background(), &sonar.CeAnalysisStatusOptions{
 					Component: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -184,17 +185,17 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing component", func() {
-				_, _, err := client.Ce.AnalysisStatus(&sonar.CeAnalysisStatusOptions{})
+				_, _, err := client.Ce.AnalysisStatus(context.Background(), &sonar.CeAnalysisStatusOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, _, err := client.Ce.AnalysisStatus(nil)
+				_, _, err := client.Ce.AnalysisStatus(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with non-existent component", func() {
-				_, resp, err := client.Ce.AnalysisStatus(&sonar.CeAnalysisStatusOptions{
+				_, resp, err := client.Ce.AnalysisStatus(context.Background(), &sonar.CeAnalysisStatusOptions{
 					Component: "non-existent-project-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -210,18 +211,18 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("Cancel", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing task ID", func() {
-				_, err := client.Ce.Cancel(&sonar.CeCancelOptions{})
+				_, err := client.Ce.Cancel(context.Background(), &sonar.CeCancelOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, err := client.Ce.Cancel(nil)
+				_, err := client.Ce.Cancel(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should handle non-existent task ID gracefully", func() {
 				// SonarQube returns 204 even for non-existent task IDs
-				resp, err := client.Ce.Cancel(&sonar.CeCancelOptions{
+				resp, err := client.Ce.Cancel(context.Background(), &sonar.CeCancelOptions{
 					ID: "non-existent-task-id",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -237,7 +238,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("CancelAll", func() {
 		Context("Functional Tests", func() {
 			It("should cancel all pending tasks", func() {
-				resp, err := client.Ce.CancelAll()
+				resp, err := client.Ce.CancelAll(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(SatisfyAny(Equal(http.StatusOK), Equal(http.StatusNoContent)))
 			})
@@ -250,7 +251,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("Component", func() {
 		Context("Functional Tests", func() {
 			It("should get component CE status", func() {
-				result, resp, err := client.Ce.Component(&sonar.CeComponentOptions{
+				result, resp, err := client.Ce.Component(context.Background(), &sonar.CeComponentOptions{
 					Component: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -261,17 +262,17 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing component", func() {
-				_, _, err := client.Ce.Component(&sonar.CeComponentOptions{})
+				_, _, err := client.Ce.Component(context.Background(), &sonar.CeComponentOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, _, err := client.Ce.Component(nil)
+				_, _, err := client.Ce.Component(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with non-existent component", func() {
-				_, resp, err := client.Ce.Component(&sonar.CeComponentOptions{
+				_, resp, err := client.Ce.Component(context.Background(), &sonar.CeComponentOptions{
 					Component: "non-existent-project-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -287,26 +288,26 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("DismissAnalysisWarning", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing component", func() {
-				_, err := client.Ce.DismissAnalysisWarning(&sonar.CeDismissAnalysisWarningOptions{
+				_, err := client.Ce.DismissAnalysisWarning(context.Background(), &sonar.CeDismissAnalysisWarningOptions{
 					Warning: "some-warning",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing warning", func() {
-				_, err := client.Ce.DismissAnalysisWarning(&sonar.CeDismissAnalysisWarningOptions{
+				_, err := client.Ce.DismissAnalysisWarning(context.Background(), &sonar.CeDismissAnalysisWarningOptions{
 					Component: testProject.Project.Key,
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, err := client.Ce.DismissAnalysisWarning(nil)
+				_, err := client.Ce.DismissAnalysisWarning(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with non-existent warning", func() {
-				resp, err := client.Ce.DismissAnalysisWarning(&sonar.CeDismissAnalysisWarningOptions{
+				resp, err := client.Ce.DismissAnalysisWarning(context.Background(), &sonar.CeDismissAnalysisWarningOptions{
 					Component: testProject.Project.Key,
 					Warning:   "non-existent-warning",
 				})
@@ -322,7 +323,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("IndexationStatus", func() {
 		Context("Functional Tests", func() {
 			It("should get indexation status", func() {
-				result, resp, err := client.Ce.IndexationStatus()
+				result, resp, err := client.Ce.IndexationStatus(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -336,7 +337,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("Info", func() {
 		Context("Functional Tests", func() {
 			It("should get CE info", func() {
-				result, resp, err := client.Ce.Info()
+				result, resp, err := client.Ce.Info(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -351,12 +352,12 @@ var _ = Describe("Ce Service", Ordered, func() {
 		Context("Functional Tests", func() {
 			It("should pause and resume CE workers", func() {
 				// Pause CE workers
-				resp, err := client.Ce.Pause()
+				resp, err := client.Ce.Pause(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(SatisfyAny(Equal(http.StatusOK), Equal(http.StatusNoContent)))
 
 				// Resume CE workers
-				resp, err = client.Ce.Resume()
+				resp, err = client.Ce.Resume(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(SatisfyAny(Equal(http.StatusOK), Equal(http.StatusNoContent)))
 			})
@@ -369,27 +370,27 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("Submit", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing project key", func() {
-				_, _, err := client.Ce.Submit(&sonar.CeSubmitOptions{
+				_, _, err := client.Ce.Submit(context.Background(), &sonar.CeSubmitOptions{
 					Report: "dummy-report",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing report", func() {
-				_, _, err := client.Ce.Submit(&sonar.CeSubmitOptions{
+				_, _, err := client.Ce.Submit(context.Background(), &sonar.CeSubmitOptions{
 					ProjectKey: testProject.Project.Key,
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, _, err := client.Ce.Submit(nil)
+				_, _, err := client.Ce.Submit(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with project key too long", func() {
 				longKey := string(make([]byte, 500))
-				_, _, err := client.Ce.Submit(&sonar.CeSubmitOptions{
+				_, _, err := client.Ce.Submit(context.Background(), &sonar.CeSubmitOptions{
 					ProjectKey: longKey,
 					Report:     "dummy-report",
 				})
@@ -405,7 +406,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 		Context("Functional Tests", func() {
 			It("should get task details when tasks exist", func() {
 				// First get any existing task from activity
-				activity, _, err := client.Ce.Activity(&sonar.CeActivityOptions{
+				activity, _, err := client.Ce.Activity(context.Background(), &sonar.CeActivityOptions{
 					CePaginationArgs: sonar.CePaginationArgs{
 						PageSize: 1,
 					},
@@ -414,7 +415,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 				if len(activity.Tasks) > 0 {
 					taskID := activity.Tasks[0].ID
-					result, resp, err := client.Ce.Task(&sonar.CeTaskOptions{
+					result, resp, err := client.Ce.Task(context.Background(), &sonar.CeTaskOptions{
 						ID: taskID,
 					})
 					Expect(err).NotTo(HaveOccurred())
@@ -428,7 +429,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 			It("should get task details with additional fields", func() {
 				// First get any existing task from activity
-				activity, _, err := client.Ce.Activity(&sonar.CeActivityOptions{
+				activity, _, err := client.Ce.Activity(context.Background(), &sonar.CeActivityOptions{
 					CePaginationArgs: sonar.CePaginationArgs{
 						PageSize: 1,
 					},
@@ -437,7 +438,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 				if len(activity.Tasks) > 0 {
 					taskID := activity.Tasks[0].ID
-					result, resp, err := client.Ce.Task(&sonar.CeTaskOptions{
+					result, resp, err := client.Ce.Task(context.Background(), &sonar.CeTaskOptions{
 						ID:               taskID,
 						AdditionalFields: []string{"warnings"},
 					})
@@ -452,17 +453,17 @@ var _ = Describe("Ce Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing task ID", func() {
-				_, _, err := client.Ce.Task(&sonar.CeTaskOptions{})
+				_, _, err := client.Ce.Task(context.Background(), &sonar.CeTaskOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, _, err := client.Ce.Task(nil)
+				_, _, err := client.Ce.Task(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with invalid additional fields", func() {
-				_, _, err := client.Ce.Task(&sonar.CeTaskOptions{
+				_, _, err := client.Ce.Task(context.Background(), &sonar.CeTaskOptions{
 					ID:               "some-task-id",
 					AdditionalFields: []string{"invalid_field"},
 				})
@@ -470,7 +471,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent task ID", func() {
-				_, resp, err := client.Ce.Task(&sonar.CeTaskOptions{
+				_, resp, err := client.Ce.Task(context.Background(), &sonar.CeTaskOptions{
 					ID: "non-existent-task-id",
 				})
 				Expect(err).To(HaveOccurred())
@@ -486,7 +487,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("TaskTypes", func() {
 		Context("Functional Tests", func() {
 			It("should list available task types", func() {
-				result, resp, err := client.Ce.TaskTypes()
+				result, resp, err := client.Ce.TaskTypes(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -501,7 +502,7 @@ var _ = Describe("Ce Service", Ordered, func() {
 	Describe("WorkerCount", func() {
 		Context("Functional Tests", func() {
 			It("should get CE worker count", func() {
-				result, resp, err := client.Ce.WorkerCount()
+				result, resp, err := client.Ce.WorkerCount(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())

--- a/integration_testing/components_test.go
+++ b/integration_testing/components_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -36,7 +37,7 @@ var _ = Describe("Components Service", Ordered, func() {
 	// =========================================================================
 	Describe("Search", func() {
 		It("should search for projects", func() {
-			result, resp, err := client.Components.Search(&sonar.ComponentsSearchOptions{
+			result, resp, err := client.Components.Search(context.Background(), &sonar.ComponentsSearchOptions{
 				Qualifiers: []string{sonar.ProjectQualifierTRK},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -46,7 +47,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should search projects with pagination", func() {
-			result, resp, err := client.Components.Search(&sonar.ComponentsSearchOptions{
+			result, resp, err := client.Components.Search(context.Background(), &sonar.ComponentsSearchOptions{
 				Qualifiers: []string{sonar.ProjectQualifierTRK},
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 5,
@@ -60,14 +61,14 @@ var _ = Describe("Components Service", Ordered, func() {
 		It("should search projects by query", func() {
 			// First create a project to search for
 			projectKey := helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -80,7 +81,7 @@ var _ = Describe("Components Service", Ordered, func() {
 			}
 
 			// Search for it
-			result, resp, err := client.Components.Search(&sonar.ComponentsSearchOptions{
+			result, resp, err := client.Components.Search(context.Background(), &sonar.ComponentsSearchOptions{
 				Qualifiers: []string{sonar.ProjectQualifierTRK},
 				Query:      query,
 			})
@@ -91,13 +92,13 @@ var _ = Describe("Components Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Components.Search(nil)
+				_, resp, err := client.Components.Search(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing qualifiers", func() {
-				_, resp, err := client.Components.Search(&sonar.ComponentsSearchOptions{})
+				_, resp, err := client.Components.Search(context.Background(), &sonar.ComponentsSearchOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -109,14 +110,14 @@ var _ = Describe("Components Service", Ordered, func() {
 	// =========================================================================
 	Describe("SearchProjects", func() {
 		It("should search for projects", func() {
-			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOptions{})
+			result, resp, err := client.Components.SearchProjects(context.Background(), &sonar.ComponentsSearchProjectsOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
 		})
 
 		It("should search projects with pagination", func() {
-			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOptions{
+			result, resp, err := client.Components.SearchProjects(context.Background(), &sonar.ComponentsSearchProjectsOptions{
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 5,
 				},
@@ -129,14 +130,14 @@ var _ = Describe("Components Service", Ordered, func() {
 		It("should search projects with filter by name", func() {
 			// First create a project to search for
 			projectKey := helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -149,7 +150,7 @@ var _ = Describe("Components Service", Ordered, func() {
 			}
 
 			// Search with filter
-			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOptions{
+			result, resp, err := client.Components.SearchProjects(context.Background(), &sonar.ComponentsSearchProjectsOptions{
 				Filter: "query = \"" + filterPrefix + "\"",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -158,7 +159,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should search projects with facets", func() {
-			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOptions{
+			result, resp, err := client.Components.SearchProjects(context.Background(), &sonar.ComponentsSearchProjectsOptions{
 				Facets: []string{"languages", "tags"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -167,7 +168,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should search projects sorted by name", func() {
-			result, resp, err := client.Components.SearchProjects(&sonar.ComponentsSearchProjectsOptions{
+			result, resp, err := client.Components.SearchProjects(context.Background(), &sonar.ComponentsSearchProjectsOptions{
 				Sort:      sonar.FieldName,
 				Ascending: true,
 			})
@@ -178,7 +179,7 @@ var _ = Describe("Components Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Components.SearchProjects(nil)
+				_, resp, err := client.Components.SearchProjects(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -194,14 +195,14 @@ var _ = Describe("Components Service", Ordered, func() {
 		BeforeAll(func() {
 			// Create a project for Show tests
 			projectKey = helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -209,7 +210,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should show component details", func() {
-			result, resp, err := client.Components.Show(&sonar.ComponentsShowOptions{
+			result, resp, err := client.Components.Show(context.Background(), &sonar.ComponentsShowOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -220,7 +221,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should return ancestors for project", func() {
-			result, resp, err := client.Components.Show(&sonar.ComponentsShowOptions{
+			result, resp, err := client.Components.Show(context.Background(), &sonar.ComponentsShowOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -231,19 +232,19 @@ var _ = Describe("Components Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Components.Show(nil)
+				_, resp, err := client.Components.Show(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing component", func() {
-				_, resp, err := client.Components.Show(&sonar.ComponentsShowOptions{})
+				_, resp, err := client.Components.Show(context.Background(), &sonar.ComponentsShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with non-existent component", func() {
-				_, resp, err := client.Components.Show(&sonar.ComponentsShowOptions{
+				_, resp, err := client.Components.Show(context.Background(), &sonar.ComponentsShowOptions{
 					Component: "non-existent-component-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -261,14 +262,14 @@ var _ = Describe("Components Service", Ordered, func() {
 		BeforeAll(func() {
 			// Create a project for Tree tests
 			projectKey = helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -276,7 +277,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get component tree", func() {
-			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
+			result, resp, err := client.Components.Tree(context.Background(), &sonar.ComponentsTreeOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -286,7 +287,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get tree with all strategy", func() {
-			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
+			result, resp, err := client.Components.Tree(context.Background(), &sonar.ComponentsTreeOptions{
 				Component: projectKey,
 				Strategy:  sonar.MeasureStrategyAll,
 			})
@@ -296,7 +297,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get tree with children strategy", func() {
-			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
+			result, resp, err := client.Components.Tree(context.Background(), &sonar.ComponentsTreeOptions{
 				Component: projectKey,
 				Strategy:  sonar.MeasureStrategyChildren,
 			})
@@ -306,7 +307,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get tree with leaves strategy", func() {
-			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
+			result, resp, err := client.Components.Tree(context.Background(), &sonar.ComponentsTreeOptions{
 				Component: projectKey,
 				Strategy:  sonar.MeasureStrategyLeaves,
 			})
@@ -316,7 +317,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get tree with pagination", func() {
-			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
+			result, resp, err := client.Components.Tree(context.Background(), &sonar.ComponentsTreeOptions{
 				Component: projectKey,
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 10,
@@ -328,7 +329,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get tree with qualifiers filter", func() {
-			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
+			result, resp, err := client.Components.Tree(context.Background(), &sonar.ComponentsTreeOptions{
 				Component:  projectKey,
 				Qualifiers: []string{"FIL", "DIR"},
 			})
@@ -338,7 +339,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get tree sorted by name", func() {
-			result, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
+			result, resp, err := client.Components.Tree(context.Background(), &sonar.ComponentsTreeOptions{
 				Component: projectKey,
 				Sort:      []string{sonar.FieldName},
 				Ascending: true,
@@ -350,19 +351,19 @@ var _ = Describe("Components Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Components.Tree(nil)
+				_, resp, err := client.Components.Tree(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing component", func() {
-				_, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{})
+				_, resp, err := client.Components.Tree(context.Background(), &sonar.ComponentsTreeOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid strategy", func() {
-				_, resp, err := client.Components.Tree(&sonar.ComponentsTreeOptions{
+				_, resp, err := client.Components.Tree(context.Background(), &sonar.ComponentsTreeOptions{
 					Component: projectKey,
 					Strategy:  "invalid-strategy",
 				})
@@ -377,7 +378,7 @@ var _ = Describe("Components Service", Ordered, func() {
 	// =========================================================================
 	Describe("Suggestions", func() {
 		It("should get suggestions without search query", func() {
-			result, resp, err := client.Components.Suggestions(&sonar.ComponentsSuggestionsOptions{})
+			result, resp, err := client.Components.Suggestions(context.Background(), &sonar.ComponentsSuggestionsOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -386,14 +387,14 @@ var _ = Describe("Components Service", Ordered, func() {
 		It("should get suggestions with search query", func() {
 			// First create a project
 			projectKey := helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -406,7 +407,7 @@ var _ = Describe("Components Service", Ordered, func() {
 			}
 
 			// Search for suggestions
-			result, resp, err := client.Components.Suggestions(&sonar.ComponentsSuggestionsOptions{
+			result, resp, err := client.Components.Suggestions(context.Background(), &sonar.ComponentsSuggestionsOptions{
 				Search: searchQuery, // Min 2 chars
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -415,7 +416,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get more suggestions for TRK qualifier", func() {
-			result, resp, err := client.Components.Suggestions(&sonar.ComponentsSuggestionsOptions{
+			result, resp, err := client.Components.Suggestions(context.Background(), &sonar.ComponentsSuggestionsOptions{
 				More: sonar.ProjectQualifierTRK,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -425,13 +426,13 @@ var _ = Describe("Components Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Components.Suggestions(nil)
+				_, resp, err := client.Components.Suggestions(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid more qualifier", func() {
-				_, resp, err := client.Components.Suggestions(&sonar.ComponentsSuggestionsOptions{
+				_, resp, err := client.Components.Suggestions(context.Background(), &sonar.ComponentsSuggestionsOptions{
 					More: "INVALID",
 				})
 				Expect(err).To(HaveOccurred())
@@ -449,14 +450,14 @@ var _ = Describe("Components Service", Ordered, func() {
 		BeforeAll(func() {
 			// Create a project for App tests
 			projectKey = helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -464,7 +465,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should get app data for component", func() {
-			result, resp, err := client.Components.App(&sonar.ComponentsAppOptions{
+			result, resp, err := client.Components.App(context.Background(), &sonar.ComponentsAppOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -474,7 +475,7 @@ var _ = Describe("Components Service", Ordered, func() {
 		})
 
 		It("should return component info", func() {
-			result, resp, err := client.Components.App(&sonar.ComponentsAppOptions{
+			result, resp, err := client.Components.App(context.Background(), &sonar.ComponentsAppOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -485,19 +486,19 @@ var _ = Describe("Components Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Components.App(nil)
+				_, resp, err := client.Components.App(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing component", func() {
-				_, resp, err := client.Components.App(&sonar.ComponentsAppOptions{})
+				_, resp, err := client.Components.App(context.Background(), &sonar.ComponentsAppOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with both branch and pullRequest", func() {
-				_, resp, err := client.Components.App(&sonar.ComponentsAppOptions{
+				_, resp, err := client.Components.App(context.Background(), &sonar.ComponentsAppOptions{
 					Component:   projectKey,
 					Branch:      "main",
 					PullRequest: "123",

--- a/integration_testing/developers_test.go
+++ b/integration_testing/developers_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -28,13 +29,13 @@ var _ = Describe("Developers Service", Ordered, func() {
 
 		// Create a uniquely named test project for developer events to avoid collisions across runs.
 		projectKey := helpers.UniqueResourceName("developers")
-		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		testProject, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    projectKey,
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		cleanupManager.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: testProject.Project.Key,
 			})
 			return err
@@ -55,7 +56,7 @@ var _ = Describe("Developers Service", Ordered, func() {
 		Context("Functional Tests", func() {
 			It("should search developer events with valid parameters", func() {
 				fromDate := time.Now().UTC().Add(-24 * time.Hour).Format("2006-01-02T15:04:05-0700")
-				result, resp, err := client.Developers.SearchEvents(&sonar.DevelopersSearchEventsOptions{
+				result, resp, err := client.Developers.SearchEvents(context.Background(), &sonar.DevelopersSearchEventsOptions{
 					From:     []string{fromDate},
 					Projects: []string{testProject.Project.Key},
 				})
@@ -77,7 +78,7 @@ var _ = Describe("Developers Service", Ordered, func() {
 
 		Context("Error Handling", func() {
 			It("should fail with missing from date", func() {
-				_, resp, err := client.Developers.SearchEvents(&sonar.DevelopersSearchEventsOptions{
+				_, resp, err := client.Developers.SearchEvents(context.Background(), &sonar.DevelopersSearchEventsOptions{
 					Projects: []string{testProject.Project.Key},
 				})
 				Expect(err).To(HaveOccurred())
@@ -86,7 +87,7 @@ var _ = Describe("Developers Service", Ordered, func() {
 
 			It("should fail with missing projects", func() {
 				fromDate := time.Now().UTC().Add(-24 * time.Hour).Format("2006-01-02T15:04:05-0700")
-				_, resp, err := client.Developers.SearchEvents(&sonar.DevelopersSearchEventsOptions{
+				_, resp, err := client.Developers.SearchEvents(context.Background(), &sonar.DevelopersSearchEventsOptions{
 					From: []string{fromDate},
 				})
 				Expect(err).To(HaveOccurred())
@@ -94,7 +95,7 @@ var _ = Describe("Developers Service", Ordered, func() {
 			})
 
 			It("should fail with nil options", func() {
-				_, resp, err := client.Developers.SearchEvents(nil)
+				_, resp, err := client.Developers.SearchEvents(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})

--- a/integration_testing/dismiss_message_test.go
+++ b/integration_testing/dismiss_message_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,14 +27,14 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 
 		// Create a test project for dismiss message operations
 		projectKey = helpers.UniqueResourceName("dms")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    "DismissMessage Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -53,7 +54,7 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 	Describe("Check", func() {
 		Context("Valid Requests", func() {
 			It("should check message dismissal status", func() {
-				result, resp, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOptions{
+				result, resp, err := client.DismissMessage.Check(context.Background(), &sonar.DismissMessageCheckOptions{
 					MessageType: "PROJECT_NCD_90",
 					ProjectKey:  projectKey,
 				})
@@ -69,21 +70,21 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing message type", func() {
-				_, _, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOptions{
+				_, _, err := client.DismissMessage.Check(context.Background(), &sonar.DismissMessageCheckOptions{
 					ProjectKey: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing project key", func() {
-				_, _, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOptions{
+				_, _, err := client.DismissMessage.Check(context.Background(), &sonar.DismissMessageCheckOptions{
 					MessageType: "PROJECT_NCD_90",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, _, err := client.DismissMessage.Check(nil)
+				_, _, err := client.DismissMessage.Check(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -95,7 +96,7 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 	Describe("Dismiss", func() {
 		Context("Valid Requests", func() {
 			It("should dismiss a message", func() {
-				resp, err := client.DismissMessage.Dismiss(&sonar.DismissMessageDismissOptions{
+				resp, err := client.DismissMessage.Dismiss(context.Background(), &sonar.DismissMessageDismissOptions{
 					MessageType: "PROJECT_NCD_90",
 					ProjectKey:  projectKey,
 				})
@@ -110,21 +111,21 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing message type", func() {
-				_, err := client.DismissMessage.Dismiss(&sonar.DismissMessageDismissOptions{
+				_, err := client.DismissMessage.Dismiss(context.Background(), &sonar.DismissMessageDismissOptions{
 					ProjectKey: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing project key", func() {
-				_, err := client.DismissMessage.Dismiss(&sonar.DismissMessageDismissOptions{
+				_, err := client.DismissMessage.Dismiss(context.Background(), &sonar.DismissMessageDismissOptions{
 					MessageType: "PROJECT_NCD_90",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, err := client.DismissMessage.Dismiss(nil)
+				_, err := client.DismissMessage.Dismiss(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -136,7 +137,7 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 	Describe("Full Workflow", func() {
 		It("should verify message is dismissed after dismissal", func() {
 			// Check message is not dismissed initially
-			initialCheck, resp, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOptions{
+			initialCheck, resp, err := client.DismissMessage.Check(context.Background(), &sonar.DismissMessageCheckOptions{
 				MessageType: "PROJECT_NCD_90",
 				ProjectKey:  projectKey,
 			})
@@ -149,7 +150,7 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 			Expect(initialCheck).NotTo(BeNil())
 
 			// Dismiss the message
-			resp, err = client.DismissMessage.Dismiss(&sonar.DismissMessageDismissOptions{
+			resp, err = client.DismissMessage.Dismiss(context.Background(), &sonar.DismissMessageDismissOptions{
 				MessageType: "PROJECT_NCD_90",
 				ProjectKey:  projectKey,
 			})
@@ -157,7 +158,7 @@ var _ = Describe("DismissMessage Service", Ordered, func() {
 			Expect(resp.StatusCode).To(SatisfyAny(Equal(http.StatusOK), Equal(http.StatusNoContent)))
 
 			// Check message is now dismissed
-			finalCheck, resp, err := client.DismissMessage.Check(&sonar.DismissMessageCheckOptions{
+			finalCheck, resp, err := client.DismissMessage.Check(context.Background(), &sonar.DismissMessageCheckOptions{
 				MessageType: "PROJECT_NCD_90",
 				ProjectKey:  projectKey,
 			})

--- a/integration_testing/duplications_test.go
+++ b/integration_testing/duplications_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,14 +27,14 @@ var _ = Describe("Duplications Service", Ordered, func() {
 
 		// Create a test project for duplications-related operations
 		projectKey = helpers.UniqueResourceName("dup")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    "Duplications Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -53,7 +54,7 @@ var _ = Describe("Duplications Service", Ordered, func() {
 	Describe("Show", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Duplications.Show(nil)
+				result, resp, err := client.Duplications.Show(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -61,7 +62,7 @@ var _ = Describe("Duplications Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				result, resp, err := client.Duplications.Show(&sonar.DuplicationsShowOptions{})
+				result, resp, err := client.Duplications.Show(context.Background(), &sonar.DuplicationsShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(result).To(BeNil())
@@ -71,7 +72,7 @@ var _ = Describe("Duplications Service", Ordered, func() {
 
 		Context("Non-Existent File", func() {
 			It("should fail for non-existent file key", func() {
-				result, resp, err := client.Duplications.Show(&sonar.DuplicationsShowOptions{
+				result, resp, err := client.Duplications.Show(context.Background(), &sonar.DuplicationsShowOptions{
 					Key: "non-existent-file-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -84,7 +85,7 @@ var _ = Describe("Duplications Service", Ordered, func() {
 
 		Context("Project Key", func() {
 			It("should work with project key (empty duplications)", func() {
-				result, resp, err := client.Duplications.Show(&sonar.DuplicationsShowOptions{
+				result, resp, err := client.Duplications.Show(context.Background(), &sonar.DuplicationsShowOptions{
 					Key: projectKey,
 				})
 				// May succeed with empty result or fail if the project doesn't have analyzed files

--- a/integration_testing/editions_test.go
+++ b/integration_testing/editions_test.go
@@ -1,6 +1,8 @@
 package integration_testing_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -32,7 +34,7 @@ var _ = Describe("License Service", Ordered, func() {
 	Describe("ActivateGracePeriod", func() {
 		Context("Functional Tests", func() {
 			It("should activate grace period or return an error on community edition", func() {
-				resp, err := client.Editions.ActivateGracePeriod()
+				resp, err := client.Editions.ActivateGracePeriod(context.Background())
 				if err != nil {
 					// Community edition does not expose this endpoint;
 					// a 404 or 403 is acceptable.
@@ -50,7 +52,7 @@ var _ = Describe("License Service", Ordered, func() {
 	Describe("Get", func() {
 		Context("Functional Tests", func() {
 			It("should return license information or an error on community edition", func() {
-				result, resp, err := client.Editions.Get()
+				result, resp, err := client.Editions.Get(context.Background())
 				if err != nil {
 					// Community edition does not expose the license endpoint;
 					// a 404 or 403 is acceptable.
@@ -69,7 +71,7 @@ var _ = Describe("License Service", Ordered, func() {
 	Describe("IsValidLicense", func() {
 		Context("Functional Tests", func() {
 			It("should return license validity or an error on community edition", func() {
-				result, resp, err := client.Editions.IsValidLicense()
+				result, resp, err := client.Editions.IsValidLicense(context.Background())
 				if err != nil {
 					// Community edition does not expose this endpoint;
 					// a 404 or 403 is acceptable.
@@ -88,14 +90,14 @@ var _ = Describe("License Service", Ordered, func() {
 	Describe("Set", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Editions.Set(nil)
+				resp, err := client.Editions.Set(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without license key", func() {
-				resp, err := client.Editions.Set(&sonar.LicenseSetOptions{})
+				resp, err := client.Editions.Set(context.Background(), &sonar.LicenseSetOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("License"))
 				Expect(resp).To(BeNil())
@@ -104,7 +106,7 @@ var _ = Describe("License Service", Ordered, func() {
 
 		Context("Functional Tests", func() {
 			It("should fail with an invalid license key", func() {
-				resp, err := client.Editions.Set(&sonar.LicenseSetOptions{
+				resp, err := client.Editions.Set(context.Background(), &sonar.LicenseSetOptions{
 					License: "invalid-license-key",
 				})
 				// Expect an error because the license key is invalid.
@@ -121,7 +123,7 @@ var _ = Describe("License Service", Ordered, func() {
 	Describe("UnsetLicense", func() {
 		Context("Functional Tests", func() {
 			It("should unset the license or return an error on community edition", func() {
-				resp, err := client.Editions.UnsetLicense()
+				resp, err := client.Editions.UnsetLicense(context.Background())
 				if err != nil {
 					// Community edition does not expose this endpoint;
 					// a 404 or 403 is acceptable.

--- a/integration_testing/emails_test.go
+++ b/integration_testing/emails_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,14 +29,14 @@ var _ = Describe("Emails Service", Ordered, func() {
 	Describe("Send", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Emails.Send(nil)
+				resp, err := client.Emails.Send(context.Background(), nil)
 				Expect(resp).To(BeNil())
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 			})
 
 			It("should fail with missing to address", func() {
-				resp, err := client.Emails.Send(&sonar.EmailsSendOptions{
+				resp, err := client.Emails.Send(context.Background(), &sonar.EmailsSendOptions{
 					Message: "Test message",
 				})
 				Expect(resp).To(BeNil())
@@ -44,7 +45,7 @@ var _ = Describe("Emails Service", Ordered, func() {
 			})
 
 			It("should fail with missing message", func() {
-				resp, err := client.Emails.Send(&sonar.EmailsSendOptions{
+				resp, err := client.Emails.Send(context.Background(), &sonar.EmailsSendOptions{
 					To: "test@example.com",
 				})
 				Expect(resp).To(BeNil())
@@ -57,7 +58,7 @@ var _ = Describe("Emails Service", Ordered, func() {
 			It("should attempt to send test email with valid parameters", func() {
 				// Email sending requires SMTP to be configured
 				// If not configured, the API returns an error
-				resp, err := client.Emails.Send(&sonar.EmailsSendOptions{
+				resp, err := client.Emails.Send(context.Background(), &sonar.EmailsSendOptions{
 					To:      "test@example.com",
 					Message: "Test message from e2e tests",
 					Subject: "Test Subject",

--- a/integration_testing/favorites_test.go
+++ b/integration_testing/favorites_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -36,14 +37,14 @@ var _ = Describe("Favorites Service", Ordered, func() {
 
 		// Create a test project for favorites-related operations
 		projectKey = helpers.UniqueResourceName("fav")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    "Favorites Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -63,14 +64,14 @@ var _ = Describe("Favorites Service", Ordered, func() {
 	Describe("Search", func() {
 		Context("Valid Requests", func() {
 			It("should search favorites with nil options", func() {
-				result, resp, err := client.Favorites.Search(nil)
+				result, resp, err := client.Favorites.Search(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
 			})
 
 			It("should search favorites with pagination", func() {
-				result, resp, err := client.Favorites.Search(&sonar.FavoritesSearchOptions{
+				result, resp, err := client.Favorites.Search(context.Background(), &sonar.FavoritesSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 10,
 						Page:     1,
@@ -89,14 +90,14 @@ var _ = Describe("Favorites Service", Ordered, func() {
 	Describe("Add", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Favorites.Add(nil)
+				resp, err := client.Favorites.Add(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required component", func() {
-				resp, err := client.Favorites.Add(&sonar.FavoritesAddOptions{})
+				resp, err := client.Favorites.Add(context.Background(), &sonar.FavoritesAddOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Component"))
 				Expect(resp).To(BeNil())
@@ -105,14 +106,14 @@ var _ = Describe("Favorites Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should add a project as favorite", func() {
-				resp, err := client.Favorites.Add(&sonar.FavoritesAddOptions{
+				resp, err := client.Favorites.Add(context.Background(), &sonar.FavoritesAddOptions{
 					Component: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Clean up: remove the favorite
-				_, _ = client.Favorites.Remove(&sonar.FavoritesRemoveOptions{
+				_, _ = client.Favorites.Remove(context.Background(), &sonar.FavoritesRemoveOptions{
 					Component: projectKey,
 				})
 			})
@@ -120,7 +121,7 @@ var _ = Describe("Favorites Service", Ordered, func() {
 
 		Context("Non-Existent Component", func() {
 			It("should fail for non-existent component", func() {
-				resp, err := client.Favorites.Add(&sonar.FavoritesAddOptions{
+				resp, err := client.Favorites.Add(context.Background(), &sonar.FavoritesAddOptions{
 					Component: "non-existent-component",
 				})
 				Expect(err).To(HaveOccurred())
@@ -137,14 +138,14 @@ var _ = Describe("Favorites Service", Ordered, func() {
 	Describe("Remove", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Favorites.Remove(nil)
+				resp, err := client.Favorites.Remove(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required component", func() {
-				resp, err := client.Favorites.Remove(&sonar.FavoritesRemoveOptions{})
+				resp, err := client.Favorites.Remove(context.Background(), &sonar.FavoritesRemoveOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Component"))
 				Expect(resp).To(BeNil())
@@ -154,13 +155,13 @@ var _ = Describe("Favorites Service", Ordered, func() {
 		Context("Valid Requests", func() {
 			It("should remove a project from favorites", func() {
 				// First add the project as favorite
-				_, err := client.Favorites.Add(&sonar.FavoritesAddOptions{
+				_, err := client.Favorites.Add(context.Background(), &sonar.FavoritesAddOptions{
 					Component: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Now remove it
-				resp, err := client.Favorites.Remove(&sonar.FavoritesRemoveOptions{
+				resp, err := client.Favorites.Remove(context.Background(), &sonar.FavoritesRemoveOptions{
 					Component: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -170,7 +171,7 @@ var _ = Describe("Favorites Service", Ordered, func() {
 
 		Context("Non-Existent Component", func() {
 			It("should fail for non-existent component", func() {
-				resp, err := client.Favorites.Remove(&sonar.FavoritesRemoveOptions{
+				resp, err := client.Favorites.Remove(context.Background(), &sonar.FavoritesRemoveOptions{
 					Component: "non-existent-component",
 				})
 				Expect(err).To(HaveOccurred())
@@ -183,12 +184,12 @@ var _ = Describe("Favorites Service", Ordered, func() {
 		Context("Not Favorited Component", func() {
 			It("should fail when removing a component that is not favorited", func() {
 				// Ensure it's not favorited first
-				_, _ = client.Favorites.Remove(&sonar.FavoritesRemoveOptions{
+				_, _ = client.Favorites.Remove(context.Background(), &sonar.FavoritesRemoveOptions{
 					Component: projectKey,
 				})
 
 				// Try to remove again
-				resp, err := client.Favorites.Remove(&sonar.FavoritesRemoveOptions{
+				resp, err := client.Favorites.Remove(context.Background(), &sonar.FavoritesRemoveOptions{
 					Component: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -205,14 +206,14 @@ var _ = Describe("Favorites Service", Ordered, func() {
 	Describe("Full Workflow", func() {
 		It("should add, verify, and remove a favorite", func() {
 			// Add favorite
-			resp, err := client.Favorites.Add(&sonar.FavoritesAddOptions{
+			resp, err := client.Favorites.Add(context.Background(), &sonar.FavoritesAddOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Search and verify it's there
-			searchResult, resp, err := client.Favorites.Search(nil)
+			searchResult, resp, err := client.Favorites.Search(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(searchResult).NotTo(BeNil())
@@ -220,14 +221,14 @@ var _ = Describe("Favorites Service", Ordered, func() {
 			Expect(containsFavorite(searchResult.Favorites, projectKey)).To(BeTrue(), "Project should be in favorites")
 
 			// Remove favorite
-			resp, err = client.Favorites.Remove(&sonar.FavoritesRemoveOptions{
+			resp, err = client.Favorites.Remove(context.Background(), &sonar.FavoritesRemoveOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify it's gone
-			searchResult, resp, err = client.Favorites.Search(nil)
+			searchResult, resp, err = client.Favorites.Search(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 

--- a/integration_testing/features_test.go
+++ b/integration_testing/features_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,7 +29,7 @@ var _ = Describe("Features Service", Ordered, func() {
 	Describe("List", func() {
 		Context("Valid Requests", func() {
 			It("should list supported features with non-empty values", func() {
-				result, resp, err := client.Features.List()
+				result, resp, err := client.Features.List(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -43,11 +44,11 @@ var _ = Describe("Features Service", Ordered, func() {
 			})
 
 			It("should return consistent results on multiple calls", func() {
-				result1, resp1, err := client.Features.List()
+				result1, resp1, err := client.Features.List(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp1.StatusCode).To(Equal(http.StatusOK))
 
-				result2, resp2, err := client.Features.List()
+				result2, resp2, err := client.Features.List(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp2.StatusCode).To(Equal(http.StatusOK))
 

--- a/integration_testing/github_provisioning_test.go
+++ b/integration_testing/github_provisioning_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,7 +29,7 @@ var _ = Describe("GithubProvisioning Service", Ordered, func() {
 	Describe("Check", func() {
 		Context("Functional Tests", func() {
 			It("should check GitHub provisioning configuration", func() {
-				result, resp, err := client.GithubProvisioning.Check()
+				result, resp, err := client.GithubProvisioning.Check(context.Background(), )
 				// Skip if GitHub integration is not configured or API not available
 				if resp != nil && (resp.StatusCode == http.StatusNotFound ||
 					resp.StatusCode == http.StatusBadRequest ||
@@ -42,7 +43,7 @@ var _ = Describe("GithubProvisioning Service", Ordered, func() {
 			})
 
 			It("should return valid provisioning status structure", func() {
-				result, resp, err := client.GithubProvisioning.Check()
+				result, resp, err := client.GithubProvisioning.Check(context.Background(), )
 				// Skip if GitHub integration is not configured
 				if resp != nil && (resp.StatusCode == http.StatusNotFound ||
 					resp.StatusCode == http.StatusBadRequest ||

--- a/integration_testing/helpers/cleanup.go
+++ b/integration_testing/helpers/cleanup.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -107,7 +108,7 @@ func CleanupOrphanedResources(client *sonar.Client, maxAge time.Duration) error 
 }
 
 func cleanupOrphanedTemplates(client *sonar.Client, _ time.Duration) error {
-	templates, _, err := client.Permissions.SearchTemplates(nil)
+	templates, _, err := client.Permissions.SearchTemplates(context.Background(), nil)
 	if err != nil {
 		return fmt.Errorf("failed to search templates: %w", err)
 	}
@@ -118,7 +119,7 @@ func cleanupOrphanedTemplates(client *sonar.Client, _ time.Duration) error {
 
 	for _, t := range templates.PermissionTemplates {
 		if strings.HasPrefix(t.Name, E2EResourcePrefix) {
-			_, _ = client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+			_, _ = client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 				TemplateName: t.Name,
 			})
 		}
@@ -129,7 +130,7 @@ func cleanupOrphanedTemplates(client *sonar.Client, _ time.Duration) error {
 
 func cleanupOrphanedProjects(client *sonar.Client, _ time.Duration) error {
 	// Search for projects with e2e prefix
-	projects, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
+	projects, _, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 		PaginationArgs:    sonar.PaginationArgs{Page: 0, PageSize: 0},
 		AnalyzedBefore:    "",
 		OnProvisionedOnly: false,
@@ -148,7 +149,7 @@ func cleanupOrphanedProjects(client *sonar.Client, _ time.Duration) error {
 
 	for _, p := range projects.Components {
 		if strings.HasPrefix(p.Key, E2EResourcePrefix) {
-			_, _ = client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, _ = client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: p.Key,
 			})
 		}
@@ -159,7 +160,7 @@ func cleanupOrphanedProjects(client *sonar.Client, _ time.Duration) error {
 
 func cleanupOrphanedUsers(client *sonar.Client, _ time.Duration) error {
 	//nolint:staticcheck // Using deprecated API until v2 API is implemented
-	users, _, err := client.Users.Search(&sonar.UsersSearchOptions{
+	users, _, err := client.Users.Search(context.Background(), &sonar.UsersSearchOptions{
 		PaginationArgs:        sonar.PaginationArgs{Page: 0, PageSize: 0},
 		Deactivated:           false,
 		ExternalIdentity:      "",
@@ -181,7 +182,7 @@ func cleanupOrphanedUsers(client *sonar.Client, _ time.Duration) error {
 	for _, u := range users.Users {
 		if strings.HasPrefix(u.Login, E2EResourcePrefix) {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, _ = client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+			_, _, _ = client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 				Login:     u.Login,
 				Anonymize: false,
 			})
@@ -193,7 +194,7 @@ func cleanupOrphanedUsers(client *sonar.Client, _ time.Duration) error {
 
 func cleanupOrphanedGroups(client *sonar.Client, _ time.Duration) error {
 	//nolint:staticcheck // Using deprecated API until v2 API is implemented
-	groups, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
+	groups, _, err := client.UserGroups.Search(context.Background(), &sonar.UserGroupsSearchOptions{
 		PaginationArgs: sonar.PaginationArgs{Page: 0, PageSize: 0},
 		Managed:        nil,
 		Fields:         nil,
@@ -210,7 +211,7 @@ func cleanupOrphanedGroups(client *sonar.Client, _ time.Duration) error {
 	for _, g := range groups.Groups {
 		if strings.HasPrefix(g.Name, E2EResourcePrefix) {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _ = client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+			_, _ = client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 				Name: g.Name,
 			})
 		}

--- a/integration_testing/hotspots_test.go
+++ b/integration_testing/hotspots_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,14 +27,14 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		// Create a test project for hotspots-related operations
 		projectKey = helpers.UniqueResourceName("hot")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    "Hotspots Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -53,7 +54,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 	Describe("Search", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Hotspots.Search(nil)
+				result, resp, err := client.Hotspots.Search(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -61,7 +62,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without project or hotspots parameter", func() {
-				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOptions{})
+				result, resp, err := client.Hotspots.Search(context.Background(), &sonar.HotspotsSearchOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
 				Expect(resp).To(BeNil())
@@ -70,7 +71,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should search hotspots for a project", func() {
-				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOptions{
+				result, resp, err := client.Hotspots.Search(context.Background(), &sonar.HotspotsSearchOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -79,7 +80,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should search hotspots with pagination", func() {
-				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOptions{
+				result, resp, err := client.Hotspots.Search(context.Background(), &sonar.HotspotsSearchOptions{
 					Project: projectKey,
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 10,
@@ -92,7 +93,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should search hotspots with status filter", func() {
-				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOptions{
+				result, resp, err := client.Hotspots.Search(context.Background(), &sonar.HotspotsSearchOptions{
 					Project: projectKey,
 					Status:  sonar.HotspotStatusToReview,
 				})
@@ -102,7 +103,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should search hotspots in new code period", func() {
-				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOptions{
+				result, resp, err := client.Hotspots.Search(context.Background(), &sonar.HotspotsSearchOptions{
 					Project:         projectKey,
 					InNewCodePeriod: true,
 				})
@@ -114,7 +115,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.Hotspots.Search(&sonar.HotspotsSearchOptions{
+				result, resp, err := client.Hotspots.Search(context.Background(), &sonar.HotspotsSearchOptions{
 					Project: "non-existent-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -132,7 +133,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 	Describe("List", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Hotspots.List(nil)
+				result, resp, err := client.Hotspots.List(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -140,7 +141,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required project", func() {
-				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOptions{})
+				result, resp, err := client.Hotspots.List(context.Background(), &sonar.HotspotsListOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Project"))
 				Expect(result).To(BeNil())
@@ -150,7 +151,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should list hotspots for a project", func() {
-				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOptions{
+				result, resp, err := client.Hotspots.List(context.Background(), &sonar.HotspotsListOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -159,7 +160,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should list hotspots with pagination", func() {
-				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOptions{
+				result, resp, err := client.Hotspots.List(context.Background(), &sonar.HotspotsListOptions{
 					Project: projectKey,
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 10,
@@ -172,7 +173,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should list hotspots with status filter", func() {
-				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOptions{
+				result, resp, err := client.Hotspots.List(context.Background(), &sonar.HotspotsListOptions{
 					Project: projectKey,
 					Status:  sonar.HotspotStatusToReview,
 				})
@@ -184,7 +185,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.Hotspots.List(&sonar.HotspotsListOptions{
+				result, resp, err := client.Hotspots.List(context.Background(), &sonar.HotspotsListOptions{
 					Project: "non-existent-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -202,7 +203,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 	Describe("Show", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Hotspots.Show(nil)
+				result, resp, err := client.Hotspots.Show(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -210,7 +211,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required hotspot key", func() {
-				result, resp, err := client.Hotspots.Show(&sonar.HotspotsShowOptions{})
+				result, resp, err := client.Hotspots.Show(context.Background(), &sonar.HotspotsShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Hotspot"))
 				Expect(result).To(BeNil())
@@ -220,7 +221,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Hotspot", func() {
 			It("should fail with non-existent hotspot key", func() {
-				result, resp, err := client.Hotspots.Show(&sonar.HotspotsShowOptions{
+				result, resp, err := client.Hotspots.Show(context.Background(), &sonar.HotspotsShowOptions{
 					Hotspot: "AXxxxxxxxxxxxxxxxxxx",
 				})
 				Expect(err).To(HaveOccurred())
@@ -238,7 +239,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 	Describe("Pull", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Hotspots.Pull(nil)
+				result, resp, err := client.Hotspots.Pull(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -246,7 +247,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required project key", func() {
-				result, resp, err := client.Hotspots.Pull(&sonar.HotspotsPullOptions{
+				result, resp, err := client.Hotspots.Pull(context.Background(), &sonar.HotspotsPullOptions{
 					BranchName: "main",
 				})
 				Expect(err).To(HaveOccurred())
@@ -256,7 +257,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required branch name", func() {
-				result, resp, err := client.Hotspots.Pull(&sonar.HotspotsPullOptions{
+				result, resp, err := client.Hotspots.Pull(context.Background(), &sonar.HotspotsPullOptions{
 					ProjectKey: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -268,7 +269,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.Hotspots.Pull(&sonar.HotspotsPullOptions{
+				result, resp, err := client.Hotspots.Pull(context.Background(), &sonar.HotspotsPullOptions{
 					ProjectKey: "non-existent-project",
 					BranchName: "main",
 				})
@@ -287,14 +288,14 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 	Describe("AddComment", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Hotspots.AddComment(nil)
+				resp, err := client.Hotspots.AddComment(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required hotspot key", func() {
-				resp, err := client.Hotspots.AddComment(&sonar.HotspotsAddCommentOptions{
+				resp, err := client.Hotspots.AddComment(context.Background(), &sonar.HotspotsAddCommentOptions{
 					Comment: "Test comment",
 				})
 				Expect(err).To(HaveOccurred())
@@ -303,7 +304,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required comment", func() {
-				resp, err := client.Hotspots.AddComment(&sonar.HotspotsAddCommentOptions{
+				resp, err := client.Hotspots.AddComment(context.Background(), &sonar.HotspotsAddCommentOptions{
 					Hotspot: "AXxxxxxxxxxxxxxxxxxx",
 				})
 				Expect(err).To(HaveOccurred())
@@ -314,7 +315,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Hotspot", func() {
 			It("should fail with non-existent hotspot key", func() {
-				resp, err := client.Hotspots.AddComment(&sonar.HotspotsAddCommentOptions{
+				resp, err := client.Hotspots.AddComment(context.Background(), &sonar.HotspotsAddCommentOptions{
 					Hotspot: "AXxxxxxxxxxxxxxxxxxx",
 					Comment: "Test comment",
 				})
@@ -332,14 +333,14 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 	Describe("Assign", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Hotspots.Assign(nil)
+				resp, err := client.Hotspots.Assign(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required hotspot key", func() {
-				resp, err := client.Hotspots.Assign(&sonar.HotspotsAssignOptions{
+				resp, err := client.Hotspots.Assign(context.Background(), &sonar.HotspotsAssignOptions{
 					Assignee: "admin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -350,7 +351,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Hotspot", func() {
 			It("should fail with non-existent hotspot key", func() {
-				resp, err := client.Hotspots.Assign(&sonar.HotspotsAssignOptions{
+				resp, err := client.Hotspots.Assign(context.Background(), &sonar.HotspotsAssignOptions{
 					Hotspot:  "AXxxxxxxxxxxxxxxxxxx",
 					Assignee: "admin",
 				})
@@ -368,14 +369,14 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 	Describe("ChangeStatus", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Hotspots.ChangeStatus(nil)
+				resp, err := client.Hotspots.ChangeStatus(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required hotspot key", func() {
-				resp, err := client.Hotspots.ChangeStatus(&sonar.HotspotsChangeStatusOptions{
+				resp, err := client.Hotspots.ChangeStatus(context.Background(), &sonar.HotspotsChangeStatusOptions{
 					Status: sonar.HotspotStatusReviewed,
 				})
 				Expect(err).To(HaveOccurred())
@@ -384,7 +385,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required status", func() {
-				resp, err := client.Hotspots.ChangeStatus(&sonar.HotspotsChangeStatusOptions{
+				resp, err := client.Hotspots.ChangeStatus(context.Background(), &sonar.HotspotsChangeStatusOptions{
 					Hotspot: "AXxxxxxxxxxxxxxxxxxx",
 				})
 				Expect(err).To(HaveOccurred())
@@ -395,7 +396,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Hotspot", func() {
 			It("should fail with non-existent hotspot key", func() {
-				resp, err := client.Hotspots.ChangeStatus(&sonar.HotspotsChangeStatusOptions{
+				resp, err := client.Hotspots.ChangeStatus(context.Background(), &sonar.HotspotsChangeStatusOptions{
 					Hotspot:    "AXxxxxxxxxxxxxxxxxxx",
 					Status:     sonar.HotspotStatusReviewed,
 					Resolution: sonar.HotspotResolutionSafe,
@@ -414,14 +415,14 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 	Describe("DeleteComment", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Hotspots.DeleteComment(nil)
+				resp, err := client.Hotspots.DeleteComment(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required comment key", func() {
-				resp, err := client.Hotspots.DeleteComment(&sonar.HotspotsDeleteCommentOptions{})
+				resp, err := client.Hotspots.DeleteComment(context.Background(), &sonar.HotspotsDeleteCommentOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Comment"))
 				Expect(resp).To(BeNil())
@@ -430,7 +431,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Comment", func() {
 			It("should fail with non-existent comment key", func() {
-				resp, err := client.Hotspots.DeleteComment(&sonar.HotspotsDeleteCommentOptions{
+				resp, err := client.Hotspots.DeleteComment(context.Background(), &sonar.HotspotsDeleteCommentOptions{
 					Comment: "AXxxxxxxxxxxxxxxxxxx",
 				})
 				Expect(err).To(HaveOccurred())
@@ -447,7 +448,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 	Describe("EditComment", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Hotspots.EditComment(nil)
+				result, resp, err := client.Hotspots.EditComment(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -455,7 +456,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required comment key", func() {
-				result, resp, err := client.Hotspots.EditComment(&sonar.HotspotsEditCommentOptions{
+				result, resp, err := client.Hotspots.EditComment(context.Background(), &sonar.HotspotsEditCommentOptions{
 					Text: "Updated comment",
 				})
 				Expect(err).To(HaveOccurred())
@@ -465,7 +466,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 
 			It("should fail without required text", func() {
-				result, resp, err := client.Hotspots.EditComment(&sonar.HotspotsEditCommentOptions{
+				result, resp, err := client.Hotspots.EditComment(context.Background(), &sonar.HotspotsEditCommentOptions{
 					Comment: "AXxxxxxxxxxxxxxxxxxx",
 				})
 				Expect(err).To(HaveOccurred())
@@ -477,7 +478,7 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 
 		Context("Non-Existent Comment", func() {
 			It("should fail with non-existent comment key", func() {
-				result, resp, err := client.Hotspots.EditComment(&sonar.HotspotsEditCommentOptions{
+				result, resp, err := client.Hotspots.EditComment(context.Background(), &sonar.HotspotsEditCommentOptions{
 					Comment: "AXxxxxxxxxxxxxxxxxxx",
 					Text:    "Updated comment",
 				})

--- a/integration_testing/issues_test.go
+++ b/integration_testing/issues_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -31,14 +32,14 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		// Create a test project for issues-related operations
 		projectKey = helpers.UniqueResourceName("iss")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    "Issues Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -58,14 +59,14 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("Search", func() {
 		Context("Valid Requests", func() {
 			It("should search issues with nil options", func() {
-				result, resp, err := client.Issues.Search(nil)
+				result, resp, err := client.Issues.Search(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
 			})
 
 			It("should search issues for a project", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
+				result, resp, err := client.Issues.Search(context.Background(), &sonar.IssuesSearchOptions{
 					Projects: []string{projectKey},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -74,7 +75,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should search issues with pagination", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
+				result, resp, err := client.Issues.Search(context.Background(), &sonar.IssuesSearchOptions{
 					Projects: []string{projectKey},
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 10,
@@ -87,7 +88,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should search issues with impact severities filter", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
+				result, resp, err := client.Issues.Search(context.Background(), &sonar.IssuesSearchOptions{
 					Projects:         []string{projectKey},
 					ImpactSeverities: []string{sonar.RuleImpactSeverityHigh, sonar.RuleImpactSeverityMedium},
 				})
@@ -97,7 +98,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should search issues with issue statuses filter", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
+				result, resp, err := client.Issues.Search(context.Background(), &sonar.IssuesSearchOptions{
 					Projects:      []string{projectKey},
 					IssueStatuses: []string{sonar.IssueStatusOpen, sonar.IssueStatusConfirmed},
 				})
@@ -107,7 +108,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should search issues with clean code categories filter", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
+				result, resp, err := client.Issues.Search(context.Background(), &sonar.IssuesSearchOptions{
 					Projects:                     []string{projectKey},
 					CleanCodeAttributeCategories: []string{sonar.CleanCodeAttributeCategoryIntentional, sonar.CleanCodeAttributeCategoryConsistent},
 				})
@@ -117,7 +118,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should search issues with additional fields", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
+				result, resp, err := client.Issues.Search(context.Background(), &sonar.IssuesSearchOptions{
 					Projects:         []string{projectKey},
 					AdditionalFields: []string{"rules", "users"},
 				})
@@ -127,7 +128,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should search issues with facets", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
+				result, resp, err := client.Issues.Search(context.Background(), &sonar.IssuesSearchOptions{
 					Projects: []string{projectKey},
 					Facets:   []string{"impactSeverities", "issueStatuses"},
 				})
@@ -139,7 +140,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should return empty results for non-existent project", func() {
-				result, resp, err := client.Issues.Search(&sonar.IssuesSearchOptions{
+				result, resp, err := client.Issues.Search(context.Background(), &sonar.IssuesSearchOptions{
 					Projects: []string{nonExistentProjectKey},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -156,7 +157,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("List", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Issues.List(nil)
+				result, resp, err := client.Issues.List(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(result).To(BeNil())
@@ -164,7 +165,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without project or component", func() {
-				result, resp, err := client.Issues.List(&sonar.IssuesListOptions{})
+				result, resp, err := client.Issues.List(context.Background(), &sonar.IssuesListOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
 				Expect(resp).To(BeNil())
@@ -173,7 +174,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should list issues for a project", func() {
-				result, resp, err := client.Issues.List(&sonar.IssuesListOptions{
+				result, resp, err := client.Issues.List(context.Background(), &sonar.IssuesListOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -182,7 +183,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should list issues with pagination", func() {
-				result, resp, err := client.Issues.List(&sonar.IssuesListOptions{
+				result, resp, err := client.Issues.List(context.Background(), &sonar.IssuesListOptions{
 					Project: projectKey,
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 10,
@@ -202,14 +203,14 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("Authors", func() {
 		Context("Valid Requests", func() {
 			It("should list authors with nil options", func() {
-				result, resp, err := client.Issues.Authors(nil)
+				result, resp, err := client.Issues.Authors(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
 			})
 
 			It("should list authors for a project", func() {
-				result, resp, err := client.Issues.Authors(&sonar.IssuesAuthorsOptions{
+				result, resp, err := client.Issues.Authors(context.Background(), &sonar.IssuesAuthorsOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -218,7 +219,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should list authors with query filter", func() {
-				result, resp, err := client.Issues.Authors(&sonar.IssuesAuthorsOptions{
+				result, resp, err := client.Issues.Authors(context.Background(), &sonar.IssuesAuthorsOptions{
 					Query: "admin",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -227,7 +228,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should list authors with pagination", func() {
-				result, resp, err := client.Issues.Authors(&sonar.IssuesAuthorsOptions{
+				result, resp, err := client.Issues.Authors(context.Background(), &sonar.IssuesAuthorsOptions{
 					PageSize: 10,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -243,14 +244,14 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("Tags", func() {
 		Context("Valid Requests", func() {
 			It("should list tags with nil options", func() {
-				result, resp, err := client.Issues.Tags(nil)
+				result, resp, err := client.Issues.Tags(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
 			})
 
 			It("should list tags for a project", func() {
-				result, resp, err := client.Issues.Tags(&sonar.IssuesTagsOptions{
+				result, resp, err := client.Issues.Tags(context.Background(), &sonar.IssuesTagsOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -259,7 +260,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should list tags with query filter", func() {
-				result, resp, err := client.Issues.Tags(&sonar.IssuesTagsOptions{
+				result, resp, err := client.Issues.Tags(context.Background(), &sonar.IssuesTagsOptions{
 					Query: "security",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -275,7 +276,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("AddComment", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Issues.AddComment(nil)
+				result, resp, err := client.Issues.AddComment(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(result).To(BeNil())
@@ -283,7 +284,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Issues.AddComment(&sonar.IssuesAddCommentOptions{
+				result, resp, err := client.Issues.AddComment(context.Background(), &sonar.IssuesAddCommentOptions{
 					Text: "Test comment",
 				})
 				Expect(err).To(HaveOccurred())
@@ -293,7 +294,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required text", func() {
-				result, resp, err := client.Issues.AddComment(&sonar.IssuesAddCommentOptions{
+				result, resp, err := client.Issues.AddComment(context.Background(), &sonar.IssuesAddCommentOptions{
 					Issue: nonExistentIssueKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -305,7 +306,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Issues.AddComment(&sonar.IssuesAddCommentOptions{
+				result, resp, err := client.Issues.AddComment(context.Background(), &sonar.IssuesAddCommentOptions{
 					Issue: nonExistentIssueKey,
 					Text:  "Test comment",
 				})
@@ -324,7 +325,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("Assign", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Issues.Assign(nil)
+				result, resp, err := client.Issues.Assign(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(result).To(BeNil())
@@ -332,7 +333,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Issues.Assign(&sonar.IssuesAssignOptions{
+				result, resp, err := client.Issues.Assign(context.Background(), &sonar.IssuesAssignOptions{
 					Assignee: "admin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -344,7 +345,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Issues.Assign(&sonar.IssuesAssignOptions{
+				result, resp, err := client.Issues.Assign(context.Background(), &sonar.IssuesAssignOptions{
 					Issue:    nonExistentIssueKey,
 					Assignee: "admin",
 				})
@@ -363,7 +364,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("Changelog", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Issues.Changelog(nil)
+				result, resp, err := client.Issues.Changelog(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(result).To(BeNil())
@@ -371,7 +372,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Issues.Changelog(&sonar.IssuesChangelogOptions{})
+				result, resp, err := client.Issues.Changelog(context.Background(), &sonar.IssuesChangelogOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Issue"))
 				Expect(result).To(BeNil())
@@ -381,7 +382,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Issues.Changelog(&sonar.IssuesChangelogOptions{
+				result, resp, err := client.Issues.Changelog(context.Background(), &sonar.IssuesChangelogOptions{
 					Issue: nonExistentIssueKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -399,7 +400,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("DoTransition", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Issues.DoTransition(nil)
+				result, resp, err := client.Issues.DoTransition(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(result).To(BeNil())
@@ -407,7 +408,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Issues.DoTransition(&sonar.IssuesDoTransitionOptions{
+				result, resp, err := client.Issues.DoTransition(context.Background(), &sonar.IssuesDoTransitionOptions{
 					Transition: sonar.IssueTransitionConfirm,
 				})
 				Expect(err).To(HaveOccurred())
@@ -417,7 +418,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required transition", func() {
-				result, resp, err := client.Issues.DoTransition(&sonar.IssuesDoTransitionOptions{
+				result, resp, err := client.Issues.DoTransition(context.Background(), &sonar.IssuesDoTransitionOptions{
 					Issue: nonExistentIssueKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -429,7 +430,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Issues.DoTransition(&sonar.IssuesDoTransitionOptions{
+				result, resp, err := client.Issues.DoTransition(context.Background(), &sonar.IssuesDoTransitionOptions{
 					Issue:      nonExistentIssueKey,
 					Transition: sonar.IssueTransitionConfirm,
 				})
@@ -448,7 +449,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("BulkChange", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Issues.BulkChange(nil)
+				result, resp, err := client.Issues.BulkChange(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(result).To(BeNil())
@@ -456,7 +457,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issues", func() {
-				result, resp, err := client.Issues.BulkChange(&sonar.IssuesBulkChangeOptions{
+				result, resp, err := client.Issues.BulkChange(context.Background(), &sonar.IssuesBulkChangeOptions{
 					AddTags: []string{"test-tag"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -468,7 +469,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issues", func() {
 			It("should handle bulk change on non-existent issues", func() {
-				result, resp, err := client.Issues.BulkChange(&sonar.IssuesBulkChangeOptions{
+				result, resp, err := client.Issues.BulkChange(context.Background(), &sonar.IssuesBulkChangeOptions{
 					Issues:  []string{nonExistentIssueKey},
 					AddTags: []string{"test-tag"},
 				})
@@ -489,7 +490,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("SetSeverity", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Issues.SetSeverity(nil)
+				result, resp, err := client.Issues.SetSeverity(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(result).To(BeNil())
@@ -497,7 +498,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Issues.SetSeverity(&sonar.IssuesSetSeverityOptions{
+				result, resp, err := client.Issues.SetSeverity(context.Background(), &sonar.IssuesSetSeverityOptions{
 					Severity: sonar.RuleSeverityMajor,
 				})
 				Expect(err).To(HaveOccurred())
@@ -509,7 +510,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Issues.SetSeverity(&sonar.IssuesSetSeverityOptions{
+				result, resp, err := client.Issues.SetSeverity(context.Background(), &sonar.IssuesSetSeverityOptions{
 					Issue:    nonExistentIssueKey,
 					Severity: sonar.RuleSeverityMajor,
 				})
@@ -528,7 +529,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("SetTags", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Issues.SetTags(nil)
+				result, resp, err := client.Issues.SetTags(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(result).To(BeNil())
@@ -536,7 +537,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Issues.SetTags(&sonar.IssuesSetTagsOptions{
+				result, resp, err := client.Issues.SetTags(context.Background(), &sonar.IssuesSetTagsOptions{
 					Tags: []string{"test-tag"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -548,7 +549,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Issues.SetTags(&sonar.IssuesSetTagsOptions{
+				result, resp, err := client.Issues.SetTags(context.Background(), &sonar.IssuesSetTagsOptions{
 					Issue: nonExistentIssueKey,
 					Tags:  []string{"test-tag"},
 				})
@@ -567,7 +568,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("SetType", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Issues.SetType(nil)
+				result, resp, err := client.Issues.SetType(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(result).To(BeNil())
@@ -575,7 +576,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Issues.SetType(&sonar.IssuesSetTypeOptions{
+				result, resp, err := client.Issues.SetType(context.Background(), &sonar.IssuesSetTypeOptions{
 					Type: sonar.RuleTypeBug,
 				})
 				Expect(err).To(HaveOccurred())
@@ -585,7 +586,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required type", func() {
-				result, resp, err := client.Issues.SetType(&sonar.IssuesSetTypeOptions{
+				result, resp, err := client.Issues.SetType(context.Background(), &sonar.IssuesSetTypeOptions{
 					Issue: nonExistentIssueKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -597,7 +598,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Issues.SetType(&sonar.IssuesSetTypeOptions{
+				result, resp, err := client.Issues.SetType(context.Background(), &sonar.IssuesSetTypeOptions{
 					Issue: nonExistentIssueKey,
 					Type:  sonar.RuleTypeBug,
 				})
@@ -616,7 +617,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("DeleteComment", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Issues.DeleteComment(nil)
+				result, resp, err := client.Issues.DeleteComment(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(result).To(BeNil())
@@ -624,7 +625,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required comment key", func() {
-				result, resp, err := client.Issues.DeleteComment(&sonar.IssuesDeleteCommentOptions{})
+				result, resp, err := client.Issues.DeleteComment(context.Background(), &sonar.IssuesDeleteCommentOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Comment"))
 				Expect(result).To(BeNil())
@@ -634,7 +635,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Comment", func() {
 			It("should fail with non-existent comment key", func() {
-				result, resp, err := client.Issues.DeleteComment(&sonar.IssuesDeleteCommentOptions{
+				result, resp, err := client.Issues.DeleteComment(context.Background(), &sonar.IssuesDeleteCommentOptions{
 					Comment: nonExistentIssueKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -652,7 +653,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("EditComment", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Issues.EditComment(nil)
+				result, resp, err := client.Issues.EditComment(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(result).To(BeNil())
@@ -660,7 +661,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required comment key", func() {
-				result, resp, err := client.Issues.EditComment(&sonar.IssuesEditCommentOptions{
+				result, resp, err := client.Issues.EditComment(context.Background(), &sonar.IssuesEditCommentOptions{
 					Text: "Updated comment",
 				})
 				Expect(err).To(HaveOccurred())
@@ -670,7 +671,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required text", func() {
-				result, resp, err := client.Issues.EditComment(&sonar.IssuesEditCommentOptions{
+				result, resp, err := client.Issues.EditComment(context.Background(), &sonar.IssuesEditCommentOptions{
 					Comment: nonExistentIssueKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -682,7 +683,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Comment", func() {
 			It("should fail with non-existent comment key", func() {
-				result, resp, err := client.Issues.EditComment(&sonar.IssuesEditCommentOptions{
+				result, resp, err := client.Issues.EditComment(context.Background(), &sonar.IssuesEditCommentOptions{
 					Comment: nonExistentIssueKey,
 					Text:    "Updated comment",
 				})
@@ -701,14 +702,14 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("Reindex", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Issues.Reindex(nil)
+				resp, err := client.Issues.Reindex(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required project key", func() {
-				resp, err := client.Issues.Reindex(&sonar.IssuesReindexOptions{})
+				resp, err := client.Issues.Reindex(context.Background(), &sonar.IssuesReindexOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Project"))
 				Expect(resp).To(BeNil())
@@ -717,7 +718,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should trigger reindex for a project", func() {
-				resp, err := client.Issues.Reindex(&sonar.IssuesReindexOptions{
+				resp, err := client.Issues.Reindex(context.Background(), &sonar.IssuesReindexOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -727,7 +728,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				resp, err := client.Issues.Reindex(&sonar.IssuesReindexOptions{
+				resp, err := client.Issues.Reindex(context.Background(), &sonar.IssuesReindexOptions{
 					Project: nonExistentProjectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -744,7 +745,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("Pull", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Issues.Pull(nil)
+				result, resp, err := client.Issues.Pull(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(result).To(BeNil())
@@ -752,7 +753,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required project key", func() {
-				result, resp, err := client.Issues.Pull(&sonar.IssuesPullOptions{})
+				result, resp, err := client.Issues.Pull(context.Background(), &sonar.IssuesPullOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("ProjectKey"))
 				Expect(result).To(BeNil())
@@ -760,7 +761,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required branch name", func() {
-				result, resp, err := client.Issues.Pull(&sonar.IssuesPullOptions{
+				result, resp, err := client.Issues.Pull(context.Background(), &sonar.IssuesPullOptions{
 					ProjectKey: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -774,7 +775,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.Issues.Pull(&sonar.IssuesPullOptions{
+				result, resp, err := client.Issues.Pull(context.Background(), &sonar.IssuesPullOptions{
 					ProjectKey: nonExistentProjectKey,
 					BranchName: "main",
 				})
@@ -793,7 +794,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("PullTaint", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Issues.PullTaint(nil)
+				result, resp, err := client.Issues.PullTaint(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(result).To(BeNil())
@@ -801,7 +802,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required project key", func() {
-				result, resp, err := client.Issues.PullTaint(&sonar.IssuesPullTaintOptions{})
+				result, resp, err := client.Issues.PullTaint(context.Background(), &sonar.IssuesPullTaintOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("ProjectKey"))
 				Expect(result).To(BeNil())
@@ -809,7 +810,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required branch name", func() {
-				result, resp, err := client.Issues.PullTaint(&sonar.IssuesPullTaintOptions{
+				result, resp, err := client.Issues.PullTaint(context.Background(), &sonar.IssuesPullTaintOptions{
 					ProjectKey: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -823,7 +824,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.Issues.PullTaint(&sonar.IssuesPullTaintOptions{
+				result, resp, err := client.Issues.PullTaint(context.Background(), &sonar.IssuesPullTaintOptions{
 					ProjectKey: nonExistentProjectKey,
 					BranchName: "main",
 				})
@@ -842,7 +843,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 	Describe("ComponentTags", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Issues.ComponentTags(nil)
+				result, resp, err := client.Issues.ComponentTags(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot be nil"))
 				Expect(result).To(BeNil())
@@ -850,7 +851,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 
 			It("should fail without required component UUID", func() {
-				result, resp, err := client.Issues.ComponentTags(&sonar.IssuesComponentTagsOptions{})
+				result, resp, err := client.Issues.ComponentTags(context.Background(), &sonar.IssuesComponentTagsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("ComponentUuid"))
 				Expect(result).To(BeNil())
@@ -862,7 +863,7 @@ var _ = Describe("Issues Service", Ordered, func() {
 			It("should handle non-existent component UUID", func() {
 				// Use a properly formatted UUID that's guaranteed to not exist
 				// Format matches SonarQube's UUID format: 8-4-4-4-12 hexadecimal digits
-				result, resp, err := client.Issues.ComponentTags(&sonar.IssuesComponentTagsOptions{
+				result, resp, err := client.Issues.ComponentTags(context.Background(), &sonar.IssuesComponentTagsOptions{
 					ComponentUuid: "00000000-0000-0000-0000-000000000000",
 				})
 

--- a/integration_testing/l10n_test.go
+++ b/integration_testing/l10n_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -29,7 +30,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 	Describe("Index", func() {
 		Context("Parameter Validation", func() {
 			It("should work with nil options", func() {
-				result, resp, err := client.L10N.GetIndex(nil)
+				result, resp, err := client.L10N.GetIndex(context.Background(), nil)
 				// Skip if API not available
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("L10N API is not available in this SonarQube version")
@@ -42,7 +43,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 
 		Context("Default Locale", func() {
 			It("should get localization messages with default locale", func() {
-				result, resp, err := client.L10N.GetIndex(nil)
+				result, resp, err := client.L10N.GetIndex(context.Background(), nil)
 				// Skip if API not available
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("L10N API is not available in this SonarQube version")
@@ -71,7 +72,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 
 		Context("Specific Locale", func() {
 			It("should get localization messages for specific locale", func() {
-				result, resp, err := client.L10N.GetIndex(&sonar.L10NIndexOptions{
+				result, resp, err := client.L10N.GetIndex(context.Background(), &sonar.L10NIndexOptions{
 					Locale: "en",
 				})
 				// Skip if API not available
@@ -93,7 +94,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 		Context("Compare Different Locales", func() {
 			It("should return different translations for different locales if available", func() {
 				// Get English locale
-				resultEN, respEN, err := client.L10N.GetIndex(&sonar.L10NIndexOptions{
+				resultEN, respEN, err := client.L10N.GetIndex(context.Background(), &sonar.L10NIndexOptions{
 					Locale: "en",
 				})
 				// Skip if API not available
@@ -104,7 +105,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 				Expect(respEN.StatusCode).To(Equal(http.StatusOK))
 
 				// Try to get French locale
-				resultFR, respFR, err := client.L10N.GetIndex(&sonar.L10NIndexOptions{
+				resultFR, respFR, err := client.L10N.GetIndex(context.Background(), &sonar.L10NIndexOptions{
 					Locale: "fr",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -130,7 +131,7 @@ var _ = Describe("L10N Service", Ordered, func() {
 			It("should get localization messages with timestamp", func() {
 				// Use a recent timestamp (1 year ago)
 				oneYearAgo := time.Now().AddDate(-1, 0, 0).Format("2006-01-02T15:04:05-0700")
-				result, resp, err := client.L10N.GetIndex(&sonar.L10NIndexOptions{
+				result, resp, err := client.L10N.GetIndex(context.Background(), &sonar.L10NIndexOptions{
 					Timestamp: oneYearAgo,
 				})
 				// Skip if API not available

--- a/integration_testing/languages_test.go
+++ b/integration_testing/languages_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,7 +29,7 @@ var _ = Describe("Languages Service", Ordered, func() {
 	Describe("List", func() {
 		Context("Parameter Validation", func() {
 			It("should succeed with nil options", func() {
-				result, resp, err := client.Languages.List(nil)
+				result, resp, err := client.Languages.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -36,7 +37,7 @@ var _ = Describe("Languages Service", Ordered, func() {
 			})
 
 			It("should succeed with empty options", func() {
-				result, resp, err := client.Languages.List(&sonar.LanguagesListOptions{})
+				result, resp, err := client.Languages.List(context.Background(), &sonar.LanguagesListOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -46,7 +47,7 @@ var _ = Describe("Languages Service", Ordered, func() {
 
 		Context("Functional Tests", func() {
 			It("should list all languages", func() {
-				result, resp, err := client.Languages.List(nil)
+				result, resp, err := client.Languages.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -54,7 +55,7 @@ var _ = Describe("Languages Service", Ordered, func() {
 			})
 
 			It("should return languages with valid properties", func() {
-				result, resp, err := client.Languages.List(nil)
+				result, resp, err := client.Languages.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -66,7 +67,7 @@ var _ = Describe("Languages Service", Ordered, func() {
 			})
 
 			It("should verify common languages present", func() {
-				result, resp, err := client.Languages.List(nil)
+				result, resp, err := client.Languages.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -91,7 +92,7 @@ var _ = Describe("Languages Service", Ordered, func() {
 			})
 
 			It("should filter languages with query", func() {
-				result, resp, err := client.Languages.List(&sonar.LanguagesListOptions{
+				result, resp, err := client.Languages.List(context.Background(), &sonar.LanguagesListOptions{
 					Query: "java",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -112,7 +113,7 @@ var _ = Describe("Languages Service", Ordered, func() {
 				}
 			})
 			It("should limit results with page size", func() {
-				result, resp, err := client.Languages.List(&sonar.LanguagesListOptions{
+				result, resp, err := client.Languages.List(context.Background(), &sonar.LanguagesListOptions{
 					PageSize: 2,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -122,11 +123,11 @@ var _ = Describe("Languages Service", Ordered, func() {
 			})
 
 			It("should return consistent results on multiple calls", func() {
-				result1, resp1, err := client.Languages.List(nil)
+				result1, resp1, err := client.Languages.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp1.StatusCode).To(Equal(http.StatusOK))
 
-				result2, resp2, err := client.Languages.List(nil)
+				result2, resp2, err := client.Languages.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp2.StatusCode).To(Equal(http.StatusOK))
 

--- a/integration_testing/measures_test.go
+++ b/integration_testing/measures_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,14 +27,14 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		// Create a test project for measures-related operations
 		projectKey = helpers.UniqueResourceName("msr")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    "Measures Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -53,7 +54,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 	Describe("Component", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Measures.Component(nil)
+				result, resp, err := client.Measures.Component(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("option struct is required"))
 				Expect(result).To(BeNil())
@@ -61,7 +62,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required component parameter", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
+				result, resp, err := client.Measures.Component(context.Background(), &sonar.MeasuresComponentOptions{
 					MetricKeys: []string{"ncloc"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -71,7 +72,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required metric keys", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
+				result, resp, err := client.Measures.Component(context.Background(), &sonar.MeasuresComponentOptions{
 					Component: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -83,7 +84,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should get component measures for an existing project", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
+				result, resp, err := client.Measures.Component(context.Background(), &sonar.MeasuresComponentOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc", "complexity", "coverage"},
 				})
@@ -94,7 +95,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get measures with single metric", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
+				result, resp, err := client.Measures.Component(context.Background(), &sonar.MeasuresComponentOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"lines"},
 				})
@@ -105,7 +106,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get measures with additional fields", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
+				result, resp, err := client.Measures.Component(context.Background(), &sonar.MeasuresComponentOptions{
 					Component:        projectKey,
 					MetricKeys:       []string{"ncloc"},
 					AdditionalFields: []string{"metrics"},
@@ -118,7 +119,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("Non-Existent Component", func() {
 			It("should fail with non-existent component", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
+				result, resp, err := client.Measures.Component(context.Background(), &sonar.MeasuresComponentOptions{
 					Component:  "non-existent-project",
 					MetricKeys: []string{"ncloc"},
 				})
@@ -132,7 +133,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("With Branch", func() {
 			It("should fail for non-existent branch", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
+				result, resp, err := client.Measures.Component(context.Background(), &sonar.MeasuresComponentOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
 					Branch:     "non-existent-branch",
@@ -147,7 +148,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("With Pull Request", func() {
 			It("should fail for non-existent pull request", func() {
-				result, resp, err := client.Measures.Component(&sonar.MeasuresComponentOptions{
+				result, resp, err := client.Measures.Component(context.Background(), &sonar.MeasuresComponentOptions{
 					Component:   projectKey,
 					MetricKeys:  []string{"ncloc"},
 					PullRequest: "99999",
@@ -167,7 +168,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 	Describe("ComponentTree", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Measures.ComponentTree(nil)
+				result, resp, err := client.Measures.ComponentTree(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("option struct is required"))
 				Expect(result).To(BeNil())
@@ -175,7 +176,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required component parameter", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
+				result, resp, err := client.Measures.ComponentTree(context.Background(), &sonar.MeasuresComponentTreeOptions{
 					MetricKeys: []string{"ncloc"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -185,7 +186,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required metric keys", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
+				result, resp, err := client.Measures.ComponentTree(context.Background(), &sonar.MeasuresComponentTreeOptions{
 					Component: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -195,7 +196,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail with invalid metric sort filter", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
+				result, resp, err := client.Measures.ComponentTree(context.Background(), &sonar.MeasuresComponentTreeOptions{
 					Component:        projectKey,
 					MetricKeys:       []string{"ncloc"},
 					MetricSortFilter: "invalid",
@@ -207,7 +208,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail with invalid strategy", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
+				result, resp, err := client.Measures.ComponentTree(context.Background(), &sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
 					Strategy:   "invalid",
@@ -221,7 +222,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should get component tree measures for an existing project", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
+				result, resp, err := client.Measures.ComponentTree(context.Background(), &sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc", "complexity"},
 				})
@@ -232,7 +233,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get component tree with children strategy", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
+				result, resp, err := client.Measures.ComponentTree(context.Background(), &sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
 					Strategy:   sonar.MeasureStrategyChildren,
@@ -243,7 +244,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get component tree with leaves strategy", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
+				result, resp, err := client.Measures.ComponentTree(context.Background(), &sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
 					Strategy:   sonar.MeasureStrategyLeaves,
@@ -254,7 +255,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get component tree with all strategy", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
+				result, resp, err := client.Measures.ComponentTree(context.Background(), &sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
 					Strategy:   sonar.MeasureStrategyAll,
@@ -265,7 +266,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get component tree with metric sort filter", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
+				result, resp, err := client.Measures.ComponentTree(context.Background(), &sonar.MeasuresComponentTreeOptions{
 					Component:        projectKey,
 					MetricKeys:       []string{"ncloc"},
 					MetricSortFilter: sonar.MeasuresMetricSortFilterWithMeasuresOnly,
@@ -278,7 +279,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get component tree with pagination", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
+				result, resp, err := client.Measures.ComponentTree(context.Background(), &sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
 					PaginationArgs: sonar.PaginationArgs{
@@ -293,7 +294,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get component tree with qualifiers filter", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
+				result, resp, err := client.Measures.ComponentTree(context.Background(), &sonar.MeasuresComponentTreeOptions{
 					Component:  projectKey,
 					MetricKeys: []string{"ncloc"},
 					Qualifiers: []string{"FIL"},
@@ -304,7 +305,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get component tree with additional fields", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
+				result, resp, err := client.Measures.ComponentTree(context.Background(), &sonar.MeasuresComponentTreeOptions{
 					Component:        projectKey,
 					MetricKeys:       []string{"ncloc"},
 					AdditionalFields: []string{"metrics"},
@@ -317,7 +318,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("Non-Existent Component", func() {
 			It("should fail with non-existent component", func() {
-				result, resp, err := client.Measures.ComponentTree(&sonar.MeasuresComponentTreeOptions{
+				result, resp, err := client.Measures.ComponentTree(context.Background(), &sonar.MeasuresComponentTreeOptions{
 					Component:  "non-existent-project",
 					MetricKeys: []string{"ncloc"},
 				})
@@ -336,7 +337,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 	Describe("Search", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Measures.Search(nil)
+				result, resp, err := client.Measures.Search(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("option struct is required"))
 				Expect(result).To(BeNil())
@@ -344,7 +345,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required metric keys", func() {
-				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOptions{
+				result, resp, err := client.Measures.Search(context.Background(), &sonar.MeasuresSearchOptions{
 					ProjectKeys: []string{projectKey},
 				})
 				Expect(err).To(HaveOccurred())
@@ -354,7 +355,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required project keys", func() {
-				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOptions{
+				result, resp, err := client.Measures.Search(context.Background(), &sonar.MeasuresSearchOptions{
 					MetricKeys: []string{"ncloc"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -366,7 +367,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should search measures for an existing project", func() {
-				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOptions{
+				result, resp, err := client.Measures.Search(context.Background(), &sonar.MeasuresSearchOptions{
 					MetricKeys:  []string{"ncloc"},
 					ProjectKeys: []string{projectKey},
 				})
@@ -376,7 +377,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should search measures with multiple metrics", func() {
-				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOptions{
+				result, resp, err := client.Measures.Search(context.Background(), &sonar.MeasuresSearchOptions{
 					MetricKeys:  []string{"ncloc", "complexity", "coverage"},
 					ProjectKeys: []string{projectKey},
 				})
@@ -391,14 +392,14 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 			BeforeAll(func() {
 				secondProjectKey = helpers.UniqueResourceName("msr2")
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    "Second Measures Test Project",
 					Project: secondProjectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", secondProjectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: secondProjectKey,
 					})
 					return err
@@ -406,7 +407,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should search measures for multiple projects", func() {
-				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOptions{
+				result, resp, err := client.Measures.Search(context.Background(), &sonar.MeasuresSearchOptions{
 					MetricKeys:  []string{"ncloc"},
 					ProjectKeys: []string{projectKey, secondProjectKey},
 				})
@@ -419,7 +420,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 		Context("Non-Existent Project", func() {
 			It("should return empty measures for non-existent project", func() {
 				// The API doesn't fail for non-existent projects, it just returns empty measures
-				result, resp, err := client.Measures.Search(&sonar.MeasuresSearchOptions{
+				result, resp, err := client.Measures.Search(context.Background(), &sonar.MeasuresSearchOptions{
 					MetricKeys:  []string{"ncloc"},
 					ProjectKeys: []string{"non-existent-project"},
 				})
@@ -438,7 +439,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 	Describe("SearchHistory", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Measures.SearchHistory(nil)
+				result, resp, err := client.Measures.SearchHistory(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("option struct is required"))
 				Expect(result).To(BeNil())
@@ -446,7 +447,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required component parameter", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
+				result, resp, err := client.Measures.SearchHistory(context.Background(), &sonar.MeasuresSearchHistoryOptions{
 					Metrics: []string{"ncloc"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -456,7 +457,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should fail without required metrics", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
+				result, resp, err := client.Measures.SearchHistory(context.Background(), &sonar.MeasuresSearchHistoryOptions{
 					Component: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -468,7 +469,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should get measure history for an existing project", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
+				result, resp, err := client.Measures.SearchHistory(context.Background(), &sonar.MeasuresSearchHistoryOptions{
 					Component: projectKey,
 					Metrics:   []string{"ncloc"},
 				})
@@ -478,7 +479,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get history with multiple metrics", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
+				result, resp, err := client.Measures.SearchHistory(context.Background(), &sonar.MeasuresSearchHistoryOptions{
 					Component: projectKey,
 					Metrics:   []string{"ncloc", "complexity", "coverage"},
 				})
@@ -488,7 +489,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get history with pagination", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
+				result, resp, err := client.Measures.SearchHistory(context.Background(), &sonar.MeasuresSearchHistoryOptions{
 					Component: projectKey,
 					Metrics:   []string{"ncloc"},
 					PaginationArgs: sonar.PaginationArgs{
@@ -503,7 +504,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 			})
 
 			It("should get history with date range", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
+				result, resp, err := client.Measures.SearchHistory(context.Background(), &sonar.MeasuresSearchHistoryOptions{
 					Component: projectKey,
 					Metrics:   []string{"ncloc"},
 					From:      "2020-01-01",
@@ -517,7 +518,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("Non-Existent Component", func() {
 			It("should fail with non-existent component", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
+				result, resp, err := client.Measures.SearchHistory(context.Background(), &sonar.MeasuresSearchHistoryOptions{
 					Component: "non-existent-project",
 					Metrics:   []string{"ncloc"},
 				})
@@ -531,7 +532,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("With Branch", func() {
 			It("should fail for non-existent branch", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
+				result, resp, err := client.Measures.SearchHistory(context.Background(), &sonar.MeasuresSearchHistoryOptions{
 					Component: projectKey,
 					Metrics:   []string{"ncloc"},
 					Branch:    "non-existent-branch",
@@ -546,7 +547,7 @@ var _ = Describe("Measures Service", Ordered, func() {
 
 		Context("With Pull Request", func() {
 			It("should fail for non-existent pull request", func() {
-				result, resp, err := client.Measures.SearchHistory(&sonar.MeasuresSearchHistoryOptions{
+				result, resp, err := client.Measures.SearchHistory(context.Background(), &sonar.MeasuresSearchHistoryOptions{
 					Component:   projectKey,
 					Metrics:     []string{"ncloc"},
 					PullRequest: "99999",

--- a/integration_testing/metrics_test.go
+++ b/integration_testing/metrics_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,7 +29,7 @@ var _ = Describe("Metrics Service", Ordered, func() {
 	Describe("Search", func() {
 		Context("Functional Tests", func() {
 			It("should search all metrics with nil options", func() {
-				result, resp, err := client.Metrics.Search(nil)
+				result, resp, err := client.Metrics.Search(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -36,7 +37,7 @@ var _ = Describe("Metrics Service", Ordered, func() {
 			})
 
 			It("should search metrics with empty options", func() {
-				result, resp, err := client.Metrics.Search(&sonar.MetricsSearchOptions{})
+				result, resp, err := client.Metrics.Search(context.Background(), &sonar.MetricsSearchOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -44,7 +45,7 @@ var _ = Describe("Metrics Service", Ordered, func() {
 			})
 
 			It("should return metrics with valid properties", func() {
-				result, resp, err := client.Metrics.Search(nil)
+				result, resp, err := client.Metrics.Search(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -57,7 +58,7 @@ var _ = Describe("Metrics Service", Ordered, func() {
 			})
 
 			It("should find common metrics", func() {
-				result, resp, err := client.Metrics.Search(nil)
+				result, resp, err := client.Metrics.Search(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -80,7 +81,7 @@ var _ = Describe("Metrics Service", Ordered, func() {
 			})
 
 			It("should support pagination", func() {
-				result, resp, err := client.Metrics.Search(&sonar.MetricsSearchOptions{
+				result, resp, err := client.Metrics.Search(context.Background(), &sonar.MetricsSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 5,
 					},
@@ -99,7 +100,7 @@ var _ = Describe("Metrics Service", Ordered, func() {
 	Describe("Types", func() {
 		Context("Functional Tests", func() {
 			It("should list metric types", func() {
-				result, resp, err := client.Metrics.Types()
+				result, resp, err := client.Metrics.Types(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -107,7 +108,7 @@ var _ = Describe("Metrics Service", Ordered, func() {
 			})
 
 			It("should return common metric types", func() {
-				result, resp, err := client.Metrics.Types()
+				result, resp, err := client.Metrics.Types(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -125,11 +126,11 @@ var _ = Describe("Metrics Service", Ordered, func() {
 			})
 
 			It("should return consistent results on multiple calls", func() {
-				result1, resp1, err := client.Metrics.Types()
+				result1, resp1, err := client.Metrics.Types(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp1.StatusCode).To(Equal(http.StatusOK))
 
-				result2, resp2, err := client.Metrics.Types()
+				result2, resp2, err := client.Metrics.Types(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp2.StatusCode).To(Equal(http.StatusOK))
 

--- a/integration_testing/monitoring_test.go
+++ b/integration_testing/monitoring_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -35,7 +36,7 @@ var _ = Describe("Monitoring Service", Ordered, func() {
 	Describe("Metrics", func() {
 		Context("Functional Tests", func() {
 			It("should get monitoring metrics", func() {
-				result, resp, err := client.Monitoring.Metrics()
+				result, resp, err := client.Monitoring.Metrics(context.Background(), )
 				checkAuthRequired(resp)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -43,7 +44,7 @@ var _ = Describe("Monitoring Service", Ordered, func() {
 			})
 
 			It("should return Prometheus format metrics with specific metric categories", func() {
-				result, resp, err := client.Monitoring.Metrics()
+				result, resp, err := client.Monitoring.Metrics(context.Background(), )
 				checkAuthRequired(resp)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -54,12 +55,12 @@ var _ = Describe("Monitoring Service", Ordered, func() {
 			})
 
 			It("should return consistent results on multiple calls", func() {
-				result1, resp1, err := client.Monitoring.Metrics()
+				result1, resp1, err := client.Monitoring.Metrics(context.Background(), )
 				checkAuthRequired(resp1)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp1.StatusCode).To(Equal(http.StatusOK))
 
-				result2, resp2, err := client.Monitoring.Metrics()
+				result2, resp2, err := client.Monitoring.Metrics(context.Background(), )
 				checkAuthRequired(resp2)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp2.StatusCode).To(Equal(http.StatusOK))

--- a/integration_testing/navigation_test.go
+++ b/integration_testing/navigation_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,14 +27,14 @@ var _ = Describe("Navigation Service", Ordered, func() {
 
 		// Create a test project for component navigation
 		projectKey = helpers.UniqueResourceName("nav")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    "Navigation Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -53,13 +54,13 @@ var _ = Describe("Navigation Service", Ordered, func() {
 	Describe("Component", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, _, err := client.Navigation.Component(nil)
+				resp, _, err := client.Navigation.Component(context.Background(), nil)
 				Expect(resp).To(BeNil())
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with empty component key", func() {
-				resp, _, err := client.Navigation.Component(&sonar.NavigationComponentOptions{
+				resp, _, err := client.Navigation.Component(context.Background(), &sonar.NavigationComponentOptions{
 					Component: "",
 				})
 				Expect(resp).To(BeNil())
@@ -69,7 +70,7 @@ var _ = Describe("Navigation Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should get component navigation with valid component key and breadcrumbs", func() {
-				result, resp, err := client.Navigation.Component(&sonar.NavigationComponentOptions{
+				result, resp, err := client.Navigation.Component(context.Background(), &sonar.NavigationComponentOptions{
 					Component: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -82,7 +83,7 @@ var _ = Describe("Navigation Service", Ordered, func() {
 
 		Context("Error Cases", func() {
 			It("should fail with non-existent component key", func() {
-				_, resp, err := client.Navigation.Component(&sonar.NavigationComponentOptions{
+				_, resp, err := client.Navigation.Component(context.Background(), &sonar.NavigationComponentOptions{
 					Component: "non-existent-component-key-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -99,7 +100,7 @@ var _ = Describe("Navigation Service", Ordered, func() {
 	Describe("Global", func() {
 		Context("Valid Requests", func() {
 			It("should get global navigation with version and edition information", func() {
-				result, resp, err := client.Navigation.Global()
+				result, resp, err := client.Navigation.Global(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -108,11 +109,11 @@ var _ = Describe("Navigation Service", Ordered, func() {
 			})
 
 			It("should return consistent results on multiple calls", func() {
-				result1, resp1, err := client.Navigation.Global()
+				result1, resp1, err := client.Navigation.Global(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp1.StatusCode).To(Equal(http.StatusOK))
 
-				result2, resp2, err := client.Navigation.Global()
+				result2, resp2, err := client.Navigation.Global(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp2.StatusCode).To(Equal(http.StatusOK))
 
@@ -127,7 +128,7 @@ var _ = Describe("Navigation Service", Ordered, func() {
 	Describe("Marketplace", func() {
 		Context("Valid Requests", func() {
 			It("should get marketplace navigation", func() {
-				result, resp, err := client.Navigation.Marketplace()
+				result, resp, err := client.Navigation.Marketplace(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -142,7 +143,7 @@ var _ = Describe("Navigation Service", Ordered, func() {
 	Describe("Settings", func() {
 		Context("Valid Requests", func() {
 			It("should get settings navigation", func() {
-				result, resp, err := client.Navigation.Settings()
+				result, resp, err := client.Navigation.Settings(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())

--- a/integration_testing/new_code_periods_test.go
+++ b/integration_testing/new_code_periods_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -52,7 +53,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 	// =========================================================================
 	Describe("Show", func() {
 		It("should show global new code period definition", func() {
-			result, resp, err := client.NewCodePeriods.Show(nil)
+			result, resp, err := client.NewCodePeriods.Show(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -62,20 +63,20 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should show project-level new code period definition", func() {
 			projectKey := helpers.UniqueResourceName("ncp-show-proj")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "NCP Show Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			result, resp, err := client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOptions{
+			result, resp, err := client.NewCodePeriods.Show(context.Background(), &sonar.NewCodePeriodsShowOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -87,7 +88,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should show branch-level new code period definition", func() {
 			projectKey := helpers.UniqueResourceName("ncp-show-branch")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "NCP Branch Show Test Project",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -95,13 +96,13 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			result, resp, err := client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOptions{
+			result, resp, err := client.NewCodePeriods.Show(context.Background(), &sonar.NewCodePeriodsShowOptions{
 				Project: projectKey,
 				Branch:  "main",
 			})
@@ -119,7 +120,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should list new code periods for project", func() {
 			projectKey := helpers.UniqueResourceName("ncp-list-proj")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "NCP List Test Project",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -127,13 +128,13 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			result, resp, err := client.NewCodePeriods.List(&sonar.NewCodePeriodsListOptions{
+			result, resp, err := client.NewCodePeriods.List(context.Background(), &sonar.NewCodePeriodsListOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -144,14 +145,14 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.NewCodePeriods.List(nil)
+				result, resp, err := client.NewCodePeriods.List(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing project key", func() {
-				result, resp, err := client.NewCodePeriods.List(&sonar.NewCodePeriodsListOptions{})
+				result, resp, err := client.NewCodePeriods.List(context.Background(), &sonar.NewCodePeriodsListOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -160,7 +161,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.NewCodePeriods.List(&sonar.NewCodePeriodsListOptions{
+				result, resp, err := client.NewCodePeriods.List(context.Background(), &sonar.NewCodePeriodsListOptions{
 					Project: "non-existent-project-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -182,7 +183,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should set project-level new code period with PREVIOUS_VERSION", func() {
 			projectKey := helpers.UniqueResourceName("ncp-prevver")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "NCP Set PreviousVersion Test",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -190,13 +191,13 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+			resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Type:    sonar.NewCodePeriodTypePreviousVersion,
 			})
@@ -211,7 +212,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should set project-level new code period with NUMBER_OF_DAYS", func() {
 			projectKey := helpers.UniqueResourceName("ncp-numdays")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "NCP Set Days Test",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -219,13 +220,13 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+			resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Type:    sonar.NewCodePeriodTypeNumberOfDays,
 				Value:   "30",
@@ -241,7 +242,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should set project-level new code period with REFERENCE_BRANCH", func() {
 			projectKey := helpers.UniqueResourceName("ncp-refbranch")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "NCP Set RefBranch Test",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -249,13 +250,13 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+			resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Type:    sonar.NewCodePeriodTypeReferenceBranch,
 				Value:   "main",
@@ -271,7 +272,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should set branch-level new code period", func() {
 			projectKey := helpers.UniqueResourceName("ncp-branchlvl")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "NCP Set Branch Test",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -279,13 +280,13 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+			resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Branch:  "main",
 				Type:    sonar.NewCodePeriodTypeNumberOfDays,
@@ -295,7 +296,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			// Verify the setting was applied
-			result, _, err := client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOptions{
+			result, _, err := client.NewCodePeriods.Show(context.Background(), &sonar.NewCodePeriodsShowOptions{
 				Project: projectKey,
 				Branch:  "main",
 			})
@@ -306,13 +307,13 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.NewCodePeriods.Set(nil)
+				resp, err := client.NewCodePeriods.Set(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing type", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+				resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -320,7 +321,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with invalid type", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+				resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 					Type:    "INVALID_TYPE",
 				})
@@ -329,7 +330,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with NUMBER_OF_DAYS and invalid value", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+				resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 					Type:    sonar.NewCodePeriodTypeNumberOfDays,
 					Value:   "invalid",
@@ -339,7 +340,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with NUMBER_OF_DAYS exceeding max value", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+				resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 					Type:    sonar.NewCodePeriodTypeNumberOfDays,
 					Value:   "100",
@@ -349,7 +350,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with NUMBER_OF_DAYS without value", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+				resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 					Type:    sonar.NewCodePeriodTypeNumberOfDays,
 					Value:   "",
@@ -359,7 +360,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with NUMBER_OF_DAYS with zero value", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+				resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 					Type:    sonar.NewCodePeriodTypeNumberOfDays,
 					Value:   "0",
@@ -369,7 +370,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with NUMBER_OF_DAYS with negative value", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+				resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 					Type:    sonar.NewCodePeriodTypeNumberOfDays,
 					Value:   "-5",
@@ -381,20 +382,20 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			It("should succeed with NUMBER_OF_DAYS minimum value", func() {
 				projectKey := helpers.UniqueResourceName("ncp-mindays")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    "NCP Min Days Test",
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+				resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 					Project: projectKey,
 					Type:    sonar.NewCodePeriodTypeNumberOfDays,
 					Value:   "1",
@@ -406,20 +407,20 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			It("should succeed with NUMBER_OF_DAYS maximum value", func() {
 				projectKey := helpers.UniqueResourceName("ncp-maxdays")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    "NCP Max Days Test",
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+				resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 					Project: projectKey,
 					Type:    sonar.NewCodePeriodTypeNumberOfDays,
 					Value:   "90",
@@ -429,7 +430,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with REFERENCE_BRANCH missing project", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+				resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 					Type:  sonar.NewCodePeriodTypeReferenceBranch,
 					Value: "main",
 				})
@@ -438,7 +439,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			})
 
 			It("should fail with SPECIFIC_ANALYSIS missing branch", func() {
-				resp, err := client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+				resp, err := client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 					Project: "some-project",
 					Type:    sonar.NewCodePeriodTypeSpecificAnalysis,
 					Value:   "some-analysis-id",
@@ -456,28 +457,28 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should unset project-level new code period", func() {
 			projectKey := helpers.UniqueResourceName("ncp-unsetproj")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "NCP Unset Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// First, set a new code period
-			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+			_, err = client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Type:    sonar.NewCodePeriodTypePreviousVersion,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Unset it
-			resp, err := client.NewCodePeriods.Unset(&sonar.NewCodePeriodsUnsetOptions{
+			resp, err := client.NewCodePeriods.Unset(context.Background(), &sonar.NewCodePeriodsUnsetOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -487,7 +488,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		It("should unset branch-level new code period", func() {
 			projectKey := helpers.UniqueResourceName("ncp-unsetbranch")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "NCP Unset Branch Test Project",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -495,14 +496,14 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// First, set a branch-level new code period
-			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+			_, err = client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Branch:  "main",
 				Type:    sonar.NewCodePeriodTypeNumberOfDays,
@@ -511,7 +512,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Unset it
-			resp, err := client.NewCodePeriods.Unset(&sonar.NewCodePeriodsUnsetOptions{
+			resp, err := client.NewCodePeriods.Unset(context.Background(), &sonar.NewCodePeriodsUnsetOptions{
 				Project: projectKey,
 				Branch:  "main",
 			})
@@ -520,7 +521,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 		})
 
 		It("should unset global new code period when called with nil options", func() {
-			resp, err := client.NewCodePeriods.Unset(nil)
+			resp, err := client.NewCodePeriods.Unset(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp).NotTo(BeNil())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -535,7 +536,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			projectKey := helpers.UniqueResourceName("ncp-lifecycle")
 
 			// Step 1: Create project
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "NCP Lifecycle Test Project",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -543,21 +544,21 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// Step 2: Show project-level (inherits from global initially)
-			result, _, err := client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOptions{
+			result, _, err := client.NewCodePeriods.Show(context.Background(), &sonar.NewCodePeriodsShowOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
 			// Step 3: Set project-level new code period
-			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+			_, err = client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Type:    sonar.NewCodePeriodTypeNumberOfDays,
 				Value:   "30",
@@ -565,7 +566,7 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 4: Set branch-level new code period
-			_, err = client.NewCodePeriods.Set(&sonar.NewCodePeriodsSetOptions{
+			_, err = client.NewCodePeriods.Set(context.Background(), &sonar.NewCodePeriodsSetOptions{
 				Project: projectKey,
 				Branch:  "main",
 				Type:    sonar.NewCodePeriodTypePreviousVersion,
@@ -573,14 +574,14 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: List all new code periods for project
-			listResult, _, err := client.NewCodePeriods.List(&sonar.NewCodePeriodsListOptions{
+			listResult, _, err := client.NewCodePeriods.List(context.Background(), &sonar.NewCodePeriodsListOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(listResult.NewCodePeriods).NotTo(BeNil())
 
 			// Step 6: Show branch-level
-			result, _, err = client.NewCodePeriods.Show(&sonar.NewCodePeriodsShowOptions{
+			result, _, err = client.NewCodePeriods.Show(context.Background(), &sonar.NewCodePeriodsShowOptions{
 				Project: projectKey,
 				Branch:  "main",
 			})
@@ -588,14 +589,14 @@ var _ = Describe("NewCodePeriods Service", Ordered, func() {
 			Expect(result.BranchKey).To(Equal("main"))
 
 			// Step 7: Unset branch-level
-			_, err = client.NewCodePeriods.Unset(&sonar.NewCodePeriodsUnsetOptions{
+			_, err = client.NewCodePeriods.Unset(context.Background(), &sonar.NewCodePeriodsUnsetOptions{
 				Project: projectKey,
 				Branch:  "main",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 8: Unset project-level
-			_, err = client.NewCodePeriods.Unset(&sonar.NewCodePeriodsUnsetOptions{
+			_, err = client.NewCodePeriods.Unset(context.Background(), &sonar.NewCodePeriodsUnsetOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/notifications_test.go
+++ b/integration_testing/notifications_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,14 +27,14 @@ var _ = Describe("Notifications Service", Ordered, func() {
 
 		// Create a test project for project-scoped notifications
 		projectKey = helpers.UniqueResourceName("notif")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    "Notifications Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -53,7 +54,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 	Describe("List", func() {
 		Context("Valid Requests", func() {
 			It("should list notifications with nil options", func() {
-				result, resp, err := client.Notifications.List(nil)
+				result, resp, err := client.Notifications.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -62,7 +63,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 			})
 
 			It("should list notifications with empty options", func() {
-				result, resp, err := client.Notifications.List(&sonar.NotificationsListOptions{})
+				result, resp, err := client.Notifications.List(context.Background(), &sonar.NotificationsListOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -76,14 +77,14 @@ var _ = Describe("Notifications Service", Ordered, func() {
 	Describe("Add", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Notifications.Add(nil)
+				resp, err := client.Notifications.Add(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required type", func() {
-				resp, err := client.Notifications.Add(&sonar.NotificationsAddOptions{})
+				resp, err := client.Notifications.Add(context.Background(), &sonar.NotificationsAddOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Type"))
 				Expect(resp).To(BeNil())
@@ -93,21 +94,21 @@ var _ = Describe("Notifications Service", Ordered, func() {
 		Context("Valid Requests", func() {
 			It("should add a global notification", func() {
 				// First get the list to know valid types
-				listResult, _, err := client.Notifications.List(nil)
+				listResult, _, err := client.Notifications.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(listResult).NotTo(BeNil())
 				Expect(listResult.GlobalTypes).NotTo(BeEmpty())
 
 				notificationType := listResult.GlobalTypes[0]
 
-				resp, err := client.Notifications.Add(&sonar.NotificationsAddOptions{
+				resp, err := client.Notifications.Add(context.Background(), &sonar.NotificationsAddOptions{
 					Type: notificationType,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Clean up
-				_, err = client.Notifications.Remove(&sonar.NotificationsRemoveOptions{
+				_, err = client.Notifications.Remove(context.Background(), &sonar.NotificationsRemoveOptions{
 					Type: notificationType,
 				})
 				if err != nil {
@@ -117,14 +118,14 @@ var _ = Describe("Notifications Service", Ordered, func() {
 
 			It("should add a project-scoped notification", func() {
 				// First get the list to know valid types
-				listResult, _, err := client.Notifications.List(nil)
+				listResult, _, err := client.Notifications.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(listResult).NotTo(BeNil())
 				Expect(listResult.PerProjectTypes).NotTo(BeEmpty())
 
 				notificationType := listResult.PerProjectTypes[0]
 
-				resp, err := client.Notifications.Add(&sonar.NotificationsAddOptions{
+				resp, err := client.Notifications.Add(context.Background(), &sonar.NotificationsAddOptions{
 					Type:    notificationType,
 					Project: projectKey,
 				})
@@ -132,7 +133,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Clean up
-				_, err = client.Notifications.Remove(&sonar.NotificationsRemoveOptions{
+				_, err = client.Notifications.Remove(context.Background(), &sonar.NotificationsRemoveOptions{
 					Type:    notificationType,
 					Project: projectKey,
 				})
@@ -144,7 +145,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 
 		Context("Invalid Type", func() {
 			It("should fail for invalid notification type", func() {
-				resp, err := client.Notifications.Add(&sonar.NotificationsAddOptions{
+				resp, err := client.Notifications.Add(context.Background(), &sonar.NotificationsAddOptions{
 					Type: "invalid-type",
 				})
 				Expect(err).To(HaveOccurred())
@@ -161,14 +162,14 @@ var _ = Describe("Notifications Service", Ordered, func() {
 	Describe("Remove", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Notifications.Remove(nil)
+				resp, err := client.Notifications.Remove(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required type", func() {
-				resp, err := client.Notifications.Remove(&sonar.NotificationsRemoveOptions{})
+				resp, err := client.Notifications.Remove(context.Background(), &sonar.NotificationsRemoveOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Type"))
 				Expect(resp).To(BeNil())
@@ -178,7 +179,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 		Context("Valid Requests", func() {
 			It("should remove a notification", func() {
 				// First get valid types
-				listResult, _, err := client.Notifications.List(nil)
+				listResult, _, err := client.Notifications.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(listResult).NotTo(BeNil())
 				Expect(listResult.GlobalTypes).NotTo(BeEmpty())
@@ -186,13 +187,13 @@ var _ = Describe("Notifications Service", Ordered, func() {
 				notificationType := listResult.GlobalTypes[0]
 
 				// Add the notification first
-				_, err = client.Notifications.Add(&sonar.NotificationsAddOptions{
+				_, err = client.Notifications.Add(context.Background(), &sonar.NotificationsAddOptions{
 					Type: notificationType,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Now remove it
-				resp, err := client.Notifications.Remove(&sonar.NotificationsRemoveOptions{
+				resp, err := client.Notifications.Remove(context.Background(), &sonar.NotificationsRemoveOptions{
 					Type: notificationType,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -203,7 +204,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 		Context("Non-Existent Notification", func() {
 			It("should fail for notification that doesn't exist", func() {
 				// Use a valid type but one that's not subscribed
-				listResult, _, err := client.Notifications.List(nil)
+				listResult, _, err := client.Notifications.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(listResult).NotTo(BeNil())
 				Expect(listResult.GlobalTypes).NotTo(BeEmpty())
@@ -225,7 +226,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 				}
 
 				if unsubscribedType != "" {
-					resp, err := client.Notifications.Remove(&sonar.NotificationsRemoveOptions{
+					resp, err := client.Notifications.Remove(context.Background(), &sonar.NotificationsRemoveOptions{
 						Type: unsubscribedType,
 					})
 					Expect(err).To(HaveOccurred())
@@ -243,7 +244,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 	Describe("Full Workflow", func() {
 		It("should add, verify, and remove a notification", func() {
 			// Get valid types
-			listResult, _, err := client.Notifications.List(nil)
+			listResult, _, err := client.Notifications.List(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(listResult).NotTo(BeNil())
 			Expect(listResult.GlobalTypes).NotTo(BeEmpty())
@@ -251,7 +252,7 @@ var _ = Describe("Notifications Service", Ordered, func() {
 			notificationType := listResult.GlobalTypes[0]
 
 			// Remove if already exists (clean state)
-			_, err = client.Notifications.Remove(&sonar.NotificationsRemoveOptions{
+			_, err = client.Notifications.Remove(context.Background(), &sonar.NotificationsRemoveOptions{
 				Type: notificationType,
 			})
 			if err != nil {
@@ -259,14 +260,14 @@ var _ = Describe("Notifications Service", Ordered, func() {
 			}
 
 			// Add the notification
-			resp, err := client.Notifications.Add(&sonar.NotificationsAddOptions{
+			resp, err := client.Notifications.Add(context.Background(), &sonar.NotificationsAddOptions{
 				Type: notificationType,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// List and verify it's there
-			listResult, resp, err = client.Notifications.List(nil)
+			listResult, resp, err = client.Notifications.List(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -280,14 +281,14 @@ var _ = Describe("Notifications Service", Ordered, func() {
 			Expect(found).To(BeTrue(), "Notification should be in the list")
 
 			// Remove the notification
-			resp, err = client.Notifications.Remove(&sonar.NotificationsRemoveOptions{
+			resp, err = client.Notifications.Remove(context.Background(), &sonar.NotificationsRemoveOptions{
 				Type: notificationType,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify it's gone
-			listResult, _, err = client.Notifications.List(nil)
+			listResult, _, err = client.Notifications.List(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			found = false

--- a/integration_testing/permissions_test.go
+++ b/integration_testing/permissions_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -45,7 +46,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testUserLogin = helpers.UniqueResourceName("user-perm")
 
 			// Create private project (codeviewer/user permissions only work on private projects)
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Permission Test Project",
 				Project:    testProjectKey,
 				Visibility: sonar.ProjectVisibilityPrivate,
@@ -53,7 +54,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -61,7 +62,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err = client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Permission Test User",
 				Password: "SecurePassword123!",
@@ -71,7 +72,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", testUserLogin, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+				_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 					Login:     testUserLogin,
 					Anonymize: true,
 				})
@@ -80,7 +81,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add user permission to project", func() {
-			resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
+			resp, err := client.Permissions.AddUser(context.Background(), &sonar.PermissionsAddUserOptions{
 				Login:      testUserLogin,
 				Permission: "codeviewer",
 				ProjectKey: testProjectKey,
@@ -89,7 +90,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify user has permission
-			result, _, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
+			result, _, err := client.Permissions.Users(context.Background(), &sonar.PermissionsUsersOptions{
 				ProjectKey: testProjectKey,
 				Permission: "codeviewer",
 			})
@@ -105,7 +106,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add admin permission to project", func() {
-			resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
+			resp, err := client.Permissions.AddUser(context.Background(), &sonar.PermissionsAddUserOptions{
 				Login:      testUserLogin,
 				Permission: "admin",
 				ProjectKey: testProjectKey,
@@ -115,7 +116,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add issueadmin permission to project", func() {
-			resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
+			resp, err := client.Permissions.AddUser(context.Background(), &sonar.PermissionsAddUserOptions{
 				Login:      testUserLogin,
 				Permission: "issueadmin",
 				ProjectKey: testProjectKey,
@@ -126,13 +127,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Permissions.AddUser(nil)
+				resp, err := client.Permissions.AddUser(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing login", func() {
-				resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
+				resp, err := client.Permissions.AddUser(context.Background(), &sonar.PermissionsAddUserOptions{
 					Permission: "codeviewer",
 					ProjectKey: testProjectKey,
 				})
@@ -141,7 +142,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
+				resp, err := client.Permissions.AddUser(context.Background(), &sonar.PermissionsAddUserOptions{
 					Login:      testUserLogin,
 					ProjectKey: testProjectKey,
 				})
@@ -150,7 +151,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with invalid permission", func() {
-				resp, err := client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
+				resp, err := client.Permissions.AddUser(context.Background(), &sonar.PermissionsAddUserOptions{
 					Login:      testUserLogin,
 					Permission: "invalid_permission",
 					ProjectKey: testProjectKey,
@@ -170,7 +171,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testUserLogin = helpers.UniqueResourceName("user-rmperm")
 
 			// Create private project (codeviewer permission only works on private projects)
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Remove User Permission Test",
 				Project:    testProjectKey,
 				Visibility: sonar.ProjectVisibilityPrivate,
@@ -178,7 +179,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -186,7 +187,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err = client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Remove Permission Test User",
 				Password: "SecurePassword123!",
@@ -196,7 +197,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", testUserLogin, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+				_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 					Login:     testUserLogin,
 					Anonymize: true,
 				})
@@ -204,7 +205,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			// Add permission first
-			_, err = client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
+			_, err = client.Permissions.AddUser(context.Background(), &sonar.PermissionsAddUserOptions{
 				Login:      testUserLogin,
 				Permission: "codeviewer",
 				ProjectKey: testProjectKey,
@@ -213,7 +214,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should remove user permission from project", func() {
-			resp, err := client.Permissions.RemoveUser(&sonar.PermissionsRemoveUserOptions{
+			resp, err := client.Permissions.RemoveUser(context.Background(), &sonar.PermissionsRemoveUserOptions{
 				Login:      testUserLogin,
 				Permission: "codeviewer",
 				ProjectKey: testProjectKey,
@@ -222,7 +223,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify user no longer has permission
-			result, _, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
+			result, _, err := client.Permissions.Users(context.Background(), &sonar.PermissionsUsersOptions{
 				ProjectKey: testProjectKey,
 				Permission: "codeviewer",
 			})
@@ -234,13 +235,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Permissions.RemoveUser(nil)
+				resp, err := client.Permissions.RemoveUser(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing login", func() {
-				resp, err := client.Permissions.RemoveUser(&sonar.PermissionsRemoveUserOptions{
+				resp, err := client.Permissions.RemoveUser(context.Background(), &sonar.PermissionsRemoveUserOptions{
 					Permission: "codeviewer",
 					ProjectKey: testProjectKey,
 				})
@@ -249,7 +250,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.RemoveUser(&sonar.PermissionsRemoveUserOptions{
+				resp, err := client.Permissions.RemoveUser(context.Background(), &sonar.PermissionsRemoveUserOptions{
 					Login:      testUserLogin,
 					ProjectKey: testProjectKey,
 				})
@@ -271,7 +272,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testGroupName = helpers.UniqueResourceName("grp-perm")
 
 			// Create private project (codeviewer permission only works on private projects)
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Group Permission Test Project",
 				Project:    testProjectKey,
 				Visibility: sonar.ProjectVisibilityPrivate,
@@ -279,7 +280,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -287,7 +288,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+			_, _, err = client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 				Name:        testGroupName,
 				Description: "Permission Test Group",
 			})
@@ -295,7 +296,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("group", testGroupName, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+				_, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 					Name: testGroupName,
 				})
 				return err
@@ -303,7 +304,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add group permission to project", func() {
-			resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOptions{
+			resp, err := client.Permissions.AddGroup(context.Background(), &sonar.PermissionsAddGroupOptions{
 				GroupName:  testGroupName,
 				Permission: "codeviewer",
 				ProjectKey: testProjectKey,
@@ -312,7 +313,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify group has permission
-			result, _, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
+			result, _, err := client.Permissions.Groups(context.Background(), &sonar.PermissionsGroupsOptions{
 				ProjectKey: testProjectKey,
 				Permission: "codeviewer",
 			})
@@ -328,7 +329,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add admin permission to group", func() {
-			resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOptions{
+			resp, err := client.Permissions.AddGroup(context.Background(), &sonar.PermissionsAddGroupOptions{
 				GroupName:  testGroupName,
 				Permission: "admin",
 				ProjectKey: testProjectKey,
@@ -337,7 +338,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify group has admin permission
-			result, _, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
+			result, _, err := client.Permissions.Groups(context.Background(), &sonar.PermissionsGroupsOptions{
 				ProjectKey: testProjectKey,
 				Permission: "admin",
 			})
@@ -354,13 +355,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Permissions.AddGroup(nil)
+				resp, err := client.Permissions.AddGroup(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing group name", func() {
-				resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOptions{
+				resp, err := client.Permissions.AddGroup(context.Background(), &sonar.PermissionsAddGroupOptions{
 					Permission: "codeviewer",
 					ProjectKey: testProjectKey,
 				})
@@ -369,7 +370,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOptions{
+				resp, err := client.Permissions.AddGroup(context.Background(), &sonar.PermissionsAddGroupOptions{
 					GroupName:  testGroupName,
 					ProjectKey: testProjectKey,
 				})
@@ -378,7 +379,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with invalid permission", func() {
-				resp, err := client.Permissions.AddGroup(&sonar.PermissionsAddGroupOptions{
+				resp, err := client.Permissions.AddGroup(context.Background(), &sonar.PermissionsAddGroupOptions{
 					GroupName:  testGroupName,
 					Permission: "invalid_permission",
 					ProjectKey: testProjectKey,
@@ -398,7 +399,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testGroupName = helpers.UniqueResourceName("grp-rmperm")
 
 			// Create private project (codeviewer permission only works on private projects)
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Remove Group Permission Test",
 				Project:    testProjectKey,
 				Visibility: sonar.ProjectVisibilityPrivate,
@@ -406,7 +407,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -414,7 +415,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+			_, _, err = client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 				Name:        testGroupName,
 				Description: "Remove Permission Test Group",
 			})
@@ -422,14 +423,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("group", testGroupName, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+				_, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 					Name: testGroupName,
 				})
 				return err
 			})
 
 			// Add permission first
-			_, err = client.Permissions.AddGroup(&sonar.PermissionsAddGroupOptions{
+			_, err = client.Permissions.AddGroup(context.Background(), &sonar.PermissionsAddGroupOptions{
 				GroupName:  testGroupName,
 				Permission: "codeviewer",
 				ProjectKey: testProjectKey,
@@ -438,7 +439,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should remove group permission from project", func() {
-			resp, err := client.Permissions.RemoveGroup(&sonar.PermissionsRemoveGroupOptions{
+			resp, err := client.Permissions.RemoveGroup(context.Background(), &sonar.PermissionsRemoveGroupOptions{
 				GroupName:  testGroupName,
 				Permission: "codeviewer",
 				ProjectKey: testProjectKey,
@@ -447,7 +448,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify group no longer has permission
-			result, _, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
+			result, _, err := client.Permissions.Groups(context.Background(), &sonar.PermissionsGroupsOptions{
 				ProjectKey: testProjectKey,
 				Permission: "codeviewer",
 			})
@@ -459,13 +460,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Permissions.RemoveGroup(nil)
+				resp, err := client.Permissions.RemoveGroup(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing group name", func() {
-				resp, err := client.Permissions.RemoveGroup(&sonar.PermissionsRemoveGroupOptions{
+				resp, err := client.Permissions.RemoveGroup(context.Background(), &sonar.PermissionsRemoveGroupOptions{
 					Permission: "codeviewer",
 					ProjectKey: testProjectKey,
 				})
@@ -474,7 +475,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.RemoveGroup(&sonar.PermissionsRemoveGroupOptions{
+				resp, err := client.Permissions.RemoveGroup(context.Background(), &sonar.PermissionsRemoveGroupOptions{
 					GroupName:  testGroupName,
 					ProjectKey: testProjectKey,
 				})
@@ -489,7 +490,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 	// =========================================================================
 	Describe("Users", func() {
 		It("should list users globally", func() {
-			result, resp, err := client.Permissions.Users(nil)
+			result, resp, err := client.Permissions.Users(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -498,7 +499,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should list users with specific permission", func() {
-			result, resp, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
+			result, resp, err := client.Permissions.Users(context.Background(), &sonar.PermissionsUsersOptions{
 				Permission: "admin",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -512,14 +513,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			BeforeEach(func() {
 				testProjectKey = helpers.UniqueResourceName("proj-listuser")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    "List Users Test",
 					Project: testProjectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", testProjectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: testProjectKey,
 					})
 					return err
@@ -527,7 +528,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should list users with project permissions", func() {
-				result, resp, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
+				result, resp, err := client.Permissions.Users(context.Background(), &sonar.PermissionsUsersOptions{
 					ProjectKey: testProjectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -538,7 +539,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with query too short", func() {
-				_, resp, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
+				_, resp, err := client.Permissions.Users(context.Background(), &sonar.PermissionsUsersOptions{
 					Query: "ab", // min 3 chars
 				})
 				Expect(err).To(HaveOccurred())
@@ -546,7 +547,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with invalid permission", func() {
-				_, resp, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
+				_, resp, err := client.Permissions.Users(context.Background(), &sonar.PermissionsUsersOptions{
 					Permission: "invalid_permission",
 				})
 				Expect(err).To(HaveOccurred())
@@ -557,7 +558,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 	Describe("Groups", func() {
 		It("should list groups with global permissions", func() {
-			result, resp, err := client.Permissions.Groups(nil)
+			result, resp, err := client.Permissions.Groups(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -574,7 +575,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should list groups with specific permission", func() {
-			result, resp, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
+			result, resp, err := client.Permissions.Groups(context.Background(), &sonar.PermissionsGroupsOptions{
 				Permission: "admin",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -588,14 +589,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			BeforeEach(func() {
 				testProjectKey = helpers.UniqueResourceName("proj-listgrp")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    "List Groups Test",
 					Project: testProjectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", testProjectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: testProjectKey,
 					})
 					return err
@@ -603,7 +604,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should list groups with project permissions", func() {
-				result, resp, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
+				result, resp, err := client.Permissions.Groups(context.Background(), &sonar.PermissionsGroupsOptions{
 					ProjectKey: testProjectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -614,7 +615,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with query too short", func() {
-				_, resp, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
+				_, resp, err := client.Permissions.Groups(context.Background(), &sonar.PermissionsGroupsOptions{
 					Query: "ab", // min 3 chars
 				})
 				Expect(err).To(HaveOccurred())
@@ -622,7 +623,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with invalid permission", func() {
-				_, resp, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
+				_, resp, err := client.Permissions.Groups(context.Background(), &sonar.PermissionsGroupsOptions{
 					Permission: "invalid_permission",
 				})
 				Expect(err).To(HaveOccurred())
@@ -638,7 +639,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		It("should create a permission template", func() {
 			templateName := helpers.UniqueResourceName("tpl")
 
-			result, resp, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			result, resp, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name:        templateName,
 				Description: "E2E Test Template",
 			})
@@ -647,7 +648,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Register cleanup
 			cleanup.RegisterCleanup("template", templateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: templateName,
 				})
 				return err
@@ -661,7 +662,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		It("should create a template with project key pattern", func() {
 			templateName := helpers.UniqueResourceName("tpl-pattern")
 
-			result, resp, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			result, resp, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name:              templateName,
 				Description:       "Template with pattern",
 				ProjectKeyPattern: "e2e-tpl-pattern-.*",
@@ -670,7 +671,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", templateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: templateName,
 				})
 				return err
@@ -683,13 +684,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Permissions.CreateTemplate(nil)
+				_, resp, err := client.Permissions.CreateTemplate(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing name", func() {
-				_, resp, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+				_, resp, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 					Description: "Test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -704,14 +705,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		BeforeEach(func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-search")
 
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			_, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name:        testTemplateName,
 				Description: "Search Test Template",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -719,7 +720,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should search all templates", func() {
-			result, resp, err := client.Permissions.SearchTemplates(nil)
+			result, resp, err := client.Permissions.SearchTemplates(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -727,7 +728,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should search templates by query", func() {
-			result, resp, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOptions{
+			result, resp, err := client.Permissions.SearchTemplates(context.Background(), &sonar.PermissionsSearchTemplatesOptions{
 				Query: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -744,7 +745,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should include default templates info", func() {
-			result, resp, err := client.Permissions.SearchTemplates(nil)
+			result, resp, err := client.Permissions.SearchTemplates(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -757,19 +758,19 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		It("should delete a template", func() {
 			templateName := helpers.UniqueResourceName("tpl-del")
 
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			_, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name: templateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			resp, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+			resp, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 				TemplateName: templateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify template is deleted
-			result, _, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOptions{
+			result, _, err := client.Permissions.SearchTemplates(context.Background(), &sonar.PermissionsSearchTemplatesOptions{
 				Query: templateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -780,13 +781,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Permissions.DeleteTemplate(nil)
+				resp, err := client.Permissions.DeleteTemplate(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{})
+				resp, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -800,14 +801,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		BeforeEach(func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-update")
 
-			result, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			result, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name:        testTemplateName,
 				Description: "Original description",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Get template ID from search
-			searchResult, _, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOptions{
+			searchResult, _, err := client.Permissions.SearchTemplates(context.Background(), &sonar.PermissionsSearchTemplatesOptions{
 				Query: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -820,7 +821,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(templateID).NotTo(BeEmpty(), "Template ID not found for: %s, result: %+v", testTemplateName, result)
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -828,7 +829,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should update template description", func() {
-			result, resp, err := client.Permissions.UpdateTemplate(&sonar.PermissionsUpdateTemplateOptions{
+			result, resp, err := client.Permissions.UpdateTemplate(context.Background(), &sonar.PermissionsUpdateTemplateOptions{
 				ID:          templateID,
 				Description: "Updated description",
 			})
@@ -841,7 +842,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		It("should update template name", func() {
 			newName := helpers.UniqueResourceName("tpl-renamed")
 
-			result, resp, err := client.Permissions.UpdateTemplate(&sonar.PermissionsUpdateTemplateOptions{
+			result, resp, err := client.Permissions.UpdateTemplate(context.Background(), &sonar.PermissionsUpdateTemplateOptions{
 				ID:   templateID,
 				Name: newName,
 			})
@@ -852,7 +853,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Update cleanup to use new name
 			cleanup.RegisterCleanup("template", newName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: newName,
 				})
 				return err
@@ -861,13 +862,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Permissions.UpdateTemplate(nil)
+				_, resp, err := client.Permissions.UpdateTemplate(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing ID", func() {
-				_, resp, err := client.Permissions.UpdateTemplate(&sonar.PermissionsUpdateTemplateOptions{
+				_, resp, err := client.Permissions.UpdateTemplate(context.Background(), &sonar.PermissionsUpdateTemplateOptions{
 					Description: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -888,13 +889,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testUserLogin = helpers.UniqueResourceName("user-tpl")
 
 			// Create template
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			_, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -902,7 +903,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err = client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Template User Test",
 				Password: "SecurePassword123!",
@@ -912,7 +913,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", testUserLogin, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+				_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 					Login:     testUserLogin,
 					Anonymize: true,
 				})
@@ -921,7 +922,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add user to template", func() {
-			resp, err := client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOptions{
+			resp, err := client.Permissions.AddUserToTemplate(context.Background(), &sonar.PermissionsAddUserToTemplateOptions{
 				Login:        testUserLogin,
 				Permission:   "codeviewer",
 				TemplateName: testTemplateName,
@@ -930,7 +931,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify user is in template
-			result, _, err := client.Permissions.TemplateUsers(&sonar.PermissionsTemplateUsersOptions{
+			result, _, err := client.Permissions.TemplateUsers(context.Background(), &sonar.PermissionsTemplateUsersOptions{
 				TemplateName: testTemplateName,
 				Permission:   "codeviewer",
 			})
@@ -947,13 +948,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Permissions.AddUserToTemplate(nil)
+				resp, err := client.Permissions.AddUserToTemplate(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing login", func() {
-				resp, err := client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOptions{
+				resp, err := client.Permissions.AddUserToTemplate(context.Background(), &sonar.PermissionsAddUserToTemplateOptions{
 					Permission:   "codeviewer",
 					TemplateName: testTemplateName,
 				})
@@ -962,7 +963,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOptions{
+				resp, err := client.Permissions.AddUserToTemplate(context.Background(), &sonar.PermissionsAddUserToTemplateOptions{
 					Login:        testUserLogin,
 					TemplateName: testTemplateName,
 				})
@@ -971,7 +972,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOptions{
+				resp, err := client.Permissions.AddUserToTemplate(context.Background(), &sonar.PermissionsAddUserToTemplateOptions{
 					Login:      testUserLogin,
 					Permission: "codeviewer",
 				})
@@ -990,13 +991,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testUserLogin = helpers.UniqueResourceName("user-tplrm")
 
 			// Create template
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			_, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1004,7 +1005,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err = client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Remove Template User Test",
 				Password: "SecurePassword123!",
@@ -1014,7 +1015,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", testUserLogin, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+				_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 					Login:     testUserLogin,
 					Anonymize: true,
 				})
@@ -1022,7 +1023,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			// Add user to template
-			_, err = client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOptions{
+			_, err = client.Permissions.AddUserToTemplate(context.Background(), &sonar.PermissionsAddUserToTemplateOptions{
 				Login:        testUserLogin,
 				Permission:   "codeviewer",
 				TemplateName: testTemplateName,
@@ -1031,7 +1032,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should remove user from template", func() {
-			resp, err := client.Permissions.RemoveUserFromTemplate(&sonar.PermissionsRemoveUserFromTemplateOptions{
+			resp, err := client.Permissions.RemoveUserFromTemplate(context.Background(), &sonar.PermissionsRemoveUserFromTemplateOptions{
 				Login:        testUserLogin,
 				Permission:   "codeviewer",
 				TemplateName: testTemplateName,
@@ -1040,7 +1041,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify user is removed from template
-			result, _, err := client.Permissions.TemplateUsers(&sonar.PermissionsTemplateUsersOptions{
+			result, _, err := client.Permissions.TemplateUsers(context.Background(), &sonar.PermissionsTemplateUsersOptions{
 				TemplateName: testTemplateName,
 				Permission:   "codeviewer",
 			})
@@ -1060,13 +1061,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testGroupName = helpers.UniqueResourceName("grp-tpl")
 
 			// Create template
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			_, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1074,7 +1075,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+			_, _, err = client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 				Name:        testGroupName,
 				Description: "Template Group Test",
 			})
@@ -1082,7 +1083,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("group", testGroupName, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+				_, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 					Name: testGroupName,
 				})
 				return err
@@ -1090,7 +1091,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add group to template", func() {
-			resp, err := client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOptions{
+			resp, err := client.Permissions.AddGroupToTemplate(context.Background(), &sonar.PermissionsAddGroupToTemplateOptions{
 				GroupName:    testGroupName,
 				Permission:   "codeviewer",
 				TemplateName: testTemplateName,
@@ -1099,7 +1100,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify group is in template
-			result, _, err := client.Permissions.TemplateGroups(&sonar.PermissionsTemplateGroupsOptions{
+			result, _, err := client.Permissions.TemplateGroups(context.Background(), &sonar.PermissionsTemplateGroupsOptions{
 				TemplateName: testTemplateName,
 				Permission:   "codeviewer",
 			})
@@ -1116,13 +1117,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Permissions.AddGroupToTemplate(nil)
+				resp, err := client.Permissions.AddGroupToTemplate(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing group name", func() {
-				resp, err := client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOptions{
+				resp, err := client.Permissions.AddGroupToTemplate(context.Background(), &sonar.PermissionsAddGroupToTemplateOptions{
 					Permission:   "codeviewer",
 					TemplateName: testTemplateName,
 				})
@@ -1131,7 +1132,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOptions{
+				resp, err := client.Permissions.AddGroupToTemplate(context.Background(), &sonar.PermissionsAddGroupToTemplateOptions{
 					GroupName:    testGroupName,
 					TemplateName: testTemplateName,
 				})
@@ -1140,7 +1141,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOptions{
+				resp, err := client.Permissions.AddGroupToTemplate(context.Background(), &sonar.PermissionsAddGroupToTemplateOptions{
 					GroupName:  testGroupName,
 					Permission: "codeviewer",
 				})
@@ -1159,13 +1160,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testGroupName = helpers.UniqueResourceName("grp-tplrm")
 
 			// Create template
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			_, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1173,7 +1174,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+			_, _, err = client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 				Name:        testGroupName,
 				Description: "Remove Template Group Test",
 			})
@@ -1181,14 +1182,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("group", testGroupName, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+				_, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 					Name: testGroupName,
 				})
 				return err
 			})
 
 			// Add group to template
-			_, err = client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOptions{
+			_, err = client.Permissions.AddGroupToTemplate(context.Background(), &sonar.PermissionsAddGroupToTemplateOptions{
 				GroupName:    testGroupName,
 				Permission:   "codeviewer",
 				TemplateName: testTemplateName,
@@ -1197,7 +1198,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should remove group from template", func() {
-			resp, err := client.Permissions.RemoveGroupFromTemplate(&sonar.PermissionsRemoveGroupFromTemplateOptions{
+			resp, err := client.Permissions.RemoveGroupFromTemplate(context.Background(), &sonar.PermissionsRemoveGroupFromTemplateOptions{
 				GroupName:    testGroupName,
 				Permission:   "codeviewer",
 				TemplateName: testTemplateName,
@@ -1206,7 +1207,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify group is removed from template
-			result, _, err := client.Permissions.TemplateGroups(&sonar.PermissionsTemplateGroupsOptions{
+			result, _, err := client.Permissions.TemplateGroups(context.Background(), &sonar.PermissionsTemplateGroupsOptions{
 				TemplateName: testTemplateName,
 				Permission:   "codeviewer",
 			})
@@ -1223,13 +1224,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		BeforeEach(func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-usrlist")
 
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			_, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1237,7 +1238,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should list template users", func() {
-			result, resp, err := client.Permissions.TemplateUsers(&sonar.PermissionsTemplateUsersOptions{
+			result, resp, err := client.Permissions.TemplateUsers(context.Background(), &sonar.PermissionsTemplateUsersOptions{
 				TemplateName: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1247,13 +1248,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Permissions.TemplateUsers(nil)
+				_, resp, err := client.Permissions.TemplateUsers(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing template identifier", func() {
-				_, resp, err := client.Permissions.TemplateUsers(&sonar.PermissionsTemplateUsersOptions{})
+				_, resp, err := client.Permissions.TemplateUsers(context.Background(), &sonar.PermissionsTemplateUsersOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -1266,13 +1267,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		BeforeEach(func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-grplist")
 
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			_, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1280,7 +1281,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should list template groups", func() {
-			result, resp, err := client.Permissions.TemplateGroups(&sonar.PermissionsTemplateGroupsOptions{
+			result, resp, err := client.Permissions.TemplateGroups(context.Background(), &sonar.PermissionsTemplateGroupsOptions{
 				TemplateName: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1290,13 +1291,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Permissions.TemplateGroups(nil)
+				_, resp, err := client.Permissions.TemplateGroups(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing template identifier", func() {
-				_, resp, err := client.Permissions.TemplateGroups(&sonar.PermissionsTemplateGroupsOptions{})
+				_, resp, err := client.Permissions.TemplateGroups(context.Background(), &sonar.PermissionsTemplateGroupsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -1312,13 +1313,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		BeforeEach(func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-creator")
 
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			_, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1326,7 +1327,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should add project creator to template", func() {
-			resp, err := client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOptions{
+			resp, err := client.Permissions.AddProjectCreatorToTemplate(context.Background(), &sonar.PermissionsAddProjectCreatorToTemplateOptions{
 				Permission:   "admin",
 				TemplateName: testTemplateName,
 			})
@@ -1334,7 +1335,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify by searching templates
-			result, _, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOptions{
+			result, _, err := client.Permissions.SearchTemplates(context.Background(), &sonar.PermissionsSearchTemplatesOptions{
 				Query: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1355,13 +1356,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Permissions.AddProjectCreatorToTemplate(nil)
+				resp, err := client.Permissions.AddProjectCreatorToTemplate(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOptions{
+				resp, err := client.Permissions.AddProjectCreatorToTemplate(context.Background(), &sonar.PermissionsAddProjectCreatorToTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				Expect(err).To(HaveOccurred())
@@ -1369,7 +1370,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOptions{
+				resp, err := client.Permissions.AddProjectCreatorToTemplate(context.Background(), &sonar.PermissionsAddProjectCreatorToTemplateOptions{
 					Permission: "admin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1384,20 +1385,20 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		BeforeEach(func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-rmcreator")
 
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			_, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
 			})
 
 			// Add project creator first
-			_, err = client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOptions{
+			_, err = client.Permissions.AddProjectCreatorToTemplate(context.Background(), &sonar.PermissionsAddProjectCreatorToTemplateOptions{
 				Permission:   "admin",
 				TemplateName: testTemplateName,
 			})
@@ -1405,7 +1406,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should remove project creator from template", func() {
-			resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(&sonar.PermissionsRemoveProjectCreatorFromTemplateOptions{
+			resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(context.Background(), &sonar.PermissionsRemoveProjectCreatorFromTemplateOptions{
 				Permission:   "admin",
 				TemplateName: testTemplateName,
 			})
@@ -1413,7 +1414,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify by searching templates
-			result, _, err := client.Permissions.SearchTemplates(&sonar.PermissionsSearchTemplatesOptions{
+			result, _, err := client.Permissions.SearchTemplates(context.Background(), &sonar.PermissionsSearchTemplatesOptions{
 				Query: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1431,13 +1432,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(nil)
+				resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing permission", func() {
-				resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(&sonar.PermissionsRemoveProjectCreatorFromTemplateOptions{
+				resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(context.Background(), &sonar.PermissionsRemoveProjectCreatorFromTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				Expect(err).To(HaveOccurred())
@@ -1445,7 +1446,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(&sonar.PermissionsRemoveProjectCreatorFromTemplateOptions{
+				resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(context.Background(), &sonar.PermissionsRemoveProjectCreatorFromTemplateOptions{
 					Permission: "admin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1468,7 +1469,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testUserLogin = helpers.UniqueResourceName("user-apply")
 
 			// Create private project (codeviewer permission only works on private projects)
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Apply Template Test",
 				Project:    testProjectKey,
 				Visibility: sonar.ProjectVisibilityPrivate,
@@ -1476,20 +1477,20 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
 			})
 
 			// Create template
-			_, _, err = client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			_, _, err = client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1497,7 +1498,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Create user and add to template
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err = client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Apply Template User",
 				Password: "SecurePassword123!",
@@ -1507,7 +1508,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", testUserLogin, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+				_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 					Login:     testUserLogin,
 					Anonymize: true,
 				})
@@ -1515,7 +1516,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			// Add user to template
-			_, err = client.Permissions.AddUserToTemplate(&sonar.PermissionsAddUserToTemplateOptions{
+			_, err = client.Permissions.AddUserToTemplate(context.Background(), &sonar.PermissionsAddUserToTemplateOptions{
 				Login:        testUserLogin,
 				Permission:   "codeviewer",
 				TemplateName: testTemplateName,
@@ -1524,7 +1525,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should apply template to project", func() {
-			resp, err := client.Permissions.ApplyTemplate(&sonar.PermissionsApplyTemplateOptions{
+			resp, err := client.Permissions.ApplyTemplate(context.Background(), &sonar.PermissionsApplyTemplateOptions{
 				ProjectKey:   testProjectKey,
 				TemplateName: testTemplateName,
 			})
@@ -1532,7 +1533,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify user has permission on project
-			result, _, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
+			result, _, err := client.Permissions.Users(context.Background(), &sonar.PermissionsUsersOptions{
 				ProjectKey: testProjectKey,
 				Permission: "codeviewer",
 			})
@@ -1549,13 +1550,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Permissions.ApplyTemplate(nil)
+				resp, err := client.Permissions.ApplyTemplate(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing project identifier", func() {
-				resp, err := client.Permissions.ApplyTemplate(&sonar.PermissionsApplyTemplateOptions{
+				resp, err := client.Permissions.ApplyTemplate(context.Background(), &sonar.PermissionsApplyTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				Expect(err).To(HaveOccurred())
@@ -1563,7 +1564,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.ApplyTemplate(&sonar.PermissionsApplyTemplateOptions{
+				resp, err := client.Permissions.ApplyTemplate(context.Background(), &sonar.PermissionsApplyTemplateOptions{
 					ProjectKey: testProjectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -1583,40 +1584,40 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-bulk")
 
 			// Create projects
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Bulk Apply Test 1",
 				Project: testProjectKey1,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey1, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: testProjectKey1,
 				})
 				return err
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Bulk Apply Test 2",
 				Project: testProjectKey2,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey2, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: testProjectKey2,
 				})
 				return err
 			})
 
 			// Create template
-			_, _, err = client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			_, _, err = client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1624,7 +1625,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		})
 
 		It("should bulk apply template to projects", func() {
-			resp, err := client.Permissions.BulkApplyTemplate(&sonar.PermissionsBulkApplyTemplateOptions{
+			resp, err := client.Permissions.BulkApplyTemplate(context.Background(), &sonar.PermissionsBulkApplyTemplateOptions{
 				TemplateName: testTemplateName,
 				Projects:     []string{testProjectKey1, testProjectKey2},
 			})
@@ -1637,7 +1638,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			queryPrefix := strings.TrimPrefix(testProjectKey1, helpers.E2EResourcePrefix)
 			queryPrefix = helpers.E2EResourcePrefix + queryPrefix[:10] // Take first part
 
-			resp, err := client.Permissions.BulkApplyTemplate(&sonar.PermissionsBulkApplyTemplateOptions{
+			resp, err := client.Permissions.BulkApplyTemplate(context.Background(), &sonar.PermissionsBulkApplyTemplateOptions{
 				TemplateName: testTemplateName,
 				Query:        queryPrefix,
 			})
@@ -1647,13 +1648,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Permissions.BulkApplyTemplate(nil)
+				resp, err := client.Permissions.BulkApplyTemplate(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.BulkApplyTemplate(&sonar.PermissionsBulkApplyTemplateOptions{
+				resp, err := client.Permissions.BulkApplyTemplate(context.Background(), &sonar.PermissionsBulkApplyTemplateOptions{
 					Projects: []string{testProjectKey1},
 				})
 				Expect(err).To(HaveOccurred())
@@ -1661,7 +1662,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with invalid qualifier", func() {
-				resp, err := client.Permissions.BulkApplyTemplate(&sonar.PermissionsBulkApplyTemplateOptions{
+				resp, err := client.Permissions.BulkApplyTemplate(context.Background(), &sonar.PermissionsBulkApplyTemplateOptions{
 					TemplateName: testTemplateName,
 					Qualifiers:   "INVALID",
 				})
@@ -1677,13 +1678,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 		BeforeEach(func() {
 			testTemplateName = helpers.UniqueResourceName("tpl-default")
 
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			_, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name: testTemplateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("template", testTemplateName, func() error {
-				_, err := client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+				_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 					TemplateName: testTemplateName,
 				})
 				return err
@@ -1692,7 +1693,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		It("should set default template for projects", func() {
 			// First, get current default template to restore later
-			searchResult, _, err := client.Permissions.SearchTemplates(nil)
+			searchResult, _, err := client.Permissions.SearchTemplates(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			var originalDefaultID string
@@ -1704,7 +1705,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			}
 
 			// Set our template as default
-			resp, err := client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOptions{
+			resp, err := client.Permissions.SetDefaultTemplate(context.Background(), &sonar.PermissionsSetDefaultTemplateOptions{
 				TemplateName: testTemplateName,
 				Qualifier:    sonar.ProjectQualifierTRK,
 			})
@@ -1712,7 +1713,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify it's now the default
-			searchResult, _, err = client.Permissions.SearchTemplates(nil)
+			searchResult, _, err = client.Permissions.SearchTemplates(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			found := false
 			for _, t := range searchResult.PermissionTemplates {
@@ -1730,7 +1731,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Restore original default
 			if originalDefaultID != "" {
-				_, _ = client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOptions{
+				_, _ = client.Permissions.SetDefaultTemplate(context.Background(), &sonar.PermissionsSetDefaultTemplateOptions{
 					TemplateID: originalDefaultID,
 					Qualifier:  sonar.ProjectQualifierTRK,
 				})
@@ -1739,13 +1740,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Permissions.SetDefaultTemplate(nil)
+				resp, err := client.Permissions.SetDefaultTemplate(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing template identifier", func() {
-				resp, err := client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOptions{
+				resp, err := client.Permissions.SetDefaultTemplate(context.Background(), &sonar.PermissionsSetDefaultTemplateOptions{
 					Qualifier: sonar.ProjectQualifierTRK,
 				})
 				Expect(err).To(HaveOccurred())
@@ -1753,7 +1754,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 
 			It("should fail with invalid qualifier", func() {
-				resp, err := client.Permissions.SetDefaultTemplate(&sonar.PermissionsSetDefaultTemplateOptions{
+				resp, err := client.Permissions.SetDefaultTemplate(context.Background(), &sonar.PermissionsSetDefaultTemplateOptions{
 					TemplateName: testTemplateName,
 					Qualifier:    "INVALID",
 				})
@@ -1772,7 +1773,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			userLogin := helpers.UniqueResourceName("user-lifecycle")
 
 			// Step 1: Create private project (codeviewer permission only works on private projects)
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Lifecycle Test Project",
 				Project:    projectKey,
 				Visibility: sonar.ProjectVisibilityPrivate,
@@ -1781,7 +1782,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Step 2: Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err = client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    userLogin,
 				Name:     "Lifecycle Test User",
 				Password: "SecurePassword123!",
@@ -1790,7 +1791,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 3: Add permission
-			_, err = client.Permissions.AddUser(&sonar.PermissionsAddUserOptions{
+			_, err = client.Permissions.AddUser(context.Background(), &sonar.PermissionsAddUserOptions{
 				Login:      userLogin,
 				Permission: "codeviewer",
 				ProjectKey: projectKey,
@@ -1798,7 +1799,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 4: Verify permission
-			result, _, err := client.Permissions.Users(&sonar.PermissionsUsersOptions{
+			result, _, err := client.Permissions.Users(context.Background(), &sonar.PermissionsUsersOptions{
 				ProjectKey: projectKey,
 				Permission: "codeviewer",
 			})
@@ -1813,7 +1814,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(found).To(BeTrue())
 
 			// Step 5: Remove permission
-			_, err = client.Permissions.RemoveUser(&sonar.PermissionsRemoveUserOptions{
+			_, err = client.Permissions.RemoveUser(context.Background(), &sonar.PermissionsRemoveUserOptions{
 				Login:      userLogin,
 				Permission: "codeviewer",
 				ProjectKey: projectKey,
@@ -1821,7 +1822,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 6: Verify permission removed
-			result, _, err = client.Permissions.Users(&sonar.PermissionsUsersOptions{
+			result, _, err = client.Permissions.Users(context.Background(), &sonar.PermissionsUsersOptions{
 				ProjectKey: projectKey,
 				Permission: "codeviewer",
 			})
@@ -1832,11 +1833,11 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Cleanup
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, _ = client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+			_, _, _ = client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 				Login:     userLogin,
 				Anonymize: true,
 			})
-			_, _ = client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, _ = client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 		})
@@ -1847,7 +1848,7 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			projectKey := helpers.UniqueResourceName("proj-tpllife")
 
 			// Step 1: Create template
-			_, _, err := client.Permissions.CreateTemplate(&sonar.PermissionsCreateTemplateOptions{
+			_, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
 				Name:        templateName,
 				Description: "Lifecycle test template",
 			})
@@ -1855,13 +1856,13 @@ var _ = Describe("Permissions Service", Ordered, func() {
 
 			// Step 2: Create group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+			_, _, err = client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 				Name: groupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 3: Add group to template
-			_, err = client.Permissions.AddGroupToTemplate(&sonar.PermissionsAddGroupToTemplateOptions{
+			_, err = client.Permissions.AddGroupToTemplate(context.Background(), &sonar.PermissionsAddGroupToTemplateOptions{
 				GroupName:    groupName,
 				Permission:   "codeviewer",
 				TemplateName: templateName,
@@ -1869,14 +1870,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 4: Add project creator to template
-			_, err = client.Permissions.AddProjectCreatorToTemplate(&sonar.PermissionsAddProjectCreatorToTemplateOptions{
+			_, err = client.Permissions.AddProjectCreatorToTemplate(context.Background(), &sonar.PermissionsAddProjectCreatorToTemplateOptions{
 				Permission:   "admin",
 				TemplateName: templateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: Create private project (codeviewer permission only works on private projects)
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Template Lifecycle Project",
 				Project:    projectKey,
 				Visibility: sonar.ProjectVisibilityPrivate,
@@ -1884,14 +1885,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 6: Apply template to project
-			_, err = client.Permissions.ApplyTemplate(&sonar.PermissionsApplyTemplateOptions{
+			_, err = client.Permissions.ApplyTemplate(context.Background(), &sonar.PermissionsApplyTemplateOptions{
 				ProjectKey:   projectKey,
 				TemplateName: templateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 7: Verify group has permission on project
-			result, _, err := client.Permissions.Groups(&sonar.PermissionsGroupsOptions{
+			result, _, err := client.Permissions.Groups(context.Background(), &sonar.PermissionsGroupsOptions{
 				ProjectKey: projectKey,
 				Permission: "codeviewer",
 			})
@@ -1906,14 +1907,14 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			Expect(found).To(BeTrue())
 
 			// Cleanup
-			_, _ = client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, _ = client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _ = client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+			_, _ = client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 				Name: groupName,
 			})
-			_, _ = client.Permissions.DeleteTemplate(&sonar.PermissionsDeleteTemplateOptions{
+			_, _ = client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
 				TemplateName: templateName,
 			})
 		})

--- a/integration_testing/plugins_test.go
+++ b/integration_testing/plugins_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,7 +27,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 	Describe("Available", func() {
 		Context("Functional Tests", func() {
 			It("should list available plugins", func() {
-				result, resp, err := client.Plugins.Available()
+				result, resp, err := client.Plugins.Available(context.Background(), )
 				// Skip if API not available or requires marketplace configuration
 				if resp != nil && (resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest) {
 					Skip("Plugins Available API is not available in this SonarQube version")
@@ -44,7 +45,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 	Describe("CancelAll", func() {
 		Context("Functional Tests", func() {
 			It("should cancel all pending plugin operations", func() {
-				resp, err := client.Plugins.CancelAll()
+				resp, err := client.Plugins.CancelAll(context.Background(), )
 				// Skip if API not available
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("Plugins CancelAll API is not available in this SonarQube version")
@@ -61,7 +62,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 	Describe("Download", func() {
 		Context("Functional Tests", func() {
 			It("should attempt to download a plugin", func() {
-				_, resp, err := client.Plugins.Download(&sonar.PluginsDownloadOptions{
+				_, resp, err := client.Plugins.Download(context.Background(), &sonar.PluginsDownloadOptions{
 					Plugin: "java",
 				})
 				// Skip if API not available - this is internal API
@@ -76,14 +77,14 @@ var _ = Describe("Plugins Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing plugin key", func() {
-				result, resp, err := client.Plugins.Download(&sonar.PluginsDownloadOptions{})
+				result, resp, err := client.Plugins.Download(context.Background(), &sonar.PluginsDownloadOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with nil options", func() {
-				result, resp, err := client.Plugins.Download(nil)
+				result, resp, err := client.Plugins.Download(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -97,19 +98,19 @@ var _ = Describe("Plugins Service", Ordered, func() {
 	Describe("Install", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing key", func() {
-				resp, err := client.Plugins.Install(&sonar.PluginsInstallOptions{})
+				resp, err := client.Plugins.Install(context.Background(), &sonar.PluginsInstallOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with nil options", func() {
-				resp, err := client.Plugins.Install(nil)
+				resp, err := client.Plugins.Install(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with non-existent plugin key", func() {
-				resp, err := client.Plugins.Install(&sonar.PluginsInstallOptions{
+				resp, err := client.Plugins.Install(context.Background(), &sonar.PluginsInstallOptions{
 					Key: "non-existent-plugin-12345",
 				})
 				// Skip if API not available
@@ -130,7 +131,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 	Describe("Installed", func() {
 		Context("Functional Tests", func() {
 			It("should list installed plugins with no options", func() {
-				result, resp, err := client.Plugins.Installed(nil)
+				result, resp, err := client.Plugins.Installed(context.Background(), nil)
 				// Skip if API not available
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("Plugins Installed API is not available in this SonarQube version")
@@ -142,7 +143,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 			})
 
 			It("should list installed plugins with category field", func() {
-				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOptions{
+				result, resp, err := client.Plugins.Installed(context.Background(), &sonar.PluginsInstalledOptions{
 					Fields: []string{"category"},
 				})
 				// Skip if API not available
@@ -155,7 +156,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 			})
 
 			It("should list bundled plugins only", func() {
-				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOptions{
+				result, resp, err := client.Plugins.Installed(context.Background(), &sonar.PluginsInstalledOptions{
 					Type: "BUNDLED",
 				})
 				// Skip if API not available
@@ -168,7 +169,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 			})
 
 			It("should list external plugins only", func() {
-				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOptions{
+				result, resp, err := client.Plugins.Installed(context.Background(), &sonar.PluginsInstalledOptions{
 					Type: "EXTERNAL",
 				})
 				// Skip if API not available
@@ -183,7 +184,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with invalid type", func() {
-				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOptions{
+				result, resp, err := client.Plugins.Installed(context.Background(), &sonar.PluginsInstalledOptions{
 					Type: "INVALID",
 				})
 				Expect(err).To(HaveOccurred())
@@ -192,7 +193,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 			})
 
 			It("should fail with invalid field", func() {
-				result, resp, err := client.Plugins.Installed(&sonar.PluginsInstalledOptions{
+				result, resp, err := client.Plugins.Installed(context.Background(), &sonar.PluginsInstalledOptions{
 					Fields: []string{"invalid_field"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -208,7 +209,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 	Describe("Pending", func() {
 		Context("Functional Tests", func() {
 			It("should list pending plugin operations", func() {
-				result, resp, err := client.Plugins.Pending()
+				result, resp, err := client.Plugins.Pending(context.Background(), )
 				// Skip if API not available
 				if resp != nil && resp.StatusCode == http.StatusNotFound {
 					Skip("Plugins Pending API is not available in this SonarQube version")
@@ -226,19 +227,19 @@ var _ = Describe("Plugins Service", Ordered, func() {
 	Describe("Uninstall", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing key", func() {
-				resp, err := client.Plugins.Uninstall(&sonar.PluginsUninstallOptions{})
+				resp, err := client.Plugins.Uninstall(context.Background(), &sonar.PluginsUninstallOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with nil options", func() {
-				resp, err := client.Plugins.Uninstall(nil)
+				resp, err := client.Plugins.Uninstall(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with non-existent plugin key", func() {
-				resp, err := client.Plugins.Uninstall(&sonar.PluginsUninstallOptions{
+				resp, err := client.Plugins.Uninstall(context.Background(), &sonar.PluginsUninstallOptions{
 					Key: "non-existent-plugin-12345",
 				})
 				// Skip if API not available
@@ -259,19 +260,19 @@ var _ = Describe("Plugins Service", Ordered, func() {
 	Describe("Update", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing key", func() {
-				resp, err := client.Plugins.Update(&sonar.PluginsUpdateOptions{})
+				resp, err := client.Plugins.Update(context.Background(), &sonar.PluginsUpdateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with nil options", func() {
-				resp, err := client.Plugins.Update(nil)
+				resp, err := client.Plugins.Update(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with non-existent plugin key", func() {
-				resp, err := client.Plugins.Update(&sonar.PluginsUpdateOptions{
+				resp, err := client.Plugins.Update(context.Background(), &sonar.PluginsUpdateOptions{
 					Key: "non-existent-plugin-12345",
 				})
 				// Skip if API not available
@@ -292,7 +293,7 @@ var _ = Describe("Plugins Service", Ordered, func() {
 	Describe("Updates", func() {
 		Context("Functional Tests", func() {
 			It("should list plugins with available updates", func() {
-				result, resp, err := client.Plugins.Updates()
+				result, resp, err := client.Plugins.Updates(context.Background(), )
 				// Skip if API not available or requires marketplace configuration
 				if resp != nil && (resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest) {
 					Skip("Plugins Updates API is not available in this SonarQube version")

--- a/integration_testing/project_analyses_test.go
+++ b/integration_testing/project_analyses_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -27,13 +28,13 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 
 		// Create a test project for project analyses operations
 		projectKey := helpers.UniqueResourceName("proj-analyses")
-		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		testProject, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    projectKey,
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		cleanupManager.RegisterCleanup("project", testProject.Project.Key, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: testProject.Project.Key,
 			})
 			return err
@@ -53,7 +54,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 	Describe("Search", func() {
 		Context("Functional Tests", func() {
 			It("should search project analyses", func() {
-				result, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{
+				result, resp, err := client.ProjectAnalyses.Search(context.Background(), &sonar.ProjectAnalysesSearchOptions{
 					Project: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -63,7 +64,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should search project analyses with pagination", func() {
-				result, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{
+				result, resp, err := client.ProjectAnalyses.Search(context.Background(), &sonar.ProjectAnalysesSearchOptions{
 					Project: testProject.Project.Key,
 					PaginationArgs: sonar.PaginationArgs{
 						Page:     1,
@@ -76,7 +77,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should search project analyses with category filter", func() {
-				result, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{
+				result, resp, err := client.ProjectAnalyses.Search(context.Background(), &sonar.ProjectAnalysesSearchOptions{
 					Project:  testProject.Project.Key,
 					Category: "VERSION",
 				})
@@ -86,7 +87,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should search project analyses with date range", func() {
-				result, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{
+				result, resp, err := client.ProjectAnalyses.Search(context.Background(), &sonar.ProjectAnalysesSearchOptions{
 					Project: testProject.Project.Key,
 					From:    "2020-01-01",
 					To:      "2030-12-31",
@@ -99,17 +100,17 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing project", func() {
-				_, _, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{})
+				_, _, err := client.ProjectAnalyses.Search(context.Background(), &sonar.ProjectAnalysesSearchOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, _, err := client.ProjectAnalyses.Search(nil)
+				_, _, err := client.ProjectAnalyses.Search(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with invalid category", func() {
-				_, _, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{
+				_, _, err := client.ProjectAnalyses.Search(context.Background(), &sonar.ProjectAnalysesSearchOptions{
 					Project:  testProject.Project.Key,
 					Category: "INVALID_CATEGORY",
 				})
@@ -117,7 +118,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should fail with invalid date format", func() {
-				_, _, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{
+				_, _, err := client.ProjectAnalyses.Search(context.Background(), &sonar.ProjectAnalysesSearchOptions{
 					Project: testProject.Project.Key,
 					From:    "invalid-date",
 				})
@@ -125,7 +126,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent project", func() {
-				_, resp, err := client.ProjectAnalyses.Search(&sonar.ProjectAnalysesSearchOptions{
+				_, resp, err := client.ProjectAnalyses.Search(context.Background(), &sonar.ProjectAnalysesSearchOptions{
 					Project: "non-existent-project-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -141,7 +142,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 	Describe("SearchAll", func() {
 		Context("Functional Tests", func() {
 			It("should search all project analyses", func() {
-				result, resp, err := client.ProjectAnalyses.SearchAll(&sonar.ProjectAnalysesSearchOptions{
+				result, resp, err := client.ProjectAnalyses.SearchAll(context.Background(), &sonar.ProjectAnalysesSearchOptions{
 					Project: testProject.Project.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -153,12 +154,12 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 
 		Context("Parameter Validation", func() {
 			It("should fail with missing project", func() {
-				_, _, err := client.ProjectAnalyses.SearchAll(&sonar.ProjectAnalysesSearchOptions{})
+				_, _, err := client.ProjectAnalyses.SearchAll(context.Background(), &sonar.ProjectAnalysesSearchOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, _, err := client.ProjectAnalyses.SearchAll(nil)
+				_, _, err := client.ProjectAnalyses.SearchAll(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -170,26 +171,26 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 	Describe("CreateEvent", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing analysis", func() {
-				_, _, err := client.ProjectAnalyses.CreateEvent(&sonar.ProjectAnalysesCreateEventOptions{
+				_, _, err := client.ProjectAnalyses.CreateEvent(context.Background(), &sonar.ProjectAnalysesCreateEventOptions{
 					Name: "test-event",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing name", func() {
-				_, _, err := client.ProjectAnalyses.CreateEvent(&sonar.ProjectAnalysesCreateEventOptions{
+				_, _, err := client.ProjectAnalyses.CreateEvent(context.Background(), &sonar.ProjectAnalysesCreateEventOptions{
 					Analysis: "some-analysis-key",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, _, err := client.ProjectAnalyses.CreateEvent(nil)
+				_, _, err := client.ProjectAnalyses.CreateEvent(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with invalid category", func() {
-				_, _, err := client.ProjectAnalyses.CreateEvent(&sonar.ProjectAnalysesCreateEventOptions{
+				_, _, err := client.ProjectAnalyses.CreateEvent(context.Background(), &sonar.ProjectAnalysesCreateEventOptions{
 					Analysis: "some-analysis-key",
 					Name:     "test-event",
 					Category: "INVALID_CATEGORY",
@@ -198,7 +199,7 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 			})
 
 			It("should fail with non-existent analysis", func() {
-				_, resp, err := client.ProjectAnalyses.CreateEvent(&sonar.ProjectAnalysesCreateEventOptions{
+				_, resp, err := client.ProjectAnalyses.CreateEvent(context.Background(), &sonar.ProjectAnalysesCreateEventOptions{
 					Analysis: "non-existent-analysis-12345",
 					Name:     "test-event",
 					Category: "VERSION",
@@ -216,26 +217,26 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 	Describe("UpdateEvent", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing event", func() {
-				_, _, err := client.ProjectAnalyses.UpdateEvent(&sonar.ProjectAnalysesUpdateEventOptions{
+				_, _, err := client.ProjectAnalyses.UpdateEvent(context.Background(), &sonar.ProjectAnalysesUpdateEventOptions{
 					Name: "updated-name",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing name", func() {
-				_, _, err := client.ProjectAnalyses.UpdateEvent(&sonar.ProjectAnalysesUpdateEventOptions{
+				_, _, err := client.ProjectAnalyses.UpdateEvent(context.Background(), &sonar.ProjectAnalysesUpdateEventOptions{
 					Event: "some-event-key",
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, _, err := client.ProjectAnalyses.UpdateEvent(nil)
+				_, _, err := client.ProjectAnalyses.UpdateEvent(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with non-existent event", func() {
-				_, resp, err := client.ProjectAnalyses.UpdateEvent(&sonar.ProjectAnalysesUpdateEventOptions{
+				_, resp, err := client.ProjectAnalyses.UpdateEvent(context.Background(), &sonar.ProjectAnalysesUpdateEventOptions{
 					Event: "non-existent-event-12345",
 					Name:  "updated-name",
 				})
@@ -252,17 +253,17 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 	Describe("DeleteEvent", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing event", func() {
-				_, err := client.ProjectAnalyses.DeleteEvent(&sonar.ProjectAnalysesDeleteEventOptions{})
+				_, err := client.ProjectAnalyses.DeleteEvent(context.Background(), &sonar.ProjectAnalysesDeleteEventOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, err := client.ProjectAnalyses.DeleteEvent(nil)
+				_, err := client.ProjectAnalyses.DeleteEvent(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with non-existent event", func() {
-				resp, err := client.ProjectAnalyses.DeleteEvent(&sonar.ProjectAnalysesDeleteEventOptions{
+				resp, err := client.ProjectAnalyses.DeleteEvent(context.Background(), &sonar.ProjectAnalysesDeleteEventOptions{
 					Event: "non-existent-event-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -278,17 +279,17 @@ var _ = Describe("ProjectAnalyses Service", Ordered, func() {
 	Describe("Delete", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with missing analysis", func() {
-				_, err := client.ProjectAnalyses.Delete(&sonar.ProjectAnalysesDeleteOptions{})
+				_, err := client.ProjectAnalyses.Delete(context.Background(), &sonar.ProjectAnalysesDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, err := client.ProjectAnalyses.Delete(nil)
+				_, err := client.ProjectAnalyses.Delete(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with non-existent analysis", func() {
-				resp, err := client.ProjectAnalyses.Delete(&sonar.ProjectAnalysesDeleteOptions{
+				resp, err := client.ProjectAnalyses.Delete(context.Background(), &sonar.ProjectAnalysesDeleteOptions{
 					Analysis: "non-existent-analysis-12345",
 				})
 				Expect(err).To(HaveOccurred())

--- a/integration_testing/project_badges_test.go
+++ b/integration_testing/project_badges_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -27,14 +28,14 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		// Create a test project for badge operations
 		projectKey = helpers.UniqueResourceName("badge")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    "ProjectBadges Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -54,7 +55,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 	Describe("Token", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.ProjectBadges.Token(nil)
+				result, resp, err := client.ProjectBadges.Token(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -62,7 +63,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should fail without required project", func() {
-				result, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOptions{})
+				result, resp, err := client.ProjectBadges.Token(context.Background(), &sonar.ProjectBadgesTokenOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Project"))
 				Expect(result).To(BeNil())
@@ -72,7 +73,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should get token for a project", func() {
-				result, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOptions{
+				result, resp, err := client.ProjectBadges.Token(context.Background(), &sonar.ProjectBadgesTokenOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -84,7 +85,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOptions{
+				result, resp, err := client.ProjectBadges.Token(context.Background(), &sonar.ProjectBadgesTokenOptions{
 					Project: "non-existent-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -102,14 +103,14 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 	Describe("RenewToken", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.ProjectBadges.RenewToken(nil)
+				resp, err := client.ProjectBadges.RenewToken(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required project", func() {
-				resp, err := client.ProjectBadges.RenewToken(&sonar.ProjectBadgesRenewTokenOptions{})
+				resp, err := client.ProjectBadges.RenewToken(context.Background(), &sonar.ProjectBadgesRenewTokenOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Project"))
 				Expect(resp).To(BeNil())
@@ -119,20 +120,20 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 		Context("Valid Requests", func() {
 			It("should renew token for a project", func() {
 				// Get current token
-				tokenBefore, _, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOptions{
+				tokenBefore, _, err := client.ProjectBadges.Token(context.Background(), &sonar.ProjectBadgesTokenOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Renew token
-				resp, err := client.ProjectBadges.RenewToken(&sonar.ProjectBadgesRenewTokenOptions{
+				resp, err := client.ProjectBadges.RenewToken(context.Background(), &sonar.ProjectBadgesRenewTokenOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Get new token
-				tokenAfter, _, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOptions{
+				tokenAfter, _, err := client.ProjectBadges.Token(context.Background(), &sonar.ProjectBadgesTokenOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -142,7 +143,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should fail for non-existent project", func() {
-				resp, err := client.ProjectBadges.RenewToken(&sonar.ProjectBadgesRenewTokenOptions{
+				resp, err := client.ProjectBadges.RenewToken(context.Background(), &sonar.ProjectBadgesRenewTokenOptions{
 					Project: "non-existent-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -159,7 +160,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 	Describe("Measure", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.ProjectBadges.Measure(nil)
+				result, resp, err := client.ProjectBadges.Measure(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -167,7 +168,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should fail without required project", func() {
-				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
+				result, resp, err := client.ProjectBadges.Measure(context.Background(), &sonar.ProjectBadgesMeasureOptions{
 					Metric: "coverage",
 				})
 				Expect(err).To(HaveOccurred())
@@ -177,7 +178,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should fail without required metric", func() {
-				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
+				result, resp, err := client.ProjectBadges.Measure(context.Background(), &sonar.ProjectBadgesMeasureOptions{
 					Project: projectKey,
 				})
 				Expect(err).To(HaveOccurred())
@@ -187,7 +188,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should fail with invalid metric", func() {
-				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
+				result, resp, err := client.ProjectBadges.Measure(context.Background(), &sonar.ProjectBadgesMeasureOptions{
 					Project: projectKey,
 					Metric:  "invalid_metric",
 				})
@@ -200,7 +201,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should get coverage badge", func() {
-				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
+				result, resp, err := client.ProjectBadges.Measure(context.Background(), &sonar.ProjectBadgesMeasureOptions{
 					Project: projectKey,
 					Metric:  "coverage",
 				})
@@ -212,7 +213,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should get ncloc badge", func() {
-				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
+				result, resp, err := client.ProjectBadges.Measure(context.Background(), &sonar.ProjectBadgesMeasureOptions{
 					Project: projectKey,
 					Metric:  "ncloc",
 				})
@@ -222,7 +223,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should get alert_status badge", func() {
-				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
+				result, resp, err := client.ProjectBadges.Measure(context.Background(), &sonar.ProjectBadgesMeasureOptions{
 					Project: projectKey,
 					Metric:  "alert_status",
 				})
@@ -234,7 +235,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should return an error badge for non-existent project", func() {
-				result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
+				result, resp, err := client.ProjectBadges.Measure(context.Background(), &sonar.ProjectBadgesMeasureOptions{
 					Project: "non-existent-project",
 					Metric:  "coverage",
 				})
@@ -257,7 +258,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 	Describe("QualityGate", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.ProjectBadges.QualityGate(nil)
+				result, resp, err := client.ProjectBadges.QualityGate(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -265,7 +266,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			})
 
 			It("should fail without required project", func() {
-				result, resp, err := client.ProjectBadges.QualityGate(&sonar.ProjectBadgesQualityGateOptions{})
+				result, resp, err := client.ProjectBadges.QualityGate(context.Background(), &sonar.ProjectBadgesQualityGateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Project"))
 				Expect(result).To(BeNil())
@@ -275,7 +276,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should get quality gate badge", func() {
-				result, resp, err := client.ProjectBadges.QualityGate(&sonar.ProjectBadgesQualityGateOptions{
+				result, resp, err := client.ProjectBadges.QualityGate(context.Background(), &sonar.ProjectBadgesQualityGateOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -288,7 +289,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 
 		Context("Non-Existent Project", func() {
 			It("should return an error badge for non-existent project", func() {
-				result, resp, err := client.ProjectBadges.QualityGate(&sonar.ProjectBadgesQualityGateOptions{
+				result, resp, err := client.ProjectBadges.QualityGate(context.Background(), &sonar.ProjectBadgesQualityGateOptions{
 					Project: "non-existent-project",
 				})
 				// Badge API may return 200 with an error badge instead of an error
@@ -310,7 +311,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 	Describe("Full Workflow", func() {
 		It("should get token, renew it, and use it for badge access", func() {
 			// Get token
-			tokenResult, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOptions{
+			tokenResult, resp, err := client.ProjectBadges.Token(context.Background(), &sonar.ProjectBadgesTokenOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -318,7 +319,7 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			Expect(tokenResult.Token).NotTo(BeEmpty())
 
 			// Use token to get badge
-			result, resp, err := client.ProjectBadges.Measure(&sonar.ProjectBadgesMeasureOptions{
+			result, resp, err := client.ProjectBadges.Measure(context.Background(), &sonar.ProjectBadgesMeasureOptions{
 				Project: projectKey,
 				Metric:  "coverage",
 				Token:   tokenResult.Token,
@@ -328,14 +329,14 @@ var _ = Describe("ProjectBadges Service", Ordered, func() {
 			Expect(result).NotTo(BeNil())
 
 			// Renew token
-			resp, err = client.ProjectBadges.RenewToken(&sonar.ProjectBadgesRenewTokenOptions{
+			resp, err = client.ProjectBadges.RenewToken(context.Background(), &sonar.ProjectBadgesRenewTokenOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Get new token
-			newTokenResult, resp, err := client.ProjectBadges.Token(&sonar.ProjectBadgesTokenOptions{
+			newTokenResult, resp, err := client.ProjectBadges.Token(context.Background(), &sonar.ProjectBadgesTokenOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/project_branches_test.go
+++ b/integration_testing/project_branches_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -41,14 +42,14 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 		BeforeEach(func() {
 			testProjectKey = helpers.UniqueResourceName("proj-branch")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Branch Test Project",
 				Project: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -56,7 +57,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 		})
 
 		It("should list branches of a project", func() {
-			result, resp, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOptions{
+			result, resp, err := client.ProjectBranches.List(context.Background(), &sonar.ProjectBranchesListOptions{
 				Project: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -80,13 +81,13 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.ProjectBranches.List(nil)
+				_, resp, err := client.ProjectBranches.List(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing project key", func() {
-				_, resp, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOptions{})
+				_, resp, err := client.ProjectBranches.List(context.Background(), &sonar.ProjectBranchesListOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -94,7 +95,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				_, resp, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOptions{
+				_, resp, err := client.ProjectBranches.List(context.Background(), &sonar.ProjectBranchesListOptions{
 					Project: "non-existent-project-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -113,7 +114,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 		BeforeEach(func() {
 			testProjectKey = helpers.UniqueResourceName("proj-rename")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Rename Branch Test Project",
 				Project:    testProjectKey,
 				MainBranch: "main",
@@ -121,7 +122,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -129,7 +130,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 		})
 
 		It("should rename the main branch", func() {
-			resp, err := client.ProjectBranches.Rename(&sonar.ProjectBranchesRenameOptions{
+			resp, err := client.ProjectBranches.Rename(context.Background(), &sonar.ProjectBranchesRenameOptions{
 				Project: testProjectKey,
 				Name:    "master",
 			})
@@ -137,7 +138,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify the branch was renamed
-			result, _, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOptions{
+			result, _, err := client.ProjectBranches.List(context.Background(), &sonar.ProjectBranchesListOptions{
 				Project: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -155,13 +156,13 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.ProjectBranches.Rename(nil)
+				resp, err := client.ProjectBranches.Rename(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.ProjectBranches.Rename(&sonar.ProjectBranchesRenameOptions{
+				resp, err := client.ProjectBranches.Rename(context.Background(), &sonar.ProjectBranchesRenameOptions{
 					Name: "new-main",
 				})
 				Expect(err).To(HaveOccurred())
@@ -169,7 +170,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 
 			It("should fail with missing name", func() {
-				resp, err := client.ProjectBranches.Rename(&sonar.ProjectBranchesRenameOptions{
+				resp, err := client.ProjectBranches.Rename(context.Background(), &sonar.ProjectBranchesRenameOptions{
 					Project: helpers.UniqueResourceName("proj"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -184,13 +185,13 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 	Describe("Delete", func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.ProjectBranches.Delete(nil)
+				resp, err := client.ProjectBranches.Delete(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOptions{
+				resp, err := client.ProjectBranches.Delete(context.Background(), &sonar.ProjectBranchesDeleteOptions{
 					Branch: "feature-branch",
 				})
 				Expect(err).To(HaveOccurred())
@@ -198,7 +199,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 
 			It("should fail with missing branch name", func() {
-				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOptions{
+				resp, err := client.ProjectBranches.Delete(context.Background(), &sonar.ProjectBranchesDeleteOptions{
 					Project: helpers.UniqueResourceName("proj"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -208,7 +209,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOptions{
+				resp, err := client.ProjectBranches.Delete(context.Background(), &sonar.ProjectBranchesDeleteOptions{
 					Project: "non-existent-project-12345",
 					Branch:  "feature-branch",
 				})
@@ -220,7 +221,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			It("should fail when trying to delete main branch", func() {
 				projectKey := helpers.UniqueResourceName("proj-del-main")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:       "Delete Main Branch Test",
 					Project:    projectKey,
 					MainBranch: "main",
@@ -228,13 +229,13 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
-				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOptions{
+				resp, err := client.ProjectBranches.Delete(context.Background(), &sonar.ProjectBranchesDeleteOptions{
 					Project: projectKey,
 					Branch:  "main",
 				})
@@ -246,20 +247,20 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			It("should fail for non-existent branch", func() {
 				projectKey := helpers.UniqueResourceName("proj-del-noexist")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    "Delete Non-existent Branch Test",
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
-				resp, err := client.ProjectBranches.Delete(&sonar.ProjectBranchesDeleteOptions{
+				resp, err := client.ProjectBranches.Delete(context.Background(), &sonar.ProjectBranchesDeleteOptions{
 					Project: projectKey,
 					Branch:  "non-existent-branch",
 				})
@@ -279,7 +280,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 		BeforeEach(func() {
 			testProjectKey = helpers.UniqueResourceName("proj-protect")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Protection Test Project",
 				Project:    testProjectKey,
 				MainBranch: "main",
@@ -287,7 +288,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -296,7 +297,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 
 		It("should set automatic deletion protection on main branch", func() {
 			// Main branch should already be protected, but we can still call the API
-			resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(&sonar.ProjectBranchesSetAutomaticDeletionProtectionOptions{
+			resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(context.Background(), &sonar.ProjectBranchesSetAutomaticDeletionProtectionOptions{
 				Project: testProjectKey,
 				Branch:  "main",
 				Value:   true,
@@ -305,7 +306,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify protection is set
-			result, _, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOptions{
+			result, _, err := client.ProjectBranches.List(context.Background(), &sonar.ProjectBranchesListOptions{
 				Project: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -323,13 +324,13 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(nil)
+				resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(&sonar.ProjectBranchesSetAutomaticDeletionProtectionOptions{
+				resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(context.Background(), &sonar.ProjectBranchesSetAutomaticDeletionProtectionOptions{
 					Branch: "main",
 					Value:  true,
 				})
@@ -338,7 +339,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 
 			It("should fail with missing branch name", func() {
-				resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(&sonar.ProjectBranchesSetAutomaticDeletionProtectionOptions{
+				resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(context.Background(), &sonar.ProjectBranchesSetAutomaticDeletionProtectionOptions{
 					Project: helpers.UniqueResourceName("proj"),
 					Value:   true,
 				})
@@ -349,7 +350,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(&sonar.ProjectBranchesSetAutomaticDeletionProtectionOptions{
+				resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(context.Background(), &sonar.ProjectBranchesSetAutomaticDeletionProtectionOptions{
 					Project: "non-existent-project-12345",
 					Branch:  "main",
 					Value:   true,
@@ -367,13 +368,13 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 	Describe("SetMain", func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.ProjectBranches.SetMain(nil)
+				resp, err := client.ProjectBranches.SetMain(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.ProjectBranches.SetMain(&sonar.ProjectBranchesSetMainOptions{
+				resp, err := client.ProjectBranches.SetMain(context.Background(), &sonar.ProjectBranchesSetMainOptions{
 					Branch: "new-main",
 				})
 				Expect(err).To(HaveOccurred())
@@ -381,7 +382,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			})
 
 			It("should fail with missing branch name", func() {
-				resp, err := client.ProjectBranches.SetMain(&sonar.ProjectBranchesSetMainOptions{
+				resp, err := client.ProjectBranches.SetMain(context.Background(), &sonar.ProjectBranchesSetMainOptions{
 					Project: helpers.UniqueResourceName("proj"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -391,7 +392,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				resp, err := client.ProjectBranches.SetMain(&sonar.ProjectBranchesSetMainOptions{
+				resp, err := client.ProjectBranches.SetMain(context.Background(), &sonar.ProjectBranchesSetMainOptions{
 					Project: "non-existent-project-12345",
 					Branch:  "develop",
 				})
@@ -403,20 +404,20 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			It("should fail for non-existent branch", func() {
 				projectKey := helpers.UniqueResourceName("proj-setmain")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    "Set Main Test Project",
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
-				resp, err := client.ProjectBranches.SetMain(&sonar.ProjectBranchesSetMainOptions{
+				resp, err := client.ProjectBranches.SetMain(context.Background(), &sonar.ProjectBranchesSetMainOptions{
 					Project: projectKey,
 					Branch:  "non-existent-branch",
 				})
@@ -435,7 +436,7 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			projectKey := helpers.UniqueResourceName("proj-lifecycle")
 
 			// Step 1: Create project with specific main branch name
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Lifecycle Test Project",
 				Project:    projectKey,
 				MainBranch: "main",
@@ -443,14 +444,14 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// Step 2: List branches
-			result, _, err := client.ProjectBranches.List(&sonar.ProjectBranchesListOptions{
+			result, _, err := client.ProjectBranches.List(context.Background(), &sonar.ProjectBranchesListOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -467,14 +468,14 @@ var _ = Describe("ProjectBranches Service", Ordered, func() {
 			Expect(mainBranch.Name).To(Equal("main"))
 
 			// Step 3: Rename main branch
-			_, err = client.ProjectBranches.Rename(&sonar.ProjectBranchesRenameOptions{
+			_, err = client.ProjectBranches.Rename(context.Background(), &sonar.ProjectBranchesRenameOptions{
 				Project: projectKey,
 				Name:    "master",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 4: Verify rename
-			result, _, err = client.ProjectBranches.List(&sonar.ProjectBranchesListOptions{
+			result, _, err = client.ProjectBranches.List(context.Background(), &sonar.ProjectBranchesListOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/project_dump_test.go
+++ b/integration_testing/project_dump_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -34,7 +35,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 	Describe("Export", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.ProjectDump.Export(nil)
+				result, resp, err := client.ProjectDump.Export(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
@@ -42,7 +43,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 			})
 
 			It("should fail without required key", func() {
-				result, resp, err := client.ProjectDump.Export(&sonar.ProjectDumpExportOptions{})
+				result, resp, err := client.ProjectDump.Export(context.Background(), &sonar.ProjectDumpExportOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(resp).To(BeNil())
@@ -52,7 +53,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 
 		Context("Functional Tests", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.ProjectDump.Export(&sonar.ProjectDumpExportOptions{
+				result, resp, err := client.ProjectDump.Export(context.Background(), &sonar.ProjectDumpExportOptions{
 					Key: "non-existent-project-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -64,7 +65,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 			It("should successfully trigger export for existing project", func() {
 				// Create a project for testing
 				projectKey := helpers.UniqueResourceName("dump-export")
-				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, resp, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    projectKey,
 					Project: projectKey,
 				})
@@ -72,12 +73,12 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{Project: projectKey})
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{Project: projectKey})
 					return err
 				})
 
 				// Trigger export
-				result, resp, err := client.ProjectDump.Export(&sonar.ProjectDumpExportOptions{
+				result, resp, err := client.ProjectDump.Export(context.Background(), &sonar.ProjectDumpExportOptions{
 					Key: projectKey,
 				})
 
@@ -101,7 +102,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 	Describe("Status", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.ProjectDump.Status(nil)
+				result, resp, err := client.ProjectDump.Status(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
@@ -109,7 +110,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 			})
 
 			It("should fail without id or key", func() {
-				result, resp, err := client.ProjectDump.Status(&sonar.ProjectDumpStatusOptions{})
+				result, resp, err := client.ProjectDump.Status(context.Background(), &sonar.ProjectDumpStatusOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("ID or Key"))
 				Expect(resp).To(BeNil())
@@ -119,7 +120,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 
 		Context("Functional Tests", func() {
 			It("should fail for non-existent project by key", func() {
-				result, resp, err := client.ProjectDump.Status(&sonar.ProjectDumpStatusOptions{
+				result, resp, err := client.ProjectDump.Status(context.Background(), &sonar.ProjectDumpStatusOptions{
 					Key: "non-existent-project-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -131,7 +132,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 			It("should get status for existing project by key", func() {
 				// Create a project for testing
 				projectKey := helpers.UniqueResourceName("dump-status")
-				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, resp, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    projectKey,
 					Project: projectKey,
 				})
@@ -139,12 +140,12 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{Project: projectKey})
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{Project: projectKey})
 					return err
 				})
 
 				// Get status
-				result, resp, err := client.ProjectDump.Status(&sonar.ProjectDumpStatusOptions{
+				result, resp, err := client.ProjectDump.Status(context.Background(), &sonar.ProjectDumpStatusOptions{
 					Key: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -163,7 +164,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 			It("should handle project dump status workflow", func() {
 				// Create a project
 				projectKey := helpers.UniqueResourceName("dump-workflow")
-				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, resp, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    projectKey,
 					Project: projectKey,
 				})
@@ -171,12 +172,12 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{Project: projectKey})
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{Project: projectKey})
 					return err
 				})
 
 				// Check initial status
-				status, resp, err := client.ProjectDump.Status(&sonar.ProjectDumpStatusOptions{
+				status, resp, err := client.ProjectDump.Status(context.Background(), &sonar.ProjectDumpStatusOptions{
 					Key: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -185,7 +186,7 @@ var _ = Describe("ProjectDump Service", Ordered, func() {
 
 				// If export is available, try to trigger it
 				if status.CanBeExported {
-					result, resp, err := client.ProjectDump.Export(&sonar.ProjectDumpExportOptions{
+					result, resp, err := client.ProjectDump.Export(context.Background(), &sonar.ProjectDumpExportOptions{
 						Key: projectKey,
 					})
 					if err == nil {

--- a/integration_testing/project_links_test.go
+++ b/integration_testing/project_links_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -40,14 +41,14 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		BeforeEach(func() {
 			testProjectKey = helpers.UniqueResourceName("proj-link")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Link Test Project",
 				Project: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -55,7 +56,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		})
 
 		It("should create a project link", func() {
-			result, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
+			result, resp, err := client.ProjectLinks.Create(context.Background(), &sonar.ProjectLinksCreateOptions{
 				ProjectKey: testProjectKey,
 				Name:       "Homepage",
 				URL:        "https://example.com",
@@ -69,7 +70,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 			linkID := result.Link.ID
 			cleanup.RegisterCleanup("project-link", linkID, func() error {
-				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
+				_, err := client.ProjectLinks.Delete(context.Background(), &sonar.ProjectLinksDeleteOptions{
 					ID: linkID,
 				})
 				return err
@@ -77,7 +78,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		})
 
 		It("should create multiple links for same project", func() {
-			result1, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
+			result1, _, err := client.ProjectLinks.Create(context.Background(), &sonar.ProjectLinksCreateOptions{
 				ProjectKey: testProjectKey,
 				Name:       "Homepage",
 				URL:        "https://example.com",
@@ -86,13 +87,13 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			Expect(result1.Link.ID).NotTo(BeEmpty())
 
 			cleanup.RegisterCleanup("project-link", result1.Link.ID, func() error {
-				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
+				_, err := client.ProjectLinks.Delete(context.Background(), &sonar.ProjectLinksDeleteOptions{
 					ID: result1.Link.ID,
 				})
 				return err
 			})
 
-			result2, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
+			result2, _, err := client.ProjectLinks.Create(context.Background(), &sonar.ProjectLinksCreateOptions{
 				ProjectKey: testProjectKey,
 				Name:       "CI",
 				URL:        "https://ci.example.com",
@@ -102,13 +103,13 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			Expect(result2.Link.ID).NotTo(Equal(result1.Link.ID))
 
 			cleanup.RegisterCleanup("project-link", result2.Link.ID, func() error {
-				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
+				_, err := client.ProjectLinks.Delete(context.Background(), &sonar.ProjectLinksDeleteOptions{
 					ID: result2.Link.ID,
 				})
 				return err
 			})
 
-			searchResult, _, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
+			searchResult, _, err := client.ProjectLinks.Search(context.Background(), &sonar.ProjectLinksSearchOptions{
 				ProjectKey: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -117,7 +118,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 		It("should create links with different types", func() {
 			// Create a generic custom link (won't match predefined type patterns)
-			customResult, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
+			customResult, _, err := client.ProjectLinks.Create(context.Background(), &sonar.ProjectLinksCreateOptions{
 				ProjectKey: testProjectKey,
 				Name:       "Documentation",
 				URL:        "https://docs.example.com",
@@ -127,7 +128,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			Expect(customResult.Link.Name).To(Equal("Documentation"))
 
 			cleanup.RegisterCleanup("project-link", customResult.Link.ID, func() error {
-				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
+				_, err := client.ProjectLinks.Delete(context.Background(), &sonar.ProjectLinksDeleteOptions{
 					ID: customResult.Link.ID,
 				})
 				return err
@@ -137,7 +138,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			// Types can be: homepage, issue, scm, ci, custom, etc.
 			// Note: Links with certain inferred types (homepage, issue, scm, ci) may be
 			// provided by SonarQube and cannot be deleted
-			searchResult, _, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
+			searchResult, _, err := client.ProjectLinks.Search(context.Background(), &sonar.ProjectLinksSearchOptions{
 				ProjectKey: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -155,13 +156,13 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.ProjectLinks.Create(nil)
+				_, resp, err := client.ProjectLinks.Create(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing name", func() {
-				_, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
+				_, resp, err := client.ProjectLinks.Create(context.Background(), &sonar.ProjectLinksCreateOptions{
 					ProjectKey: testProjectKey,
 					URL:        "https://example.com",
 				})
@@ -170,7 +171,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			})
 
 			It("should fail with missing URL", func() {
-				_, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
+				_, resp, err := client.ProjectLinks.Create(context.Background(), &sonar.ProjectLinksCreateOptions{
 					ProjectKey: testProjectKey,
 					Name:       "Homepage",
 				})
@@ -179,7 +180,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			})
 
 			It("should fail with missing project identifier", func() {
-				_, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
+				_, resp, err := client.ProjectLinks.Create(context.Background(), &sonar.ProjectLinksCreateOptions{
 					Name: "Homepage",
 					URL:  "https://example.com",
 				})
@@ -190,7 +191,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				_, resp, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
+				_, resp, err := client.ProjectLinks.Create(context.Background(), &sonar.ProjectLinksCreateOptions{
 					ProjectKey: "non-existent-project-12345",
 					Name:       "Homepage",
 					URL:        "https://example.com",
@@ -216,20 +217,20 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		BeforeEach(func() {
 			testProjectKey = helpers.UniqueResourceName("proj-search-link")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Search Link Test Project",
 				Project: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
 			})
 
-			result, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
+			result, _, err := client.ProjectLinks.Create(context.Background(), &sonar.ProjectLinksCreateOptions{
 				ProjectKey: testProjectKey,
 				Name:       "Test Link",
 				URL:        "https://test.example.com",
@@ -238,7 +239,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			testLinkID = result.Link.ID
 
 			cleanup.RegisterCleanup("project-link", testLinkID, func() error {
-				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
+				_, err := client.ProjectLinks.Delete(context.Background(), &sonar.ProjectLinksDeleteOptions{
 					ID: testLinkID,
 				})
 				return err
@@ -246,7 +247,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		})
 
 		It("should search links by project key", func() {
-			result, resp, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
+			result, resp, err := client.ProjectLinks.Search(context.Background(), &sonar.ProjectLinksSearchOptions{
 				ProjectKey: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -269,20 +270,20 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		It("should return empty list for project without links", func() {
 			newProjectKey := helpers.UniqueResourceName("proj-no-links")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "No Links Project",
 				Project: newProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", newProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: newProjectKey,
 				})
 				return err
 			})
 
-			result, resp, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
+			result, resp, err := client.ProjectLinks.Search(context.Background(), &sonar.ProjectLinksSearchOptions{
 				ProjectKey: newProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -293,13 +294,13 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.ProjectLinks.Search(nil)
+				_, resp, err := client.ProjectLinks.Search(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing project identifier", func() {
-				_, resp, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{})
+				_, resp, err := client.ProjectLinks.Search(context.Background(), &sonar.ProjectLinksSearchOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -307,7 +308,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				_, resp, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
+				_, resp, err := client.ProjectLinks.Search(context.Background(), &sonar.ProjectLinksSearchOptions{
 					ProjectKey: "non-existent-project-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -324,20 +325,20 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		It("should delete a project link", func() {
 			projectKey := helpers.UniqueResourceName("proj-del-link")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Delete Link Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			result, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
+			result, _, err := client.ProjectLinks.Create(context.Background(), &sonar.ProjectLinksCreateOptions{
 				ProjectKey: projectKey,
 				Name:       "To Delete",
 				URL:        "https://delete.example.com",
@@ -347,19 +348,19 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 			// Register cleanup in case deletion fails
 			cleanup.RegisterCleanup("project-link", linkID, func() error {
-				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
+				_, err := client.ProjectLinks.Delete(context.Background(), &sonar.ProjectLinksDeleteOptions{
 					ID: linkID,
 				})
 				return err
 			})
 
-			resp, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
+			resp, err := client.ProjectLinks.Delete(context.Background(), &sonar.ProjectLinksDeleteOptions{
 				ID: linkID,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
-			searchResult, _, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
+			searchResult, _, err := client.ProjectLinks.Search(context.Background(), &sonar.ProjectLinksSearchOptions{
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -370,13 +371,13 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.ProjectLinks.Delete(nil)
+				resp, err := client.ProjectLinks.Delete(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing ID", func() {
-				resp, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{})
+				resp, err := client.ProjectLinks.Delete(context.Background(), &sonar.ProjectLinksDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -384,7 +385,7 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent link", func() {
-				resp, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
+				resp, err := client.ProjectLinks.Delete(context.Background(), &sonar.ProjectLinksDeleteOptions{
 					ID: "99999999",
 				})
 				Expect(err).To(HaveOccurred())
@@ -401,20 +402,20 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 		It("should complete full link lifecycle", func() {
 			projectKey := helpers.UniqueResourceName("proj-link-lifecycle")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Link Lifecycle Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			createResult, _, err := client.ProjectLinks.Create(&sonar.ProjectLinksCreateOptions{
+			createResult, _, err := client.ProjectLinks.Create(context.Background(), &sonar.ProjectLinksCreateOptions{
 				ProjectKey: projectKey,
 				Name:       "Lifecycle Link",
 				URL:        "https://lifecycle.example.com",
@@ -425,13 +426,13 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 
 			// Register cleanup in case test fails before deletion
 			cleanup.RegisterCleanup("project-link", linkID, func() error {
-				_, err := client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
+				_, err := client.ProjectLinks.Delete(context.Background(), &sonar.ProjectLinksDeleteOptions{
 					ID: linkID,
 				})
 				return err
 			})
 
-			searchResult, _, err := client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
+			searchResult, _, err := client.ProjectLinks.Search(context.Background(), &sonar.ProjectLinksSearchOptions{
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -446,12 +447,12 @@ var _ = Describe("ProjectLinks Service", Ordered, func() {
 			}
 			Expect(found).To(BeTrue())
 
-			_, err = client.ProjectLinks.Delete(&sonar.ProjectLinksDeleteOptions{
+			_, err = client.ProjectLinks.Delete(context.Background(), &sonar.ProjectLinksDeleteOptions{
 				ID: linkID,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			searchResult, _, err = client.ProjectLinks.Search(&sonar.ProjectLinksSearchOptions{
+			searchResult, _, err = client.ProjectLinks.Search(context.Background(), &sonar.ProjectLinksSearchOptions{
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/project_tags_test.go
+++ b/integration_testing/project_tags_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -36,7 +37,7 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 	// =========================================================================
 	Describe("Search", func() {
 		It("should search for all tags", func() {
-			result, resp, err := client.ProjectTags.Search(nil)
+			result, resp, err := client.ProjectTags.Search(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -47,14 +48,14 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 			// First set a tag on a project
 			projectKey := helpers.UniqueResourceName("proj-tag-search")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Tag Search Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -62,14 +63,14 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 
 			// Set a unique tag
 			tagName := "e2e-test-tag"
-			_, err = client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
+			_, err = client.ProjectTags.Set(context.Background(), &sonar.ProjectTagsSetOptions{
 				Project: projectKey,
 				Tags:    []string{tagName},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Search for the tag
-			result, resp, err := client.ProjectTags.Search(&sonar.ProjectTagsSearchOptions{
+			result, resp, err := client.ProjectTags.Search(context.Background(), &sonar.ProjectTagsSearchOptions{
 				Query: tagName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -79,7 +80,7 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 		})
 
 		It("should search tags with pagination", func() {
-			result, resp, err := client.ProjectTags.Search(&sonar.ProjectTagsSearchOptions{
+			result, resp, err := client.ProjectTags.Search(context.Background(), &sonar.ProjectTagsSearchOptions{
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 5,
 					Page:     1,
@@ -100,14 +101,14 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 		BeforeEach(func() {
 			testProjectKey = helpers.UniqueResourceName("proj-tag")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Tag Test Project",
 				Project: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -115,7 +116,7 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 		})
 
 		It("should set a single tag on a project", func() {
-			resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
+			resp, err := client.ProjectTags.Set(context.Background(), &sonar.ProjectTagsSetOptions{
 				Project: testProjectKey,
 				Tags:    []string{"backend"},
 			})
@@ -124,7 +125,7 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 		})
 
 		It("should set multiple tags on a project", func() {
-			resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
+			resp, err := client.ProjectTags.Set(context.Background(), &sonar.ProjectTagsSetOptions{
 				Project: testProjectKey,
 				Tags:    []string{"backend", "api", "golang"},
 			})
@@ -134,14 +135,14 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 
 		It("should replace existing tags", func() {
 			// Set initial tags
-			_, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
+			_, err := client.ProjectTags.Set(context.Background(), &sonar.ProjectTagsSetOptions{
 				Project: testProjectKey,
 				Tags:    []string{"old-tag"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Replace with new tags
-			resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
+			resp, err := client.ProjectTags.Set(context.Background(), &sonar.ProjectTagsSetOptions{
 				Project: testProjectKey,
 				Tags:    []string{"new-tag"},
 			})
@@ -151,14 +152,14 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 
 		It("should clear all tags with empty array", func() {
 			// Set initial tags
-			_, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
+			_, err := client.ProjectTags.Set(context.Background(), &sonar.ProjectTagsSetOptions{
 				Project: testProjectKey,
 				Tags:    []string{"tag1", "tag2", "tag3"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Clear all tags by passing an empty array
-			resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
+			resp, err := client.ProjectTags.Set(context.Background(), &sonar.ProjectTagsSetOptions{
 				Project: testProjectKey,
 				Tags:    []string{},
 			})
@@ -166,7 +167,7 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify tags were cleared by setting them again
-			_, err = client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
+			_, err = client.ProjectTags.Set(context.Background(), &sonar.ProjectTagsSetOptions{
 				Project: testProjectKey,
 				Tags:    []string{"verified"},
 			})
@@ -175,13 +176,13 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.ProjectTags.Set(nil)
+				resp, err := client.ProjectTags.Set(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
+				resp, err := client.ProjectTags.Set(context.Background(), &sonar.ProjectTagsSetOptions{
 					Tags: []string{"tag1"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -191,7 +192,7 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				resp, err := client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
+				resp, err := client.ProjectTags.Set(context.Background(), &sonar.ProjectTagsSetOptions{
 					Project: "non-existent-project-12345",
 					Tags:    []string{"tag1"},
 				})
@@ -210,42 +211,42 @@ var _ = Describe("ProjectTags Service", Ordered, func() {
 			projectKey := helpers.UniqueResourceName("proj-tag-lifecycle")
 
 			// Step 1: Create project
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Tag Lifecycle Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// Step 2: Set initial tags
-			_, err = client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
+			_, err = client.ProjectTags.Set(context.Background(), &sonar.ProjectTagsSetOptions{
 				Project: projectKey,
 				Tags:    []string{"initial-tag", "e2e-lifecycle"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 3: Search for the tag
-			result, _, err := client.ProjectTags.Search(&sonar.ProjectTagsSearchOptions{
+			result, _, err := client.ProjectTags.Search(context.Background(), &sonar.ProjectTagsSearchOptions{
 				Query: "e2e-lifecycle",
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Tags).To(ContainElement("e2e-lifecycle"))
 
 			// Step 4: Update tags (replaces all previous tags)
-			_, err = client.ProjectTags.Set(&sonar.ProjectTagsSetOptions{
+			_, err = client.ProjectTags.Set(context.Background(), &sonar.ProjectTagsSetOptions{
 				Project: projectKey,
 				Tags:    []string{"updated-tag"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: Verify update by searching
-			result, _, err = client.ProjectTags.Search(&sonar.ProjectTagsSearchOptions{
+			result, _, err = client.ProjectTags.Search(context.Background(), &sonar.ProjectTagsSearchOptions{
 				Query: "updated-tag",
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/projects_test.go
+++ b/integration_testing/projects_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -38,7 +39,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		It("should create a project with minimal parameters", func() {
 			projectKey := helpers.UniqueResourceName("proj-min")
 
-			result, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			result, resp, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Minimal Project",
 				Project: projectKey,
 			})
@@ -46,7 +47,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup immediately after successful Create to avoid orphaned resources
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -61,7 +62,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		It("should create a project with full configuration", func() {
 			projectKey := helpers.UniqueResourceName("proj-full")
 
-			result, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			result, resp, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Full Config Project",
 				Project:    projectKey,
 				Visibility: sonar.ProjectVisibilityPrivate,
@@ -71,7 +72,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup immediately after successful Create to avoid orphaned resources
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -86,7 +87,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		It("should create a public project", func() {
 			projectKey := helpers.UniqueResourceName("proj-pub")
 
-			result, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			result, resp, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Public Project",
 				Project:    projectKey,
 				Visibility: sonar.ProjectVisibilityPublic,
@@ -95,7 +96,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup immediately after successful Create to avoid orphaned resources
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
@@ -108,13 +109,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Projects.Create(nil)
+				_, resp, err := client.Projects.Create(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing name", func() {
-				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, resp, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Project: helpers.UniqueResourceName("proj-noname"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -122,7 +123,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, resp, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name: "No Key Project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -130,7 +131,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with invalid visibility", func() {
-				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, resp, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:       "Invalid Visibility",
 					Project:    helpers.UniqueResourceName("proj-badvis"),
 					Visibility: "invalid",
@@ -145,21 +146,21 @@ var _ = Describe("Projects Service", Ordered, func() {
 				projectKey := helpers.UniqueResourceName("proj-dup")
 
 				// Create first project
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    "Original Project",
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
 				// Try to create duplicate
-				_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, resp, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    "Duplicate Project",
 					Project: projectKey,
 				})
@@ -180,7 +181,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		BeforeEach(func() {
 			testProjectKey = helpers.UniqueResourceName("proj-search")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Search Test Project",
 				Project:    testProjectKey,
 				Visibility: sonar.ProjectVisibilityPrivate,
@@ -188,7 +189,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", testProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: testProjectKey,
 				})
 				return err
@@ -196,7 +197,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should search all projects", func() {
-			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{})
+			result, resp, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -204,7 +205,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should search projects by query", func() {
-			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
+			result, resp, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 				Query: testProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -221,7 +222,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should search projects with pagination", func() {
-			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
+			result, resp, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 5,
 					Page:     1,
@@ -234,7 +235,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should search projects by visibility", func() {
-			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
+			result, resp, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 				Visibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -246,7 +247,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should search projects by qualifier", func() {
-			result, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
+			result, resp, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 				Qualifiers: []string{sonar.ProjectQualifierTRK},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -259,13 +260,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Projects.Search(nil)
+				_, resp, err := client.Projects.Search(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid visibility", func() {
-				_, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
+				_, resp, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 					Visibility: "invalid",
 				})
 				Expect(err).To(HaveOccurred())
@@ -273,7 +274,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with invalid qualifier", func() {
-				_, resp, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
+				_, resp, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 					Qualifiers: []string{"INVALID"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -289,7 +290,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		It("should delete a project", func() {
 			projectKey := helpers.UniqueResourceName("proj-del")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Delete Test Project",
 				Project: projectKey,
 			})
@@ -298,21 +299,21 @@ var _ = Describe("Projects Service", Ordered, func() {
 			// Register cleanup to handle orphaned resources if delete or assertions fail
 			// The cleanup will gracefully handle "not found" errors if the project was already deleted
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				// Ignore not found errors since the test may have already deleted it
 				return helpers.IgnoreNotFoundError(err)
 			})
 
-			resp, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			resp, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify project is deleted
-			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
+			result, _, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 				Query: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -323,13 +324,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Projects.Delete(nil)
+				resp, err := client.Projects.Delete(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{})
+				resp, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -337,7 +338,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail to delete non-existent project", func() {
-				resp, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				resp, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: "non-existent-project-key-12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -356,7 +357,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			oldKey := helpers.UniqueResourceName("proj-oldkey")
 			newKey := helpers.UniqueResourceName("proj-newkey")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Update Key Project",
 				Project: oldKey,
 			})
@@ -364,13 +365,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup with old key first in case UpdateKey fails
 			cleanup.RegisterCleanup("project", oldKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: oldKey,
 				})
 				return helpers.IgnoreNotFoundError(err)
 			})
 
-			resp, err := client.Projects.UpdateKey(&sonar.ProjectsUpdateKeyOptions{
+			resp, err := client.Projects.UpdateKey(context.Background(), &sonar.ProjectsUpdateKeyOptions{
 				From: oldKey,
 				To:   newKey,
 			})
@@ -379,14 +380,14 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup with new key
 			cleanup.RegisterCleanup("project", newKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: newKey,
 				})
 				return err
 			})
 
 			// Verify old key no longer exists
-			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
+			result, _, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 				Query: oldKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -395,7 +396,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			}
 
 			// Verify new key exists
-			result, _, err = client.Projects.Search(&sonar.ProjectsSearchOptions{
+			result, _, err = client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 				Query: newKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -411,13 +412,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Projects.UpdateKey(nil)
+				resp, err := client.Projects.UpdateKey(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing from key", func() {
-				resp, err := client.Projects.UpdateKey(&sonar.ProjectsUpdateKeyOptions{
+				resp, err := client.Projects.UpdateKey(context.Background(), &sonar.ProjectsUpdateKeyOptions{
 					To: helpers.UniqueResourceName("proj-to"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -425,7 +426,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with missing to key", func() {
-				resp, err := client.Projects.UpdateKey(&sonar.ProjectsUpdateKeyOptions{
+				resp, err := client.Projects.UpdateKey(context.Background(), &sonar.ProjectsUpdateKeyOptions{
 					From: helpers.UniqueResourceName("proj-from"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -441,7 +442,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		It("should update project visibility from public to private", func() {
 			projectKey := helpers.UniqueResourceName("proj-vis")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Visibility Test Project",
 				Project:    projectKey,
 				Visibility: sonar.ProjectVisibilityPublic,
@@ -449,13 +450,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
+			resp, err := client.Projects.UpdateVisibility(context.Background(), &sonar.ProjectsUpdateVisibilityOptions{
 				Project:    projectKey,
 				Visibility: sonar.ProjectVisibilityPrivate,
 			})
@@ -463,7 +464,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify visibility changed
-			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
+			result, _, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 				Query: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -481,7 +482,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		It("should update project visibility from private to public", func() {
 			projectKey := helpers.UniqueResourceName("proj-vis2")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Visibility Test Project 2",
 				Project:    projectKey,
 				Visibility: sonar.ProjectVisibilityPrivate,
@@ -489,13 +490,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
+			resp, err := client.Projects.UpdateVisibility(context.Background(), &sonar.ProjectsUpdateVisibilityOptions{
 				Project:    projectKey,
 				Visibility: sonar.ProjectVisibilityPublic,
 			})
@@ -503,7 +504,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify visibility changed
-			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
+			result, _, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 				Query: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -520,13 +521,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Projects.UpdateVisibility(nil)
+				resp, err := client.Projects.UpdateVisibility(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
+				resp, err := client.Projects.UpdateVisibility(context.Background(), &sonar.ProjectsUpdateVisibilityOptions{
 					Visibility: sonar.ProjectVisibilityPrivate,
 				})
 				Expect(err).To(HaveOccurred())
@@ -534,7 +535,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with missing visibility", func() {
-				resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
+				resp, err := client.Projects.UpdateVisibility(context.Background(), &sonar.ProjectsUpdateVisibilityOptions{
 					Project: helpers.UniqueResourceName("proj"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -542,7 +543,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with invalid visibility", func() {
-				resp, err := client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
+				resp, err := client.Projects.UpdateVisibility(context.Background(), &sonar.ProjectsUpdateVisibilityOptions{
 					Project:    helpers.UniqueResourceName("proj"),
 					Visibility: "invalid",
 				})
@@ -560,7 +561,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			projectKey1 := helpers.UniqueResourceName("proj-bulk1")
 			projectKey2 := helpers.UniqueResourceName("proj-bulk2")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Bulk Delete 1",
 				Project: projectKey1,
 			})
@@ -568,13 +569,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup immediately after successful Create (ignores 404 if bulk delete succeeds)
 			cleanup.RegisterCleanup("project", projectKey1, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey1,
 				})
 				return helpers.IgnoreNotFoundError(err)
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Bulk Delete 2",
 				Project: projectKey2,
 			})
@@ -582,20 +583,20 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup immediately after successful Create (ignores 404 if bulk delete succeeds)
 			cleanup.RegisterCleanup("project", projectKey2, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey2,
 				})
 				return helpers.IgnoreNotFoundError(err)
 			})
 
-			resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOptions{
+			resp, err := client.Projects.BulkDelete(context.Background(), &sonar.ProjectsBulkDeleteOptions{
 				Projects: []string{projectKey1, projectKey2},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify projectKey1 is deleted
-			result, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
+			result, _, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 				Query: projectKey1,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -604,7 +605,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			}
 
 			// Verify projectKey2 is deleted
-			result, _, err = client.Projects.Search(&sonar.ProjectsSearchOptions{
+			result, _, err = client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 				Query: projectKey2,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -618,7 +619,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			projectKey1 := uniquePrefix + "-a"
 			projectKey2 := uniquePrefix + "-b"
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Bulk Query Delete 1",
 				Project: projectKey1,
 			})
@@ -626,13 +627,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup immediately after successful Create (ignores 404 if bulk delete succeeds)
 			cleanup.RegisterCleanup("project", projectKey1, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey1,
 				})
 				return helpers.IgnoreNotFoundError(err)
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Bulk Query Delete 2",
 				Project: projectKey2,
 			})
@@ -640,13 +641,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup immediately after successful Create (ignores 404 if bulk delete succeeds)
 			cleanup.RegisterCleanup("project", projectKey2, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey2,
 				})
 				return helpers.IgnoreNotFoundError(err)
 			})
 
-			resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOptions{
+			resp, err := client.Projects.BulkDelete(context.Background(), &sonar.ProjectsBulkDeleteOptions{
 				Query: uniquePrefix,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -655,19 +656,19 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Projects.BulkDelete(nil)
+				resp, err := client.Projects.BulkDelete(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with no filter", func() {
-				resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOptions{})
+				resp, err := client.Projects.BulkDelete(context.Background(), &sonar.ProjectsBulkDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid visibility", func() {
-				resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOptions{
+				resp, err := client.Projects.BulkDelete(context.Background(), &sonar.ProjectsBulkDeleteOptions{
 					Query:      "test",
 					Visibility: "invalid",
 				})
@@ -676,7 +677,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			})
 
 			It("should fail with invalid qualifier", func() {
-				resp, err := client.Projects.BulkDelete(&sonar.ProjectsBulkDeleteOptions{
+				resp, err := client.Projects.BulkDelete(context.Background(), &sonar.ProjectsBulkDeleteOptions{
 					Query:      "test",
 					Qualifiers: []string{"INVALID"},
 				})
@@ -691,7 +692,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 	// =========================================================================
 	Describe("SearchMyProjects", func() {
 		It("should search my projects", func() {
-			result, resp, err := client.Projects.SearchMyProjects(&sonar.ProjectsSearchMyProjectsOptions{})
+			result, resp, err := client.Projects.SearchMyProjects(context.Background(), &sonar.ProjectsSearchMyProjectsOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -699,7 +700,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should search my projects with pagination", func() {
-			result, resp, err := client.Projects.SearchMyProjects(&sonar.ProjectsSearchMyProjectsOptions{
+			result, resp, err := client.Projects.SearchMyProjects(context.Background(), &sonar.ProjectsSearchMyProjectsOptions{
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 5,
 					Page:     1,
@@ -712,7 +713,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Projects.SearchMyProjects(nil)
+				_, resp, err := client.Projects.SearchMyProjects(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -724,14 +725,14 @@ var _ = Describe("Projects Service", Ordered, func() {
 	// =========================================================================
 	Describe("SearchMyScannableProjects", func() {
 		It("should search my scannable projects", func() {
-			result, resp, err := client.Projects.SearchMyScannableProjects(nil)
+			result, resp, err := client.Projects.SearchMyScannableProjects(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
 		})
 
 		It("should search my scannable projects with query", func() {
-			result, resp, err := client.Projects.SearchMyScannableProjects(&sonar.ProjectsSearchMyScannableProjectsOptions{
+			result, resp, err := client.Projects.SearchMyScannableProjects(context.Background(), &sonar.ProjectsSearchMyScannableProjectsOptions{
 				Query: helpers.E2EResourcePrefix,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -757,7 +758,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		AfterAll(func() {
 			// Restore original default visibility
-			_, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOptions{
+			_, err := client.Projects.UpdateDefaultVisibility(context.Background(), &sonar.ProjectsUpdateDefaultVisibilityOptions{
 				ProjectVisibility: originalVisibility,
 			})
 			if err != nil {
@@ -766,7 +767,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should update default visibility to private", func() {
-			resp, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOptions{
+			resp, err := client.Projects.UpdateDefaultVisibility(context.Background(), &sonar.ProjectsUpdateDefaultVisibilityOptions{
 				ProjectVisibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -774,7 +775,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 		})
 
 		It("should update default visibility to public", func() {
-			resp, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOptions{
+			resp, err := client.Projects.UpdateDefaultVisibility(context.Background(), &sonar.ProjectsUpdateDefaultVisibilityOptions{
 				ProjectVisibility: sonar.ProjectVisibilityPublic,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -783,19 +784,19 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Projects.UpdateDefaultVisibility(nil)
+				resp, err := client.Projects.UpdateDefaultVisibility(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing visibility", func() {
-				resp, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOptions{})
+				resp, err := client.Projects.UpdateDefaultVisibility(context.Background(), &sonar.ProjectsUpdateDefaultVisibilityOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid visibility", func() {
-				resp, err := client.Projects.UpdateDefaultVisibility(&sonar.ProjectsUpdateDefaultVisibilityOptions{
+				resp, err := client.Projects.UpdateDefaultVisibility(context.Background(), &sonar.ProjectsUpdateDefaultVisibilityOptions{
 					ProjectVisibility: "invalid",
 				})
 				Expect(err).To(HaveOccurred())
@@ -813,7 +814,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			newProjectKey := helpers.UniqueResourceName("proj-lifecycle-new")
 
 			// Step 1: Create project
-			result, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			result, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:       "Lifecycle Test",
 				Project:    projectKey,
 				Visibility: sonar.ProjectVisibilityPublic,
@@ -822,13 +823,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 
 			// Register cleanup for both possible project keys to handle orphans
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return helpers.IgnoreNotFoundError(err)
 			})
 			cleanup.RegisterCleanup("project", newProjectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: newProjectKey,
 				})
 				return helpers.IgnoreNotFoundError(err)
@@ -838,7 +839,7 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(result.Project.Visibility).To(Equal(sonar.ProjectVisibilityPublic))
 
 			// Step 2: Search for project
-			searchResult, _, err := client.Projects.Search(&sonar.ProjectsSearchOptions{
+			searchResult, _, err := client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 				Query: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -852,21 +853,21 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(found).To(BeTrue())
 
 			// Step 3: Update visibility
-			_, err = client.Projects.UpdateVisibility(&sonar.ProjectsUpdateVisibilityOptions{
+			_, err = client.Projects.UpdateVisibility(context.Background(), &sonar.ProjectsUpdateVisibilityOptions{
 				Project:    projectKey,
 				Visibility: sonar.ProjectVisibilityPrivate,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 4: Update key
-			_, err = client.Projects.UpdateKey(&sonar.ProjectsUpdateKeyOptions{
+			_, err = client.Projects.UpdateKey(context.Background(), &sonar.ProjectsUpdateKeyOptions{
 				From: projectKey,
 				To:   newProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: Verify changes
-			searchResult, _, err = client.Projects.Search(&sonar.ProjectsSearchOptions{
+			searchResult, _, err = client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 				Query: newProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -881,13 +882,13 @@ var _ = Describe("Projects Service", Ordered, func() {
 			Expect(found).To(BeTrue())
 
 			// Step 6: Delete project
-			_, err = client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err = client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: newProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 7: Verify deletion
-			searchResult, _, err = client.Projects.Search(&sonar.ProjectsSearchOptions{
+			searchResult, _, err = client.Projects.Search(context.Background(), &sonar.ProjectsSearchOptions{
 				Query: newProjectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/push_test.go
+++ b/integration_testing/push_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -27,13 +28,13 @@ var _ = Describe("Push Service", Ordered, func() {
 
 		// Create a test project for push events
 		projectKey := helpers.UniqueResourceName("push")
-		testProject, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		testProject, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    projectKey,
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		cleanupManager.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: testProject.Project.Key,
 			})
 			return err
@@ -53,7 +54,7 @@ var _ = Describe("Push Service", Ordered, func() {
 	Describe("SonarlintEvents", func() {
 		Context("Functional Tests", func() {
 			It("should connect to sonarlint events stream with valid parameters", func() {
-				resp, err := client.Push.SonarlintEvents(&sonar.PushSonarlintEventsOptions{
+				resp, err := client.Push.SonarlintEvents(context.Background(), &sonar.PushSonarlintEventsOptions{
 					Languages:   []string{"java"},
 					ProjectKeys: []string{testProject.Project.Key},
 				})
@@ -72,7 +73,7 @@ var _ = Describe("Push Service", Ordered, func() {
 			})
 
 			It("should connect with multiple languages", func() {
-				resp, err := client.Push.SonarlintEvents(&sonar.PushSonarlintEventsOptions{
+				resp, err := client.Push.SonarlintEvents(context.Background(), &sonar.PushSonarlintEventsOptions{
 					Languages:   []string{"java", "js", "py"},
 					ProjectKeys: []string{testProject.Project.Key},
 				})
@@ -91,21 +92,21 @@ var _ = Describe("Push Service", Ordered, func() {
 
 		Context("Error Handling", func() {
 			It("should fail with missing languages", func() {
-				_, err := client.Push.SonarlintEvents(&sonar.PushSonarlintEventsOptions{
+				_, err := client.Push.SonarlintEvents(context.Background(), &sonar.PushSonarlintEventsOptions{
 					ProjectKeys: []string{testProject.Project.Key},
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with missing project keys", func() {
-				_, err := client.Push.SonarlintEvents(&sonar.PushSonarlintEventsOptions{
+				_, err := client.Push.SonarlintEvents(context.Background(), &sonar.PushSonarlintEventsOptions{
 					Languages: []string{"java"},
 				})
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should fail with nil options", func() {
-				_, err := client.Push.SonarlintEvents(nil)
+				_, err := client.Push.SonarlintEvents(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 			})
 		})

--- a/integration_testing/qualitygates_test.go
+++ b/integration_testing/qualitygates_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -36,7 +37,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 	// =========================================================================
 	Describe("List", func() {
 		It("should list all quality gates", func() {
-			result, resp, err := client.Qualitygates.List()
+			result, resp, err := client.Qualitygates.List(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -45,7 +46,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		})
 
 		It("should include built-in quality gate", func() {
-			result, resp, err := client.Qualitygates.List()
+			result, resp, err := client.Qualitygates.List(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -67,7 +68,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should create a new quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg")
 
-			result, resp, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			result, resp, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -76,7 +77,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(result.Name).To(Equal(gateName))
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
@@ -85,14 +86,14 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualitygates.Create(nil)
+				result, resp, err := client.Qualitygates.Create(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with empty name", func() {
-				result, resp, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{})
+				result, resp, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -103,20 +104,20 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			It("should fail with duplicate name", func() {
 				gateName := helpers.UniqueResourceName("qg-dup")
 
-				_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+				_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 					Name: gateName,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-					_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+					_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 						Name: gateName,
 					})
 					return err
 				})
 
 				// Try to create with same name
-				result, resp, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+				result, resp, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 					Name: gateName,
 				})
 				Expect(err).To(HaveOccurred())
@@ -133,19 +134,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should show quality gate details", func() {
 			gateName := helpers.UniqueResourceName("qg-show")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
+			result, resp, err := client.Qualitygates.Show(context.Background(), &sonar.QualitygatesShowOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -157,14 +158,14 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualitygates.Show(nil)
+				result, resp, err := client.Qualitygates.Show(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with empty name", func() {
-				result, resp, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{})
+				result, resp, err := client.Qualitygates.Show(context.Background(), &sonar.QualitygatesShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -173,7 +174,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent quality gate", func() {
-				result, resp, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
+				result, resp, err := client.Qualitygates.Show(context.Background(), &sonar.QualitygatesShowOptions{
 					Name: "non-existent-gate-xyz",
 				})
 				Expect(err).To(HaveOccurred())
@@ -192,19 +193,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			originalName := helpers.UniqueResourceName("qg-rename")
 			newName := helpers.UniqueResourceName("qg-renamed")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: originalName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", newName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: newName,
 				})
 				return err
 			})
 
-			resp, err := client.Qualitygates.Rename(&sonar.QualitygatesRenameOptions{
+			resp, err := client.Qualitygates.Rename(context.Background(), &sonar.QualitygatesRenameOptions{
 				CurrentName: originalName,
 				Name:        newName,
 			})
@@ -212,7 +213,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			// Verify rename succeeded
-			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
+			result, _, err := client.Qualitygates.Show(context.Background(), &sonar.QualitygatesShowOptions{
 				Name: newName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -221,13 +222,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.Rename(nil)
+				resp, err := client.Qualitygates.Rename(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with empty current name", func() {
-				resp, err := client.Qualitygates.Rename(&sonar.QualitygatesRenameOptions{
+				resp, err := client.Qualitygates.Rename(context.Background(), &sonar.QualitygatesRenameOptions{
 					Name: "new-name",
 				})
 				Expect(err).To(HaveOccurred())
@@ -235,7 +236,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with empty new name", func() {
-				resp, err := client.Qualitygates.Rename(&sonar.QualitygatesRenameOptions{
+				resp, err := client.Qualitygates.Rename(context.Background(), &sonar.QualitygatesRenameOptions{
 					CurrentName: "current-name",
 				})
 				Expect(err).To(HaveOccurred())
@@ -252,19 +253,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			sourceName := helpers.UniqueResourceName("qg-source")
 			copyName := helpers.UniqueResourceName("qg-copy")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: sourceName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", sourceName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: sourceName,
 				})
 				return err
 			})
 
-			resp, err := client.Qualitygates.Copy(&sonar.QualitygatesCopyOptions{
+			resp, err := client.Qualitygates.Copy(context.Background(), &sonar.QualitygatesCopyOptions{
 				SourceName: sourceName,
 				Name:       copyName,
 			})
@@ -272,14 +273,14 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			cleanup.RegisterCleanup("qualitygate", copyName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: copyName,
 				})
 				return err
 			})
 
 			// Verify copy exists
-			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
+			result, _, err := client.Qualitygates.Show(context.Background(), &sonar.QualitygatesShowOptions{
 				Name: copyName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -288,13 +289,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.Copy(nil)
+				resp, err := client.Qualitygates.Copy(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with empty source name", func() {
-				resp, err := client.Qualitygates.Copy(&sonar.QualitygatesCopyOptions{
+				resp, err := client.Qualitygates.Copy(context.Background(), &sonar.QualitygatesCopyOptions{
 					Name: "new-copy",
 				})
 				Expect(err).To(HaveOccurred())
@@ -302,7 +303,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with empty target name", func() {
-				resp, err := client.Qualitygates.Copy(&sonar.QualitygatesCopyOptions{
+				resp, err := client.Qualitygates.Copy(context.Background(), &sonar.QualitygatesCopyOptions{
 					SourceName: "source",
 				})
 				Expect(err).To(HaveOccurred())
@@ -318,19 +319,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should delete a quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-destroy")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			resp, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+			resp, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify deletion
-			_, _, err = client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
+			_, _, err = client.Qualitygates.Show(context.Background(), &sonar.QualitygatesShowOptions{
 				Name: gateName,
 			})
 			Expect(err).To(HaveOccurred())
@@ -338,13 +339,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.Delete(nil)
+				resp, err := client.Qualitygates.Delete(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with empty name", func() {
-				resp, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{})
+				resp, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -352,7 +353,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent quality gate", func() {
-				resp, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				resp, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: "non-existent-gate-xyz",
 				})
 				Expect(err).To(HaveOccurred())
@@ -369,36 +370,36 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should set a quality gate as default", func() {
 			gateName := helpers.UniqueResourceName("qg-default")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			resp, err := client.Qualitygates.SetDefault(&sonar.QualitygatesSetDefaultOptions{
+			resp, err := client.Qualitygates.SetDefault(context.Background(), &sonar.QualitygatesSetDefaultOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify it's now default
-			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
+			result, _, err := client.Qualitygates.Show(context.Background(), &sonar.QualitygatesShowOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.IsDefault).To(BeTrue())
 
 			// Restore Sonar way as default
-			listResult, _, _ := client.Qualitygates.List()
+			listResult, _, _ := client.Qualitygates.List(context.Background(), )
 			for _, gate := range listResult.Qualitygates {
 				if gate.IsBuiltIn {
-					_, _ = client.Qualitygates.SetDefault(&sonar.QualitygatesSetDefaultOptions{
+					_, _ = client.Qualitygates.SetDefault(context.Background(), &sonar.QualitygatesSetDefaultOptions{
 						Name: gate.Name,
 					})
 					break
@@ -408,13 +409,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.SetDefault(nil)
+				resp, err := client.Qualitygates.SetDefault(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with empty name", func() {
-				resp, err := client.Qualitygates.SetDefault(&sonar.QualitygatesSetDefaultOptions{})
+				resp, err := client.Qualitygates.SetDefault(context.Background(), &sonar.QualitygatesSetDefaultOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -428,19 +429,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should create a condition for a quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-cond")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
+			result, resp, err := client.Qualitygates.CreateCondition(context.Background(), &sonar.QualitygatesCreateConditionOptions{
 				GateName: gateName,
 				Metric:   "coverage",
 				Op:       "LT",
@@ -457,19 +458,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should create condition with GT operator", func() {
 			gateName := helpers.UniqueResourceName("qg-condgt")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
+			result, resp, err := client.Qualitygates.CreateCondition(context.Background(), &sonar.QualitygatesCreateConditionOptions{
 				GateName: gateName,
 				Metric:   "duplicated_lines_density",
 				Op:       "GT",
@@ -482,14 +483,14 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualitygates.CreateCondition(nil)
+				result, resp, err := client.Qualitygates.CreateCondition(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing gate name", func() {
-				result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
+				result, resp, err := client.Qualitygates.CreateCondition(context.Background(), &sonar.QualitygatesCreateConditionOptions{
 					Metric: "coverage",
 					Error:  "80",
 				})
@@ -499,7 +500,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing metric", func() {
-				result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
+				result, resp, err := client.Qualitygates.CreateCondition(context.Background(), &sonar.QualitygatesCreateConditionOptions{
 					GateName: "some-gate",
 					Error:    "80",
 				})
@@ -509,7 +510,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing error threshold", func() {
-				result, resp, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
+				result, resp, err := client.Qualitygates.CreateCondition(context.Background(), &sonar.QualitygatesCreateConditionOptions{
 					GateName: "some-gate",
 					Metric:   "coverage",
 				})
@@ -527,20 +528,20 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should update a condition", func() {
 			gateName := helpers.UniqueResourceName("qg-upd")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
 			// Create a condition first
-			condResult, _, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
+			condResult, _, err := client.Qualitygates.CreateCondition(context.Background(), &sonar.QualitygatesCreateConditionOptions{
 				GateName: gateName,
 				Metric:   "coverage",
 				Op:       "LT",
@@ -549,7 +550,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Update it
-			resp, err := client.Qualitygates.UpdateCondition(&sonar.QualitygatesUpdateConditionOptions{
+			resp, err := client.Qualitygates.UpdateCondition(context.Background(), &sonar.QualitygatesUpdateConditionOptions{
 				ID:     condResult.ID,
 				Metric: "coverage",
 				Op:     "LT",
@@ -559,7 +560,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			// Verify update - find the condition with our ID
-			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
+			result, _, err := client.Qualitygates.Show(context.Background(), &sonar.QualitygatesShowOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -577,13 +578,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.UpdateCondition(nil)
+				resp, err := client.Qualitygates.UpdateCondition(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing ID", func() {
-				resp, err := client.Qualitygates.UpdateCondition(&sonar.QualitygatesUpdateConditionOptions{
+				resp, err := client.Qualitygates.UpdateCondition(context.Background(), &sonar.QualitygatesUpdateConditionOptions{
 					Metric: "coverage",
 					Error:  "80",
 				})
@@ -600,20 +601,20 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should delete a condition", func() {
 			gateName := helpers.UniqueResourceName("qg-delcond")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
 			// Create a condition first
-			condResult, _, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
+			condResult, _, err := client.Qualitygates.CreateCondition(context.Background(), &sonar.QualitygatesCreateConditionOptions{
 				GateName: gateName,
 				Metric:   "coverage",
 				Op:       "LT",
@@ -622,14 +623,14 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Delete it
-			resp, err := client.Qualitygates.DeleteCondition(&sonar.QualitygatesDeleteConditionOptions{
+			resp, err := client.Qualitygates.DeleteCondition(context.Background(), &sonar.QualitygatesDeleteConditionOptions{
 				ID: condResult.ID,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify deletion - the specific condition should no longer exist
-			result, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
+			result, _, err := client.Qualitygates.Show(context.Background(), &sonar.QualitygatesShowOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -640,13 +641,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.DeleteCondition(nil)
+				resp, err := client.Qualitygates.DeleteCondition(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing ID", func() {
-				resp, err := client.Qualitygates.DeleteCondition(&sonar.QualitygatesDeleteConditionOptions{})
+				resp, err := client.Qualitygates.DeleteCondition(context.Background(), &sonar.QualitygatesDeleteConditionOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -661,32 +662,32 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			gateName := helpers.UniqueResourceName("qg-sel")
 			projectKey := helpers.UniqueResourceName("proj-qg")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "QualityGate Select Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.Qualitygates.Assign(&sonar.QualitygatesAssignOptions{
+			resp, err := client.Qualitygates.Assign(context.Background(), &sonar.QualitygatesAssignOptions{
 				GateName:   gateName,
 				ProjectKey: projectKey,
 			})
@@ -694,7 +695,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify association
-			result, _, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOptions{
+			result, _, err := client.Qualitygates.GetByProject(context.Background(), &sonar.QualitygatesGetByProjectOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -703,13 +704,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.Assign(nil)
+				resp, err := client.Qualitygates.Assign(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing gate name", func() {
-				resp, err := client.Qualitygates.Assign(&sonar.QualitygatesAssignOptions{
+				resp, err := client.Qualitygates.Assign(context.Background(), &sonar.QualitygatesAssignOptions{
 					ProjectKey: "some-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -717,7 +718,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.Qualitygates.Assign(&sonar.QualitygatesAssignOptions{
+				resp, err := client.Qualitygates.Assign(context.Background(), &sonar.QualitygatesAssignOptions{
 					GateName: "some-gate",
 				})
 				Expect(err).To(HaveOccurred())
@@ -731,47 +732,47 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			gateName := helpers.UniqueResourceName("qg-desel")
 			projectKey := helpers.UniqueResourceName("proj-qgde")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "QualityGate Deselect Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// Associate first
-			_, err = client.Qualitygates.Assign(&sonar.QualitygatesAssignOptions{
+			_, err = client.Qualitygates.Assign(context.Background(), &sonar.QualitygatesAssignOptions{
 				GateName:   gateName,
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Deselect
-			resp, err := client.Qualitygates.Unassign(&sonar.QualitygatesUnassignOptions{
+			resp, err := client.Qualitygates.Unassign(context.Background(), &sonar.QualitygatesUnassignOptions{
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify - project should now use default gate
-			result, _, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOptions{
+			result, _, err := client.Qualitygates.GetByProject(context.Background(), &sonar.QualitygatesGetByProjectOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -780,13 +781,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.Unassign(nil)
+				resp, err := client.Qualitygates.Unassign(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing project key", func() {
-				resp, err := client.Qualitygates.Unassign(&sonar.QualitygatesUnassignOptions{})
+				resp, err := client.Qualitygates.Unassign(context.Background(), &sonar.QualitygatesUnassignOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -800,20 +801,20 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should get quality gate for a project", func() {
 			projectKey := helpers.UniqueResourceName("proj-getqg")
 
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "GetByProject Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOptions{
+			result, resp, err := client.Qualitygates.GetByProject(context.Background(), &sonar.QualitygatesGetByProjectOptions{
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -825,14 +826,14 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualitygates.GetByProject(nil)
+				result, resp, err := client.Qualitygates.GetByProject(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with empty project", func() {
-				result, resp, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOptions{})
+				result, resp, err := client.Qualitygates.GetByProject(context.Background(), &sonar.QualitygatesGetByProjectOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -841,7 +842,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("error cases", func() {
 			It("should fail for non-existent project", func() {
-				result, resp, err := client.Qualitygates.GetByProject(&sonar.QualitygatesGetByProjectOptions{
+				result, resp, err := client.Qualitygates.GetByProject(context.Background(), &sonar.QualitygatesGetByProjectOptions{
 					Project: "non-existent-project-xyz",
 				})
 				Expect(err).To(HaveOccurred())
@@ -859,19 +860,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should search projects for a quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-search")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualitygates.Search(&sonar.QualitygatesSearchOptions{
+			result, resp, err := client.Qualitygates.Search(context.Background(), &sonar.QualitygatesSearchOptions{
 				GateName: gateName,
 				Selected: sonar.SelectionFilterAll,
 			})
@@ -884,40 +885,40 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			gateName := helpers.UniqueResourceName("qg-searchq")
 			projectKey := helpers.UniqueResourceName("proj-searchq")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Search Query Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// Associate project with gate
-			_, err = client.Qualitygates.Assign(&sonar.QualitygatesAssignOptions{
+			_, err = client.Qualitygates.Assign(context.Background(), &sonar.QualitygatesAssignOptions{
 				GateName:   gateName,
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Search
-			result, resp, err := client.Qualitygates.Search(&sonar.QualitygatesSearchOptions{
+			result, resp, err := client.Qualitygates.Search(context.Background(), &sonar.QualitygatesSearchOptions{
 				GateName: gateName,
 				Query:    projectKey,
 			})
@@ -929,14 +930,14 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualitygates.Search(nil)
+				result, resp, err := client.Qualitygates.Search(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing gate name", func() {
-				result, resp, err := client.Qualitygates.Search(&sonar.QualitygatesSearchOptions{})
+				result, resp, err := client.Qualitygates.Search(context.Background(), &sonar.QualitygatesSearchOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -951,19 +952,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should add group permission to quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-grp")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			resp, err := client.Qualitygates.AddGroup(&sonar.QualitygatesAddGroupOptions{
+			resp, err := client.Qualitygates.AddGroup(context.Background(), &sonar.QualitygatesAddGroupOptions{
 				GateName:  gateName,
 				GroupName: "sonar-users",
 			})
@@ -971,7 +972,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify the group was actually added
-			groupsResult, _, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOptions{
+			groupsResult, _, err := client.Qualitygates.SearchGroups(context.Background(), &sonar.QualitygatesSearchGroupsOptions{
 				GateName: gateName,
 				Selected: sonar.SelectionFilterSelected,
 			})
@@ -988,13 +989,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.AddGroup(nil)
+				resp, err := client.Qualitygates.AddGroup(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing gate name", func() {
-				resp, err := client.Qualitygates.AddGroup(&sonar.QualitygatesAddGroupOptions{
+				resp, err := client.Qualitygates.AddGroup(context.Background(), &sonar.QualitygatesAddGroupOptions{
 					GroupName: "sonar-users",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1002,7 +1003,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing group name", func() {
-				resp, err := client.Qualitygates.AddGroup(&sonar.QualitygatesAddGroupOptions{
+				resp, err := client.Qualitygates.AddGroup(context.Background(), &sonar.QualitygatesAddGroupOptions{
 					GateName: "some-gate",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1015,19 +1016,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should search groups for a quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-sgrp")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOptions{
+			result, resp, err := client.Qualitygates.SearchGroups(context.Background(), &sonar.QualitygatesSearchGroupsOptions{
 				GateName: gateName,
 				Selected: sonar.SelectionFilterAll,
 			})
@@ -1038,14 +1039,14 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualitygates.SearchGroups(nil)
+				result, resp, err := client.Qualitygates.SearchGroups(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing gate name", func() {
-				result, resp, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOptions{})
+				result, resp, err := client.Qualitygates.SearchGroups(context.Background(), &sonar.QualitygatesSearchGroupsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -1057,27 +1058,27 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should remove group permission from quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-rmgrp")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
 			// Add group first
-			_, err = client.Qualitygates.AddGroup(&sonar.QualitygatesAddGroupOptions{
+			_, err = client.Qualitygates.AddGroup(context.Background(), &sonar.QualitygatesAddGroupOptions{
 				GateName:  gateName,
 				GroupName: "sonar-users",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Remove group
-			resp, err := client.Qualitygates.RemoveGroup(&sonar.QualitygatesRemoveGroupOptions{
+			resp, err := client.Qualitygates.RemoveGroup(context.Background(), &sonar.QualitygatesRemoveGroupOptions{
 				GateName:  gateName,
 				GroupName: "sonar-users",
 			})
@@ -1085,7 +1086,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify the group was actually removed
-			groupsResult, _, err := client.Qualitygates.SearchGroups(&sonar.QualitygatesSearchGroupsOptions{
+			groupsResult, _, err := client.Qualitygates.SearchGroups(context.Background(), &sonar.QualitygatesSearchGroupsOptions{
 				GateName: gateName,
 				Selected: sonar.SelectionFilterSelected,
 			})
@@ -1097,13 +1098,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.RemoveGroup(nil)
+				resp, err := client.Qualitygates.RemoveGroup(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing gate name", func() {
-				resp, err := client.Qualitygates.RemoveGroup(&sonar.QualitygatesRemoveGroupOptions{
+				resp, err := client.Qualitygates.RemoveGroup(context.Background(), &sonar.QualitygatesRemoveGroupOptions{
 					GroupName: "sonar-users",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1111,7 +1112,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing group name", func() {
-				resp, err := client.Qualitygates.RemoveGroup(&sonar.QualitygatesRemoveGroupOptions{
+				resp, err := client.Qualitygates.RemoveGroup(context.Background(), &sonar.QualitygatesRemoveGroupOptions{
 					GateName: "some-gate",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1127,19 +1128,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should add user permission to quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-usr")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			resp, err := client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOptions{
+			resp, err := client.Qualitygates.AddUser(context.Background(), &sonar.QualitygatesAddUserOptions{
 				GateName: gateName,
 				Login:    "admin",
 			})
@@ -1149,13 +1150,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.AddUser(nil)
+				resp, err := client.Qualitygates.AddUser(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing gate name", func() {
-				resp, err := client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOptions{
+				resp, err := client.Qualitygates.AddUser(context.Background(), &sonar.QualitygatesAddUserOptions{
 					Login: "admin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1163,7 +1164,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing login", func() {
-				resp, err := client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOptions{
+				resp, err := client.Qualitygates.AddUser(context.Background(), &sonar.QualitygatesAddUserOptions{
 					GateName: "some-gate",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1176,19 +1177,19 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should search users for a quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-susr")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualitygates.SearchUsers(&sonar.QualitygatesSearchUsersOptions{
+			result, resp, err := client.Qualitygates.SearchUsers(context.Background(), &sonar.QualitygatesSearchUsersOptions{
 				GateName: gateName,
 				Selected: sonar.SelectionFilterAll,
 			})
@@ -1199,14 +1200,14 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualitygates.SearchUsers(nil)
+				result, resp, err := client.Qualitygates.SearchUsers(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing gate name", func() {
-				result, resp, err := client.Qualitygates.SearchUsers(&sonar.QualitygatesSearchUsersOptions{})
+				result, resp, err := client.Qualitygates.SearchUsers(context.Background(), &sonar.QualitygatesSearchUsersOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -1218,27 +1219,27 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 		It("should remove user permission from quality gate", func() {
 			gateName := helpers.UniqueResourceName("qg-rmusr")
 
-			_, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
 			// Add user first
-			_, err = client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOptions{
+			_, err = client.Qualitygates.AddUser(context.Background(), &sonar.QualitygatesAddUserOptions{
 				GateName: gateName,
 				Login:    "admin",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Remove user
-			resp, err := client.Qualitygates.RemoveUser(&sonar.QualitygatesRemoveUserOptions{
+			resp, err := client.Qualitygates.RemoveUser(context.Background(), &sonar.QualitygatesRemoveUserOptions{
 				GateName: gateName,
 				Login:    "admin",
 			})
@@ -1248,13 +1249,13 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualitygates.RemoveUser(nil)
+				resp, err := client.Qualitygates.RemoveUser(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing gate name", func() {
-				resp, err := client.Qualitygates.RemoveUser(&sonar.QualitygatesRemoveUserOptions{
+				resp, err := client.Qualitygates.RemoveUser(context.Background(), &sonar.QualitygatesRemoveUserOptions{
 					Login: "admin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1262,7 +1263,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			})
 
 			It("should fail with missing login", func() {
-				resp, err := client.Qualitygates.RemoveUser(&sonar.QualitygatesRemoveUserOptions{
+				resp, err := client.Qualitygates.RemoveUser(context.Background(), &sonar.QualitygatesRemoveUserOptions{
 					GateName: "some-gate",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1280,28 +1281,28 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			projectKey := helpers.UniqueResourceName("proj-lifecycle")
 
 			// Step 1: Create quality gate
-			createResult, _, err := client.Qualitygates.Create(&sonar.QualitygatesCreateOptions{
+			createResult, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(createResult.Name).To(Equal(gateName))
 
 			cleanup.RegisterCleanup("qualitygate", gateName, func() error {
-				_, err := client.Qualitygates.Delete(&sonar.QualitygatesDeleteOptions{
+				_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
 					Name: gateName,
 				})
 				return err
 			})
 
 			// Step 2: Show the quality gate
-			showResult, _, err := client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
+			showResult, _, err := client.Qualitygates.Show(context.Background(), &sonar.QualitygatesShowOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(showResult).NotTo(BeNil())
 
 			// Step 3: Create condition
-			condResult, _, err := client.Qualitygates.CreateCondition(&sonar.QualitygatesCreateConditionOptions{
+			condResult, _, err := client.Qualitygates.CreateCondition(context.Background(), &sonar.QualitygatesCreateConditionOptions{
 				GateName: gateName,
 				Metric:   "coverage",
 				Op:       "LT",
@@ -1311,7 +1312,7 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			conditionID := condResult.ID
 
 			// Step 4: Update condition
-			_, err = client.Qualitygates.UpdateCondition(&sonar.QualitygatesUpdateConditionOptions{
+			_, err = client.Qualitygates.UpdateCondition(context.Background(), &sonar.QualitygatesUpdateConditionOptions{
 				ID:     conditionID,
 				Metric: "coverage",
 				Op:     "LT",
@@ -1320,27 +1321,27 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: Create project and associate
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Lifecycle Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			_, err = client.Qualitygates.Assign(&sonar.QualitygatesAssignOptions{
+			_, err = client.Qualitygates.Assign(context.Background(), &sonar.QualitygatesAssignOptions{
 				GateName:   gateName,
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5.5: Get project status for the quality gate
-			projectStatusResult, _, err := client.Qualitygates.ProjectStatus(&sonar.QualitygatesProjectStatusOptions{
+			projectStatusResult, _, err := client.Qualitygates.ProjectStatus(context.Background(), &sonar.QualitygatesProjectStatusOptions{
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1348,14 +1349,14 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(projectStatusResult.ProjectStatus).NotTo(BeNil())
 
 			// Step 6: Add user permission
-			_, err = client.Qualitygates.AddUser(&sonar.QualitygatesAddUserOptions{
+			_, err = client.Qualitygates.AddUser(context.Background(), &sonar.QualitygatesAddUserOptions{
 				GateName: gateName,
 				Login:    "admin",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 7: Search users
-			usersResult, _, err := client.Qualitygates.SearchUsers(&sonar.QualitygatesSearchUsersOptions{
+			usersResult, _, err := client.Qualitygates.SearchUsers(context.Background(), &sonar.QualitygatesSearchUsersOptions{
 				GateName: gateName,
 				Selected: sonar.SelectionFilterSelected,
 			})
@@ -1363,26 +1364,26 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			Expect(usersResult.Users).To(HaveLen(1))
 
 			// Step 8: Remove user permission
-			_, err = client.Qualitygates.RemoveUser(&sonar.QualitygatesRemoveUserOptions{
+			_, err = client.Qualitygates.RemoveUser(context.Background(), &sonar.QualitygatesRemoveUserOptions{
 				GateName: gateName,
 				Login:    "admin",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 9: Deselect project
-			_, err = client.Qualitygates.Unassign(&sonar.QualitygatesUnassignOptions{
+			_, err = client.Qualitygates.Unassign(context.Background(), &sonar.QualitygatesUnassignOptions{
 				ProjectKey: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 10: Delete condition
-			_, err = client.Qualitygates.DeleteCondition(&sonar.QualitygatesDeleteConditionOptions{
+			_, err = client.Qualitygates.DeleteCondition(context.Background(), &sonar.QualitygatesDeleteConditionOptions{
 				ID: conditionID,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 11: Verify condition was deleted
-			showResult, _, err = client.Qualitygates.Show(&sonar.QualitygatesShowOptions{
+			showResult, _, err = client.Qualitygates.Show(context.Background(), &sonar.QualitygatesShowOptions{
 				Name: gateName,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_testing/qualityprofiles_test.go
+++ b/integration_testing/qualityprofiles_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -36,7 +37,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 	// =========================================================================
 	Describe("Search", func() {
 		It("should list all quality profiles", func() {
-			result, resp, err := client.Qualityprofiles.Search(&sonar.QualityprofilesSearchOptions{})
+			result, resp, err := client.Qualityprofiles.Search(context.Background(), &sonar.QualityprofilesSearchOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -44,7 +45,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		})
 
 		It("should filter by language", func() {
-			result, resp, err := client.Qualityprofiles.Search(&sonar.QualityprofilesSearchOptions{
+			result, resp, err := client.Qualityprofiles.Search(context.Background(), &sonar.QualityprofilesSearchOptions{
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -55,7 +56,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		})
 
 		It("should include defaults", func() {
-			result, resp, err := client.Qualityprofiles.Search(&sonar.QualityprofilesSearchOptions{
+			result, resp, err := client.Qualityprofiles.Search(context.Background(), &sonar.QualityprofilesSearchOptions{
 				Defaults: true,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -73,7 +74,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should create a new quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp")
 
-			result, resp, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			result, resp, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
@@ -83,7 +84,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(result.Profile.Name).To(Equal(profileName))
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -93,14 +94,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualityprofiles.Create(nil)
+				result, resp, err := client.Qualityprofiles.Create(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing name", func() {
-				result, resp, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+				result, resp, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -109,7 +110,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				result, resp, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+				result, resp, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 					Name: "test-profile",
 				})
 				Expect(err).To(HaveOccurred())
@@ -126,21 +127,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should show quality profile details", func() {
 			profileName := helpers.UniqueResourceName("qp-show")
 
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			createResult, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOptions{
+			result, resp, err := client.Qualityprofiles.Show(context.Background(), &sonar.QualityprofilesShowOptions{
 				Key: createResult.Profile.Key,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -151,14 +152,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualityprofiles.Show(nil)
+				result, resp, err := client.Qualityprofiles.Show(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with empty key", func() {
-				result, resp, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOptions{})
+				result, resp, err := client.Qualityprofiles.Show(context.Background(), &sonar.QualityprofilesShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -174,7 +175,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			originalName := helpers.UniqueResourceName("qp-rename")
 			newName := helpers.UniqueResourceName("qp-renamed")
 
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			createResult, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     originalName,
 				Language: "java",
 			})
@@ -183,7 +184,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			// Register cleanup that tries both names in case rename fails
 			cleanup.RegisterCleanup("qualityprofile", originalName+"-or-"+newName, func() error {
 				// Try deleting by new name first (expected case)
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: newName,
 					Language:       "java",
 				})
@@ -191,14 +192,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 					return nil
 				}
 				// If that fails, try deleting by original name (rename failed)
-				_, err = client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err = client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: originalName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			resp, err := client.Qualityprofiles.Rename(&sonar.QualityprofilesRenameOptions{
+			resp, err := client.Qualityprofiles.Rename(context.Background(), &sonar.QualityprofilesRenameOptions{
 				Key:  createResult.Profile.Key,
 				Name: newName,
 			})
@@ -206,7 +207,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify rename
-			result, _, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOptions{
+			result, _, err := client.Qualityprofiles.Show(context.Background(), &sonar.QualityprofilesShowOptions{
 				Key: createResult.Profile.Key,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -215,13 +216,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.Rename(nil)
+				resp, err := client.Qualityprofiles.Rename(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing key", func() {
-				resp, err := client.Qualityprofiles.Rename(&sonar.QualityprofilesRenameOptions{
+				resp, err := client.Qualityprofiles.Rename(context.Background(), &sonar.QualityprofilesRenameOptions{
 					Name: "new-name",
 				})
 				Expect(err).To(HaveOccurred())
@@ -229,7 +230,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing name", func() {
-				resp, err := client.Qualityprofiles.Rename(&sonar.QualityprofilesRenameOptions{
+				resp, err := client.Qualityprofiles.Rename(context.Background(), &sonar.QualityprofilesRenameOptions{
 					Key: "some-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -246,21 +247,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			sourceName := helpers.UniqueResourceName("qp-source")
 			copyName := helpers.UniqueResourceName("qp-copy")
 
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			createResult, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     sourceName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", sourceName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: sourceName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.Copy(&sonar.QualityprofilesCopyOptions{
+			result, resp, err := client.Qualityprofiles.Copy(context.Background(), &sonar.QualityprofilesCopyOptions{
 				FromKey: createResult.Profile.Key,
 				ToName:  copyName,
 			})
@@ -270,7 +271,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(result.Name).To(Equal(copyName))
 
 			cleanup.RegisterCleanup("qualityprofile", copyName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: copyName,
 					Language:       "java",
 				})
@@ -280,14 +281,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualityprofiles.Copy(nil)
+				result, resp, err := client.Qualityprofiles.Copy(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing from key", func() {
-				result, resp, err := client.Qualityprofiles.Copy(&sonar.QualityprofilesCopyOptions{
+				result, resp, err := client.Qualityprofiles.Copy(context.Background(), &sonar.QualityprofilesCopyOptions{
 					ToName: "new-copy",
 				})
 				Expect(err).To(HaveOccurred())
@@ -296,7 +297,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing to name", func() {
-				result, resp, err := client.Qualityprofiles.Copy(&sonar.QualityprofilesCopyOptions{
+				result, resp, err := client.Qualityprofiles.Copy(context.Background(), &sonar.QualityprofilesCopyOptions{
 					FromKey: "some-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -313,13 +314,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should delete a quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-delete")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			resp, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+			resp, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 			})
@@ -329,13 +330,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.Delete(nil)
+				resp, err := client.Qualityprofiles.Delete(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				resp, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -343,7 +344,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				resp, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				resp, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -360,7 +361,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName := helpers.UniqueResourceName("qp-default")
 
 			// Capture the current default profile for this language FIRST
-			searchResult, _, err := client.Qualityprofiles.Search(&sonar.QualityprofilesSearchOptions{
+			searchResult, _, err := client.Qualityprofiles.Search(context.Background(), &sonar.QualityprofilesSearchOptions{
 				Language: "java",
 				Defaults: true,
 			})
@@ -374,7 +375,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			}
 			Expect(originalDefaultName).NotTo(BeEmpty(), "Should find original default Java profile")
 
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			createResult, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
@@ -383,7 +384,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			// Use DeferCleanup to ensure restoration happens even if test fails
 			DeferCleanup(func() {
 				// Restore the original default profile
-				_, restoreErr := client.Qualityprofiles.SetDefault(&sonar.QualityprofilesSetDefaultOptions{
+				_, restoreErr := client.Qualityprofiles.SetDefault(context.Background(), &sonar.QualityprofilesSetDefaultOptions{
 					QualityProfile: originalDefaultName,
 					Language:       "java",
 				})
@@ -391,13 +392,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 					GinkgoWriter.Printf("Failed to restore default profile %s: %v\n", originalDefaultName, restoreErr)
 				}
 				// Delete the test profile
-				_, _ = client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, _ = client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 			})
 
-			resp, err := client.Qualityprofiles.SetDefault(&sonar.QualityprofilesSetDefaultOptions{
+			resp, err := client.Qualityprofiles.SetDefault(context.Background(), &sonar.QualityprofilesSetDefaultOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 			})
@@ -405,7 +406,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify it's now default
-			result, _, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOptions{
+			result, _, err := client.Qualityprofiles.Show(context.Background(), &sonar.QualityprofilesShowOptions{
 				Key: createResult.Profile.Key,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -414,13 +415,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.SetDefault(nil)
+				resp, err := client.Qualityprofiles.SetDefault(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.SetDefault(&sonar.QualityprofilesSetDefaultOptions{
+				resp, err := client.Qualityprofiles.SetDefault(context.Background(), &sonar.QualityprofilesSetDefaultOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -428,7 +429,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				resp, err := client.Qualityprofiles.SetDefault(&sonar.QualityprofilesSetDefaultOptions{
+				resp, err := client.Qualityprofiles.SetDefault(context.Background(), &sonar.QualityprofilesSetDefaultOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -445,34 +446,34 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName := helpers.UniqueResourceName("qp-proj")
 			projectKey := helpers.UniqueResourceName("proj-qp")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "QualityProfile AddProject Test",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			resp, err := client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOptions{
+			resp, err := client.Qualityprofiles.AddProject(context.Background(), &sonar.QualityprofilesAddProjectOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Project:        projectKey,
@@ -483,13 +484,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.AddProject(nil)
+				resp, err := client.Qualityprofiles.AddProject(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOptions{
+				resp, err := client.Qualityprofiles.AddProject(context.Background(), &sonar.QualityprofilesAddProjectOptions{
 					Language: "java",
 					Project:  "some-project",
 				})
@@ -498,7 +499,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing project", func() {
-				resp, err := client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOptions{
+				resp, err := client.Qualityprofiles.AddProject(context.Background(), &sonar.QualityprofilesAddProjectOptions{
 					QualityProfile: "test",
 					Language:       "java",
 				})
@@ -513,35 +514,35 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName := helpers.UniqueResourceName("qp-rmproj")
 			projectKey := helpers.UniqueResourceName("proj-rmqp")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "QualityProfile RemoveProject Test",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// Add first
-			_, err = client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOptions{
+			_, err = client.Qualityprofiles.AddProject(context.Background(), &sonar.QualityprofilesAddProjectOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Project:        projectKey,
@@ -549,7 +550,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Remove
-			resp, err := client.Qualityprofiles.RemoveProject(&sonar.QualityprofilesRemoveProjectOptions{
+			resp, err := client.Qualityprofiles.RemoveProject(context.Background(), &sonar.QualityprofilesRemoveProjectOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Project:        projectKey,
@@ -560,13 +561,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.RemoveProject(nil)
+				resp, err := client.Qualityprofiles.RemoveProject(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.RemoveProject(&sonar.QualityprofilesRemoveProjectOptions{
+				resp, err := client.Qualityprofiles.RemoveProject(context.Background(), &sonar.QualityprofilesRemoveProjectOptions{
 					Language: "java",
 					Project:  "some-project",
 				})
@@ -583,21 +584,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should list projects for a quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-projects")
 
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			createResult, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.Projects(&sonar.QualityprofilesProjectsOptions{
+			result, resp, err := client.Qualityprofiles.Projects(context.Background(), &sonar.QualityprofilesProjectsOptions{
 				Key: createResult.Profile.Key,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -607,14 +608,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualityprofiles.Projects(nil)
+				result, resp, err := client.Qualityprofiles.Projects(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing key", func() {
-				result, resp, err := client.Qualityprofiles.Projects(&sonar.QualityprofilesProjectsOptions{})
+				result, resp, err := client.Qualityprofiles.Projects(context.Background(), &sonar.QualityprofilesProjectsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
@@ -629,21 +630,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should show profile inheritance", func() {
 			profileName := helpers.UniqueResourceName("qp-inh")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.Inheritance(&sonar.QualityprofilesInheritanceOptions{
+			result, resp, err := client.Qualityprofiles.Inheritance(context.Background(), &sonar.QualityprofilesInheritanceOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 			})
@@ -655,14 +656,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualityprofiles.Inheritance(nil)
+				result, resp, err := client.Qualityprofiles.Inheritance(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing profile name", func() {
-				result, resp, err := client.Qualityprofiles.Inheritance(&sonar.QualityprofilesInheritanceOptions{
+				result, resp, err := client.Qualityprofiles.Inheritance(context.Background(), &sonar.QualityprofilesInheritanceOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -671,7 +672,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				result, resp, err := client.Qualityprofiles.Inheritance(&sonar.QualityprofilesInheritanceOptions{
+				result, resp, err := client.Qualityprofiles.Inheritance(context.Background(), &sonar.QualityprofilesInheritanceOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -689,21 +690,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			parentName := helpers.UniqueResourceName("qp-parent")
 			childName := helpers.UniqueResourceName("qp-child")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     parentName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", parentName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: parentName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			_, _, err = client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			_, _, err = client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     childName,
 				Language: "java",
 			})
@@ -711,18 +712,18 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("qualityprofile", childName, func() error {
 				// Remove parent first
-				_, _ = client.Qualityprofiles.ChangeParent(&sonar.QualityprofilesChangeParentOptions{
+				_, _ = client.Qualityprofiles.ChangeParent(context.Background(), &sonar.QualityprofilesChangeParentOptions{
 					QualityProfile: childName,
 					Language:       "java",
 				})
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: childName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			resp, err := client.Qualityprofiles.ChangeParent(&sonar.QualityprofilesChangeParentOptions{
+			resp, err := client.Qualityprofiles.ChangeParent(context.Background(), &sonar.QualityprofilesChangeParentOptions{
 				QualityProfile:       childName,
 				Language:             "java",
 				ParentQualityProfile: parentName,
@@ -731,7 +732,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify parent was set by checking ancestors
-			result, _, err := client.Qualityprofiles.Inheritance(&sonar.QualityprofilesInheritanceOptions{
+			result, _, err := client.Qualityprofiles.Inheritance(context.Background(), &sonar.QualityprofilesInheritanceOptions{
 				QualityProfile: childName,
 				Language:       "java",
 			})
@@ -742,13 +743,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.ChangeParent(nil)
+				resp, err := client.Qualityprofiles.ChangeParent(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.ChangeParent(&sonar.QualityprofilesChangeParentOptions{
+				resp, err := client.Qualityprofiles.ChangeParent(context.Background(), &sonar.QualityprofilesChangeParentOptions{
 					Language:             "java",
 					ParentQualityProfile: "some-parent",
 				})
@@ -757,7 +758,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				resp, err := client.Qualityprofiles.ChangeParent(&sonar.QualityprofilesChangeParentOptions{
+				resp, err := client.Qualityprofiles.ChangeParent(context.Background(), &sonar.QualityprofilesChangeParentOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -774,35 +775,35 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName1 := helpers.UniqueResourceName("qp-cmp1")
 			profileName2 := helpers.UniqueResourceName("qp-cmp2")
 
-			result1, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			result1, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName1,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName1, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName1,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result2, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			result2, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName2,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName2, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName2,
 					Language:       "java",
 				})
 				return err
 			})
 
-			compareResult, resp, err := client.Qualityprofiles.Compare(&sonar.QualityprofilesCompareOptions{
+			compareResult, resp, err := client.Qualityprofiles.Compare(context.Background(), &sonar.QualityprofilesCompareOptions{
 				LeftKey:  result1.Profile.Key,
 				RightKey: result2.Profile.Key,
 			})
@@ -813,14 +814,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualityprofiles.Compare(nil)
+				result, resp, err := client.Qualityprofiles.Compare(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing left key", func() {
-				result, resp, err := client.Qualityprofiles.Compare(&sonar.QualityprofilesCompareOptions{
+				result, resp, err := client.Qualityprofiles.Compare(context.Background(), &sonar.QualityprofilesCompareOptions{
 					RightKey: "some-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -829,7 +830,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing right key", func() {
-				result, resp, err := client.Qualityprofiles.Compare(&sonar.QualityprofilesCompareOptions{
+				result, resp, err := client.Qualityprofiles.Compare(context.Background(), &sonar.QualityprofilesCompareOptions{
 					LeftKey: "some-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -846,21 +847,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should show quality profile changelog", func() {
 			profileName := helpers.UniqueResourceName("qp-chlog")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.Changelog(&sonar.QualityprofilesChangelogOptions{
+			result, resp, err := client.Qualityprofiles.Changelog(context.Background(), &sonar.QualityprofilesChangelogOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 			})
@@ -871,14 +872,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualityprofiles.Changelog(nil)
+				result, resp, err := client.Qualityprofiles.Changelog(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing profile name", func() {
-				result, resp, err := client.Qualityprofiles.Changelog(&sonar.QualityprofilesChangelogOptions{
+				result, resp, err := client.Qualityprofiles.Changelog(context.Background(), &sonar.QualityprofilesChangelogOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -887,7 +888,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				result, resp, err := client.Qualityprofiles.Changelog(&sonar.QualityprofilesChangelogOptions{
+				result, resp, err := client.Qualityprofiles.Changelog(context.Background(), &sonar.QualityprofilesChangelogOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -904,21 +905,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should backup a quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-backup")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.Backup(&sonar.QualityprofilesBackupOptions{
+			result, resp, err := client.Qualityprofiles.Backup(context.Background(), &sonar.QualityprofilesBackupOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 			})
@@ -930,14 +931,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualityprofiles.Backup(nil)
+				result, resp, err := client.Qualityprofiles.Backup(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing profile name", func() {
-				result, resp, err := client.Qualityprofiles.Backup(&sonar.QualityprofilesBackupOptions{
+				result, resp, err := client.Qualityprofiles.Backup(context.Background(), &sonar.QualityprofilesBackupOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -946,7 +947,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				result, resp, err := client.Qualityprofiles.Backup(&sonar.QualityprofilesBackupOptions{
+				result, resp, err := client.Qualityprofiles.Backup(context.Background(), &sonar.QualityprofilesBackupOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -971,13 +972,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.Restore(nil)
+				resp, err := client.Qualityprofiles.Restore(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with empty backup", func() {
-				resp, err := client.Qualityprofiles.Restore(&sonar.QualityprofilesRestoreOptions{})
+				resp, err := client.Qualityprofiles.Restore(context.Background(), &sonar.QualityprofilesRestoreOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -992,7 +993,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName := helpers.UniqueResourceName("qp-activate")
 
 			// Create a profile
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			createResult, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
@@ -1000,7 +1001,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileKey := createResult.Profile.Key
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -1008,7 +1009,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			// Find an available Java rule to activate
-			rulesResult, _, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			rulesResult, _, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				Languages: []string{"java"},
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 1,
@@ -1019,7 +1020,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			ruleKey := rulesResult.Rules[0].Key
 
 			// Activate the rule
-			resp, err := client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOptions{
+			resp, err := client.Qualityprofiles.ActivateRule(context.Background(), &sonar.QualityprofilesActivateRuleOptions{
 				Key:  profileKey,
 				Rule: ruleKey,
 			})
@@ -1029,13 +1030,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.ActivateRule(nil)
+				resp, err := client.Qualityprofiles.ActivateRule(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing key", func() {
-				resp, err := client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOptions{
+				resp, err := client.Qualityprofiles.ActivateRule(context.Background(), &sonar.QualityprofilesActivateRuleOptions{
 					Rule: "java:S1234",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1043,7 +1044,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing rule", func() {
-				resp, err := client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOptions{
+				resp, err := client.Qualityprofiles.ActivateRule(context.Background(), &sonar.QualityprofilesActivateRuleOptions{
 					Key: "some-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1057,7 +1058,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName := helpers.UniqueResourceName("qp-deactivate")
 
 			// Create a profile
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			createResult, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
@@ -1065,7 +1066,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileKey := createResult.Profile.Key
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -1073,7 +1074,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			// Find an available Java rule to activate then deactivate
-			rulesResult, _, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			rulesResult, _, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				Languages: []string{"java"},
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 1,
@@ -1084,14 +1085,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			ruleKey := rulesResult.Rules[0].Key
 
 			// First activate the rule
-			_, err = client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOptions{
+			_, err = client.Qualityprofiles.ActivateRule(context.Background(), &sonar.QualityprofilesActivateRuleOptions{
 				Key:  profileKey,
 				Rule: ruleKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Now deactivate it
-			resp, err := client.Qualityprofiles.DeactivateRule(&sonar.QualityprofilesDeactivateRuleOptions{
+			resp, err := client.Qualityprofiles.DeactivateRule(context.Background(), &sonar.QualityprofilesDeactivateRuleOptions{
 				Key:  profileKey,
 				Rule: ruleKey,
 			})
@@ -1101,13 +1102,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.DeactivateRule(nil)
+				resp, err := client.Qualityprofiles.DeactivateRule(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing key", func() {
-				resp, err := client.Qualityprofiles.DeactivateRule(&sonar.QualityprofilesDeactivateRuleOptions{
+				resp, err := client.Qualityprofiles.DeactivateRule(context.Background(), &sonar.QualityprofilesDeactivateRuleOptions{
 					Rule: "java:S1234",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1115,7 +1116,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing rule", func() {
-				resp, err := client.Qualityprofiles.DeactivateRule(&sonar.QualityprofilesDeactivateRuleOptions{
+				resp, err := client.Qualityprofiles.DeactivateRule(context.Background(), &sonar.QualityprofilesDeactivateRuleOptions{
 					Key: "some-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1132,7 +1133,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName := helpers.UniqueResourceName("qp-bulk-activate")
 
 			// Create a profile
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			createResult, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
@@ -1140,7 +1141,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileKey := createResult.Profile.Key
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -1148,7 +1149,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			// Bulk activate rules by language
-			resp, err := client.Qualityprofiles.ActivateRules(&sonar.QualityprofilesActivateRulesOptions{
+			resp, err := client.Qualityprofiles.ActivateRules(context.Background(), &sonar.QualityprofilesActivateRulesOptions{
 				TargetKey: profileKey,
 				Languages: []string{"java"},
 			})
@@ -1158,13 +1159,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.ActivateRules(nil)
+				resp, err := client.Qualityprofiles.ActivateRules(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing target key", func() {
-				resp, err := client.Qualityprofiles.ActivateRules(&sonar.QualityprofilesActivateRulesOptions{
+				resp, err := client.Qualityprofiles.ActivateRules(context.Background(), &sonar.QualityprofilesActivateRulesOptions{
 					Languages: []string{"java"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -1178,7 +1179,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileName := helpers.UniqueResourceName("qp-bulk-deactivate")
 
 			// Create a profile
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			createResult, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
@@ -1186,7 +1187,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileKey := createResult.Profile.Key
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -1194,7 +1195,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			// Find an available Java rule and activate it first
-			rulesResult, _, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			rulesResult, _, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				Languages: []string{"java"},
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 1,
@@ -1205,14 +1206,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			ruleKey := rulesResult.Rules[0].Key
 
 			// Activate a rule first
-			_, err = client.Qualityprofiles.ActivateRule(&sonar.QualityprofilesActivateRuleOptions{
+			_, err = client.Qualityprofiles.ActivateRule(context.Background(), &sonar.QualityprofilesActivateRuleOptions{
 				Key:  profileKey,
 				Rule: ruleKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Bulk deactivate rules
-			resp, err := client.Qualityprofiles.DeactivateRules(&sonar.QualityprofilesDeactivateRulesOptions{
+			resp, err := client.Qualityprofiles.DeactivateRules(context.Background(), &sonar.QualityprofilesDeactivateRulesOptions{
 				TargetKey: profileKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1221,13 +1222,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.DeactivateRules(nil)
+				resp, err := client.Qualityprofiles.DeactivateRules(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing target key", func() {
-				resp, err := client.Qualityprofiles.DeactivateRules(&sonar.QualityprofilesDeactivateRulesOptions{})
+				resp, err := client.Qualityprofiles.DeactivateRules(context.Background(), &sonar.QualityprofilesDeactivateRulesOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -1239,7 +1240,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 	// =========================================================================
 	Describe("Exporters", func() {
 		It("should list exporters", func() {
-			result, resp, err := client.Qualityprofiles.Exporters()
+			result, resp, err := client.Qualityprofiles.Exporters(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -1248,7 +1249,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 	Describe("Importers", func() {
 		It("should list importers", func() {
-			result, resp, err := client.Qualityprofiles.Importers()
+			result, resp, err := client.Qualityprofiles.Importers(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -1262,21 +1263,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should add group permission to quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-grp")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			resp, err := client.Qualityprofiles.AddGroup(&sonar.QualityprofilesAddGroupOptions{
+			resp, err := client.Qualityprofiles.AddGroup(context.Background(), &sonar.QualityprofilesAddGroupOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Group:          "sonar-users",
@@ -1287,13 +1288,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.AddGroup(nil)
+				resp, err := client.Qualityprofiles.AddGroup(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.AddGroup(&sonar.QualityprofilesAddGroupOptions{
+				resp, err := client.Qualityprofiles.AddGroup(context.Background(), &sonar.QualityprofilesAddGroupOptions{
 					Language: "java",
 					Group:    "sonar-users",
 				})
@@ -1302,7 +1303,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing group", func() {
-				resp, err := client.Qualityprofiles.AddGroup(&sonar.QualityprofilesAddGroupOptions{
+				resp, err := client.Qualityprofiles.AddGroup(context.Background(), &sonar.QualityprofilesAddGroupOptions{
 					QualityProfile: "test",
 					Language:       "java",
 				})
@@ -1316,21 +1317,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should search groups for a quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-sgrp")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.SearchGroups(&sonar.QualityprofilesSearchGroupsOptions{
+			result, resp, err := client.Qualityprofiles.SearchGroups(context.Background(), &sonar.QualityprofilesSearchGroupsOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Selected:       sonar.SelectionFilterAll,
@@ -1342,14 +1343,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualityprofiles.SearchGroups(nil)
+				result, resp, err := client.Qualityprofiles.SearchGroups(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing profile name", func() {
-				result, resp, err := client.Qualityprofiles.SearchGroups(&sonar.QualityprofilesSearchGroupsOptions{
+				result, resp, err := client.Qualityprofiles.SearchGroups(context.Background(), &sonar.QualityprofilesSearchGroupsOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1358,7 +1359,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				result, resp, err := client.Qualityprofiles.SearchGroups(&sonar.QualityprofilesSearchGroupsOptions{
+				result, resp, err := client.Qualityprofiles.SearchGroups(context.Background(), &sonar.QualityprofilesSearchGroupsOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1372,14 +1373,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should remove group permission from quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-rmgrp")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -1387,7 +1388,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			// Add group first
-			_, err = client.Qualityprofiles.AddGroup(&sonar.QualityprofilesAddGroupOptions{
+			_, err = client.Qualityprofiles.AddGroup(context.Background(), &sonar.QualityprofilesAddGroupOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Group:          "sonar-users",
@@ -1395,7 +1396,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Remove group
-			resp, err := client.Qualityprofiles.RemoveGroup(&sonar.QualityprofilesRemoveGroupOptions{
+			resp, err := client.Qualityprofiles.RemoveGroup(context.Background(), &sonar.QualityprofilesRemoveGroupOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Group:          "sonar-users",
@@ -1406,13 +1407,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.RemoveGroup(nil)
+				resp, err := client.Qualityprofiles.RemoveGroup(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.RemoveGroup(&sonar.QualityprofilesRemoveGroupOptions{
+				resp, err := client.Qualityprofiles.RemoveGroup(context.Background(), &sonar.QualityprofilesRemoveGroupOptions{
 					Language: "java",
 					Group:    "sonar-users",
 				})
@@ -1421,7 +1422,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing group", func() {
-				resp, err := client.Qualityprofiles.RemoveGroup(&sonar.QualityprofilesRemoveGroupOptions{
+				resp, err := client.Qualityprofiles.RemoveGroup(context.Background(), &sonar.QualityprofilesRemoveGroupOptions{
 					QualityProfile: "test",
 					Language:       "java",
 				})
@@ -1438,21 +1439,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should add user permission to quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-usr")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			resp, err := client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOptions{
+			resp, err := client.Qualityprofiles.AddUser(context.Background(), &sonar.QualityprofilesAddUserOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Login:          "admin",
@@ -1463,13 +1464,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.AddUser(nil)
+				resp, err := client.Qualityprofiles.AddUser(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOptions{
+				resp, err := client.Qualityprofiles.AddUser(context.Background(), &sonar.QualityprofilesAddUserOptions{
 					Language: "java",
 					Login:    "admin",
 				})
@@ -1478,7 +1479,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing login", func() {
-				resp, err := client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOptions{
+				resp, err := client.Qualityprofiles.AddUser(context.Background(), &sonar.QualityprofilesAddUserOptions{
 					QualityProfile: "test",
 					Language:       "java",
 				})
@@ -1492,21 +1493,21 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should search users for a quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-susr")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
 				return err
 			})
 
-			result, resp, err := client.Qualityprofiles.SearchUsers(&sonar.QualityprofilesSearchUsersOptions{
+			result, resp, err := client.Qualityprofiles.SearchUsers(context.Background(), &sonar.QualityprofilesSearchUsersOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Selected:       sonar.SelectionFilterAll,
@@ -1518,14 +1519,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Qualityprofiles.SearchUsers(nil)
+				result, resp, err := client.Qualityprofiles.SearchUsers(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing profile name", func() {
-				result, resp, err := client.Qualityprofiles.SearchUsers(&sonar.QualityprofilesSearchUsersOptions{
+				result, resp, err := client.Qualityprofiles.SearchUsers(context.Background(), &sonar.QualityprofilesSearchUsersOptions{
 					Language: "java",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1534,7 +1535,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing language", func() {
-				result, resp, err := client.Qualityprofiles.SearchUsers(&sonar.QualityprofilesSearchUsersOptions{
+				result, resp, err := client.Qualityprofiles.SearchUsers(context.Background(), &sonar.QualityprofilesSearchUsersOptions{
 					QualityProfile: "test",
 				})
 				Expect(err).To(HaveOccurred())
@@ -1548,14 +1549,14 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 		It("should remove user permission from quality profile", func() {
 			profileName := helpers.UniqueResourceName("qp-rmusr")
 
-			_, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -1563,7 +1564,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			// Add user first
-			_, err = client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOptions{
+			_, err = client.Qualityprofiles.AddUser(context.Background(), &sonar.QualityprofilesAddUserOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Login:          "admin",
@@ -1571,7 +1572,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Remove user
-			resp, err := client.Qualityprofiles.RemoveUser(&sonar.QualityprofilesRemoveUserOptions{
+			resp, err := client.Qualityprofiles.RemoveUser(context.Background(), &sonar.QualityprofilesRemoveUserOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Login:          "admin",
@@ -1582,13 +1583,13 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Qualityprofiles.RemoveUser(nil)
+				resp, err := client.Qualityprofiles.RemoveUser(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing profile name", func() {
-				resp, err := client.Qualityprofiles.RemoveUser(&sonar.QualityprofilesRemoveUserOptions{
+				resp, err := client.Qualityprofiles.RemoveUser(context.Background(), &sonar.QualityprofilesRemoveUserOptions{
 					Language: "java",
 					Login:    "admin",
 				})
@@ -1597,7 +1598,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			It("should fail with missing login", func() {
-				resp, err := client.Qualityprofiles.RemoveUser(&sonar.QualityprofilesRemoveUserOptions{
+				resp, err := client.Qualityprofiles.RemoveUser(context.Background(), &sonar.QualityprofilesRemoveUserOptions{
 					QualityProfile: "test",
 					Language:       "java",
 				})
@@ -1616,7 +1617,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			projectKey := helpers.UniqueResourceName("proj-qplc")
 
 			// Step 1: Create quality profile
-			createResult, _, err := client.Qualityprofiles.Create(&sonar.QualityprofilesCreateOptions{
+			createResult, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
 				Name:     profileName,
 				Language: "java",
 			})
@@ -1624,7 +1625,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			profileKey := createResult.Profile.Key
 
 			cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
-				_, err := client.Qualityprofiles.Delete(&sonar.QualityprofilesDeleteOptions{
+				_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
 					QualityProfile: profileName,
 					Language:       "java",
 				})
@@ -1632,34 +1633,34 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			})
 
 			// Step 2: Show the profile
-			showResult, _, err := client.Qualityprofiles.Show(&sonar.QualityprofilesShowOptions{
+			showResult, _, err := client.Qualityprofiles.Show(context.Background(), &sonar.QualityprofilesShowOptions{
 				Key: profileKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(showResult.Profile.Name).To(Equal(profileName))
 
 			// Step 3: View changelog
-			_, _, err = client.Qualityprofiles.Changelog(&sonar.QualityprofilesChangelogOptions{
+			_, _, err = client.Qualityprofiles.Changelog(context.Background(), &sonar.QualityprofilesChangelogOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 4: Create project and associate
-			_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "Lifecycle Test Project",
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
-			_, err = client.Qualityprofiles.AddProject(&sonar.QualityprofilesAddProjectOptions{
+			_, err = client.Qualityprofiles.AddProject(context.Background(), &sonar.QualityprofilesAddProjectOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Project:        projectKey,
@@ -1667,7 +1668,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: List projects and verify our project is associated
-			projectsResult, _, err := client.Qualityprofiles.Projects(&sonar.QualityprofilesProjectsOptions{
+			projectsResult, _, err := client.Qualityprofiles.Projects(context.Background(), &sonar.QualityprofilesProjectsOptions{
 				Key: profileKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1681,7 +1682,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(foundProject).To(BeTrue(), "Project %s should be associated with the quality profile", projectKey)
 
 			// Step 6: Add user permission
-			_, err = client.Qualityprofiles.AddUser(&sonar.QualityprofilesAddUserOptions{
+			_, err = client.Qualityprofiles.AddUser(context.Background(), &sonar.QualityprofilesAddUserOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Login:          "admin",
@@ -1689,7 +1690,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 7: Search users and verify admin is selected
-			usersResult, _, err := client.Qualityprofiles.SearchUsers(&sonar.QualityprofilesSearchUsersOptions{
+			usersResult, _, err := client.Qualityprofiles.SearchUsers(context.Background(), &sonar.QualityprofilesSearchUsersOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Selected:       sonar.SelectionFilterSelected,
@@ -1705,7 +1706,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(foundAdmin).To(BeTrue(), "Admin user should have permission on quality profile")
 
 			// Step 8: Remove user permission
-			_, err = client.Qualityprofiles.RemoveUser(&sonar.QualityprofilesRemoveUserOptions{
+			_, err = client.Qualityprofiles.RemoveUser(context.Background(), &sonar.QualityprofilesRemoveUserOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Login:          "admin",
@@ -1713,7 +1714,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 9: Remove project association
-			_, err = client.Qualityprofiles.RemoveProject(&sonar.QualityprofilesRemoveProjectOptions{
+			_, err = client.Qualityprofiles.RemoveProject(context.Background(), &sonar.QualityprofilesRemoveProjectOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 				Project:        projectKey,
@@ -1721,7 +1722,7 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 10: Backup profile
-			backupResult, _, err := client.Qualityprofiles.Backup(&sonar.QualityprofilesBackupOptions{
+			backupResult, _, err := client.Qualityprofiles.Backup(context.Background(), &sonar.QualityprofilesBackupOptions{
 				QualityProfile: profileName,
 				Language:       "java",
 			})

--- a/integration_testing/rules_test.go
+++ b/integration_testing/rules_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -37,7 +38,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 	// =========================================================================
 	Describe("App", func() {
 		It("should return rules application data", func() {
-			result, resp, err := client.Rules.App()
+			result, resp, err := client.Rules.App(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -46,7 +47,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should include canWrite flag", func() {
-			result, resp, err := client.Rules.App()
+			result, resp, err := client.Rules.App(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			// CanWrite is a boolean indicating if the user can modify rules
@@ -60,7 +61,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 	// =========================================================================
 	Describe("Repositories", func() {
 		It("should list all rule repositories", func() {
-			result, resp, err := client.Rules.Repositories(&sonar.RulesRepositoriesOptions{})
+			result, resp, err := client.Rules.Repositories(context.Background(), &sonar.RulesRepositoriesOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -68,7 +69,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter by language", func() {
-			result, resp, err := client.Rules.Repositories(&sonar.RulesRepositoriesOptions{
+			result, resp, err := client.Rules.Repositories(context.Background(), &sonar.RulesRepositoriesOptions{
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -79,7 +80,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter by query", func() {
-			result, resp, err := client.Rules.Repositories(&sonar.RulesRepositoriesOptions{
+			result, resp, err := client.Rules.Repositories(context.Background(), &sonar.RulesRepositoriesOptions{
 				Query: "sonar",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -91,7 +92,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should allow nil options", func() {
-			result, resp, err := client.Rules.Repositories(nil)
+			result, resp, err := client.Rules.Repositories(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -103,7 +104,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 	// =========================================================================
 	Describe("Tags", func() {
 		It("should list all rule tags", func() {
-			result, resp, err := client.Rules.Tags(&sonar.RulesTagsOptions{})
+			result, resp, err := client.Rules.Tags(context.Background(), &sonar.RulesTagsOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -111,7 +112,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should limit by page size", func() {
-			result, resp, err := client.Rules.Tags(&sonar.RulesTagsOptions{
+			result, resp, err := client.Rules.Tags(context.Background(), &sonar.RulesTagsOptions{
 				PageSize: 5,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -120,7 +121,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter by query", func() {
-			result, resp, err := client.Rules.Tags(&sonar.RulesTagsOptions{
+			result, resp, err := client.Rules.Tags(context.Background(), &sonar.RulesTagsOptions{
 				Query: "sec",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -132,7 +133,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should allow nil options", func() {
-			result, resp, err := client.Rules.Tags(nil)
+			result, resp, err := client.Rules.Tags(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -140,7 +141,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with invalid page size (negative)", func() {
-				_, resp, err := client.Rules.Tags(&sonar.RulesTagsOptions{
+				_, resp, err := client.Rules.Tags(context.Background(), &sonar.RulesTagsOptions{
 					PageSize: -1,
 				})
 				Expect(err).To(HaveOccurred())
@@ -148,7 +149,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 			})
 
 			It("should fail with page size exceeding max", func() {
-				_, resp, err := client.Rules.Tags(&sonar.RulesTagsOptions{
+				_, resp, err := client.Rules.Tags(context.Background(), &sonar.RulesTagsOptions{
 					PageSize: 501,
 				})
 				Expect(err).To(HaveOccurred())
@@ -162,7 +163,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 	// =========================================================================
 	Describe("Search", func() {
 		It("should search for all rules", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{})
+			result, resp, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -171,7 +172,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter by language", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			result, resp, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				Languages: []string{"java"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -183,7 +184,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 		It("should filter by repository", func() {
 			// First get available repositories
-			repos, _, err := client.Rules.Repositories(&sonar.RulesRepositoriesOptions{
+			repos, _, err := client.Rules.Repositories(context.Background(), &sonar.RulesRepositoriesOptions{
 				Language: "java",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -191,7 +192,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 			repoKey := repos.Repositories[0].Key
 
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			result, resp, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				Repositories: []string{repoKey},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -202,7 +203,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter by severity", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			result, resp, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				Severities: []string{sonar.RuleSeverityCritical},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -213,7 +214,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter by type", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			result, resp, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				Types: []string{sonar.RuleTypeBug},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -224,7 +225,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter by status", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			result, resp, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				Statuses: []string{sonar.RuleStatusReady},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -236,13 +237,13 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 		It("should filter by tags", func() {
 			// First get available tags
-			tags, _, err := client.Rules.Tags(&sonar.RulesTagsOptions{
+			tags, _, err := client.Rules.Tags(context.Background(), &sonar.RulesTagsOptions{
 				PageSize: 1,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			if len(tags.Tags) > 0 {
 				targetTag := tags.Tags[0]
-				result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
+				result, resp, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 					Tags: []string{targetTag},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -273,7 +274,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should filter template rules", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			result, resp, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				IsTemplate: true,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -284,7 +285,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should paginate results", func() {
-			result1, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			result1, resp, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				PaginationArgs: sonar.PaginationArgs{
 					Page:     1,
 					PageSize: 5,
@@ -295,7 +296,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 			Expect(len(result1.Rules)).To(BeNumerically("<=", 5))
 
 			if result1.Paging.Total > 5 {
-				result2, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
+				result2, resp, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{
 						Page:     2,
 						PageSize: 5,
@@ -311,7 +312,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should include facets", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			result, resp, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				Facets: []string{"languages", "repositories", "tags"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -320,7 +321,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should search by query", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			result, resp, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				Query: "null",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -329,7 +330,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should include external rules", func() {
-			result, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			result, resp, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				IncludeExternal: true,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -338,7 +339,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should allow nil options", func() {
-			result, resp, err := client.Rules.Search(nil)
+			result, resp, err := client.Rules.Search(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -346,7 +347,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with search query too short", func() {
-				_, resp, err := client.Rules.Search(&sonar.RulesSearchOptions{
+				_, resp, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 					Query: "a",
 				})
 				Expect(err).To(HaveOccurred())
@@ -363,7 +364,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 		BeforeAll(func() {
 			// Get an existing rule key for show tests
-			result, _, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			result, _, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 1,
 				},
@@ -374,7 +375,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should show rule details", func() {
-			result, resp, err := client.Rules.Show(&sonar.RulesShowOptions{
+			result, resp, err := client.Rules.Show(context.Background(), &sonar.RulesShowOptions{
 				Key: existingRuleKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -385,7 +386,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should include actives when requested", func() {
-			result, resp, err := client.Rules.Show(&sonar.RulesShowOptions{
+			result, resp, err := client.Rules.Show(context.Background(), &sonar.RulesShowOptions{
 				Key:     existingRuleKey,
 				Actives: true,
 			})
@@ -397,19 +398,19 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Rules.Show(nil)
+				_, resp, err := client.Rules.Show(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing key", func() {
-				_, resp, err := client.Rules.Show(&sonar.RulesShowOptions{})
+				_, resp, err := client.Rules.Show(context.Background(), &sonar.RulesShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with non-existent rule", func() {
-				_, resp, err := client.Rules.Show(&sonar.RulesShowOptions{
+				_, resp, err := client.Rules.Show(context.Background(), &sonar.RulesShowOptions{
 					Key: "nonexistent:rule-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -426,7 +427,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 		BeforeAll(func() {
 			// Find a template rule to use for creating custom rules
-			result, _, err := client.Rules.Search(&sonar.RulesSearchOptions{
+			result, _, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 				IsTemplate: true,
 				Languages:  []string{"java"},
 				PaginationArgs: sonar.PaginationArgs{
@@ -445,7 +446,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 			It("should create a custom rule from template", func() {
 				customKey := helpers.UniqueResourceName("rule")
 
-				result, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
+				result, resp, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "E2E Test Rule " + customKey,
 					MarkdownDescription: "This is a test rule created by e2e tests",
@@ -459,7 +460,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 				// Register cleanup
 				cleanup.RegisterCleanup("rule", result.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
+					_, err := client.Rules.Delete(context.Background(), &sonar.RulesDeleteOptions{
 						Key: result.Rule.Key,
 					})
 					return err
@@ -469,7 +470,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 			It("should create a custom rule with severity", func() {
 				customKey := helpers.UniqueResourceName("rule")
 
-				result, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
+				result, resp, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "E2E Severity Rule " + customKey,
 					MarkdownDescription: "Rule with custom severity",
@@ -481,7 +482,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(result.Rule.Severity).To(Equal(sonar.RuleSeverityCritical))
 
 				cleanup.RegisterCleanup("rule", result.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
+					_, err := client.Rules.Delete(context.Background(), &sonar.RulesDeleteOptions{
 						Key: result.Rule.Key,
 					})
 					return err
@@ -491,7 +492,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 			It("should create a custom rule with status", func() {
 				customKey := helpers.UniqueResourceName("rule")
 
-				result, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
+				result, resp, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "E2E Status Rule " + customKey,
 					MarkdownDescription: "Rule with custom status",
@@ -503,7 +504,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(result.Rule.Status).To(Equal(sonar.RuleStatusBeta))
 
 				cleanup.RegisterCleanup("rule", result.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
+					_, err := client.Rules.Delete(context.Background(), &sonar.RulesDeleteOptions{
 						Key: result.Rule.Key,
 					})
 					return err
@@ -512,13 +513,13 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 			Context("parameter validation", func() {
 				It("should fail with nil options", func() {
-					_, resp, err := client.Rules.Create(nil)
+					_, resp, err := client.Rules.Create(context.Background(), nil)
 					Expect(err).To(HaveOccurred())
 					Expect(resp).To(BeNil())
 				})
 
 				It("should fail with missing custom key", func() {
-					_, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
+					_, resp, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 						Name:                "Test Rule",
 						MarkdownDescription: "Description",
 						TemplateKey:         templateRule.Key,
@@ -528,7 +529,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				})
 
 				It("should fail with missing name", func() {
-					_, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
+					_, resp, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 						CustomKey:           "test-rule",
 						MarkdownDescription: "Description",
 						TemplateKey:         templateRule.Key,
@@ -538,7 +539,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				})
 
 				It("should fail with missing markdown description", func() {
-					_, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
+					_, resp, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 						CustomKey:   "test-rule",
 						Name:        "Test Rule",
 						TemplateKey: templateRule.Key,
@@ -548,7 +549,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				})
 
 				It("should fail with missing template key", func() {
-					_, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
+					_, resp, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 						CustomKey:           "test-rule",
 						Name:                "Test Rule",
 						MarkdownDescription: "Description",
@@ -559,7 +560,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 				It("should fail with custom key too long", func() {
 					longKey := strings.Repeat("a", 201)
-					_, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
+					_, resp, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 						CustomKey:           longKey,
 						Name:                "Test Rule",
 						MarkdownDescription: "Description",
@@ -571,7 +572,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 				It("should fail with name too long", func() {
 					longName := strings.Repeat("a", 201)
-					_, resp, err := client.Rules.Create(&sonar.RulesCreateOptions{
+					_, resp, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 						CustomKey:           "test-rule",
 						Name:                longName,
 						MarkdownDescription: "Description",
@@ -591,7 +592,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				customKey := helpers.UniqueResourceName("rule")
 
 				// Create rule
-				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOptions{
+				createResult, _, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "Original Name",
 					MarkdownDescription: "Original description",
@@ -600,7 +601,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("rule", createResult.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
+					_, err := client.Rules.Delete(context.Background(), &sonar.RulesDeleteOptions{
 						Key: createResult.Rule.Key,
 					})
 					return err
@@ -608,7 +609,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 				// Update rule
 				updatedName := "Updated Name " + customKey
-				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
+				updateResult, resp, err := client.Rules.Update(context.Background(), &sonar.RulesUpdateOptions{
 					Key:                 createResult.Rule.Key,
 					Name:                updatedName,
 					MarkdownDescription: "Updated description",
@@ -621,7 +622,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 			It("should update a custom rule severity", func() {
 				customKey := helpers.UniqueResourceName("rule")
 
-				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOptions{
+				createResult, _, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "Severity Update Rule",
 					MarkdownDescription: "Testing severity update",
@@ -631,13 +632,13 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("rule", createResult.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
+					_, err := client.Rules.Delete(context.Background(), &sonar.RulesDeleteOptions{
 						Key: createResult.Rule.Key,
 					})
 					return err
 				})
 
-				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
+				updateResult, resp, err := client.Rules.Update(context.Background(), &sonar.RulesUpdateOptions{
 					Key:      createResult.Rule.Key,
 					Severity: sonar.RuleSeverityBlocker,
 				})
@@ -649,7 +650,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 			It("should update a custom rule status", func() {
 				customKey := helpers.UniqueResourceName("rule")
 
-				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOptions{
+				createResult, _, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "Status Update Rule",
 					MarkdownDescription: "Testing status update",
@@ -659,13 +660,13 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("rule", createResult.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
+					_, err := client.Rules.Delete(context.Background(), &sonar.RulesDeleteOptions{
 						Key: createResult.Rule.Key,
 					})
 					return err
 				})
 
-				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
+				updateResult, resp, err := client.Rules.Update(context.Background(), &sonar.RulesUpdateOptions{
 					Key:    createResult.Rule.Key,
 					Status: sonar.RuleStatusDeprecated,
 				})
@@ -678,7 +679,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				customKey := helpers.UniqueResourceName("rule")
 
 				// Create a custom rule for testing tag updates
-				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOptions{
+				createResult, _, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "Tag Update Test Rule",
 					MarkdownDescription: "Testing tag updates",
@@ -687,14 +688,14 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("rule", createResult.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
+					_, err := client.Rules.Delete(context.Background(), &sonar.RulesDeleteOptions{
 						Key: createResult.Rule.Key,
 					})
 					return err
 				})
 
 				// Add a custom tag
-				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
+				updateResult, resp, err := client.Rules.Update(context.Background(), &sonar.RulesUpdateOptions{
 					Key:  createResult.Rule.Key,
 					Tags: []string{"e2e-test-tag"},
 				})
@@ -703,7 +704,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(updateResult.Rule.Tags).To(ContainElement("e2e-test-tag"))
 
 				// Clear tags
-				clearResult, _, err := client.Rules.Update(&sonar.RulesUpdateOptions{
+				clearResult, _, err := client.Rules.Update(context.Background(), &sonar.RulesUpdateOptions{
 					Key:  createResult.Rule.Key,
 					Tags: []string{},
 				})
@@ -715,7 +716,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				customKey := helpers.UniqueResourceName("rule")
 
 				// Create a custom rule for testing note updates
-				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOptions{
+				createResult, _, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "Note Update Test Rule",
 					MarkdownDescription: "Testing note updates",
@@ -724,14 +725,14 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("rule", createResult.Rule.Key, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
+					_, err := client.Rules.Delete(context.Background(), &sonar.RulesDeleteOptions{
 						Key: createResult.Rule.Key,
 					})
 					return err
 				})
 
 				// Add a note
-				updateResult, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
+				updateResult, resp, err := client.Rules.Update(context.Background(), &sonar.RulesUpdateOptions{
 					Key:          createResult.Rule.Key,
 					MarkdownNote: "E2E test note: This is a test note added during e2e testing",
 				})
@@ -740,7 +741,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(updateResult.Rule.MdNote).To(ContainSubstring("E2E test note"))
 
 				// Update the note with different content
-				updateResult2, _, err := client.Rules.Update(&sonar.RulesUpdateOptions{
+				updateResult2, _, err := client.Rules.Update(context.Background(), &sonar.RulesUpdateOptions{
 					Key:          createResult.Rule.Key,
 					MarkdownNote: "Updated note content",
 				})
@@ -751,13 +752,13 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 			Context("parameter validation", func() {
 				It("should fail with nil options", func() {
-					_, resp, err := client.Rules.Update(nil)
+					_, resp, err := client.Rules.Update(context.Background(), nil)
 					Expect(err).To(HaveOccurred())
 					Expect(resp).To(BeNil())
 				})
 
 				It("should fail with missing key", func() {
-					_, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
+					_, resp, err := client.Rules.Update(context.Background(), &sonar.RulesUpdateOptions{
 						Name: "Updated Name",
 					})
 					Expect(err).To(HaveOccurred())
@@ -766,7 +767,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 				It("should fail with key too long", func() {
 					longKey := strings.Repeat("a", 201)
-					_, resp, err := client.Rules.Update(&sonar.RulesUpdateOptions{
+					_, resp, err := client.Rules.Update(context.Background(), &sonar.RulesUpdateOptions{
 						Key:  longKey,
 						Name: "Updated Name",
 					})
@@ -784,7 +785,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 				customKey := helpers.UniqueResourceName("rule")
 
 				// Create rule
-				createResult, _, err := client.Rules.Create(&sonar.RulesCreateOptions{
+				createResult, _, err := client.Rules.Create(context.Background(), &sonar.RulesCreateOptions{
 					CustomKey:           customKey,
 					Name:                "Rule To Delete",
 					MarkdownDescription: "This rule will be deleted",
@@ -793,14 +794,14 @@ var _ = Describe("Rules Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Delete rule
-				resp, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
+				resp, err := client.Rules.Delete(context.Background(), &sonar.RulesDeleteOptions{
 					Key: createResult.Rule.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 				// Verify deletion - rule is marked as REMOVED
-				showResult, _, err := client.Rules.Show(&sonar.RulesShowOptions{
+				showResult, _, err := client.Rules.Show(context.Background(), &sonar.RulesShowOptions{
 					Key: createResult.Rule.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -809,13 +810,13 @@ var _ = Describe("Rules Service", Ordered, func() {
 
 			Context("parameter validation", func() {
 				It("should fail with nil options", func() {
-					resp, err := client.Rules.Delete(nil)
+					resp, err := client.Rules.Delete(context.Background(), nil)
 					Expect(err).To(HaveOccurred())
 					Expect(resp).To(BeNil())
 				})
 
 				It("should fail with missing key", func() {
-					resp, err := client.Rules.Delete(&sonar.RulesDeleteOptions{})
+					resp, err := client.Rules.Delete(context.Background(), &sonar.RulesDeleteOptions{})
 					Expect(err).To(HaveOccurred())
 					Expect(resp).To(BeNil())
 				})
@@ -828,7 +829,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 	// =========================================================================
 	Describe("List", func() {
 		It("should list rules", func() {
-			result, resp, err := client.Rules.List(&sonar.RulesListOptions{})
+			result, resp, err := client.Rules.List(context.Background(), &sonar.RulesListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -836,7 +837,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should paginate results", func() {
-			result, resp, err := client.Rules.List(&sonar.RulesListOptions{
+			result, resp, err := client.Rules.List(context.Background(), &sonar.RulesListOptions{
 				PaginationArgs: sonar.PaginationArgs{
 					PageSize: 10,
 				},
@@ -847,7 +848,7 @@ var _ = Describe("Rules Service", Ordered, func() {
 		})
 
 		It("should allow nil options", func() {
-			result, resp, err := client.Rules.List(nil)
+			result, resp, err := client.Rules.List(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())

--- a/integration_testing/server_test.go
+++ b/integration_testing/server_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -30,7 +31,7 @@ var _ = Describe("Server Service", Ordered, func() {
 	Describe("Version", func() {
 		Context("Functional Tests", func() {
 			It("should return server version", func() {
-				version, resp, err := client.Server.Version()
+				version, resp, err := client.Server.Version(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(version).NotTo(BeNil())
@@ -38,7 +39,7 @@ var _ = Describe("Server Service", Ordered, func() {
 			})
 
 			It("should return version in expected format", func() {
-				version, resp, err := client.Server.Version()
+				version, resp, err := client.Server.Version(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(version).NotTo(BeNil())
@@ -50,11 +51,11 @@ var _ = Describe("Server Service", Ordered, func() {
 			})
 
 			It("should return consistent version on multiple calls", func() {
-				version1, resp1, err := client.Server.Version()
+				version1, resp1, err := client.Server.Version(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp1.StatusCode).To(Equal(http.StatusOK))
 
-				version2, resp2, err := client.Server.Version()
+				version2, resp2, err := client.Server.Version(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp2.StatusCode).To(Equal(http.StatusOK))
 
@@ -62,7 +63,7 @@ var _ = Describe("Server Service", Ordered, func() {
 			})
 
 			It("should return version with major version >= 9", func() {
-				version, resp, err := client.Server.Version()
+				version, resp, err := client.Server.Version(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(version).NotTo(BeNil())

--- a/integration_testing/settings_test.go
+++ b/integration_testing/settings_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -36,7 +37,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 	// =========================================================================
 	Describe("ListDefinitions", func() {
 		It("should list all setting definitions", func() {
-			result, resp, err := client.Settings.ListDefinitions(&sonar.SettingsListDefinitionsOptions{})
+			result, resp, err := client.Settings.ListDefinitions(context.Background(), &sonar.SettingsListDefinitionsOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -44,7 +45,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 		})
 
 		It("should return definitions with proper structure", func() {
-			result, resp, err := client.Settings.ListDefinitions(&sonar.SettingsListDefinitionsOptions{})
+			result, resp, err := client.Settings.ListDefinitions(context.Background(), &sonar.SettingsListDefinitionsOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			// Each definition should have at least a key
@@ -56,21 +57,21 @@ var _ = Describe("Settings Service", Ordered, func() {
 		It("should list definitions for a specific project", func() {
 			// First create a project
 			projectKey := helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// List definitions for the project
-			result, resp, err := client.Settings.ListDefinitions(&sonar.SettingsListDefinitionsOptions{
+			result, resp, err := client.Settings.ListDefinitions(context.Background(), &sonar.SettingsListDefinitionsOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -80,7 +81,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Settings.ListDefinitions(nil)
+				_, resp, err := client.Settings.ListDefinitions(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -92,7 +93,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 	// =========================================================================
 	Describe("Values", func() {
 		It("should list all setting values", func() {
-			result, resp, err := client.Settings.Values(&sonar.SettingsValuesOptions{})
+			result, resp, err := client.Settings.Values(context.Background(), &sonar.SettingsValuesOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -100,7 +101,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 		})
 
 		It("should filter by specific keys", func() {
-			result, resp, err := client.Settings.Values(&sonar.SettingsValuesOptions{
+			result, resp, err := client.Settings.Values(context.Background(), &sonar.SettingsValuesOptions{
 				Keys: []string{"sonar.core.id", "sonar.core.startTime"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -115,21 +116,21 @@ var _ = Describe("Settings Service", Ordered, func() {
 		It("should get values for a specific project", func() {
 			// First create a project
 			projectKey := helpers.UniqueResourceName("proj")
-			_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    projectKey,
 				Project: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return err
 			})
 
 			// Get values for the project
-			result, resp, err := client.Settings.Values(&sonar.SettingsValuesOptions{
+			result, resp, err := client.Settings.Values(context.Background(), &sonar.SettingsValuesOptions{
 				Component: projectKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -139,7 +140,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Settings.Values(nil)
+				_, resp, err := client.Settings.Values(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -153,7 +154,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 		Describe("Set", func() {
 			It("should set a global setting value", func() {
 				// Set a simple string setting
-				resp, err := client.Settings.Set(&sonar.SettingsSetOptions{
+				resp, err := client.Settings.Set(context.Background(), &sonar.SettingsSetOptions{
 					Key:   "sonar.login.message",
 					Value: "E2E Test Login Message",
 				})
@@ -161,7 +162,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Verify the value was set
-				values, _, err := client.Settings.Values(&sonar.SettingsValuesOptions{
+				values, _, err := client.Settings.Values(context.Background(), &sonar.SettingsValuesOptions{
 					Keys: []string{"sonar.login.message"},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -169,7 +170,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 				Expect(values.Settings[0].Value).To(Equal("E2E Test Login Message"))
 
 				// Clean up - reset the setting
-				_, _ = client.Settings.Reset(&sonar.SettingsResetOptions{
+				_, _ = client.Settings.Reset(context.Background(), &sonar.SettingsResetOptions{
 					Keys: []string{"sonar.login.message"},
 				})
 			})
@@ -177,21 +178,21 @@ var _ = Describe("Settings Service", Ordered, func() {
 			It("should set a project-level setting", func() {
 				// Create a project
 				projectKey := helpers.UniqueResourceName("proj")
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    projectKey,
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
 				// Set a project-level setting (sonar.exclusions is a multi-value setting)
-				resp, err := client.Settings.Set(&sonar.SettingsSetOptions{
+				resp, err := client.Settings.Set(context.Background(), &sonar.SettingsSetOptions{
 					Key:       "sonar.exclusions",
 					Values:    []string{"**/test/**"},
 					Component: projectKey,
@@ -200,7 +201,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Verify the value was set
-				values, _, err := client.Settings.Values(&sonar.SettingsValuesOptions{
+				values, _, err := client.Settings.Values(context.Background(), &sonar.SettingsValuesOptions{
 					Component: projectKey,
 					Keys:      []string{"sonar.exclusions"},
 				})
@@ -211,21 +212,21 @@ var _ = Describe("Settings Service", Ordered, func() {
 			It("should set a multi-value setting", func() {
 				// Create a project for testing
 				projectKey := helpers.UniqueResourceName("proj")
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    projectKey,
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
 				// Set a multi-value setting on the project
-				resp, err := client.Settings.Set(&sonar.SettingsSetOptions{
+				resp, err := client.Settings.Set(context.Background(), &sonar.SettingsSetOptions{
 					Key:       "sonar.exclusions",
 					Values:    []string{"**/test/**", "**/vendor/**"},
 					Component: projectKey,
@@ -236,13 +237,13 @@ var _ = Describe("Settings Service", Ordered, func() {
 
 			Context("parameter validation", func() {
 				It("should fail with nil options", func() {
-					resp, err := client.Settings.Set(nil)
+					resp, err := client.Settings.Set(context.Background(), nil)
 					Expect(err).To(HaveOccurred())
 					Expect(resp).To(BeNil())
 				})
 
 				It("should fail with missing key", func() {
-					resp, err := client.Settings.Set(&sonar.SettingsSetOptions{
+					resp, err := client.Settings.Set(context.Background(), &sonar.SettingsSetOptions{
 						Value: "some value",
 					})
 					Expect(err).To(HaveOccurred())
@@ -250,7 +251,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 				})
 
 				It("should fail with missing value/values/fieldValues", func() {
-					resp, err := client.Settings.Set(&sonar.SettingsSetOptions{
+					resp, err := client.Settings.Set(context.Background(), &sonar.SettingsSetOptions{
 						Key: "some.key",
 					})
 					Expect(err).To(HaveOccurred())
@@ -262,21 +263,21 @@ var _ = Describe("Settings Service", Ordered, func() {
 		Describe("Reset", func() {
 			It("should reset a global setting value", func() {
 				// First set a value
-				_, err := client.Settings.Set(&sonar.SettingsSetOptions{
+				_, err := client.Settings.Set(context.Background(), &sonar.SettingsSetOptions{
 					Key:   "sonar.login.message",
 					Value: "Message to be reset",
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Reset the setting
-				resp, err := client.Settings.Reset(&sonar.SettingsResetOptions{
+				resp, err := client.Settings.Reset(context.Background(), &sonar.SettingsResetOptions{
 					Keys: []string{"sonar.login.message"},
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Verify the value was reset (should not be found or have default value)
-				values, _, err := client.Settings.Values(&sonar.SettingsValuesOptions{
+				values, _, err := client.Settings.Values(context.Background(), &sonar.SettingsValuesOptions{
 					Keys: []string{"sonar.login.message"},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -289,21 +290,21 @@ var _ = Describe("Settings Service", Ordered, func() {
 			It("should reset a project-level setting", func() {
 				// Create a project
 				projectKey := helpers.UniqueResourceName("proj")
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    projectKey,
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
 				// Set a project-level setting (sonar.exclusions is a multi-value setting)
-				_, err = client.Settings.Set(&sonar.SettingsSetOptions{
+				_, err = client.Settings.Set(context.Background(), &sonar.SettingsSetOptions{
 					Key:       "sonar.exclusions",
 					Values:    []string{"**/test/**"},
 					Component: projectKey,
@@ -311,7 +312,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Reset the project-level setting
-				resp, err := client.Settings.Reset(&sonar.SettingsResetOptions{
+				resp, err := client.Settings.Reset(context.Background(), &sonar.SettingsResetOptions{
 					Keys:      []string{"sonar.exclusions"},
 					Component: projectKey,
 				})
@@ -322,28 +323,28 @@ var _ = Describe("Settings Service", Ordered, func() {
 			It("should reset multiple settings at once", func() {
 				// Create a project
 				projectKey := helpers.UniqueResourceName("proj")
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    projectKey,
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return err
 				})
 
 				// Set multiple settings (sonar.exclusions and sonar.inclusions are multi-value)
-				_, err = client.Settings.Set(&sonar.SettingsSetOptions{
+				_, err = client.Settings.Set(context.Background(), &sonar.SettingsSetOptions{
 					Key:       "sonar.exclusions",
 					Values:    []string{"**/test/**"},
 					Component: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				_, err = client.Settings.Set(&sonar.SettingsSetOptions{
+				_, err = client.Settings.Set(context.Background(), &sonar.SettingsSetOptions{
 					Key:       "sonar.inclusions",
 					Values:    []string{"**/src/**"},
 					Component: projectKey,
@@ -351,7 +352,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Reset multiple settings
-				resp, err := client.Settings.Reset(&sonar.SettingsResetOptions{
+				resp, err := client.Settings.Reset(context.Background(), &sonar.SettingsResetOptions{
 					Keys:      []string{"sonar.exclusions", "sonar.inclusions"},
 					Component: projectKey,
 				})
@@ -361,19 +362,19 @@ var _ = Describe("Settings Service", Ordered, func() {
 
 			Context("parameter validation", func() {
 				It("should fail with nil options", func() {
-					resp, err := client.Settings.Reset(nil)
+					resp, err := client.Settings.Reset(context.Background(), nil)
 					Expect(err).To(HaveOccurred())
 					Expect(resp).To(BeNil())
 				})
 
 				It("should fail with missing keys", func() {
-					resp, err := client.Settings.Reset(&sonar.SettingsResetOptions{})
+					resp, err := client.Settings.Reset(context.Background(), &sonar.SettingsResetOptions{})
 					Expect(err).To(HaveOccurred())
 					Expect(resp).To(BeNil())
 				})
 
 				It("should fail with empty keys array", func() {
-					resp, err := client.Settings.Reset(&sonar.SettingsResetOptions{
+					resp, err := client.Settings.Reset(context.Background(), &sonar.SettingsResetOptions{
 						Keys: []string{},
 					})
 					Expect(err).To(HaveOccurred())
@@ -388,7 +389,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 	// =========================================================================
 	Describe("LoginMessage", func() {
 		It("should get the login message", func() {
-			result, resp, err := client.Settings.LoginMessage()
+			result, resp, err := client.Settings.LoginMessage(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -397,14 +398,14 @@ var _ = Describe("Settings Service", Ordered, func() {
 
 		It("should return the set login message", func() {
 			// Set a login message
-			_, err := client.Settings.Set(&sonar.SettingsSetOptions{
+			_, err := client.Settings.Set(context.Background(), &sonar.SettingsSetOptions{
 				Key:   "sonar.login.message",
 				Value: "Welcome to E2E Testing!",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify the value was set using Values endpoint
-			values, _, err := client.Settings.Values(&sonar.SettingsValuesOptions{
+			values, _, err := client.Settings.Values(context.Background(), &sonar.SettingsValuesOptions{
 				Keys: []string{"sonar.login.message"},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -413,13 +414,13 @@ var _ = Describe("Settings Service", Ordered, func() {
 
 			// The LoginMessage endpoint may return empty due to SonarQube behavior
 			// but the setting value is correctly stored
-			result, resp, err := client.Settings.LoginMessage()
+			result, resp, err := client.Settings.LoginMessage(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
 
 			// Clean up
-			_, _ = client.Settings.Reset(&sonar.SettingsResetOptions{
+			_, _ = client.Settings.Reset(context.Background(), &sonar.SettingsResetOptions{
 				Keys: []string{"sonar.login.message"},
 			})
 		})
@@ -430,7 +431,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 	// =========================================================================
 	Describe("CheckSecretKey", func() {
 		It("should check if secret key is available", func() {
-			result, resp, err := client.Settings.CheckSecretKey()
+			result, resp, err := client.Settings.CheckSecretKey(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -444,7 +445,7 @@ var _ = Describe("Settings Service", Ordered, func() {
 	Describe("GenerateSecretKey", func() {
 		It("should generate a secret key", func() {
 			Skip("Skipping secret key generation test - it may fail if key already exists")
-			result, resp, err := client.Settings.GenerateSecretKey()
+			result, resp, err := client.Settings.GenerateSecretKey(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -458,14 +459,14 @@ var _ = Describe("Settings Service", Ordered, func() {
 	Describe("Encrypt", func() {
 		It("should encrypt a value if secret key is available", func() {
 			// First check if secret key is available
-			checkResult, _, err := client.Settings.CheckSecretKey()
+			checkResult, _, err := client.Settings.CheckSecretKey(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 
 			if !checkResult.SecretKeyAvailable {
 				Skip("Secret key not available, skipping encryption test")
 			}
 
-			result, resp, err := client.Settings.Encrypt(&sonar.SettingsEncryptOptions{
+			result, resp, err := client.Settings.Encrypt(context.Background(), &sonar.SettingsEncryptOptions{
 				Value: "my-secret-value",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -478,13 +479,13 @@ var _ = Describe("Settings Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Settings.Encrypt(nil)
+				_, resp, err := client.Settings.Encrypt(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing value", func() {
-				_, resp, err := client.Settings.Encrypt(&sonar.SettingsEncryptOptions{})
+				_, resp, err := client.Settings.Encrypt(context.Background(), &sonar.SettingsEncryptOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})

--- a/integration_testing/sources_test.go
+++ b/integration_testing/sources_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -24,14 +25,14 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		// Create a test project for source-related operations
 		projectKey = helpers.UniqueResourceName("src")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    "Sources Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -51,7 +52,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 	Describe("Index", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Sources.Index(nil)
+				result, resp, err := client.Sources.Index(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("option struct is required"))
 				Expect(result).To(BeNil())
@@ -59,7 +60,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 			})
 
 			It("should fail without required resource parameter", func() {
-				result, resp, err := client.Sources.Index(&sonar.SourcesIndexOptions{})
+				result, resp, err := client.Sources.Index(context.Background(), &sonar.SourcesIndexOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Resource"))
 				Expect(result).To(BeNil())
@@ -69,7 +70,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("Non-Existent Resource", func() {
 			It("should fail with non-existent file key", func() {
-				result, resp, err := client.Sources.Index(&sonar.SourcesIndexOptions{
+				result, resp, err := client.Sources.Index(context.Background(), &sonar.SourcesIndexOptions{
 					Resource: "non-existent:src/main.go",
 				})
 				// API should return an error for non-existent resource
@@ -84,7 +85,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 		Context("With Valid Project (No Analysis)", func() {
 			It("should fail for project without analyzed files", func() {
 				// Projects without analysis have no source files indexed
-				result, resp, err := client.Sources.Index(&sonar.SourcesIndexOptions{
+				result, resp, err := client.Sources.Index(context.Background(), &sonar.SourcesIndexOptions{
 					Resource: projectKey + ":src/main.go",
 				})
 				// Should fail because there's no analyzed source
@@ -98,7 +99,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Line Range", func() {
 			It("should fail for non-existent file with line range", func() {
-				result, resp, err := client.Sources.Index(&sonar.SourcesIndexOptions{
+				result, resp, err := client.Sources.Index(context.Background(), &sonar.SourcesIndexOptions{
 					Resource: "non-existent:src/main.go",
 					From:     1,
 					To:       10,
@@ -118,7 +119,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 	Describe("IssueSnippets", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Sources.IssueSnippets(nil)
+				result, resp, err := client.Sources.IssueSnippets(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("option struct is required"))
 				Expect(result).To(BeNil())
@@ -126,7 +127,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 			})
 
 			It("should fail without required issue key", func() {
-				result, resp, err := client.Sources.IssueSnippets(&sonar.SourcesIssueSnippetsOptions{})
+				result, resp, err := client.Sources.IssueSnippets(context.Background(), &sonar.SourcesIssueSnippetsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("IssueKey"))
 				Expect(result).To(BeNil())
@@ -136,7 +137,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("Non-Existent Issue", func() {
 			It("should fail with non-existent issue key", func() {
-				result, resp, err := client.Sources.IssueSnippets(&sonar.SourcesIssueSnippetsOptions{
+				result, resp, err := client.Sources.IssueSnippets(context.Background(), &sonar.SourcesIssueSnippetsOptions{
 					IssueKey: "AXxxxxxxxxxxxxxxxxxx",
 				})
 				// API should return an error for non-existent issue
@@ -155,7 +156,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 	Describe("Lines", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Sources.Lines(nil)
+				result, resp, err := client.Sources.Lines(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("option struct is required"))
 				Expect(result).To(BeNil())
@@ -163,7 +164,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 			})
 
 			It("should fail without required key parameter", func() {
-				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOptions{})
+				result, resp, err := client.Sources.Lines(context.Background(), &sonar.SourcesLinesOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(result).To(BeNil())
@@ -173,7 +174,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("Non-Existent File", func() {
 			It("should fail with non-existent file key", func() {
-				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOptions{
+				result, resp, err := client.Sources.Lines(context.Background(), &sonar.SourcesLinesOptions{
 					Key: "non-existent:src/main.go",
 				})
 				// API should return an error for non-existent file
@@ -187,7 +188,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Valid Project (No Analysis)", func() {
 			It("should fail for project without analyzed files", func() {
-				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOptions{
+				result, resp, err := client.Sources.Lines(context.Background(), &sonar.SourcesLinesOptions{
 					Key: projectKey + ":src/main.go",
 				})
 				// Should fail because there's no analyzed source
@@ -201,7 +202,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Line Range", func() {
 			It("should fail for non-existent file with line range", func() {
-				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOptions{
+				result, resp, err := client.Sources.Lines(context.Background(), &sonar.SourcesLinesOptions{
 					Key:  "non-existent:src/main.go",
 					From: 1,
 					To:   10,
@@ -216,7 +217,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Branch", func() {
 			It("should fail for non-existent branch", func() {
-				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOptions{
+				result, resp, err := client.Sources.Lines(context.Background(), &sonar.SourcesLinesOptions{
 					Key:    projectKey + ":src/main.go",
 					Branch: "non-existent-branch",
 				})
@@ -230,7 +231,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Pull Request", func() {
 			It("should fail for non-existent pull request", func() {
-				result, resp, err := client.Sources.Lines(&sonar.SourcesLinesOptions{
+				result, resp, err := client.Sources.Lines(context.Background(), &sonar.SourcesLinesOptions{
 					Key:         projectKey + ":src/main.go",
 					PullRequest: "99999",
 				})
@@ -249,7 +250,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 	Describe("Raw", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Sources.Raw(nil)
+				result, resp, err := client.Sources.Raw(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("option struct is required"))
 				Expect(result).To(BeEmpty())
@@ -257,7 +258,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 			})
 
 			It("should fail without required key parameter", func() {
-				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOptions{})
+				result, resp, err := client.Sources.Raw(context.Background(), &sonar.SourcesRawOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(result).To(BeEmpty())
@@ -267,7 +268,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("Non-Existent File", func() {
 			It("should fail with non-existent file key", func() {
-				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOptions{
+				result, resp, err := client.Sources.Raw(context.Background(), &sonar.SourcesRawOptions{
 					Key: "non-existent:src/main.go",
 				})
 				// API should return an error for non-existent file
@@ -281,7 +282,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Valid Project (No Analysis)", func() {
 			It("should fail for project without analyzed files", func() {
-				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOptions{
+				result, resp, err := client.Sources.Raw(context.Background(), &sonar.SourcesRawOptions{
 					Key: projectKey + ":src/main.go",
 				})
 				// Should fail because there's no analyzed source
@@ -295,7 +296,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Branch", func() {
 			It("should fail for non-existent branch", func() {
-				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOptions{
+				result, resp, err := client.Sources.Raw(context.Background(), &sonar.SourcesRawOptions{
 					Key:    projectKey + ":src/main.go",
 					Branch: "non-existent-branch",
 				})
@@ -309,7 +310,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Pull Request", func() {
 			It("should fail for non-existent pull request", func() {
-				result, resp, err := client.Sources.Raw(&sonar.SourcesRawOptions{
+				result, resp, err := client.Sources.Raw(context.Background(), &sonar.SourcesRawOptions{
 					Key:         projectKey + ":src/main.go",
 					PullRequest: "99999",
 				})
@@ -328,7 +329,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 	Describe("Scm", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Sources.Scm(nil)
+				result, resp, err := client.Sources.Scm(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("option struct is required"))
 				Expect(result).To(BeNil())
@@ -336,7 +337,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 			})
 
 			It("should fail without required key parameter", func() {
-				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOptions{})
+				result, resp, err := client.Sources.Scm(context.Background(), &sonar.SourcesScmOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(result).To(BeNil())
@@ -346,7 +347,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("Non-Existent File", func() {
 			It("should fail with non-existent file key", func() {
-				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOptions{
+				result, resp, err := client.Sources.Scm(context.Background(), &sonar.SourcesScmOptions{
 					Key: "non-existent:src/main.go",
 				})
 				// API should return an error for non-existent file
@@ -360,7 +361,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Valid Project (No Analysis)", func() {
 			It("should fail for project without analyzed files", func() {
-				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOptions{
+				result, resp, err := client.Sources.Scm(context.Background(), &sonar.SourcesScmOptions{
 					Key: projectKey + ":src/main.go",
 				})
 				// Should fail because there's no analyzed source
@@ -374,7 +375,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Line Range", func() {
 			It("should fail for non-existent file with line range", func() {
-				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOptions{
+				result, resp, err := client.Sources.Scm(context.Background(), &sonar.SourcesScmOptions{
 					Key:  "non-existent:src/main.go",
 					From: 1,
 					To:   10,
@@ -389,7 +390,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With CommitsByLine Option", func() {
 			It("should fail for non-existent file with commits_by_line", func() {
-				result, resp, err := client.Sources.Scm(&sonar.SourcesScmOptions{
+				result, resp, err := client.Sources.Scm(context.Background(), &sonar.SourcesScmOptions{
 					Key:           "non-existent:src/main.go",
 					CommitsByLine: true,
 				})
@@ -408,7 +409,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 	Describe("Show", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Sources.Show(nil)
+				result, resp, err := client.Sources.Show(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("option struct is required"))
 				Expect(result).To(BeNil())
@@ -416,7 +417,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 			})
 
 			It("should fail without required key parameter", func() {
-				result, resp, err := client.Sources.Show(&sonar.SourcesShowOptions{})
+				result, resp, err := client.Sources.Show(context.Background(), &sonar.SourcesShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(result).To(BeNil())
@@ -426,7 +427,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("Non-Existent File", func() {
 			It("should fail with non-existent file key", func() {
-				result, resp, err := client.Sources.Show(&sonar.SourcesShowOptions{
+				result, resp, err := client.Sources.Show(context.Background(), &sonar.SourcesShowOptions{
 					Key: "non-existent:src/main.go",
 				})
 				// API should return an error for non-existent file
@@ -440,7 +441,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Valid Project (No Analysis)", func() {
 			It("should fail for project without analyzed files", func() {
-				result, resp, err := client.Sources.Show(&sonar.SourcesShowOptions{
+				result, resp, err := client.Sources.Show(context.Background(), &sonar.SourcesShowOptions{
 					Key: projectKey + ":src/main.go",
 				})
 				// Should fail because there's no analyzed source
@@ -454,7 +455,7 @@ var _ = Describe("Sources Service", Ordered, func() {
 
 		Context("With Line Range", func() {
 			It("should fail for non-existent file with line range", func() {
-				result, resp, err := client.Sources.Show(&sonar.SourcesShowOptions{
+				result, resp, err := client.Sources.Show(context.Background(), &sonar.SourcesShowOptions{
 					Key:  "non-existent:src/main.go",
 					From: 1,
 					To:   10,

--- a/integration_testing/system_test.go
+++ b/integration_testing/system_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -25,7 +26,7 @@ var _ = Describe("System Service", Ordered, func() {
 	Describe("Health Check Endpoints", func() {
 		Describe("Health", func() {
 			It("should return health status with GREEN/YELLOW/RED", func() {
-				health, resp, err := client.System.Health()
+				health, resp, err := client.System.Health(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(health).NotTo(BeNil())
@@ -33,7 +34,7 @@ var _ = Describe("System Service", Ordered, func() {
 			})
 
 			It("should return nodes information for clustered setup", func() {
-				health, _, err := client.System.Health()
+				health, _, err := client.System.Health(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(health).NotTo(BeNil())
 				// Nodes may be empty for non-clustered setups
@@ -49,7 +50,7 @@ var _ = Describe("System Service", Ordered, func() {
 
 		Describe("Liveness", func() {
 			It("should return 204 when system is alive", func() {
-				_, resp, err := client.System.Liveness()
+				_, resp, err := client.System.Liveness(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 			})
@@ -57,7 +58,7 @@ var _ = Describe("System Service", Ordered, func() {
 
 		Describe("Ping", func() {
 			It("should return 'pong' response", func() {
-				pong, resp, err := client.System.Ping()
+				pong, resp, err := client.System.Ping(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(pong).NotTo(BeNil())
@@ -67,7 +68,7 @@ var _ = Describe("System Service", Ordered, func() {
 
 		Describe("Status", func() {
 			It("should return current system status", func() {
-				status, resp, err := client.System.Status()
+				status, resp, err := client.System.Status(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(status).NotTo(BeNil())
@@ -82,7 +83,7 @@ var _ = Describe("System Service", Ordered, func() {
 			})
 
 			It("should include version information when system is UP", func() {
-				status, _, err := client.System.Status()
+				status, _, err := client.System.Status(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(status).NotTo(BeNil())
 				if status.Status == "UP" {
@@ -95,14 +96,14 @@ var _ = Describe("System Service", Ordered, func() {
 	Describe("System Information Endpoints", func() {
 		Describe("Info", func() {
 			It("should return detailed system information", func() {
-				info, resp, err := client.System.Info()
+				info, resp, err := client.System.Info(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(info).NotTo(BeNil())
 			})
 
 			It("should contain sections for system details", func() {
-				info, _, err := client.System.Info()
+				info, _, err := client.System.Info(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(info).NotTo(BeNil())
 				// Check for common sections that should exist
@@ -115,7 +116,7 @@ var _ = Describe("System Service", Ordered, func() {
 	Describe("Database Migration", func() {
 		Describe("DbMigrationStatus", func() {
 			It("should return database migration status", func() {
-				status, resp, err := client.System.DbMigrationStatus()
+				status, resp, err := client.System.DbMigrationStatus(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(status).NotTo(BeNil())
@@ -142,7 +143,7 @@ var _ = Describe("System Service", Ordered, func() {
 	Describe("Upgrades", func() {
 		Describe("Upgrades", func() {
 			It("should return upgrade information", func() {
-				upgrades, resp, err := client.System.Upgrades()
+				upgrades, resp, err := client.System.Upgrades(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(upgrades).NotTo(BeNil())
@@ -162,14 +163,14 @@ var _ = Describe("System Service", Ordered, func() {
 
 			AfterEach(func() {
 				// Restore original log level
-				_, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOptions{
+				_, err := client.System.ChangeLogLevel(context.Background(), &sonar.SystemChangeLogLevelOptions{
 					Level: originalLevel,
 				})
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should change log level to DEBUG", func() {
-				resp, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOptions{
+				resp, err := client.System.ChangeLogLevel(context.Background(), &sonar.SystemChangeLogLevelOptions{
 					Level: "DEBUG",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -177,7 +178,7 @@ var _ = Describe("System Service", Ordered, func() {
 			})
 
 			It("should change log level to TRACE", func() {
-				resp, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOptions{
+				resp, err := client.System.ChangeLogLevel(context.Background(), &sonar.SystemChangeLogLevelOptions{
 					Level: "TRACE",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -185,7 +186,7 @@ var _ = Describe("System Service", Ordered, func() {
 			})
 
 			It("should change log level to INFO", func() {
-				resp, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOptions{
+				resp, err := client.System.ChangeLogLevel(context.Background(), &sonar.SystemChangeLogLevelOptions{
 					Level: "INFO",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -193,7 +194,7 @@ var _ = Describe("System Service", Ordered, func() {
 			})
 
 			It("should reject invalid log levels", func() {
-				resp, err := client.System.ChangeLogLevel(&sonar.SystemChangeLogLevelOptions{
+				resp, err := client.System.ChangeLogLevel(context.Background(), &sonar.SystemChangeLogLevelOptions{
 					Level: "INVALID_LEVEL",
 				})
 				// This should fail with validation error
@@ -204,7 +205,7 @@ var _ = Describe("System Service", Ordered, func() {
 
 		Describe("Logs", func() {
 			It("should retrieve app logs", func() {
-				logs, resp, err := client.System.Logs(&sonar.SystemLogsOptions{
+				logs, resp, err := client.System.Logs(context.Background(), &sonar.SystemLogsOptions{
 					Name: "app",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -214,7 +215,7 @@ var _ = Describe("System Service", Ordered, func() {
 			})
 
 			It("should retrieve web logs", func() {
-				logs, resp, err := client.System.Logs(&sonar.SystemLogsOptions{
+				logs, resp, err := client.System.Logs(context.Background(), &sonar.SystemLogsOptions{
 					Name: "web",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -223,7 +224,7 @@ var _ = Describe("System Service", Ordered, func() {
 			})
 
 			It("should retrieve ce logs", func() {
-				logs, resp, err := client.System.Logs(&sonar.SystemLogsOptions{
+				logs, resp, err := client.System.Logs(context.Background(), &sonar.SystemLogsOptions{
 					Name: "ce",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -232,7 +233,7 @@ var _ = Describe("System Service", Ordered, func() {
 			})
 
 			It("should reject invalid log names", func() {
-				_, resp, err := client.System.Logs(&sonar.SystemLogsOptions{
+				_, resp, err := client.System.Logs(context.Background(), &sonar.SystemLogsOptions{
 					Name: "invalid_log_name",
 				})
 				// This should fail with validation error

--- a/integration_testing/user_groups_test.go
+++ b/integration_testing/user_groups_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -37,7 +38,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("with default options", func() {
 			It("should return list of groups", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{})
+				result, resp, err := client.UserGroups.Search(context.Background(), &sonar.UserGroupsSearchOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -49,7 +50,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("with query filter", func() {
 			It("should filter groups by query", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
+				result, resp, err := client.UserGroups.Search(context.Background(), &sonar.UserGroupsSearchOptions{
 					Query: "admin",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -68,7 +69,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should return empty list for non-matching query", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
+				result, resp, err := client.UserGroups.Search(context.Background(), &sonar.UserGroupsSearchOptions{
 					Query: "nonexistentgroupxyz123",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -81,7 +82,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("with pagination", func() {
 			It("should support page size", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
+				result, resp, err := client.UserGroups.Search(context.Background(), &sonar.UserGroupsSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 1,
 					},
@@ -96,7 +97,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("with fields selection", func() {
 			It("should return specified fields", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
+				result, resp, err := client.UserGroups.Search(context.Background(), &sonar.UserGroupsSearchOptions{
 					Fields: []string{sonar.FieldName, sonar.FieldDescription, "membersCount"},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -113,14 +114,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Search(nil)
+				_, resp, err := client.UserGroups.Search(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid page size", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
+				_, _, err := client.UserGroups.Search(context.Background(), &sonar.UserGroupsSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 1000, // Too large
 					},
@@ -130,7 +131,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with invalid field", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
+				_, resp, err := client.UserGroups.Search(context.Background(), &sonar.UserGroupsSearchOptions{
 					Fields: []string{"invalid_field"},
 				})
 				Expect(err).To(HaveOccurred())
@@ -145,7 +146,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 				groupName := helpers.UniqueResourceName("group")
 
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+				result, resp, err := client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 					Name: groupName,
 				})
 
@@ -154,7 +155,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 				// Register cleanup
 				cleanup.RegisterCleanup("group", groupName, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+					_, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 						Name: groupName,
 					})
 					return err
@@ -172,7 +173,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 				groupName := helpers.UniqueResourceName("group-desc")
 
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+				result, resp, err := client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 					Name:        groupName,
 					Description: "E2E test group with description",
 				})
@@ -182,7 +183,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 				// Register cleanup
 				cleanup.RegisterCleanup("group", groupName, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+					_, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 						Name: groupName,
 					})
 					return err
@@ -201,7 +202,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 				// Create first group
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+				_, _, err := client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 					Name: groupName,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -209,7 +210,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 				// Register cleanup
 				cleanup.RegisterCleanup("group", groupName, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+					_, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 						Name: groupName,
 					})
 					return err
@@ -217,7 +218,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 				// Try to create duplicate
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+				_, resp, err := client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 					Name: groupName,
 				})
 				Expect(err).To(HaveOccurred())
@@ -230,14 +231,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Create(nil)
+				_, resp, err := client.UserGroups.Create(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing name", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+				_, resp, err := client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 					Description: "Test description",
 				})
 				Expect(err).To(HaveOccurred())
@@ -246,7 +247,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with name too long", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+				_, resp, err := client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 					Name: strings.Repeat("a", sonar.MaxGroupNameLength+1),
 				})
 				Expect(err).To(HaveOccurred())
@@ -255,7 +256,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with description too long", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+				_, resp, err := client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 					Name:        "validname",
 					Description: strings.Repeat("a", sonar.MaxGroupDescriptionLength+1),
 				})
@@ -274,7 +275,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 			nameToCleanup := testGroupName
 
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+			_, _, err := client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 				Name:        testGroupName,
 				Description: "Original description",
 			})
@@ -282,7 +283,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("group", nameToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+				_, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 					Name: nameToCleanup,
 				})
 				return err
@@ -291,7 +292,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should update group description", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOptions{
+			resp, err := client.UserGroups.Update(context.Background(), &sonar.UserGroupsUpdateOptions{
 				CurrentName: testGroupName,
 				Description: "Updated description",
 			})
@@ -302,7 +303,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Verify update
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
+			result, _, err := client.UserGroups.Search(context.Background(), &sonar.UserGroupsSearchOptions{
 				Query:  testGroupName,
 				Fields: []string{sonar.FieldName, sonar.FieldDescription},
 			})
@@ -322,7 +323,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 			newName := helpers.UniqueResourceName("group-renamed")
 
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOptions{
+			resp, err := client.UserGroups.Update(context.Background(), &sonar.UserGroupsUpdateOptions{
 				CurrentName: testGroupName,
 				Name:        newName,
 			})
@@ -336,7 +337,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Verify update
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
+			result, _, err := client.UserGroups.Search(context.Background(), &sonar.UserGroupsSearchOptions{
 				Query: newName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -353,14 +354,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.Update(nil)
+				resp, err := client.UserGroups.Update(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing current name", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOptions{
+				resp, err := client.UserGroups.Update(context.Background(), &sonar.UserGroupsUpdateOptions{
 					Name: "newname",
 				})
 				Expect(err).To(HaveOccurred())
@@ -369,7 +370,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with name too long", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOptions{
+				resp, err := client.UserGroups.Update(context.Background(), &sonar.UserGroupsUpdateOptions{
 					CurrentName: testGroupName,
 					Name:        strings.Repeat("a", sonar.MaxGroupNameLength+1),
 				})
@@ -379,7 +380,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail with description too long", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOptions{
+				resp, err := client.UserGroups.Update(context.Background(), &sonar.UserGroupsUpdateOptions{
 					CurrentName: testGroupName,
 					Description: strings.Repeat("a", sonar.MaxGroupDescriptionLength+1),
 				})
@@ -389,7 +390,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail for non-existent group", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Update(&sonar.UserGroupsUpdateOptions{
+				_, err := client.UserGroups.Update(context.Background(), &sonar.UserGroupsUpdateOptions{
 					CurrentName: "nonexistentgroup12345",
 					Description: "New description",
 				})
@@ -404,14 +405,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Create group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+			_, _, err := client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 				Name: groupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Delete group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+			resp, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 				Name: groupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -419,7 +420,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Verify deletion
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
+			result, _, err := client.UserGroups.Search(context.Background(), &sonar.UserGroupsSearchOptions{
 				Query: groupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -431,21 +432,21 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.Delete(nil)
+				resp, err := client.UserGroups.Delete(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing name", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{})
+				resp, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail for non-existent group", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+				_, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 					Name: "nonexistentgroup12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -467,14 +468,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Create group first
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+			_, _, err := client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 				Name: testGroupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("group", groupToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+				_, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 					Name: groupToCleanup,
 				})
 				return err
@@ -482,7 +483,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err = client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Test User for Group",
 				Password: "SecurePassword123!",
@@ -492,7 +493,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", userToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+				_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 					Login:     userToCleanup,
 					Anonymize: true,
 				})
@@ -502,7 +503,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should add user to group", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
+			resp, err := client.UserGroups.AddUser(context.Background(), &sonar.UserGroupsAddUserOptions{
 				Name:  testGroupName,
 				Login: testUserLogin,
 			})
@@ -511,7 +512,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Verify user is in group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
+			result, _, err := client.UserGroups.Users(context.Background(), &sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
 				Selected: sonar.SelectionFilterSelected,
 			})
@@ -529,7 +530,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should add user to group by login only", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
+			resp, err := client.UserGroups.AddUser(context.Background(), &sonar.UserGroupsAddUserOptions{
 				Name:  testGroupName,
 				Login: testUserLogin,
 			})
@@ -540,14 +541,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.AddUser(nil)
+				resp, err := client.UserGroups.AddUser(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing group name", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
+				resp, err := client.UserGroups.AddUser(context.Background(), &sonar.UserGroupsAddUserOptions{
 					Login: testUserLogin,
 				})
 				Expect(err).To(HaveOccurred())
@@ -556,7 +557,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail for non-existent group", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
+				_, err := client.UserGroups.AddUser(context.Background(), &sonar.UserGroupsAddUserOptions{
 					Name:  "nonexistentgroup12345",
 					Login: testUserLogin,
 				})
@@ -565,7 +566,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail for non-existent user", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
+				_, err := client.UserGroups.AddUser(context.Background(), &sonar.UserGroupsAddUserOptions{
 					Name:  testGroupName,
 					Login: "nonexistentuser12345",
 				})
@@ -588,14 +589,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Create group first
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+			_, _, err := client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 				Name: testGroupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("group", groupToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+				_, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 					Name: groupToCleanup,
 				})
 				return err
@@ -603,7 +604,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err = client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Test User for Remove",
 				Password: "SecurePassword123!",
@@ -613,7 +614,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", userToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+				_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 					Login:     userToCleanup,
 					Anonymize: true,
 				})
@@ -622,7 +623,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Add user to group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, err = client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
+			_, err = client.UserGroups.AddUser(context.Background(), &sonar.UserGroupsAddUserOptions{
 				Name:  testGroupName,
 				Login: testUserLogin,
 			})
@@ -631,7 +632,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should remove user from group", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.UserGroups.RemoveUser(&sonar.UserGroupsRemoveUserOptions{
+			resp, err := client.UserGroups.RemoveUser(context.Background(), &sonar.UserGroupsRemoveUserOptions{
 				Name:  testGroupName,
 				Login: testUserLogin,
 			})
@@ -640,7 +641,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Verify user is not in group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
+			result, _, err := client.UserGroups.Users(context.Background(), &sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
 				Selected: sonar.SelectionFilterSelected,
 			})
@@ -653,14 +654,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.RemoveUser(nil)
+				resp, err := client.UserGroups.RemoveUser(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing group name", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.UserGroups.RemoveUser(&sonar.UserGroupsRemoveUserOptions{
+				resp, err := client.UserGroups.RemoveUser(context.Background(), &sonar.UserGroupsRemoveUserOptions{
 					Login: testUserLogin,
 				})
 				Expect(err).To(HaveOccurred())
@@ -669,7 +670,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail for non-existent group", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.RemoveUser(&sonar.UserGroupsRemoveUserOptions{
+				_, err := client.UserGroups.RemoveUser(context.Background(), &sonar.UserGroupsRemoveUserOptions{
 					Name:  "nonexistentgroup12345",
 					Login: testUserLogin,
 				})
@@ -692,14 +693,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Create group first
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+			_, _, err := client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 				Name: testGroupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("group", groupToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+				_, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 					Name: groupToCleanup,
 				})
 				return err
@@ -707,7 +708,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err = client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Test User in Group",
 				Password: "SecurePassword123!",
@@ -717,7 +718,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", userToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+				_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 					Login:     userToCleanup,
 					Anonymize: true,
 				})
@@ -726,7 +727,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Add user to group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, err = client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
+			_, err = client.UserGroups.AddUser(context.Background(), &sonar.UserGroupsAddUserOptions{
 				Name:  testGroupName,
 				Login: testUserLogin,
 			})
@@ -735,7 +736,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should list selected users in group", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
+			result, resp, err := client.UserGroups.Users(context.Background(), &sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
 				Selected: sonar.SelectionFilterSelected,
 			})
@@ -758,7 +759,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should list all users with membership info", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
+			result, resp, err := client.UserGroups.Users(context.Background(), &sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
 				Selected: sonar.SelectionFilterAll,
 			})
@@ -771,7 +772,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should list deselected users", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
+			result, resp, err := client.UserGroups.Users(context.Background(), &sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
 				Selected: sonar.SelectionFilterDeselected,
 			})
@@ -786,7 +787,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should filter users by query", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
+			result, resp, err := client.UserGroups.Users(context.Background(), &sonar.UserGroupsUsersOptions{
 				Name:     testGroupName,
 				Query:    testUserLogin,
 				Selected: sonar.SelectionFilterAll,
@@ -808,7 +809,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("with pagination", func() {
 			It("should support page size", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
+				result, resp, err := client.UserGroups.Users(context.Background(), &sonar.UserGroupsUsersOptions{
 					Name: testGroupName,
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 1,
@@ -824,21 +825,21 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Users(nil)
+				_, resp, err := client.UserGroups.Users(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing name", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{})
+				_, resp, err := client.UserGroups.Users(context.Background(), &sonar.UserGroupsUsersOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid selected value", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
+				_, resp, err := client.UserGroups.Users(context.Background(), &sonar.UserGroupsUsersOptions{
 					Name:     testGroupName,
 					Selected: "invalid",
 				})
@@ -848,7 +849,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			It("should fail for non-existent group", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
+				_, _, err := client.UserGroups.Users(context.Background(), &sonar.UserGroupsUsersOptions{
 					Name: "nonexistentgroup12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -863,7 +864,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 1: Create group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			createResult, _, err := client.UserGroups.Create(&sonar.UserGroupsCreateOptions{
+			createResult, _, err := client.UserGroups.Create(context.Background(), &sonar.UserGroupsCreateOptions{
 				Name:        groupName,
 				Description: "Lifecycle test group",
 			})
@@ -874,7 +875,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 2: Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err = client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    userLogin,
 				Name:     "Lifecycle Test User",
 				Password: "SecurePassword123!",
@@ -884,7 +885,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 3: Add user to group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, err = client.UserGroups.AddUser(&sonar.UserGroupsAddUserOptions{
+			_, err = client.UserGroups.AddUser(context.Background(), &sonar.UserGroupsAddUserOptions{
 				Name:  groupName,
 				Login: userLogin,
 			})
@@ -892,7 +893,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 4: Verify user in group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			usersResult, _, err := client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
+			usersResult, _, err := client.UserGroups.Users(context.Background(), &sonar.UserGroupsUsersOptions{
 				Name:     groupName,
 				Selected: sonar.SelectionFilterSelected,
 			})
@@ -908,7 +909,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 5: Update group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, err = client.UserGroups.Update(&sonar.UserGroupsUpdateOptions{
+			_, err = client.UserGroups.Update(context.Background(), &sonar.UserGroupsUpdateOptions{
 				CurrentName: groupName,
 				Description: "Updated lifecycle description",
 			})
@@ -916,7 +917,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 6: Remove user from group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, err = client.UserGroups.RemoveUser(&sonar.UserGroupsRemoveUserOptions{
+			_, err = client.UserGroups.RemoveUser(context.Background(), &sonar.UserGroupsRemoveUserOptions{
 				Name:  groupName,
 				Login: userLogin,
 			})
@@ -924,7 +925,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 7: Verify user removed
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			usersResult, _, err = client.UserGroups.Users(&sonar.UserGroupsUsersOptions{
+			usersResult, _, err = client.UserGroups.Users(context.Background(), &sonar.UserGroupsUsersOptions{
 				Name:     groupName,
 				Selected: sonar.SelectionFilterSelected,
 			})
@@ -935,7 +936,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 8: Cleanup - deactivate user first
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+			_, _, err = client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 				Login:     userLogin,
 				Anonymize: true,
 			})
@@ -943,14 +944,14 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 			// Step 9: Delete group
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, err = client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+			_, err = client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 				Name: groupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify group deleted
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			searchResult, _, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
+			searchResult, _, err := client.UserGroups.Search(context.Background(), &sonar.UserGroupsSearchOptions{
 				Query: groupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -963,7 +964,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 	Describe("Default Groups", func() {
 		It("should find sonar-users group", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
+			result, resp, err := client.UserGroups.Search(context.Background(), &sonar.UserGroupsSearchOptions{
 				Query: "sonar-users",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -981,7 +982,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 
 		It("should find sonar-administrators group", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.UserGroups.Search(&sonar.UserGroupsSearchOptions{
+			result, resp, err := client.UserGroups.Search(context.Background(), &sonar.UserGroupsSearchOptions{
 				Query: "sonar-administrators",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1000,7 +1001,7 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 		It("should not delete default groups", func() {
 			// Try to delete sonar-users (default group) - should fail
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, err := client.UserGroups.Delete(&sonar.UserGroupsDeleteOptions{
+			_, err := client.UserGroups.Delete(context.Background(), &sonar.UserGroupsDeleteOptions{
 				Name: "sonar-users",
 			})
 			// Default groups cannot be deleted

--- a/integration_testing/user_tokens_test.go
+++ b/integration_testing/user_tokens_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -38,7 +39,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			It("should generate a user token", func() {
 				tokenName := helpers.UniqueResourceName("token")
 
-				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+				result, resp, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 					Name: tokenName,
 				})
 
@@ -46,7 +47,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				// Register cleanup
 				cleanup.RegisterCleanup("token", tokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+					_, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 						Name: tokenName,
 					})
 					return err
@@ -63,7 +64,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			It("should generate a token with explicit USER_TOKEN type", func() {
 				tokenName := helpers.UniqueResourceName("token-user")
 
-				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+				result, resp, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 					Name: tokenName,
 					Type: "USER_TOKEN",
 				})
@@ -72,7 +73,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				// Register cleanup
 				cleanup.RegisterCleanup("token", tokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+					_, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 						Name: tokenName,
 					})
 					return err
@@ -90,7 +91,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			It("should generate a global analysis token", func() {
 				tokenName := helpers.UniqueResourceName("token-global")
 
-				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+				result, resp, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 					Name: tokenName,
 					Type: "GLOBAL_ANALYSIS_TOKEN",
 				})
@@ -99,7 +100,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				// Register cleanup
 				cleanup.RegisterCleanup("token", tokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+					_, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 						Name: tokenName,
 					})
 					return err
@@ -120,14 +121,14 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				// Create a project for the token
 				testProjectKey = helpers.UniqueResourceName("proj-token")
 
-				_, _, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 					Name:    "Token Test Project",
 					Project: testProjectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("project", testProjectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: testProjectKey,
 					})
 					return err
@@ -137,7 +138,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			It("should generate a project analysis token", func() {
 				tokenName := helpers.UniqueResourceName("token-proj")
 
-				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+				result, resp, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 					Name:       tokenName,
 					Type:       "PROJECT_ANALYSIS_TOKEN",
 					ProjectKey: testProjectKey,
@@ -147,7 +148,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				// Register cleanup
 				cleanup.RegisterCleanup("token", tokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+					_, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 						Name: tokenName,
 					})
 					return err
@@ -167,7 +168,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				// Set expiration date to 30 days from now
 				expirationDate := "2027-01-01"
 
-				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+				result, resp, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 					Name:           tokenName,
 					ExpirationDate: expirationDate,
 				})
@@ -176,7 +177,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				// Register cleanup
 				cleanup.RegisterCleanup("token", tokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+					_, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 						Name: tokenName,
 					})
 					return err
@@ -196,7 +197,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				testUserLogin = helpers.UniqueResourceName("user-token")
 
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
+				_, _, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 					Login:    testUserLogin,
 					Name:     "Token Test User",
 					Password: "SecurePassword123!",
@@ -206,7 +207,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				cleanup.RegisterCleanup("user", testUserLogin, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+					_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 						Login:     testUserLogin,
 						Anonymize: true,
 					})
@@ -217,7 +218,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			It("should generate a token for another user", func() {
 				tokenName := helpers.UniqueResourceName("token-other")
 
-				result, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+				result, resp, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 					Name:  tokenName,
 					Login: testUserLogin,
 				})
@@ -226,7 +227,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				// Register cleanup
 				cleanup.RegisterCleanup("token", tokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+					_, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 						Name:  tokenName,
 						Login: testUserLogin,
 					})
@@ -245,21 +246,21 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				tokenName := helpers.UniqueResourceName("token-dup")
 
 				// Generate first token
-				_, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+				_, _, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 					Name: tokenName,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Register cleanup
 				cleanup.RegisterCleanup("token", tokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+					_, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 						Name: tokenName,
 					})
 					return err
 				})
 
 				// Try to generate duplicate
-				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+				_, resp, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 					Name: tokenName,
 				})
 				Expect(err).To(HaveOccurred())
@@ -271,19 +272,19 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.UserTokens.Generate(nil)
+				_, resp, err := client.UserTokens.Generate(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing name", func() {
-				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{})
+				_, resp, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid type", func() {
-				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+				_, resp, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 					Name: "test-token",
 					Type: "INVALID_TYPE",
 				})
@@ -292,7 +293,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			})
 
 			It("should fail with PROJECT_ANALYSIS_TOKEN without project key", func() {
-				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+				_, resp, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 					Name: "test-token",
 					Type: "PROJECT_ANALYSIS_TOKEN",
 				})
@@ -302,7 +303,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 			It("should fail with name too long", func() {
 				longName := strings.Repeat("a", sonar.MaxTokenNameLength+1)
-				_, resp, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+				_, resp, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 					Name: longName,
 				})
 				Expect(err).To(HaveOccurred())
@@ -317,13 +318,13 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 		BeforeEach(func() {
 			tokenName = helpers.UniqueResourceName("token-search")
 
-			_, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+			_, _, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 				Name: tokenName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("token", tokenName, func() error {
-				_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+				_, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 					Name: tokenName,
 				})
 				return err
@@ -331,7 +332,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 		})
 
 		It("should search tokens for current user", func() {
-			result, resp, err := client.UserTokens.Search(nil)
+			result, resp, err := client.UserTokens.Search(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -351,7 +352,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 		})
 
 		It("should search tokens with empty options", func() {
-			result, resp, err := client.UserTokens.Search(&sonar.UserTokensSearchOptions{})
+			result, resp, err := client.UserTokens.Search(context.Background(), &sonar.UserTokensSearchOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -367,7 +368,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				userTokenName = helpers.UniqueResourceName("token-usrsrch")
 
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
+				_, _, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 					Login:    testUserLogin,
 					Name:     "Search Test User",
 					Password: "SecurePassword123!",
@@ -377,7 +378,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				cleanup.RegisterCleanup("user", testUserLogin, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+					_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 						Login:     testUserLogin,
 						Anonymize: true,
 					})
@@ -385,14 +386,14 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				})
 
 				// Generate a token for the test user
-				_, _, err = client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+				_, _, err = client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 					Name:  userTokenName,
 					Login: testUserLogin,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				cleanup.RegisterCleanup("token", userTokenName, func() error {
-					_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+					_, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 						Name:  userTokenName,
 						Login: testUserLogin,
 					})
@@ -401,7 +402,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			})
 
 			It("should search tokens for specific user", func() {
-				result, resp, err := client.UserTokens.Search(&sonar.UserTokensSearchOptions{
+				result, resp, err := client.UserTokens.Search(context.Background(), &sonar.UserTokensSearchOptions{
 					Login: testUserLogin,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -423,7 +424,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 		})
 
 		It("should return token details", func() {
-			result, resp, err := client.UserTokens.Search(nil)
+			result, resp, err := client.UserTokens.Search(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -445,20 +446,20 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			tokenName := helpers.UniqueResourceName("token-revoke")
 
 			// Generate a token first
-			_, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+			_, _, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 				Name: tokenName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Revoke the token
-			resp, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+			resp, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 				Name: tokenName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify token is revoked by searching
-			result, _, err := client.UserTokens.Search(nil)
+			result, _, err := client.UserTokens.Search(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			for _, t := range result.UserTokens {
 				Expect(t.Name).NotTo(Equal(tokenName))
@@ -474,7 +475,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				userTokenName = helpers.UniqueResourceName("token-usrrev")
 
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
+				_, _, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 					Login:    testUserLogin,
 					Name:     "Revoke Test User",
 					Password: "SecurePassword123!",
@@ -484,7 +485,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 				cleanup.RegisterCleanup("user", testUserLogin, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+					_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 						Login:     testUserLogin,
 						Anonymize: true,
 					})
@@ -492,7 +493,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				})
 
 				// Generate a token for the test user
-				_, _, err = client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+				_, _, err = client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 					Name:  userTokenName,
 					Login: testUserLogin,
 				})
@@ -500,7 +501,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			})
 
 			It("should revoke a token for another user", func() {
-				resp, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+				resp, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 					Name:  userTokenName,
 					Login: testUserLogin,
 				})
@@ -508,7 +509,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Verify token is revoked
-				result, _, err := client.UserTokens.Search(&sonar.UserTokensSearchOptions{
+				result, _, err := client.UserTokens.Search(context.Background(), &sonar.UserTokensSearchOptions{
 					Login: testUserLogin,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -520,20 +521,20 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.UserTokens.Revoke(nil)
+				resp, err := client.UserTokens.Revoke(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing name", func() {
-				resp, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{})
+				resp, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should handle revoking non-existent token gracefully", func() {
 				// SonarQube API is idempotent - revoking a non-existent token succeeds silently
-				resp, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+				resp, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 					Name: "nonexistent-token-xyz12345",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -547,7 +548,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			tokenName := helpers.UniqueResourceName("token-lifecycle")
 
 			// Step 1: Generate token
-			generateResult, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+			generateResult, _, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 				Name: tokenName,
 				Type: "USER_TOKEN",
 			})
@@ -557,7 +558,7 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			generatedToken := generateResult.Token
 
 			// Step 2: Search and verify token exists
-			searchResult, _, err := client.UserTokens.Search(nil)
+			searchResult, _, err := client.UserTokens.Search(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			found := false
 			for _, t := range searchResult.UserTokens {
@@ -579,18 +580,18 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Use the token to make an authenticated request
-			authResult, _, err := tokenClient.Authentication.Validate()
+			authResult, _, err := tokenClient.Authentication.Validate(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(authResult.Valid).To(BeTrue())
 
 			// Step 4: Revoke token
-			_, err = client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+			_, err = client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 				Name: tokenName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: Verify token no longer exists
-			searchResult, _, err = client.UserTokens.Search(nil)
+			searchResult, _, err = client.UserTokens.Search(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			for _, t := range searchResult.UserTokens {
 				Expect(t.Name).NotTo(Equal(tokenName))
@@ -605,45 +606,45 @@ var _ = Describe("UserTokens Service", Ordered, func() {
 			token3Name := helpers.UniqueResourceName("token-multi3")
 
 			// Generate multiple tokens
-			_, _, err := client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+			_, _, err := client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 				Name: token1Name,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("token", token1Name, func() error {
-				_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+				_, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 					Name: token1Name,
 				})
 				return err
 			})
 
-			_, _, err = client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+			_, _, err = client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 				Name: token2Name,
 				Type: "GLOBAL_ANALYSIS_TOKEN",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("token", token2Name, func() error {
-				_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+				_, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 					Name: token2Name,
 				})
 				return err
 			})
 
-			_, _, err = client.UserTokens.Generate(&sonar.UserTokensGenerateOptions{
+			_, _, err = client.UserTokens.Generate(context.Background(), &sonar.UserTokensGenerateOptions{
 				Name: token3Name,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			cleanup.RegisterCleanup("token", token3Name, func() error {
-				_, err := client.UserTokens.Revoke(&sonar.UserTokensRevokeOptions{
+				_, err := client.UserTokens.Revoke(context.Background(), &sonar.UserTokensRevokeOptions{
 					Name: token3Name,
 				})
 				return err
 			})
 
 			// Search and verify all tokens exist
-			result, _, err := client.UserTokens.Search(nil)
+			result, _, err := client.UserTokens.Search(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			foundTokens := make(map[string]bool)

--- a/integration_testing/users_test.go
+++ b/integration_testing/users_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -37,7 +38,7 @@ var _ = Describe("Users Service", Ordered, func() {
 	Describe("Current", func() {
 		It("should return the current authenticated user", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			user, resp, err := client.Users.Current()
+			user, resp, err := client.Users.Current(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(user).NotTo(BeNil())
@@ -47,7 +48,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 		It("should return user permissions for admin", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			user, resp, err := client.Users.Current()
+			user, resp, err := client.Users.Current(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(user).NotTo(BeNil())
@@ -57,7 +58,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 		It("should return groups for the current user", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			user, resp, err := client.Users.Current()
+			user, resp, err := client.Users.Current(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(user).NotTo(BeNil())
@@ -70,7 +71,7 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("without options", func() {
 			It("should return list of users", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.Users.Search(nil)
+				result, resp, err := client.Users.Search(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -81,7 +82,7 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("with query filter", func() {
 			It("should filter users by query", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.Users.Search(&sonar.UsersSearchOptions{
+				result, resp, err := client.Users.Search(context.Background(), &sonar.UsersSearchOptions{
 					Query: "admin",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -100,7 +101,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should return empty list for non-matching query", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.Users.Search(&sonar.UsersSearchOptions{
+				result, resp, err := client.Users.Search(context.Background(), &sonar.UsersSearchOptions{
 					Query: "nonexistentuserxyz123",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -113,7 +114,7 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("with pagination", func() {
 			It("should support page size", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.Users.Search(&sonar.UsersSearchOptions{
+				result, resp, err := client.Users.Search(context.Background(), &sonar.UsersSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 1,
 					},
@@ -128,7 +129,7 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should reject invalid page size", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Search(&sonar.UsersSearchOptions{
+				_, _, err := client.Users.Search(context.Background(), &sonar.UsersSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 1000, // Too large
 					},
@@ -144,7 +145,7 @@ var _ = Describe("Users Service", Ordered, func() {
 				login := helpers.UniqueResourceName("user")
 
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
+				result, resp, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 					Login:    login,
 					Name:     "E2E Test User",
 					Password: "SecurePassword123!",
@@ -156,7 +157,7 @@ var _ = Describe("Users Service", Ordered, func() {
 				// Register cleanup
 				cleanup.RegisterCleanup("user", login, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+					_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 						Login:     login,
 						Anonymize: true,
 					})
@@ -178,7 +179,7 @@ var _ = Describe("Users Service", Ordered, func() {
 				scmAccount2 := fmt.Sprintf("gitlab:%s", login)
 
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				result, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
+				result, resp, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 					Login:       login,
 					Name:        "E2E Full User",
 					Email:       "e2e-test@example.com",
@@ -192,7 +193,7 @@ var _ = Describe("Users Service", Ordered, func() {
 				// Register cleanup
 				cleanup.RegisterCleanup("user", login, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+					_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 						Login:     login,
 						Anonymize: true,
 					})
@@ -212,7 +213,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 				// Create first user
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
+				_, _, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 					Login:    login,
 					Name:     "First User",
 					Password: "SecurePassword123!",
@@ -223,7 +224,7 @@ var _ = Describe("Users Service", Ordered, func() {
 				// Register cleanup
 				cleanup.RegisterCleanup("user", login, func() error {
 					//nolint:staticcheck // Using deprecated API until v2 API is implemented
-					_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+					_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 						Login:     login,
 						Anonymize: true,
 					})
@@ -232,7 +233,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 				// Try to create duplicate
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
+				_, resp, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 					Login:    login,
 					Name:     "Duplicate User",
 					Password: "AnotherPassword123!",
@@ -248,14 +249,14 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Create(nil)
+				_, resp, err := client.Users.Create(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
+				_, resp, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 					Name:     "Test User",
 					Password: "SecurePassword123!",
 				})
@@ -265,7 +266,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing name", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
+				_, resp, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 					Login:    "testuser",
 					Password: "SecurePassword123!",
 				})
@@ -275,7 +276,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with login too short", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
+				_, resp, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 					Login:    "x",
 					Name:     "Test User",
 					Password: "SecurePassword123!",
@@ -286,7 +287,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing password for local user", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
+				_, resp, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 					Login: "testuser",
 					Name:  "Test User",
 					Local: true,
@@ -297,7 +298,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with password too short", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Create(&sonar.UsersCreateOptions{
+				_, resp, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 					Login:    "testuser",
 					Name:     "Test User",
 					Password: "short",
@@ -318,7 +319,7 @@ var _ = Describe("Users Service", Ordered, func() {
 			loginToCleanup := testUserLogin
 
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Original Name",
 				Email:    "original@example.com",
@@ -329,7 +330,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", loginToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+				_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 					Login:     loginToCleanup,
 					Anonymize: true,
 				})
@@ -339,7 +340,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 		It("should update user name", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.Update(&sonar.UsersUpdateOptions{
+			result, resp, err := client.Users.Update(context.Background(), &sonar.UsersUpdateOptions{
 				Login: testUserLogin,
 				Name:  "Updated Name",
 			})
@@ -351,7 +352,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 		It("should update user email", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.Update(&sonar.UsersUpdateOptions{
+			result, resp, err := client.Users.Update(context.Background(), &sonar.UsersUpdateOptions{
 				Login: testUserLogin,
 				Email: "updated@example.com",
 			})
@@ -367,7 +368,7 @@ var _ = Describe("Users Service", Ordered, func() {
 			scmAccount2 := fmt.Sprintf("bitbucket:%s", testUserLogin)
 
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.Update(&sonar.UsersUpdateOptions{
+			result, resp, err := client.Users.Update(context.Background(), &sonar.UsersUpdateOptions{
 				Login:       testUserLogin,
 				ScmAccounts: []string{scmAccount1, scmAccount2},
 			})
@@ -380,14 +381,14 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Update(nil)
+				_, resp, err := client.Users.Update(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Update(&sonar.UsersUpdateOptions{
+				_, resp, err := client.Users.Update(context.Background(), &sonar.UsersUpdateOptions{
 					Name: "Some Name",
 				})
 				Expect(err).To(HaveOccurred())
@@ -396,7 +397,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail for non-existent user", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Update(&sonar.UsersUpdateOptions{
+				_, resp, err := client.Users.Update(context.Background(), &sonar.UsersUpdateOptions{
 					Login: "nonexistentuser12345",
 					Name:  "New Name",
 				})
@@ -417,7 +418,7 @@ var _ = Describe("Users Service", Ordered, func() {
 			loginToCleanup := testUserLogin
 
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    testUserLogin,
 				Name:     "Password Test User",
 				Password: "OldPassword123!",
@@ -427,7 +428,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			cleanup.RegisterCleanup("user", loginToCleanup, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+				_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 					Login:     loginToCleanup,
 					Anonymize: true,
 				})
@@ -437,7 +438,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 		It("should change user password", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.Users.ChangePassword(&sonar.UsersChangePasswordOptions{
+			resp, err := client.Users.ChangePassword(context.Background(), &sonar.UsersChangePasswordOptions{
 				Login:    testUserLogin,
 				Password: "NewPassword456!",
 			})
@@ -453,7 +454,7 @@ var _ = Describe("Users Service", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			currentUser, _, err := newClient.Users.Current()
+			currentUser, _, err := newClient.Users.Current(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(currentUser.Login).To(Equal(testUserLogin))
 		})
@@ -461,14 +462,14 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.ChangePassword(nil)
+				resp, err := client.Users.ChangePassword(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.ChangePassword(&sonar.UsersChangePasswordOptions{
+				resp, err := client.Users.ChangePassword(context.Background(), &sonar.UsersChangePasswordOptions{
 					Password: "NewPassword123!",
 				})
 				Expect(err).To(HaveOccurred())
@@ -477,7 +478,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing password", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.ChangePassword(&sonar.UsersChangePasswordOptions{
+				resp, err := client.Users.ChangePassword(context.Background(), &sonar.UsersChangePasswordOptions{
 					Login: testUserLogin,
 				})
 				Expect(err).To(HaveOccurred())
@@ -486,7 +487,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with password too short", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.ChangePassword(&sonar.UsersChangePasswordOptions{
+				resp, err := client.Users.ChangePassword(context.Background(), &sonar.UsersChangePasswordOptions{
 					Login:    testUserLogin,
 					Password: "short",
 				})
@@ -503,7 +504,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    oldLogin,
 				Name:     "Login Update User",
 				Password: "SecurePassword123!",
@@ -513,7 +514,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Update login
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.Users.UpdateLogin(&sonar.UsersUpdateLoginOptions{
+			resp, err := client.Users.UpdateLogin(context.Background(), &sonar.UsersUpdateLoginOptions{
 				Login:    oldLogin,
 				NewLogin: newLogin,
 			})
@@ -523,7 +524,7 @@ var _ = Describe("Users Service", Ordered, func() {
 			// Register cleanup with new login
 			cleanup.RegisterCleanup("user", newLogin, func() error {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+				_, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 					Login:     newLogin,
 					Anonymize: true,
 				})
@@ -532,7 +533,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Verify new login exists
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, _, err := client.Users.Search(&sonar.UsersSearchOptions{
+			result, _, err := client.Users.Search(context.Background(), &sonar.UsersSearchOptions{
 				Query: newLogin,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -549,14 +550,14 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.UpdateLogin(nil)
+				resp, err := client.Users.UpdateLogin(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.UpdateLogin(&sonar.UsersUpdateLoginOptions{
+				resp, err := client.Users.UpdateLogin(context.Background(), &sonar.UsersUpdateLoginOptions{
 					NewLogin: "newlogin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -565,7 +566,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing new login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.UpdateLogin(&sonar.UsersUpdateLoginOptions{
+				resp, err := client.Users.UpdateLogin(context.Background(), &sonar.UsersUpdateLoginOptions{
 					Login: "oldlogin",
 				})
 				Expect(err).To(HaveOccurred())
@@ -574,7 +575,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with new login too short", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.UpdateLogin(&sonar.UsersUpdateLoginOptions{
+				resp, err := client.Users.UpdateLogin(context.Background(), &sonar.UsersUpdateLoginOptions{
 					Login:    "someuser",
 					NewLogin: "x",
 				})
@@ -587,7 +588,7 @@ var _ = Describe("Users Service", Ordered, func() {
 	Describe("Groups", func() {
 		It("should return groups for a user", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.Groups(&sonar.UsersGroupsOptions{
+			result, resp, err := client.Users.Groups(context.Background(), &sonar.UsersGroupsOptions{
 				Login: "admin",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -599,7 +600,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 		It("should filter groups with query", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.Groups(&sonar.UsersGroupsOptions{
+			result, resp, err := client.Users.Groups(context.Background(), &sonar.UsersGroupsOptions{
 				Login: "admin",
 				Query: "sonar",
 			})
@@ -611,14 +612,14 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Groups(nil)
+				_, resp, err := client.Users.Groups(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Groups(&sonar.UsersGroupsOptions{})
+				_, resp, err := client.Users.Groups(context.Background(), &sonar.UsersGroupsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -628,7 +629,7 @@ var _ = Describe("Users Service", Ordered, func() {
 	Describe("IdentityProviders", func() {
 		It("should return list of identity providers", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.IdentityProviders()
+			result, resp, err := client.Users.IdentityProviders(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -638,7 +639,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 		It("should successfully call the API", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.IdentityProviders()
+			result, resp, err := client.Users.IdentityProviders(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -652,7 +653,7 @@ var _ = Describe("Users Service", Ordered, func() {
 	Describe("SetHomepage", func() {
 		It("should set homepage to PROJECTS", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.Users.SetHomepage(&sonar.UsersSetHomepageOptions{
+			resp, err := client.Users.SetHomepage(context.Background(), &sonar.UsersSetHomepageOptions{
 				Type: "PROJECTS",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -661,7 +662,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 		It("should set homepage to ISSUES", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.Users.SetHomepage(&sonar.UsersSetHomepageOptions{
+			resp, err := client.Users.SetHomepage(context.Background(), &sonar.UsersSetHomepageOptions{
 				Type: "ISSUES",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -671,21 +672,21 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.SetHomepage(nil)
+				resp, err := client.Users.SetHomepage(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing type", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.SetHomepage(&sonar.UsersSetHomepageOptions{})
+				resp, err := client.Users.SetHomepage(context.Background(), &sonar.UsersSetHomepageOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid type", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.SetHomepage(&sonar.UsersSetHomepageOptions{
+				resp, err := client.Users.SetHomepage(context.Background(), &sonar.UsersSetHomepageOptions{
 					Type: "INVALID_TYPE",
 				})
 				Expect(err).To(HaveOccurred())
@@ -697,7 +698,7 @@ var _ = Describe("Users Service", Ordered, func() {
 	Describe("DismissNotice", func() {
 		It("should dismiss a notice", func() {
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.Users.DismissNotice(&sonar.UsersDismissNoticeOptions{
+			resp, err := client.Users.DismissNotice(context.Background(), &sonar.UsersDismissNoticeOptions{
 				Notice: "educationPrinciples",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -707,7 +708,7 @@ var _ = Describe("Users Service", Ordered, func() {
 		It("should handle already dismissed notice gracefully", func() {
 			// Dismiss the same notice twice - should succeed silently
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.Users.DismissNotice(&sonar.UsersDismissNoticeOptions{
+			resp, err := client.Users.DismissNotice(context.Background(), &sonar.UsersDismissNoticeOptions{
 				Notice: "sonarlintAd",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -715,7 +716,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Dismiss again
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err = client.Users.DismissNotice(&sonar.UsersDismissNoticeOptions{
+			resp, err = client.Users.DismissNotice(context.Background(), &sonar.UsersDismissNoticeOptions{
 				Notice: "sonarlintAd",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -725,21 +726,21 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.DismissNotice(nil)
+				resp, err := client.Users.DismissNotice(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing notice", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.DismissNotice(&sonar.UsersDismissNoticeOptions{})
+				resp, err := client.Users.DismissNotice(context.Background(), &sonar.UsersDismissNoticeOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid notice type", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.DismissNotice(&sonar.UsersDismissNoticeOptions{
+				resp, err := client.Users.DismissNotice(context.Background(), &sonar.UsersDismissNoticeOptions{
 					Notice: "invalidNoticeType",
 				})
 				Expect(err).To(HaveOccurred())
@@ -754,7 +755,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    login,
 				Name:     "Deactivate Test User",
 				Password: "SecurePassword123!",
@@ -764,7 +765,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Deactivate user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+			result, resp, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 				Login: login,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -775,7 +776,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Verify user is deactivated
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			searchResult, _, err := client.Users.Search(&sonar.UsersSearchOptions{
+			searchResult, _, err := client.Users.Search(context.Background(), &sonar.UsersSearchOptions{
 				Query:       login,
 				Deactivated: true,
 			})
@@ -796,7 +797,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    login,
 				Name:     "Anonymize Test User",
 				Email:    "anon@example.com",
@@ -807,7 +808,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Deactivate with anonymize
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			result, resp, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+			result, resp, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 				Login:     login,
 				Anonymize: true,
 			})
@@ -820,21 +821,21 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Deactivate(nil)
+				_, resp, err := client.Users.Deactivate(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{})
+				_, resp, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail for non-existent user", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				_, resp, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+				_, resp, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 					Login: "nonexistentuser12345",
 				})
 				Expect(err).To(HaveOccurred())
@@ -851,7 +852,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err := client.Users.Create(&sonar.UsersCreateOptions{
+			_, _, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    login,
 				Name:     "Anonymize Test User 2",
 				Email:    "anon2@example.com",
@@ -862,14 +863,14 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Deactivate first (required before anonymize)
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+			_, _, err = client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 				Login: login,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Anonymize
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			resp, err := client.Users.Anonymize(&sonar.UsersAnonymizeOptions{
+			resp, err := client.Users.Anonymize(context.Background(), &sonar.UsersAnonymizeOptions{
 				Login: login,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -879,14 +880,14 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.Anonymize(nil)
+				resp, err := client.Users.Anonymize(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.Anonymize(&sonar.UsersAnonymizeOptions{})
+				resp, err := client.Users.Anonymize(context.Background(), &sonar.UsersAnonymizeOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -897,14 +898,14 @@ var _ = Describe("Users Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.UpdateIdentityProvider(nil)
+				resp, err := client.Users.UpdateIdentityProvider(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with missing login", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.UpdateIdentityProvider(&sonar.UsersUpdateIdentityProviderOptions{
+				resp, err := client.Users.UpdateIdentityProvider(context.Background(), &sonar.UsersUpdateIdentityProviderOptions{
 					NewExternalProvider: "sonarqube",
 				})
 				Expect(err).To(HaveOccurred())
@@ -913,7 +914,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			It("should fail with missing new external provider", func() {
 				//nolint:staticcheck // Using deprecated API until v2 API is implemented
-				resp, err := client.Users.UpdateIdentityProvider(&sonar.UsersUpdateIdentityProviderOptions{
+				resp, err := client.Users.UpdateIdentityProvider(context.Background(), &sonar.UsersUpdateIdentityProviderOptions{
 					Login: "someuser",
 				})
 				Expect(err).To(HaveOccurred())
@@ -929,7 +930,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Step 1: Create user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			createResult, _, err := client.Users.Create(&sonar.UsersCreateOptions{
+			createResult, _, err := client.Users.Create(context.Background(), &sonar.UsersCreateOptions{
 				Login:    login,
 				Name:     "Lifecycle User " + timestamp,
 				Email:    "lifecycle" + timestamp + "@example.com",
@@ -942,7 +943,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Step 2: Search and verify
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			searchResult, _, err := client.Users.Search(&sonar.UsersSearchOptions{
+			searchResult, _, err := client.Users.Search(context.Background(), &sonar.UsersSearchOptions{
 				Query: login,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -957,7 +958,7 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Step 3: Update user
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			updateResult, _, err := client.Users.Update(&sonar.UsersUpdateOptions{
+			updateResult, _, err := client.Users.Update(context.Background(), &sonar.UsersUpdateOptions{
 				Login: login,
 				Name:  "Updated Lifecycle User",
 			})
@@ -966,14 +967,14 @@ var _ = Describe("Users Service", Ordered, func() {
 
 			// Step 4: Get user groups
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			_, _, err = client.Users.Groups(&sonar.UsersGroupsOptions{
+			_, _, err = client.Users.Groups(context.Background(), &sonar.UsersGroupsOptions{
 				Login: login,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 5: Deactivate and anonymize
 			//nolint:staticcheck // Using deprecated API until v2 API is implemented
-			deactivateResult, _, err := client.Users.Deactivate(&sonar.UsersDeactivateOptions{
+			deactivateResult, _, err := client.Users.Deactivate(context.Background(), &sonar.UsersDeactivateOptions{
 				Login:     login,
 				Anonymize: true,
 			})

--- a/integration_testing/v2_analysis_test.go
+++ b/integration_testing/v2_analysis_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"bytes"
 	"net/http"
 
@@ -37,7 +38,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 	// =========================================================================
 	Describe("GetVersion", func() {
 		It("should return the scanner engine version", func() {
-			version, resp, err := client.V2.Analysis.GetVersion()
+			version, resp, err := client.V2.Analysis.GetVersion(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(version).NotTo(BeNil())
@@ -51,7 +52,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 	Describe("GetJresMetadata", func() {
 		Context("without options", func() {
 			It("should return a list of available JREs", func() {
-				jres, resp, err := client.V2.Analysis.GetJresMetadata(nil)
+				jres, resp, err := client.V2.Analysis.GetJresMetadata(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(jres).NotTo(BeEmpty())
@@ -67,7 +68,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 
 		Context("with OS filter", func() {
 			It("should filter JREs by operating system", func() {
-				jres, resp, err := client.V2.Analysis.GetJresMetadata(&sonar.AnalysisJresOptions{
+				jres, resp, err := client.V2.Analysis.GetJresMetadata(context.Background(), &sonar.AnalysisJresOptions{
 					Os: "linux",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -80,7 +81,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 
 		Context("with OS and arch filter", func() {
 			It("should filter JREs by OS and architecture", func() {
-				jres, resp, err := client.V2.Analysis.GetJresMetadata(&sonar.AnalysisJresOptions{
+				jres, resp, err := client.V2.Analysis.GetJresMetadata(context.Background(), &sonar.AnalysisJresOptions{
 					Os:   "linux",
 					Arch: "x64",
 				})
@@ -100,13 +101,13 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 	Describe("GetJreMetadata", func() {
 		Context("with valid JRE ID", func() {
 			It("should return metadata for a specific JRE", func() {
-				jres, resp, err := client.V2.Analysis.GetJresMetadata(nil)
+				jres, resp, err := client.V2.Analysis.GetJresMetadata(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(jres).NotTo(BeEmpty())
 
 				jreID := jres[0].Id
-				jre, resp, err := client.V2.Analysis.GetJreMetadata(jreID)
+				jre, resp, err := client.V2.Analysis.GetJreMetadata(context.Background(), jreID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(jre).NotTo(BeNil())
@@ -118,7 +119,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with empty JRE ID", func() {
-				jre, resp, err := client.V2.Analysis.GetJreMetadata("")
+				jre, resp, err := client.V2.Analysis.GetJreMetadata(context.Background(), "")
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(jre).To(BeNil())
@@ -132,7 +133,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 	Describe("DownloadJre", func() {
 		Context("with valid JRE ID", func() {
 			It("should download a JRE binary", func() {
-				jres, resp, err := client.V2.Analysis.GetJresMetadata(&sonar.AnalysisJresOptions{
+				jres, resp, err := client.V2.Analysis.GetJresMetadata(context.Background(), &sonar.AnalysisJresOptions{
 					Os:   "linux",
 					Arch: "x64",
 				})
@@ -143,7 +144,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 				}
 
 				var buf bytes.Buffer
-				resp, err = client.V2.Analysis.DownloadJre(jres[0].Id, &buf)
+				resp, err = client.V2.Analysis.DownloadJre(context.Background(), jres[0].Id, &buf)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp).NotTo(BeNil())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -154,7 +155,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 		Context("parameter validation", func() {
 			It("should fail with empty JRE ID", func() {
 				var buf bytes.Buffer
-				resp, err := client.V2.Analysis.DownloadJre("", &buf)
+				resp, err := client.V2.Analysis.DownloadJre(context.Background(), "", &buf)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -166,7 +167,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 	// =========================================================================
 	Describe("GetScannerEngineMetadata", func() {
 		It("should return scanner engine metadata", func() {
-			engine, resp, err := client.V2.Analysis.GetScannerEngineMetadata()
+			engine, resp, err := client.V2.Analysis.GetScannerEngineMetadata(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(engine).NotTo(BeNil())
@@ -181,7 +182,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 	Describe("DownloadScannerEngine", func() {
 		It("should download the scanner engine binary", func() {
 			var buf bytes.Buffer
-			resp, err := client.V2.Analysis.DownloadScannerEngine(&buf)
+			resp, err := client.V2.Analysis.DownloadScannerEngine(context.Background(), &buf)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp).NotTo(BeNil())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -197,7 +198,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 
 		BeforeAll(func() {
 			projectKey = helpers.UniqueResourceName("v2arproj")
-			_, resp, err := client.Projects.Create(&sonar.ProjectsCreateOptions{
+			_, resp, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 				Name:    "V2 Active Rules Test",
 				Project: projectKey,
 			})
@@ -205,7 +206,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			cleanup.RegisterCleanup("project", projectKey, func() error {
-				_, cleanupErr := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+				_, cleanupErr := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 					Project: projectKey,
 				})
 				return helpers.IgnoreNotFoundError(cleanupErr)
@@ -214,7 +215,7 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 
 		Context("with valid project key", func() {
 			It("should return active rules for the project", func() {
-				rules, resp, err := client.V2.Analysis.GetActiveRules(&sonar.AnalysisActiveRuleOptions{
+				rules, resp, err := client.V2.Analysis.GetActiveRules(context.Background(), &sonar.AnalysisActiveRuleOptions{
 					ProjectKey: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -225,14 +226,14 @@ var _ = Describe("V2 Analysis Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				rules, resp, err := client.V2.Analysis.GetActiveRules(nil)
+				rules, resp, err := client.V2.Analysis.GetActiveRules(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(rules).To(BeNil())
 			})
 
 			It("should fail with empty project key", func() {
-				rules, resp, err := client.V2.Analysis.GetActiveRules(&sonar.AnalysisActiveRuleOptions{})
+				rules, resp, err := client.V2.Analysis.GetActiveRules(context.Background(), &sonar.AnalysisActiveRuleOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(rules).To(BeNil())

--- a/integration_testing/v2_authorizations_test.go
+++ b/integration_testing/v2_authorizations_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -37,7 +38,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 	Describe("SearchGroups", func() {
 		Context("without options", func() {
 			It("should return a list of groups", func() {
-				result, resp, err := client.V2.Authorizations.SearchGroups(nil)
+				result, resp, err := client.V2.Authorizations.SearchGroups(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -49,7 +50,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 		Context("with query filter", func() {
 			It("should filter groups by query", func() {
 				groupName := helpers.UniqueResourceName("v2srchg")
-				group, resp, err := client.V2.Authorizations.CreateGroup(&sonar.AuthorizationsCreateGroupOptions{
+				group, resp, err := client.V2.Authorizations.CreateGroup(context.Background(), &sonar.AuthorizationsCreateGroupOptions{
 					Name:        groupName,
 					Description: "Search test group",
 				})
@@ -57,11 +58,11 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 
 				cleanup.RegisterCleanup("v2-group-search", group.Id, func() error {
-					_, cleanupErr := client.V2.Authorizations.DeleteGroup(group.Id)
+					_, cleanupErr := client.V2.Authorizations.DeleteGroup(context.Background(), group.Id)
 					return helpers.IgnoreNotFoundError(cleanupErr)
 				})
 
-				result, resp, err := client.V2.Authorizations.SearchGroups(&sonar.AuthorizationsSearchGroupsOptions{
+				result, resp, err := client.V2.Authorizations.SearchGroups(context.Background(), &sonar.AuthorizationsSearchGroupsOptions{
 					Query: groupName,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -80,7 +81,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 
 		Context("with pagination", func() {
 			It("should respect page size", func() {
-				result, resp, err := client.V2.Authorizations.SearchGroups(&sonar.AuthorizationsSearchGroupsOptions{
+				result, resp, err := client.V2.Authorizations.SearchGroups(context.Background(), &sonar.AuthorizationsSearchGroupsOptions{
 					PaginationParamsV2: sonar.PaginationParamsV2{
 						PageSize: 1,
 					},
@@ -98,7 +99,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 		Context("with valid parameters", func() {
 			It("should create a group", func() {
 				groupName := helpers.UniqueResourceName("v2grp")
-				group, resp, err := client.V2.Authorizations.CreateGroup(&sonar.AuthorizationsCreateGroupOptions{
+				group, resp, err := client.V2.Authorizations.CreateGroup(context.Background(), &sonar.AuthorizationsCreateGroupOptions{
 					Name:        groupName,
 					Description: "V2 integration test group",
 				})
@@ -110,14 +111,14 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 				Expect(group.Id).NotTo(BeEmpty())
 
 				cleanup.RegisterCleanup("v2-group-create", group.Id, func() error {
-					_, cleanupErr := client.V2.Authorizations.DeleteGroup(group.Id)
+					_, cleanupErr := client.V2.Authorizations.DeleteGroup(context.Background(), group.Id)
 					return helpers.IgnoreNotFoundError(cleanupErr)
 				})
 			})
 
 			It("should create a group with name only", func() {
 				groupName := helpers.UniqueResourceName("v2grpmin")
-				group, resp, err := client.V2.Authorizations.CreateGroup(&sonar.AuthorizationsCreateGroupOptions{
+				group, resp, err := client.V2.Authorizations.CreateGroup(context.Background(), &sonar.AuthorizationsCreateGroupOptions{
 					Name: groupName,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -127,7 +128,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 				Expect(group.Id).NotTo(BeEmpty())
 
 				cleanup.RegisterCleanup("v2-group-min", group.Id, func() error {
-					_, cleanupErr := client.V2.Authorizations.DeleteGroup(group.Id)
+					_, cleanupErr := client.V2.Authorizations.DeleteGroup(context.Background(), group.Id)
 					return helpers.IgnoreNotFoundError(cleanupErr)
 				})
 			})
@@ -135,14 +136,14 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil request", func() {
-				group, resp, err := client.V2.Authorizations.CreateGroup(nil)
+				group, resp, err := client.V2.Authorizations.CreateGroup(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(group).To(BeNil())
 			})
 
 			It("should fail with empty name", func() {
-				group, resp, err := client.V2.Authorizations.CreateGroup(&sonar.AuthorizationsCreateGroupOptions{
+				group, resp, err := client.V2.Authorizations.CreateGroup(context.Background(), &sonar.AuthorizationsCreateGroupOptions{
 					Description: "No Name Group",
 				})
 				Expect(err).To(HaveOccurred())
@@ -159,7 +160,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 			groupName := helpers.UniqueResourceName("v2gfetch")
 			var resp *http.Response
 			var err error
-			createdGroup, resp, err = client.V2.Authorizations.CreateGroup(&sonar.AuthorizationsCreateGroupOptions{
+			createdGroup, resp, err = client.V2.Authorizations.CreateGroup(context.Background(), &sonar.AuthorizationsCreateGroupOptions{
 				Name:        groupName,
 				Description: "Fetch test group",
 			})
@@ -167,14 +168,14 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 
 			cleanup.RegisterCleanup("v2-group-fetch", createdGroup.Id, func() error {
-				_, cleanupErr := client.V2.Authorizations.DeleteGroup(createdGroup.Id)
+				_, cleanupErr := client.V2.Authorizations.DeleteGroup(context.Background(), createdGroup.Id)
 				return helpers.IgnoreNotFoundError(cleanupErr)
 			})
 		})
 
 		Context("with valid group ID", func() {
 			It("should fetch the group by ID", func() {
-				fetched, resp, err := client.V2.Authorizations.GetGroup(createdGroup.Id)
+				fetched, resp, err := client.V2.Authorizations.GetGroup(context.Background(), createdGroup.Id)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(fetched).NotTo(BeNil())
@@ -186,7 +187,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with empty group ID", func() {
-				group, resp, err := client.V2.Authorizations.GetGroup("")
+				group, resp, err := client.V2.Authorizations.GetGroup(context.Background(), "")
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(group).To(BeNil())
@@ -201,7 +202,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 			groupName := helpers.UniqueResourceName("v2gupd")
 			var resp *http.Response
 			var err error
-			createdGroup, resp, err = client.V2.Authorizations.CreateGroup(&sonar.AuthorizationsCreateGroupOptions{
+			createdGroup, resp, err = client.V2.Authorizations.CreateGroup(context.Background(), &sonar.AuthorizationsCreateGroupOptions{
 				Name:        groupName,
 				Description: "Original description",
 			})
@@ -209,7 +210,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 
 			cleanup.RegisterCleanup("v2-group-update", createdGroup.Id, func() error {
-				_, cleanupErr := client.V2.Authorizations.DeleteGroup(createdGroup.Id)
+				_, cleanupErr := client.V2.Authorizations.DeleteGroup(context.Background(), createdGroup.Id)
 				return helpers.IgnoreNotFoundError(cleanupErr)
 			})
 		})
@@ -217,7 +218,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 		Context("with valid parameters", func() {
 			It("should update group name", func() {
 				newName := helpers.UniqueResourceName("v2gnew")
-				updated, resp, err := client.V2.Authorizations.UpdateGroup(createdGroup.Id, &sonar.AuthorizationsUpdateGroupOptions{
+				updated, resp, err := client.V2.Authorizations.UpdateGroup(context.Background(), createdGroup.Id, &sonar.AuthorizationsUpdateGroupOptions{
 					Name: newName,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -228,7 +229,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 
 			It("should update group description", func() {
 				description := "Updated description"
-				updated, resp, err := client.V2.Authorizations.UpdateGroup(createdGroup.Id, &sonar.AuthorizationsUpdateGroupOptions{
+				updated, resp, err := client.V2.Authorizations.UpdateGroup(context.Background(), createdGroup.Id, &sonar.AuthorizationsUpdateGroupOptions{
 					Description: &description,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -240,7 +241,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with empty group ID", func() {
-				group, resp, err := client.V2.Authorizations.UpdateGroup("", &sonar.AuthorizationsUpdateGroupOptions{
+				group, resp, err := client.V2.Authorizations.UpdateGroup(context.Background(), "", &sonar.AuthorizationsUpdateGroupOptions{
 					Name: "Updated",
 				})
 				Expect(err).To(HaveOccurred())
@@ -249,7 +250,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 			})
 
 			It("should fail with nil request", func() {
-				group, resp, err := client.V2.Authorizations.UpdateGroup(createdGroup.Id, nil)
+				group, resp, err := client.V2.Authorizations.UpdateGroup(context.Background(), createdGroup.Id, nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(group).To(BeNil())
@@ -261,18 +262,18 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 		Context("with valid group ID", func() {
 			It("should delete a group", func() {
 				groupName := helpers.UniqueResourceName("v2gdel")
-				group, resp, err := client.V2.Authorizations.CreateGroup(&sonar.AuthorizationsCreateGroupOptions{
+				group, resp, err := client.V2.Authorizations.CreateGroup(context.Background(), &sonar.AuthorizationsCreateGroupOptions{
 					Name: groupName,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 
 				cleanup.RegisterCleanup("v2-group-delete", group.Id, func() error {
-					_, cleanupErr := client.V2.Authorizations.DeleteGroup(group.Id)
+					_, cleanupErr := client.V2.Authorizations.DeleteGroup(context.Background(), group.Id)
 					return helpers.IgnoreNotFoundError(cleanupErr)
 				})
 
-				resp, err = client.V2.Authorizations.DeleteGroup(group.Id)
+				resp, err = client.V2.Authorizations.DeleteGroup(context.Background(), group.Id)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp).NotTo(BeNil())
 				Expect(resp.StatusCode).To(BeNumerically(">=", 200))
@@ -282,7 +283,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with empty group ID", func() {
-				resp, err := client.V2.Authorizations.DeleteGroup("")
+				resp, err := client.V2.Authorizations.DeleteGroup(context.Background(), "")
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
@@ -295,7 +296,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 	Describe("SearchGroupMemberships", func() {
 		Context("without options", func() {
 			It("should return a list of group memberships", func() {
-				result, resp, err := client.V2.Authorizations.SearchGroupMemberships(nil)
+				result, resp, err := client.V2.Authorizations.SearchGroupMemberships(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -305,13 +306,13 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 
 		Context("with group filter", func() {
 			It("should filter memberships by group ID", func() {
-				groups, resp, err := client.V2.Authorizations.SearchGroups(nil)
+				groups, resp, err := client.V2.Authorizations.SearchGroups(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(groups.Groups).NotTo(BeEmpty())
 
 				groupID := groups.Groups[0].Id
-				result, resp, err := client.V2.Authorizations.SearchGroupMemberships(&sonar.AuthorizationsSearchGroupMembershipsOptions{
+				result, resp, err := client.V2.Authorizations.SearchGroupMemberships(context.Background(), &sonar.AuthorizationsSearchGroupMembershipsOptions{
 					GroupId: groupID,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -334,19 +335,19 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 			groupName := helpers.UniqueResourceName("v2gmem")
 			var resp *http.Response
 			var err error
-			createdGroup, resp, err = client.V2.Authorizations.CreateGroup(&sonar.AuthorizationsCreateGroupOptions{
+			createdGroup, resp, err = client.V2.Authorizations.CreateGroup(context.Background(), &sonar.AuthorizationsCreateGroupOptions{
 				Name: groupName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 
 			cleanup.RegisterCleanup("v2-group-membership", createdGroup.Id, func() error {
-				_, cleanupErr := client.V2.Authorizations.DeleteGroup(createdGroup.Id)
+				_, cleanupErr := client.V2.Authorizations.DeleteGroup(context.Background(), createdGroup.Id)
 				return helpers.IgnoreNotFoundError(cleanupErr)
 			})
 
 			login := helpers.UniqueResourceName("v2umem")
-			createdUser, resp, err = client.V2.UsersManagement.Create(&sonar.UsersCreateOptionsV2{
+			createdUser, resp, err = client.V2.UsersManagement.Create(context.Background(), &sonar.UsersCreateOptionsV2{
 				Login:    login,
 				Name:     "V2 Membership User",
 				Password: "testPassword123!",
@@ -355,7 +356,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			cleanup.RegisterCleanup("v2-user-membership", createdUser.Id, func() error {
-				_, cleanupErr := client.V2.UsersManagement.Deactivate(&sonar.UsersDeactivateOptionsV2{
+				_, cleanupErr := client.V2.UsersManagement.Deactivate(context.Background(), &sonar.UsersDeactivateOptionsV2{
 					Id:        createdUser.Id,
 					Anonymize: true,
 				})
@@ -365,7 +366,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 
 		Context("with valid parameters", func() {
 			It("should create a group membership", func() {
-				membership, resp, err := client.V2.Authorizations.CreateGroupMembership(&sonar.AuthorizationsCreateGroupMembershipOptions{
+				membership, resp, err := client.V2.Authorizations.CreateGroupMembership(context.Background(), &sonar.AuthorizationsCreateGroupMembershipOptions{
 					GroupId: createdGroup.Id,
 					UserId:  createdUser.Id,
 				})
@@ -377,11 +378,11 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 				Expect(membership.Id).NotTo(BeEmpty())
 
 				cleanup.RegisterCleanup("v2-membership", membership.Id, func() error {
-					_, cleanupErr := client.V2.Authorizations.DeleteGroupMembership(membership.Id)
+					_, cleanupErr := client.V2.Authorizations.DeleteGroupMembership(context.Background(), membership.Id)
 					return helpers.IgnoreNotFoundError(cleanupErr)
 				})
 
-				result, resp, err := client.V2.Authorizations.SearchGroupMemberships(&sonar.AuthorizationsSearchGroupMembershipsOptions{
+				result, resp, err := client.V2.Authorizations.SearchGroupMemberships(context.Background(), &sonar.AuthorizationsSearchGroupMembershipsOptions{
 					GroupId: createdGroup.Id,
 					UserId:  createdUser.Id,
 				})
@@ -393,14 +394,14 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil request", func() {
-				membership, resp, err := client.V2.Authorizations.CreateGroupMembership(nil)
+				membership, resp, err := client.V2.Authorizations.CreateGroupMembership(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(membership).To(BeNil())
 			})
 
 			It("should fail with empty group ID", func() {
-				membership, resp, err := client.V2.Authorizations.CreateGroupMembership(&sonar.AuthorizationsCreateGroupMembershipOptions{
+				membership, resp, err := client.V2.Authorizations.CreateGroupMembership(context.Background(), &sonar.AuthorizationsCreateGroupMembershipOptions{
 					UserId: createdUser.Id,
 				})
 				Expect(err).To(HaveOccurred())
@@ -409,7 +410,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 			})
 
 			It("should fail with empty user ID", func() {
-				membership, resp, err := client.V2.Authorizations.CreateGroupMembership(&sonar.AuthorizationsCreateGroupMembershipOptions{
+				membership, resp, err := client.V2.Authorizations.CreateGroupMembership(context.Background(), &sonar.AuthorizationsCreateGroupMembershipOptions{
 					GroupId: createdGroup.Id,
 				})
 				Expect(err).To(HaveOccurred())
@@ -423,19 +424,19 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 		Context("with valid membership ID", func() {
 			It("should delete a group membership", func() {
 				groupName := helpers.UniqueResourceName("v2gmdel")
-				group, resp, err := client.V2.Authorizations.CreateGroup(&sonar.AuthorizationsCreateGroupOptions{
+				group, resp, err := client.V2.Authorizations.CreateGroup(context.Background(), &sonar.AuthorizationsCreateGroupOptions{
 					Name: groupName,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 
 				cleanup.RegisterCleanup("v2-group-delm", group.Id, func() error {
-					_, cleanupErr := client.V2.Authorizations.DeleteGroup(group.Id)
+					_, cleanupErr := client.V2.Authorizations.DeleteGroup(context.Background(), group.Id)
 					return helpers.IgnoreNotFoundError(cleanupErr)
 				})
 
 				login := helpers.UniqueResourceName("v2umdel")
-				user, resp, err := client.V2.UsersManagement.Create(&sonar.UsersCreateOptionsV2{
+				user, resp, err := client.V2.UsersManagement.Create(context.Background(), &sonar.UsersCreateOptionsV2{
 					Login:    login,
 					Name:     "V2 Del Membership User",
 					Password: "testPassword123!",
@@ -444,14 +445,14 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 				cleanup.RegisterCleanup("v2-user-delm", user.Id, func() error {
-					_, cleanupErr := client.V2.UsersManagement.Deactivate(&sonar.UsersDeactivateOptionsV2{
+					_, cleanupErr := client.V2.UsersManagement.Deactivate(context.Background(), &sonar.UsersDeactivateOptionsV2{
 						Id:        user.Id,
 						Anonymize: true,
 					})
 					return helpers.IgnoreNotFoundError(cleanupErr)
 				})
 
-				membership, resp, err := client.V2.Authorizations.CreateGroupMembership(&sonar.AuthorizationsCreateGroupMembershipOptions{
+				membership, resp, err := client.V2.Authorizations.CreateGroupMembership(context.Background(), &sonar.AuthorizationsCreateGroupMembershipOptions{
 					GroupId: group.Id,
 					UserId:  user.Id,
 				})
@@ -459,11 +460,11 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 
 				cleanup.RegisterCleanup("v2-membership-del", membership.Id, func() error {
-					_, cleanupErr := client.V2.Authorizations.DeleteGroupMembership(membership.Id)
+					_, cleanupErr := client.V2.Authorizations.DeleteGroupMembership(context.Background(), membership.Id)
 					return helpers.IgnoreNotFoundError(cleanupErr)
 				})
 
-				resp, err = client.V2.Authorizations.DeleteGroupMembership(membership.Id)
+				resp, err = client.V2.Authorizations.DeleteGroupMembership(context.Background(), membership.Id)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp).NotTo(BeNil())
 				Expect(resp.StatusCode).To(BeNumerically(">=", 200))
@@ -473,7 +474,7 @@ var _ = Describe("V2 Authorizations Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with empty membership ID", func() {
-				resp, err := client.V2.Authorizations.DeleteGroupMembership("")
+				resp, err := client.V2.Authorizations.DeleteGroupMembership(context.Background(), "")
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})

--- a/integration_testing/v2_clean_code_policy_test.go
+++ b/integration_testing/v2_clean_code_policy_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -37,14 +38,14 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 	Describe("CreateRule", func() {
 		Context("parameter validation", func() {
 			It("should fail with nil request", func() {
-				result, resp, err := client.V2.CleanCodePolicy.CreateRule(nil)
+				result, resp, err := client.V2.CleanCodePolicy.CreateRule(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing key", func() {
-				result, resp, err := client.V2.CleanCodePolicy.CreateRule(&sonar.CleanCodePolicyCreateRuleOptions{
+				result, resp, err := client.V2.CleanCodePolicy.CreateRule(context.Background(), &sonar.CleanCodePolicyCreateRuleOptions{
 					TemplateKey:         "java:S100",
 					Name:                "Test Rule",
 					MarkdownDescription: "Test description",
@@ -56,7 +57,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 			})
 
 			It("should fail with missing template key", func() {
-				result, resp, err := client.V2.CleanCodePolicy.CreateRule(&sonar.CleanCodePolicyCreateRuleOptions{
+				result, resp, err := client.V2.CleanCodePolicy.CreateRule(context.Background(), &sonar.CleanCodePolicyCreateRuleOptions{
 					Key:                 "custom:test_rule",
 					Name:                "Test Rule",
 					MarkdownDescription: "Test description",
@@ -68,7 +69,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 			})
 
 			It("should fail with missing name", func() {
-				result, resp, err := client.V2.CleanCodePolicy.CreateRule(&sonar.CleanCodePolicyCreateRuleOptions{
+				result, resp, err := client.V2.CleanCodePolicy.CreateRule(context.Background(), &sonar.CleanCodePolicyCreateRuleOptions{
 					Key:                 "custom:test_rule",
 					TemplateKey:         "java:S100",
 					MarkdownDescription: "Test description",
@@ -80,7 +81,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 			})
 
 			It("should fail with missing markdown description", func() {
-				result, resp, err := client.V2.CleanCodePolicy.CreateRule(&sonar.CleanCodePolicyCreateRuleOptions{
+				result, resp, err := client.V2.CleanCodePolicy.CreateRule(context.Background(), &sonar.CleanCodePolicyCreateRuleOptions{
 					Key:         "custom:test_rule",
 					TemplateKey: "java:S100",
 					Name:        "Test Rule",
@@ -92,7 +93,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 			})
 
 			It("should fail with empty impacts", func() {
-				result, resp, err := client.V2.CleanCodePolicy.CreateRule(&sonar.CleanCodePolicyCreateRuleOptions{
+				result, resp, err := client.V2.CleanCodePolicy.CreateRule(context.Background(), &sonar.CleanCodePolicyCreateRuleOptions{
 					Key:                 "custom:test_rule",
 					TemplateKey:         "java:S100",
 					Name:                "Test Rule",
@@ -105,7 +106,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 			})
 
 			It("should fail with invalid clean code attribute", func() {
-				result, resp, err := client.V2.CleanCodePolicy.CreateRule(&sonar.CleanCodePolicyCreateRuleOptions{
+				result, resp, err := client.V2.CleanCodePolicy.CreateRule(context.Background(), &sonar.CleanCodePolicyCreateRuleOptions{
 					Key:                 "custom:test_rule",
 					TemplateKey:         "java:S100",
 					Name:                "Test Rule",
@@ -119,7 +120,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 			})
 
 			It("should fail with invalid impact severity", func() {
-				result, resp, err := client.V2.CleanCodePolicy.CreateRule(&sonar.CleanCodePolicyCreateRuleOptions{
+				result, resp, err := client.V2.CleanCodePolicy.CreateRule(context.Background(), &sonar.CleanCodePolicyCreateRuleOptions{
 					Key:                 "custom:test_rule",
 					TemplateKey:         "java:S100",
 					Name:                "Test Rule",
@@ -137,7 +138,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 
 			BeforeAll(func() {
 				// Find a template rule to use for creating custom rules.
-				result, _, err := client.Rules.Search(&sonar.RulesSearchOptions{
+				result, _, err := client.Rules.Search(context.Background(), &sonar.RulesSearchOptions{
 					IsTemplate: true,
 					Languages:  []string{"java"},
 					PaginationArgs: sonar.PaginationArgs{
@@ -153,7 +154,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 				customKey := helpers.UniqueResourceName("rule")
 				ruleKey := templateRule.Repo + ":" + customKey
 
-				result, resp, err := client.V2.CleanCodePolicy.CreateRule(&sonar.CleanCodePolicyCreateRuleOptions{
+				result, resp, err := client.V2.CleanCodePolicy.CreateRule(context.Background(), &sonar.CleanCodePolicyCreateRuleOptions{
 					Key:                 ruleKey,
 					TemplateKey:         templateRule.Key,
 					Name:                "E2E V2 Test Rule " + customKey,
@@ -173,7 +174,7 @@ var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {
 
 				// Register cleanup using V1 Rules.Delete.
 				cleanup.RegisterCleanup("rule", ruleKey, func() error {
-					_, err := client.Rules.Delete(&sonar.RulesDeleteOptions{
+					_, err := client.Rules.Delete(context.Background(), &sonar.RulesDeleteOptions{
 						Key: ruleKey,
 					})
 					return err

--- a/integration_testing/v2_dop_translation_test.go
+++ b/integration_testing/v2_dop_translation_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 	"os"
 
@@ -37,7 +38,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 	// =========================================================================
 	Describe("GetDopSettings", func() {
 		It("should return DevOps Platform settings", func() {
-			result, resp, err := client.V2.DopTranslation.GetDopSettings()
+			result, resp, err := client.V2.DopTranslation.GetDopSettings(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -53,14 +54,14 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 	Describe("CreateBoundProject", func() {
 		Context("parameter validation", func() {
 			It("should fail with nil request", func() {
-				result, resp, err := client.V2.DopTranslation.CreateBoundProject(nil)
+				result, resp, err := client.V2.DopTranslation.CreateBoundProject(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing required fields", func() {
-				result, resp, err := client.V2.DopTranslation.CreateBoundProject(&sonar.DopTranslationBoundProjectOptions{
+				result, resp, err := client.V2.DopTranslation.CreateBoundProject(context.Background(), &sonar.DopTranslationBoundProjectOptions{
 					ProjectKey:  helpers.UniqueResourceName("v2dopproj"),
 					ProjectName: "Test DOP Project",
 				})
@@ -70,7 +71,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 			})
 
 			It("should fail without project key", func() {
-				result, resp, err := client.V2.DopTranslation.CreateBoundProject(&sonar.DopTranslationBoundProjectOptions{
+				result, resp, err := client.V2.DopTranslation.CreateBoundProject(context.Background(), &sonar.DopTranslationBoundProjectOptions{
 					DevOpsPlatformSettingId: "nonexistent-setting-id",
 					ProjectName:             "Test DOP Project",
 					RepositoryIdentifier:    "test/repo",
@@ -81,7 +82,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 			})
 
 			It("should fail without repository identifier", func() {
-				result, resp, err := client.V2.DopTranslation.CreateBoundProject(&sonar.DopTranslationBoundProjectOptions{
+				result, resp, err := client.V2.DopTranslation.CreateBoundProject(context.Background(), &sonar.DopTranslationBoundProjectOptions{
 					DevOpsPlatformSettingId: "nonexistent-setting-id",
 					ProjectKey:              helpers.UniqueResourceName("v2dopproj"),
 					ProjectName:             "Test DOP Project",
@@ -99,7 +100,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				settings, _, err := client.V2.DopTranslation.GetDopSettings()
+				settings, _, err := client.V2.DopTranslation.GetDopSettings(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 
 				if len(settings.DopSettings) == 0 {
@@ -117,7 +118,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 			It("should create a bound project", func() {
 				projectKey := helpers.UniqueResourceName("v2dopproj")
 
-				result, resp, err := client.V2.DopTranslation.CreateBoundProject(&sonar.DopTranslationBoundProjectOptions{
+				result, resp, err := client.V2.DopTranslation.CreateBoundProject(context.Background(), &sonar.DopTranslationBoundProjectOptions{
 					DevOpsPlatformSettingId: dopSettingID,
 					ProjectKey:              projectKey,
 					ProjectName:             "E2E V2 DOP Bound Project " + projectKey,
@@ -130,7 +131,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 				Expect(result.NewProjectCreated).To(BeTrue())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return helpers.IgnoreNotFoundError(err)
@@ -145,14 +146,14 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 	Describe("CreateOrUpdateBoundProject", func() {
 		Context("parameter validation", func() {
 			It("should fail with nil request", func() {
-				result, resp, err := client.V2.DopTranslation.CreateOrUpdateBoundProject(nil)
+				result, resp, err := client.V2.DopTranslation.CreateOrUpdateBoundProject(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail with missing required fields", func() {
-				result, resp, err := client.V2.DopTranslation.CreateOrUpdateBoundProject(&sonar.DopTranslationBoundProjectOptions{
+				result, resp, err := client.V2.DopTranslation.CreateOrUpdateBoundProject(context.Background(), &sonar.DopTranslationBoundProjectOptions{
 					ProjectKey:  helpers.UniqueResourceName("v2dopproj"),
 					ProjectName: "Test DOP Project",
 				})
@@ -169,7 +170,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 			)
 
 			BeforeAll(func() {
-				settings, _, err := client.V2.DopTranslation.GetDopSettings()
+				settings, _, err := client.V2.DopTranslation.GetDopSettings(context.Background(), )
 				Expect(err).NotTo(HaveOccurred())
 
 				if len(settings.DopSettings) == 0 {
@@ -187,7 +188,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 			It("should create a bound project", func() {
 				projectKey := helpers.UniqueResourceName("v2dopproj")
 
-				result, resp, err := client.V2.DopTranslation.CreateOrUpdateBoundProject(&sonar.DopTranslationBoundProjectOptions{
+				result, resp, err := client.V2.DopTranslation.CreateOrUpdateBoundProject(context.Background(), &sonar.DopTranslationBoundProjectOptions{
 					DevOpsPlatformSettingId: dopSettingID,
 					ProjectKey:              projectKey,
 					ProjectName:             "E2E V2 DOP CreateOrUpdate Project " + projectKey,
@@ -200,7 +201,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 				Expect(result.NewProjectCreated).To(BeTrue())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return helpers.IgnoreNotFoundError(err)
@@ -212,7 +213,7 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 				projectKey := helpers.UniqueResourceName("v2dopupd")
 
 				// First create the project.
-				createResult, _, err := client.V2.DopTranslation.CreateOrUpdateBoundProject(&sonar.DopTranslationBoundProjectOptions{
+				createResult, _, err := client.V2.DopTranslation.CreateOrUpdateBoundProject(context.Background(), &sonar.DopTranslationBoundProjectOptions{
 					DevOpsPlatformSettingId: dopSettingID,
 					ProjectKey:              projectKey,
 					ProjectName:             "E2E V2 DOP Update Project " + projectKey,
@@ -222,14 +223,14 @@ var _ = Describe("V2 DOP Translation Service", Ordered, func() {
 				Expect(createResult.NewProjectCreated).To(BeTrue())
 
 				cleanup.RegisterCleanup("project", projectKey, func() error {
-					_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 						Project: projectKey,
 					})
 					return helpers.IgnoreNotFoundError(err)
 				})
 
 				// Now update it (same project key, idempotent PUT).
-				updateResult, resp, err := client.V2.DopTranslation.CreateOrUpdateBoundProject(&sonar.DopTranslationBoundProjectOptions{
+				updateResult, resp, err := client.V2.DopTranslation.CreateOrUpdateBoundProject(context.Background(), &sonar.DopTranslationBoundProjectOptions{
 					DevOpsPlatformSettingId: dopSettingID,
 					ProjectKey:              projectKey,
 					ProjectName:             "E2E V2 DOP Updated Project " + projectKey,

--- a/integration_testing/v2_marketplace_test.go
+++ b/integration_testing/v2_marketplace_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -27,7 +28,7 @@ var _ = Describe("V2 Marketplace Service", Ordered, func() {
 			// typically not available in local test environments. We verify
 			// the API call completes (successfully or with a meaningful server
 			// error) without panicking.
-			result, resp, err := client.V2.Marketplace.BillAzureAccount()
+			result, resp, err := client.V2.Marketplace.BillAzureAccount(context.Background(), )
 			if err != nil {
 				// Expected in non-Azure environments: verify we got a server
 				// error response rather than a client-side failure

--- a/integration_testing/v2_system_test.go
+++ b/integration_testing/v2_system_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -25,7 +26,7 @@ var _ = Describe("V2 System Service", Ordered, func() {
 	// =========================================================================
 	Describe("GetMigrationsStatus", func() {
 		It("should return migration status", func() {
-			result, resp, err := client.V2.System.GetMigrationsStatus()
+			result, resp, err := client.V2.System.GetMigrationsStatus(context.Background(), )
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(result).NotTo(BeNil())
@@ -39,7 +40,7 @@ var _ = Describe("V2 System Service", Ordered, func() {
 	Describe("CheckLiveness", func() {
 		Context("without passcode", func() {
 			It("should return a successful liveness check", func() {
-				resp, err := client.V2.System.CheckLiveness(nil)
+				resp, err := client.V2.System.CheckLiveness(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp).NotTo(BeNil())
 				Expect(resp.StatusCode).To(BeNumerically(">=", 200))
@@ -49,7 +50,7 @@ var _ = Describe("V2 System Service", Ordered, func() {
 
 		Context("with empty passcode", func() {
 			It("should return a successful liveness check", func() {
-				resp, err := client.V2.System.CheckLiveness(&sonar.SystemPasscodeOptionV2{})
+				resp, err := client.V2.System.CheckLiveness(context.Background(), &sonar.SystemPasscodeOptionV2{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp).NotTo(BeNil())
 				Expect(resp.StatusCode).To(BeNumerically(">=", 200))
@@ -64,7 +65,7 @@ var _ = Describe("V2 System Service", Ordered, func() {
 	Describe("GetHealth", func() {
 		Context("without passcode", func() {
 			It("should return system health", func() {
-				result, resp, err := client.V2.System.GetHealth(nil)
+				result, resp, err := client.V2.System.GetHealth(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -75,7 +76,7 @@ var _ = Describe("V2 System Service", Ordered, func() {
 
 		Context("with empty passcode", func() {
 			It("should return system health", func() {
-				result, resp, err := client.V2.System.GetHealth(&sonar.SystemPasscodeOptionV2{})
+				result, resp, err := client.V2.System.GetHealth(context.Background(), &sonar.SystemPasscodeOptionV2{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())

--- a/integration_testing/v2_users_test.go
+++ b/integration_testing/v2_users_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -37,7 +38,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 	Describe("Search", func() {
 		Context("without options", func() {
 			It("should return a list of users", func() {
-				result, resp, err := client.V2.UsersManagement.Search(nil)
+				result, resp, err := client.V2.UsersManagement.Search(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -48,7 +49,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 
 		Context("with query filter", func() {
 			It("should filter users by query", func() {
-				result, resp, err := client.V2.UsersManagement.Search(&sonar.UsersSearchOptionV2{
+				result, resp, err := client.V2.UsersManagement.Search(context.Background(), &sonar.UsersSearchOptionV2{
 					Query: "admin",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -67,7 +68,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 
 		Context("with pagination", func() {
 			It("should respect page size", func() {
-				result, resp, err := client.V2.UsersManagement.Search(&sonar.UsersSearchOptionV2{
+				result, resp, err := client.V2.UsersManagement.Search(context.Background(), &sonar.UsersSearchOptionV2{
 					PaginationParamsV2: sonar.PaginationParamsV2{
 						PageSize: 1,
 					},
@@ -83,7 +84,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 		Context("with active filter", func() {
 			It("should filter by active status", func() {
 				active := true
-				result, resp, err := client.V2.UsersManagement.Search(&sonar.UsersSearchOptionV2{
+				result, resp, err := client.V2.UsersManagement.Search(context.Background(), &sonar.UsersSearchOptionV2{
 					Active: &active,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -103,7 +104,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 		Context("with valid parameters", func() {
 			It("should create a local user", func() {
 				login := helpers.UniqueResourceName("v2user")
-				user, resp, err := client.V2.UsersManagement.Create(&sonar.UsersCreateOptionsV2{
+				user, resp, err := client.V2.UsersManagement.Create(context.Background(), &sonar.UsersCreateOptionsV2{
 					Login:    login,
 					Name:     "V2 Test User",
 					Password: "testPassword123!",
@@ -118,7 +119,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 				Expect(user.Id).NotTo(BeEmpty())
 
 				cleanup.RegisterCleanup("v2-user", user.Id, func() error {
-					_, cleanupErr := client.V2.UsersManagement.Deactivate(&sonar.UsersDeactivateOptionsV2{
+					_, cleanupErr := client.V2.UsersManagement.Deactivate(context.Background(), &sonar.UsersDeactivateOptionsV2{
 						Id:        user.Id,
 						Anonymize: true,
 					})
@@ -128,7 +129,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 
 			It("should create a user with email and SCM accounts", func() {
 				login := helpers.UniqueResourceName("v2usr-full")
-				user, resp, err := client.V2.UsersManagement.Create(&sonar.UsersCreateOptionsV2{
+				user, resp, err := client.V2.UsersManagement.Create(context.Background(), &sonar.UsersCreateOptionsV2{
 					Login:       login,
 					Name:        "V2 Full User",
 					Password:    "testPassword123!",
@@ -142,7 +143,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 				Expect(user.ScmAccounts).To(ConsistOf("github-account", "gitlab-account"))
 
 				cleanup.RegisterCleanup("v2-user", user.Id, func() error {
-					_, cleanupErr := client.V2.UsersManagement.Deactivate(&sonar.UsersDeactivateOptionsV2{
+					_, cleanupErr := client.V2.UsersManagement.Deactivate(context.Background(), &sonar.UsersDeactivateOptionsV2{
 						Id:        user.Id,
 						Anonymize: true,
 					})
@@ -153,14 +154,14 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil request", func() {
-				user, resp, err := client.V2.UsersManagement.Create(nil)
+				user, resp, err := client.V2.UsersManagement.Create(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(user).To(BeNil())
 			})
 
 			It("should fail with empty login", func() {
-				user, resp, err := client.V2.UsersManagement.Create(&sonar.UsersCreateOptionsV2{
+				user, resp, err := client.V2.UsersManagement.Create(context.Background(), &sonar.UsersCreateOptionsV2{
 					Name:     "No Login User",
 					Password: "testPassword123!",
 				})
@@ -170,7 +171,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 			})
 
 			It("should fail with empty name", func() {
-				user, resp, err := client.V2.UsersManagement.Create(&sonar.UsersCreateOptionsV2{
+				user, resp, err := client.V2.UsersManagement.Create(context.Background(), &sonar.UsersCreateOptionsV2{
 					Login:    helpers.UniqueResourceName("v2user"),
 					Password: "testPassword123!",
 				})
@@ -180,7 +181,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 			})
 
 			It("should fail with login too short", func() {
-				user, resp, err := client.V2.UsersManagement.Create(&sonar.UsersCreateOptionsV2{
+				user, resp, err := client.V2.UsersManagement.Create(context.Background(), &sonar.UsersCreateOptionsV2{
 					Login:    "a",
 					Name:     "Short Login User",
 					Password: "testPassword123!",
@@ -202,7 +203,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 			login := helpers.UniqueResourceName("v2fetch")
 			var resp *http.Response
 			var err error
-			createdUser, resp, err = client.V2.UsersManagement.Create(&sonar.UsersCreateOptionsV2{
+			createdUser, resp, err = client.V2.UsersManagement.Create(context.Background(), &sonar.UsersCreateOptionsV2{
 				Login:    login,
 				Name:     "V2 Fetch Test User",
 				Password: "testPassword123!",
@@ -211,7 +212,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			cleanup.RegisterCleanup("v2-user-fetch", createdUser.Id, func() error {
-				_, cleanupErr := client.V2.UsersManagement.Deactivate(&sonar.UsersDeactivateOptionsV2{
+				_, cleanupErr := client.V2.UsersManagement.Deactivate(context.Background(), &sonar.UsersDeactivateOptionsV2{
 					Id:        createdUser.Id,
 					Anonymize: true,
 				})
@@ -221,7 +222,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 
 		Context("with valid user ID", func() {
 			It("should fetch the user by ID", func() {
-				fetched, resp, err := client.V2.UsersManagement.Get(createdUser.Id)
+				fetched, resp, err := client.V2.UsersManagement.Get(context.Background(), createdUser.Id)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(fetched).NotTo(BeNil())
@@ -234,7 +235,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with empty user ID", func() {
-				user, resp, err := client.V2.UsersManagement.Get("")
+				user, resp, err := client.V2.UsersManagement.Get(context.Background(), "")
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(user).To(BeNil())
@@ -252,7 +253,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 			login := helpers.UniqueResourceName("v2upd")
 			var resp *http.Response
 			var err error
-			createdUser, resp, err = client.V2.UsersManagement.Create(&sonar.UsersCreateOptionsV2{
+			createdUser, resp, err = client.V2.UsersManagement.Create(context.Background(), &sonar.UsersCreateOptionsV2{
 				Login:    login,
 				Name:     "V2 Update Original",
 				Password: "testPassword123!",
@@ -261,7 +262,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			cleanup.RegisterCleanup("v2-user-update", createdUser.Id, func() error {
-				_, cleanupErr := client.V2.UsersManagement.Deactivate(&sonar.UsersDeactivateOptionsV2{
+				_, cleanupErr := client.V2.UsersManagement.Deactivate(context.Background(), &sonar.UsersDeactivateOptionsV2{
 					Id:        createdUser.Id,
 					Anonymize: true,
 				})
@@ -271,7 +272,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 
 		Context("with valid parameters", func() {
 			It("should update user name", func() {
-				updated, resp, err := client.V2.UsersManagement.Update(createdUser.Id, &sonar.UsersUpdateOptionsV2{
+				updated, resp, err := client.V2.UsersManagement.Update(context.Background(), createdUser.Id, &sonar.UsersUpdateOptionsV2{
 					Name: "V2 Updated Name",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -281,7 +282,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 			})
 
 			It("should update user email", func() {
-				updated, resp, err := client.V2.UsersManagement.Update(createdUser.Id, &sonar.UsersUpdateOptionsV2{
+				updated, resp, err := client.V2.UsersManagement.Update(context.Background(), createdUser.Id, &sonar.UsersUpdateOptionsV2{
 					Email: "v2-updated@example.com",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -291,7 +292,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 			})
 
 			It("should update SCM accounts", func() {
-				updated, resp, err := client.V2.UsersManagement.Update(createdUser.Id, &sonar.UsersUpdateOptionsV2{
+				updated, resp, err := client.V2.UsersManagement.Update(context.Background(), createdUser.Id, &sonar.UsersUpdateOptionsV2{
 					ScmAccounts: &sonar.UpdateFieldListStringV2{
 						Value:   []string{"new-github", "new-gitlab"},
 						Defined: true,
@@ -306,7 +307,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with empty user ID", func() {
-				user, resp, err := client.V2.UsersManagement.Update("", &sonar.UsersUpdateOptionsV2{
+				user, resp, err := client.V2.UsersManagement.Update(context.Background(), "", &sonar.UsersUpdateOptionsV2{
 					Name: "Updated Name",
 				})
 				Expect(err).To(HaveOccurred())
@@ -315,7 +316,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 			})
 
 			It("should fail with nil request", func() {
-				user, resp, err := client.V2.UsersManagement.Update(createdUser.Id, nil)
+				user, resp, err := client.V2.UsersManagement.Update(context.Background(), createdUser.Id, nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(user).To(BeNil())
@@ -330,7 +331,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 		Context("with valid parameters", func() {
 			It("should deactivate a user", func() {
 				login := helpers.UniqueResourceName("v2deact")
-				created, resp, err := client.V2.UsersManagement.Create(&sonar.UsersCreateOptionsV2{
+				created, resp, err := client.V2.UsersManagement.Create(context.Background(), &sonar.UsersCreateOptionsV2{
 					Login:    login,
 					Name:     "V2 Deactivate Test",
 					Password: "testPassword123!",
@@ -339,21 +340,21 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 				cleanup.RegisterCleanup("v2-user-deact", created.Id, func() error {
-					_, cleanupErr := client.V2.UsersManagement.Deactivate(&sonar.UsersDeactivateOptionsV2{
+					_, cleanupErr := client.V2.UsersManagement.Deactivate(context.Background(), &sonar.UsersDeactivateOptionsV2{
 						Id:        created.Id,
 						Anonymize: true,
 					})
 					return helpers.IgnoreNotFoundError(cleanupErr)
 				})
 
-				resp, err = client.V2.UsersManagement.Deactivate(&sonar.UsersDeactivateOptionsV2{
+				resp, err = client.V2.UsersManagement.Deactivate(context.Background(), &sonar.UsersDeactivateOptionsV2{
 					Id: created.Id,
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp).NotTo(BeNil())
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
-				fetched, resp, err := client.V2.UsersManagement.Get(created.Id)
+				fetched, resp, err := client.V2.UsersManagement.Get(context.Background(), created.Id)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(fetched).NotTo(BeNil())
@@ -362,7 +363,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 
 			It("should deactivate a user with anonymize", func() {
 				login := helpers.UniqueResourceName("v2anon")
-				created, resp, err := client.V2.UsersManagement.Create(&sonar.UsersCreateOptionsV2{
+				created, resp, err := client.V2.UsersManagement.Create(context.Background(), &sonar.UsersCreateOptionsV2{
 					Login:    login,
 					Name:     "V2 Anonymize Test",
 					Password: "testPassword123!",
@@ -371,7 +372,7 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-				resp, err = client.V2.UsersManagement.Deactivate(&sonar.UsersDeactivateOptionsV2{
+				resp, err = client.V2.UsersManagement.Deactivate(context.Background(), &sonar.UsersDeactivateOptionsV2{
 					Id:        created.Id,
 					Anonymize: true,
 				})
@@ -383,13 +384,13 @@ var _ = Describe("V2 Users Management Service", Ordered, func() {
 
 		Context("parameter validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.V2.UsersManagement.Deactivate(nil)
+				resp, err := client.V2.UsersManagement.Deactivate(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with empty user ID", func() {
-				resp, err := client.V2.UsersManagement.Deactivate(&sonar.UsersDeactivateOptionsV2{})
+				resp, err := client.V2.UsersManagement.Deactivate(context.Background(), &sonar.UsersDeactivateOptionsV2{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})

--- a/integration_testing/views_test.go
+++ b/integration_testing/views_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -34,21 +35,21 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("Create", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Views.Create(nil)
+				resp, err := client.Views.Create(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required name", func() {
-				resp, err := client.Views.Create(&sonar.ViewsCreateOptions{})
+				resp, err := client.Views.Create(context.Background(), &sonar.ViewsCreateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Name"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with invalid visibility", func() {
-				resp, err := client.Views.Create(&sonar.ViewsCreateOptions{
+				resp, err := client.Views.Create(context.Background(), &sonar.ViewsCreateOptions{
 					Name:       "Test View",
 					Visibility: "invalid",
 				})
@@ -60,7 +61,7 @@ var _ = Describe("Views Service", Ordered, func() {
 		Context("Functional Tests", func() {
 			It("should create or return an enterprise-only error", func() {
 				viewKey := helpers.UniqueResourceName("view")
-				resp, err := client.Views.Create(&sonar.ViewsCreateOptions{
+				resp, err := client.Views.Create(context.Background(), &sonar.ViewsCreateOptions{
 					Name: viewKey,
 					Key:  viewKey,
 				})
@@ -70,7 +71,7 @@ var _ = Describe("Views Service", Ordered, func() {
 				} else {
 					Expect(resp.StatusCode).To(BeNumerically("<", 400))
 					cleanup.RegisterCleanup("view", viewKey, func() error {
-						_, cleanupErr := client.Views.Delete(&sonar.ViewsDeleteOptions{
+						_, cleanupErr := client.Views.Delete(context.Background(), &sonar.ViewsDeleteOptions{
 							Key: viewKey,
 						})
 						return cleanupErr
@@ -86,7 +87,7 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("List", func() {
 		Context("Functional Tests", func() {
 			It("should return a list or an enterprise-only error", func() {
-				result, resp, err := client.Views.List()
+				result, resp, err := client.Views.List(context.Background())
 				if err != nil {
 					// Community edition does not expose views endpoints.
 					Expect(resp).NotTo(BeNil())
@@ -104,7 +105,7 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("Search", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with invalid pagination", func() {
-				_, _, err := client.Views.Search(&sonar.ViewsSearchOptions{
+				_, _, err := client.Views.Search(context.Background(), &sonar.ViewsSearchOptions{
 					PaginationArgs: sonar.PaginationArgs{Page: -1},
 				})
 				Expect(err).To(HaveOccurred())
@@ -113,7 +114,7 @@ var _ = Describe("Views Service", Ordered, func() {
 
 		Context("Functional Tests", func() {
 			It("should return results or an enterprise-only error", func() {
-				result, resp, err := client.Views.Search(nil)
+				result, resp, err := client.Views.Search(context.Background(), nil)
 				if err != nil {
 					Expect(resp).NotTo(BeNil())
 				} else {
@@ -130,13 +131,13 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("Show", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				_, _, err := client.Views.Show(nil)
+				_, _, err := client.Views.Show(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 			})
 
 			It("should fail without key", func() {
-				_, _, err := client.Views.Show(&sonar.ViewsShowOptions{})
+				_, _, err := client.Views.Show(context.Background(), &sonar.ViewsShowOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 			})
@@ -144,7 +145,7 @@ var _ = Describe("Views Service", Ordered, func() {
 
 		Context("Functional Tests", func() {
 			It("should fail for a non-existent view", func() {
-				result, resp, err := client.Views.Show(&sonar.ViewsShowOptions{
+				result, resp, err := client.Views.Show(context.Background(), &sonar.ViewsShowOptions{
 					Key: "non-existent-view-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -162,14 +163,14 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("Update", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Views.Update(nil)
+				resp, err := client.Views.Update(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required key", func() {
-				resp, err := client.Views.Update(&sonar.ViewsUpdateOptions{
+				resp, err := client.Views.Update(context.Background(), &sonar.ViewsUpdateOptions{
 					Name: "New Name",
 				})
 				Expect(err).To(HaveOccurred())
@@ -178,7 +179,7 @@ var _ = Describe("Views Service", Ordered, func() {
 			})
 
 			It("should fail without required name", func() {
-				resp, err := client.Views.Update(&sonar.ViewsUpdateOptions{
+				resp, err := client.Views.Update(context.Background(), &sonar.ViewsUpdateOptions{
 					Key: "my-view",
 				})
 				Expect(err).To(HaveOccurred())
@@ -194,14 +195,14 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("Delete", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Views.Delete(nil)
+				resp, err := client.Views.Delete(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without key", func() {
-				resp, err := client.Views.Delete(&sonar.ViewsDeleteOptions{})
+				resp, err := client.Views.Delete(context.Background(), &sonar.ViewsDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 				Expect(resp).To(BeNil())
@@ -210,7 +211,7 @@ var _ = Describe("Views Service", Ordered, func() {
 
 		Context("Functional Tests", func() {
 			It("should fail for a non-existent view", func() {
-				resp, err := client.Views.Delete(&sonar.ViewsDeleteOptions{
+				resp, err := client.Views.Delete(context.Background(), &sonar.ViewsDeleteOptions{
 					Key: "non-existent-view",
 				})
 				Expect(err).To(HaveOccurred())
@@ -225,14 +226,14 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("AddProject", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Views.AddProject(nil)
+				resp, err := client.Views.AddProject(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without key", func() {
-				resp, err := client.Views.AddProject(&sonar.ViewsAddProjectOptions{
+				resp, err := client.Views.AddProject(context.Background(), &sonar.ViewsAddProjectOptions{
 					Project: "my-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -241,7 +242,7 @@ var _ = Describe("Views Service", Ordered, func() {
 			})
 
 			It("should fail without project key", func() {
-				resp, err := client.Views.AddProject(&sonar.ViewsAddProjectOptions{
+				resp, err := client.Views.AddProject(context.Background(), &sonar.ViewsAddProjectOptions{
 					Key: "my-view",
 				})
 				Expect(err).To(HaveOccurred())
@@ -254,14 +255,14 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("RemoveProject", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Views.RemoveProject(nil)
+				resp, err := client.Views.RemoveProject(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without key", func() {
-				resp, err := client.Views.RemoveProject(&sonar.ViewsRemoveProjectOptions{
+				resp, err := client.Views.RemoveProject(context.Background(), &sonar.ViewsRemoveProjectOptions{
 					Project: "my-project",
 				})
 				Expect(err).To(HaveOccurred())
@@ -270,7 +271,7 @@ var _ = Describe("Views Service", Ordered, func() {
 			})
 
 			It("should fail without project key", func() {
-				resp, err := client.Views.RemoveProject(&sonar.ViewsRemoveProjectOptions{
+				resp, err := client.Views.RemoveProject(context.Background(), &sonar.ViewsRemoveProjectOptions{
 					Key: "my-view",
 				})
 				Expect(err).To(HaveOccurred())
@@ -286,13 +287,13 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("MoveOptions", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				_, _, err := client.Views.MoveOptions(nil)
+				_, _, err := client.Views.MoveOptions(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 			})
 
 			It("should fail without key", func() {
-				_, _, err := client.Views.MoveOptions(&sonar.ViewsMoveOptionsOptions{})
+				_, _, err := client.Views.MoveOptions(context.Background(), &sonar.ViewsMoveOptionsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 			})
@@ -305,14 +306,14 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("Move", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Views.Move(nil)
+				resp, err := client.Views.Move(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without key", func() {
-				resp, err := client.Views.Move(&sonar.ViewsMoveOptions{
+				resp, err := client.Views.Move(context.Background(), &sonar.ViewsMoveOptions{
 					Destination: "dest",
 				})
 				Expect(err).To(HaveOccurred())
@@ -321,7 +322,7 @@ var _ = Describe("Views Service", Ordered, func() {
 			})
 
 			It("should fail without destination", func() {
-				resp, err := client.Views.Move(&sonar.ViewsMoveOptions{
+				resp, err := client.Views.Move(context.Background(), &sonar.ViewsMoveOptions{
 					Key: "my-view",
 				})
 				Expect(err).To(HaveOccurred())
@@ -337,19 +338,19 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("Projects", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				_, _, err := client.Views.Projects(nil)
+				_, _, err := client.Views.Projects(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 			})
 
 			It("should fail without key", func() {
-				_, _, err := client.Views.Projects(&sonar.ViewsProjectsOptions{})
+				_, _, err := client.Views.Projects(context.Background(), &sonar.ViewsProjectsOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Key"))
 			})
 
 			It("should fail with invalid selected value", func() {
-				_, _, err := client.Views.Projects(&sonar.ViewsProjectsOptions{
+				_, _, err := client.Views.Projects(context.Background(), &sonar.ViewsProjectsOptions{
 					Key:      "my-view",
 					Selected: "invalid",
 				})
@@ -364,14 +365,14 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("AddApplication", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Views.AddApplication(nil)
+				resp, err := client.Views.AddApplication(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without portfolio key", func() {
-				resp, err := client.Views.AddApplication(&sonar.ViewsAddApplicationOptions{
+				resp, err := client.Views.AddApplication(context.Background(), &sonar.ViewsAddApplicationOptions{
 					Application: "my-app",
 				})
 				Expect(err).To(HaveOccurred())
@@ -380,7 +381,7 @@ var _ = Describe("Views Service", Ordered, func() {
 			})
 
 			It("should fail without application key", func() {
-				resp, err := client.Views.AddApplication(&sonar.ViewsAddApplicationOptions{
+				resp, err := client.Views.AddApplication(context.Background(), &sonar.ViewsAddApplicationOptions{
 					Portfolio: "my-portfolio",
 				})
 				Expect(err).To(HaveOccurred())
@@ -393,14 +394,14 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("RemoveApplication", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Views.RemoveApplication(nil)
+				resp, err := client.Views.RemoveApplication(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without portfolio key", func() {
-				resp, err := client.Views.RemoveApplication(&sonar.ViewsRemoveApplicationOptions{
+				resp, err := client.Views.RemoveApplication(context.Background(), &sonar.ViewsRemoveApplicationOptions{
 					Application: "my-app",
 				})
 				Expect(err).To(HaveOccurred())
@@ -409,7 +410,7 @@ var _ = Describe("Views Service", Ordered, func() {
 			})
 
 			It("should fail without application key", func() {
-				resp, err := client.Views.RemoveApplication(&sonar.ViewsRemoveApplicationOptions{
+				resp, err := client.Views.RemoveApplication(context.Background(), &sonar.ViewsRemoveApplicationOptions{
 					Portfolio: "my-portfolio",
 				})
 				Expect(err).To(HaveOccurred())
@@ -425,14 +426,14 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("AddPortfolio", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Views.AddPortfolio(nil)
+				resp, err := client.Views.AddPortfolio(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without portfolio", func() {
-				resp, err := client.Views.AddPortfolio(&sonar.ViewsAddPortfolioOptions{
+				resp, err := client.Views.AddPortfolio(context.Background(), &sonar.ViewsAddPortfolioOptions{
 					Reference: "ref-portfolio",
 				})
 				Expect(err).To(HaveOccurred())
@@ -441,7 +442,7 @@ var _ = Describe("Views Service", Ordered, func() {
 			})
 
 			It("should fail without reference", func() {
-				resp, err := client.Views.AddPortfolio(&sonar.ViewsAddPortfolioOptions{
+				resp, err := client.Views.AddPortfolio(context.Background(), &sonar.ViewsAddPortfolioOptions{
 					Portfolio: "parent-portfolio",
 				})
 				Expect(err).To(HaveOccurred())
@@ -454,7 +455,7 @@ var _ = Describe("Views Service", Ordered, func() {
 	Describe("RemovePortfolio", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Views.RemovePortfolio(nil)
+				resp, err := client.Views.RemovePortfolio(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
 				Expect(resp).To(BeNil())

--- a/integration_testing/webhooks_test.go
+++ b/integration_testing/webhooks_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,14 +27,14 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 		// Create a test project for project-scoped webhooks
 		projectKey = helpers.UniqueResourceName("webhook")
-		_, _, err = client.Projects.Create(&sonar.ProjectsCreateOptions{
+		_, _, err = client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
 			Name:    "Webhooks Test Project",
 			Project: projectKey,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		cleanup.RegisterCleanup("project", projectKey, func() error {
-			_, err := client.Projects.Delete(&sonar.ProjectsDeleteOptions{
+			_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
 				Project: projectKey,
 			})
 			return err
@@ -53,7 +54,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 	Describe("List", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Webhooks.List(nil)
+				result, resp, err := client.Webhooks.List(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -63,14 +64,14 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should list global webhooks", func() {
-				result, resp, err := client.Webhooks.List(&sonar.WebhooksListOptions{})
+				result, resp, err := client.Webhooks.List(context.Background(), &sonar.WebhooksListOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
 			})
 
 			It("should list project webhooks", func() {
-				result, resp, err := client.Webhooks.List(&sonar.WebhooksListOptions{
+				result, resp, err := client.Webhooks.List(context.Background(), &sonar.WebhooksListOptions{
 					Project: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -86,7 +87,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 	Describe("Create", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Webhooks.Create(nil)
+				result, resp, err := client.Webhooks.Create(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -94,7 +95,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should fail without required name", func() {
-				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
+				result, resp, err := client.Webhooks.Create(context.Background(), &sonar.WebhooksCreateOptions{
 					URL: "https://example.com/webhook",
 				})
 				Expect(err).To(HaveOccurred())
@@ -104,7 +105,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should fail without required URL", func() {
-				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
+				result, resp, err := client.Webhooks.Create(context.Background(), &sonar.WebhooksCreateOptions{
 					Name: "Test Webhook",
 				})
 				Expect(err).To(HaveOccurred())
@@ -114,7 +115,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should fail with secret too short", func() {
-				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
+				result, resp, err := client.Webhooks.Create(context.Background(), &sonar.WebhooksCreateOptions{
 					Name:   "Test Webhook",
 					URL:    "https://example.com/webhook",
 					Secret: "short",
@@ -129,7 +130,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 		Context("Valid Requests", func() {
 			It("should create a global webhook", func() {
 				webhookName := helpers.UniqueResourceName("wh")
-				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
+				result, resp, err := client.Webhooks.Create(context.Background(), &sonar.WebhooksCreateOptions{
 					Name: webhookName,
 					URL:  "https://example.com/webhook",
 				})
@@ -140,14 +141,14 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 				Expect(result.Webhook.Name).To(Equal(webhookName))
 
 				// Clean up
-				_, _ = client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{
+				_, _ = client.Webhooks.Delete(context.Background(), &sonar.WebhooksDeleteOptions{
 					Webhook: result.Webhook.Key,
 				})
 			})
 
 			It("should create a project webhook", func() {
 				webhookName := helpers.UniqueResourceName("wh")
-				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
+				result, resp, err := client.Webhooks.Create(context.Background(), &sonar.WebhooksCreateOptions{
 					Name:    webhookName,
 					URL:     "https://example.com/webhook",
 					Project: projectKey,
@@ -158,14 +159,14 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 				Expect(result.Webhook.Key).NotTo(BeEmpty())
 
 				// Clean up
-				_, _ = client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{
+				_, _ = client.Webhooks.Delete(context.Background(), &sonar.WebhooksDeleteOptions{
 					Webhook: result.Webhook.Key,
 				})
 			})
 
 			It("should create a webhook with secret", func() {
 				webhookName := helpers.UniqueResourceName("wh")
-				result, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
+				result, resp, err := client.Webhooks.Create(context.Background(), &sonar.WebhooksCreateOptions{
 					Name:   webhookName,
 					URL:    "https://example.com/webhook",
 					Secret: "super-secret-key-16chars",
@@ -176,7 +177,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 				Expect(result.Webhook.HasSecret).To(BeTrue())
 
 				// Clean up
-				_, _ = client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{
+				_, _ = client.Webhooks.Delete(context.Background(), &sonar.WebhooksDeleteOptions{
 					Webhook: result.Webhook.Key,
 				})
 			})
@@ -189,14 +190,14 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 	Describe("Update", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Webhooks.Update(nil)
+				resp, err := client.Webhooks.Update(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required webhook key", func() {
-				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOptions{
+				resp, err := client.Webhooks.Update(context.Background(), &sonar.WebhooksUpdateOptions{
 					Name: "Updated Name",
 					URL:  "https://example.com/updated",
 				})
@@ -206,7 +207,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should fail without required name", func() {
-				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOptions{
+				resp, err := client.Webhooks.Update(context.Background(), &sonar.WebhooksUpdateOptions{
 					Webhook: "some-key",
 					URL:     "https://example.com/updated",
 				})
@@ -216,7 +217,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should fail without required URL", func() {
-				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOptions{
+				resp, err := client.Webhooks.Update(context.Background(), &sonar.WebhooksUpdateOptions{
 					Webhook: "some-key",
 					Name:    "Updated Name",
 				})
@@ -230,7 +231,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			It("should update a webhook", func() {
 				// Create a webhook first
 				webhookName := helpers.UniqueResourceName("wh")
-				createResult, _, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
+				createResult, _, err := client.Webhooks.Create(context.Background(), &sonar.WebhooksCreateOptions{
 					Name: webhookName,
 					URL:  "https://example.com/webhook",
 				})
@@ -238,7 +239,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 				// Update it
 				updatedName := webhookName + "-updated"
-				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOptions{
+				resp, err := client.Webhooks.Update(context.Background(), &sonar.WebhooksUpdateOptions{
 					Webhook: createResult.Webhook.Key,
 					Name:    updatedName,
 					URL:     "https://example.com/updated",
@@ -247,7 +248,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// Clean up
-				_, _ = client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{
+				_, _ = client.Webhooks.Delete(context.Background(), &sonar.WebhooksDeleteOptions{
 					Webhook: createResult.Webhook.Key,
 				})
 			})
@@ -255,7 +256,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 		Context("Non-Existent Webhook", func() {
 			It("should fail for non-existent webhook", func() {
-				resp, err := client.Webhooks.Update(&sonar.WebhooksUpdateOptions{
+				resp, err := client.Webhooks.Update(context.Background(), &sonar.WebhooksUpdateOptions{
 					Webhook: "non-existent-webhook-key",
 					Name:    "Updated Name",
 					URL:     "https://example.com/updated",
@@ -274,14 +275,14 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 	Describe("Delete", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Webhooks.Delete(nil)
+				resp, err := client.Webhooks.Delete(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required webhook key", func() {
-				resp, err := client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{})
+				resp, err := client.Webhooks.Delete(context.Background(), &sonar.WebhooksDeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Webhook"))
 				Expect(resp).To(BeNil())
@@ -292,14 +293,14 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			It("should delete a webhook", func() {
 				// Create a webhook first
 				webhookName := helpers.UniqueResourceName("wh")
-				createResult, _, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
+				createResult, _, err := client.Webhooks.Create(context.Background(), &sonar.WebhooksCreateOptions{
 					Name: webhookName,
 					URL:  "https://example.com/webhook",
 				})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Delete it
-				resp, err := client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{
+				resp, err := client.Webhooks.Delete(context.Background(), &sonar.WebhooksDeleteOptions{
 					Webhook: createResult.Webhook.Key,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -309,7 +310,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 		Context("Non-Existent Webhook", func() {
 			It("should fail for non-existent webhook", func() {
-				resp, err := client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{
+				resp, err := client.Webhooks.Delete(context.Background(), &sonar.WebhooksDeleteOptions{
 					Webhook: "non-existent-webhook-key",
 				})
 				Expect(err).To(HaveOccurred())
@@ -326,7 +327,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 	Describe("Deliveries", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Webhooks.Deliveries(nil)
+				result, resp, err := client.Webhooks.Deliveries(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -336,7 +337,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 		Context("Valid Requests", func() {
 			It("should list deliveries for a project", func() {
-				result, resp, err := client.Webhooks.Deliveries(&sonar.WebhooksDeliveriesOptions{
+				result, resp, err := client.Webhooks.Deliveries(context.Background(), &sonar.WebhooksDeliveriesOptions{
 					ComponentKey: projectKey,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -345,7 +346,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should list deliveries with pagination", func() {
-				result, resp, err := client.Webhooks.Deliveries(&sonar.WebhooksDeliveriesOptions{
+				result, resp, err := client.Webhooks.Deliveries(context.Background(), &sonar.WebhooksDeliveriesOptions{
 					ComponentKey: projectKey,
 					PaginationArgs: sonar.PaginationArgs{
 						PageSize: 10,
@@ -365,7 +366,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 	Describe("Delivery", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				result, resp, err := client.Webhooks.Delivery(nil)
+				result, resp, err := client.Webhooks.Delivery(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("is required"))
 				Expect(result).To(BeNil())
@@ -373,7 +374,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			})
 
 			It("should fail without required DeliveryID", func() {
-				result, resp, err := client.Webhooks.Delivery(&sonar.WebhooksDeliveryOptions{})
+				result, resp, err := client.Webhooks.Delivery(context.Background(), &sonar.WebhooksDeliveryOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("DeliveryID"))
 				Expect(result).To(BeNil())
@@ -383,7 +384,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 		Context("Non-Existent Delivery", func() {
 			It("should fail for non-existent delivery", func() {
-				result, resp, err := client.Webhooks.Delivery(&sonar.WebhooksDeliveryOptions{
+				result, resp, err := client.Webhooks.Delivery(context.Background(), &sonar.WebhooksDeliveryOptions{
 					DeliveryID: "non-existent-delivery-id",
 				})
 				Expect(err).To(HaveOccurred())
@@ -402,7 +403,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 		It("should create, list, update, and delete a webhook", func() {
 			// Create a webhook
 			webhookName := helpers.UniqueResourceName("wh")
-			createResult, resp, err := client.Webhooks.Create(&sonar.WebhooksCreateOptions{
+			createResult, resp, err := client.Webhooks.Create(context.Background(), &sonar.WebhooksCreateOptions{
 				Name: webhookName,
 				URL:  "https://example.com/webhook",
 			})
@@ -412,7 +413,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			webhookKey := createResult.Webhook.Key
 
 			// List and verify it's there
-			listResult, resp, err := client.Webhooks.List(&sonar.WebhooksListOptions{})
+			listResult, resp, err := client.Webhooks.List(context.Background(), &sonar.WebhooksListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -428,7 +429,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 
 			// Update the webhook
 			updatedName := webhookName + "-updated"
-			resp, err = client.Webhooks.Update(&sonar.WebhooksUpdateOptions{
+			resp, err = client.Webhooks.Update(context.Background(), &sonar.WebhooksUpdateOptions{
 				Webhook: webhookKey,
 				Name:    updatedName,
 				URL:     "https://example.com/updated",
@@ -437,7 +438,7 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify update
-			listResult, _, err = client.Webhooks.List(&sonar.WebhooksListOptions{})
+			listResult, _, err = client.Webhooks.List(context.Background(), &sonar.WebhooksListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, w := range listResult.Webhooks {
@@ -449,14 +450,14 @@ var _ = Describe("Webhooks Service", Ordered, func() {
 			}
 
 			// Delete the webhook
-			resp, err = client.Webhooks.Delete(&sonar.WebhooksDeleteOptions{
+			resp, err = client.Webhooks.Delete(context.Background(), &sonar.WebhooksDeleteOptions{
 				Webhook: webhookKey,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 			// Verify it's gone
-			listResult, _, err = client.Webhooks.List(&sonar.WebhooksListOptions{})
+			listResult, _, err = client.Webhooks.List(context.Background(), &sonar.WebhooksListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			found = false

--- a/integration_testing/webservices_test.go
+++ b/integration_testing/webservices_test.go
@@ -1,6 +1,7 @@
 package integration_testing_test
 
 import (
+	"context"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,7 +29,7 @@ var _ = Describe("Webservices Service", Ordered, func() {
 	Describe("List", func() {
 		Context("Functional Tests", func() {
 			It("should list webservices with nil options", func() {
-				result, resp, err := client.Webservices.List(nil)
+				result, resp, err := client.Webservices.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -36,7 +37,7 @@ var _ = Describe("Webservices Service", Ordered, func() {
 			})
 
 			It("should list webservices with empty options", func() {
-				result, resp, err := client.Webservices.List(&sonar.WebservicesListOptions{})
+				result, resp, err := client.Webservices.List(context.Background(), &sonar.WebservicesListOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -44,7 +45,7 @@ var _ = Describe("Webservices Service", Ordered, func() {
 			})
 
 			It("should return webservices with valid properties", func() {
-				result, resp, err := client.Webservices.List(nil)
+				result, resp, err := client.Webservices.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -66,14 +67,14 @@ var _ = Describe("Webservices Service", Ordered, func() {
 			})
 
 			It("should find common API paths", func() {
-				result, resp, err := client.Webservices.List(nil)
+				result, resp, err := client.Webservices.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
 			})
 
 			It("should filter and search for specific web service domains", func() {
-				result, resp, err := client.Webservices.List(nil)
+				result, resp, err := client.Webservices.List(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(result).NotTo(BeNil())
@@ -97,12 +98,12 @@ var _ = Describe("Webservices Service", Ordered, func() {
 			})
 
 			It("should include internals when requested", func() {
-				withoutInternals, _, err := client.Webservices.List(&sonar.WebservicesListOptions{
+				withoutInternals, _, err := client.Webservices.List(context.Background(), &sonar.WebservicesListOptions{
 					IncludeInternals: false,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				withInternals, _, err := client.Webservices.List(&sonar.WebservicesListOptions{
+				withInternals, _, err := client.Webservices.List(context.Background(), &sonar.WebservicesListOptions{
 					IncludeInternals: true,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -130,7 +131,7 @@ var _ = Describe("Webservices Service", Ordered, func() {
 		Context("Functional Tests", func() {
 			It("should get response example for an action with example", func() {
 				// First find an action with a response example
-				list, _, err := client.Webservices.List(&sonar.WebservicesListOptions{
+				list, _, err := client.Webservices.List(context.Background(), &sonar.WebservicesListOptions{
 					IncludeInternals: true,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -154,7 +155,7 @@ var _ = Describe("Webservices Service", Ordered, func() {
 					Skip("No action with response example found in this SonarQube version")
 				}
 
-				result, resp, err := client.Webservices.ResponseExample(&sonar.WebservicesResponseExampleOptions{
+				result, resp, err := client.Webservices.ResponseExample(context.Background(), &sonar.WebservicesResponseExampleOptions{
 					Controller: controller,
 					Action:     action,
 				})
@@ -167,20 +168,20 @@ var _ = Describe("Webservices Service", Ordered, func() {
 
 		Context("Error Handling", func() {
 			It("should fail with nil options", func() {
-				_, resp, err := client.Webservices.ResponseExample(nil)
+				_, resp, err := client.Webservices.ResponseExample(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail with empty options", func() {
-				_, resp, err := client.Webservices.ResponseExample(&sonar.WebservicesResponseExampleOptions{})
+				_, resp, err := client.Webservices.ResponseExample(context.Background(), &sonar.WebservicesResponseExampleOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(resp).To(BeNil())
 				Expect(err.Error()).To(ContainSubstring("Action"))
 			})
 
 			It("should fail with missing action", func() {
-				_, resp, err := client.Webservices.ResponseExample(&sonar.WebservicesResponseExampleOptions{
+				_, resp, err := client.Webservices.ResponseExample(context.Background(), &sonar.WebservicesResponseExampleOptions{
 					Controller: "api/system",
 				})
 				Expect(err).To(HaveOccurred())
@@ -189,7 +190,7 @@ var _ = Describe("Webservices Service", Ordered, func() {
 			})
 
 			It("should fail with missing controller", func() {
-				_, resp, err := client.Webservices.ResponseExample(&sonar.WebservicesResponseExampleOptions{
+				_, resp, err := client.Webservices.ResponseExample(context.Background(), &sonar.WebservicesResponseExampleOptions{
 					Action: "status",
 				})
 				Expect(err).To(HaveOccurred())

--- a/internal/cli/invoke.go
+++ b/internal/cli/invoke.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -65,18 +66,22 @@ func ClassifyMethod(method reflect.Method) MethodReturnPattern {
 
 // InvokeMethod calls a service method via reflection and returns the result.
 // It handles all four return patterns, extracting the response value and error.
+// context.Background() is automatically prepended when the method's first parameter
+// is context.Context.
 func InvokeMethod(service reflect.Value, methodName string, opt reflect.Value, pattern MethodReturnPattern, hasOpt bool) (any, *http.Response, error) {
 	method := service.MethodByName(methodName)
 	if !method.IsValid() {
 		return nil, nil, fmt.Errorf("method %q not found on service", methodName)
 	}
 
+	ctxVal := reflect.ValueOf(context.Background())
+
 	var results []reflect.Value
 
 	if hasOpt {
-		results = method.Call([]reflect.Value{opt})
+		results = method.Call([]reflect.Value{ctxVal, opt})
 	} else {
-		results = method.Call(nil)
+		results = method.Call([]reflect.Value{ctxVal})
 	}
 
 	switch pattern {
@@ -97,13 +102,16 @@ func InvokeMethod(service reflect.Value, methodName string, opt reflect.Value, p
 
 // InvokeStreamingMethod calls a streaming service method (like Push.SonarlintEvents)
 // and pipes the response body to the writer. The response body is left open for streaming.
+// context.Background() is automatically prepended as the first argument.
 func InvokeStreamingMethod(service reflect.Value, methodName string, opt reflect.Value, writer io.Writer) error {
 	method := service.MethodByName(methodName)
 	if !method.IsValid() {
 		return fmt.Errorf("method %q not found on service", methodName)
 	}
 
-	results := method.Call([]reflect.Value{opt})
+	ctxVal := reflect.ValueOf(context.Background())
+
+	results := method.Call([]reflect.Value{ctxVal, opt})
 
 	// Push.SonarlintEvents returns (*http.Response, error)
 	if len(results) != expectedDoubleReturn {

--- a/internal/cli/invoke_test.go
+++ b/internal/cli/invoke_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"reflect"
@@ -18,35 +19,35 @@ type fakeResponse struct {
 // fakeService is a mock service for testing InvokeMethod.
 type fakeService struct{}
 
-// ResponseBodyMethod simulates a (*Response, *http.Response, error) method.
-func (f *fakeService) ResponseBodyMethod(opt *struct{}) (*fakeResponse, *http.Response, error) {
+// ResponseBodyMethod simulates a (ctx, *Options) -> (*Response, *http.Response, error) method.
+func (f *fakeService) ResponseBodyMethod(ctx context.Context, opt *struct{}) (*fakeResponse, *http.Response, error) {
 	return &fakeResponse{Name: "ok"}, nil, nil
 }
 
-// NoBodyMethod simulates a (*http.Response, error) method.
-func (f *fakeService) NoBodyMethod() (*http.Response, error) {
+// NoBodyMethod simulates a (ctx) -> (*http.Response, error) method.
+func (f *fakeService) NoBodyMethod(ctx context.Context) (*http.Response, error) {
 	return nil, nil
 }
 
-// RawBytesMethod simulates a ([]byte, *http.Response, error) method.
-func (f *fakeService) RawBytesMethod(opt *struct{}) ([]byte, *http.Response, error) {
+// RawBytesMethod simulates a (ctx, *Options) -> ([]byte, *http.Response, error) method.
+func (f *fakeService) RawBytesMethod(ctx context.Context, opt *struct{}) ([]byte, *http.Response, error) {
 	return []byte("hello"), nil, nil
 }
 
-// RawStringMethod simulates a (*string, *http.Response, error) method.
-func (f *fakeService) RawStringMethod(opt *struct{}) (*string, *http.Response, error) {
+// RawStringMethod simulates a (ctx, *Options) -> (*string, *http.Response, error) method.
+func (f *fakeService) RawStringMethod(ctx context.Context, opt *struct{}) (*string, *http.Response, error) {
 	s := "world"
 
 	return &s, nil, nil
 }
 
-// SliceMethod simulates a ([]SomeStruct, *http.Response, error) method.
-func (f *fakeService) SliceMethod(opt *struct{}) ([]fakeResponse, *http.Response, error) {
+// SliceMethod simulates a (ctx, *Options) -> ([]SomeStruct, *http.Response, error) method.
+func (f *fakeService) SliceMethod(ctx context.Context, opt *struct{}) ([]fakeResponse, *http.Response, error) {
 	return []fakeResponse{{Name: "a"}, {Name: "b"}}, nil, nil
 }
 
 // ErrorMethod simulates a method that returns an error.
-func (f *fakeService) ErrorMethod(opt *struct{}) (*fakeResponse, *http.Response, error) {
+func (f *fakeService) ErrorMethod(ctx context.Context, opt *struct{}) (*fakeResponse, *http.Response, error) {
 	return nil, nil, errors.New("something failed")
 }
 

--- a/internal/cli/pagination_test.go
+++ b/internal/cli/pagination_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"net/http"
 	"reflect"
 	"testing"
@@ -141,7 +142,7 @@ type paginatedService struct {
 }
 
 // Search simulates a paginated method that returns pages of results.
-func (s *paginatedService) Search(opt *paginatedOptions) (*paginatedResponse, *http.Response, error) {
+func (s *paginatedService) Search(ctx context.Context, opt *paginatedOptions) (*paginatedResponse, *http.Response, error) {
 	s.callCount++
 
 	// Return different data based on page.

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -101,9 +101,11 @@ func buildMethodCommand(serviceName string, _ reflect.Type, method reflect.Metho
 	pattern := ClassifyMethod(method)
 
 	// Determine if this method takes an option struct parameter.
-	// Method signatures: receiver is index 0 (for reflect.Type.Method on pointer type).
+	// Method signatures (receiver is index 0 for reflect.Type.Method on pointer type):
+	//   NumIn() == 2: receiver + ctx              (no option param)
+	//   NumIn() == 3: receiver + ctx + option     (has option param)
 	methodType := method.Type
-	hasOpt := methodType.NumIn() == 2 //nolint:mnd // 2 = receiver + option param
+	hasOpt := methodType.NumIn() == 3 //nolint:mnd // 3 = receiver + ctx + option param
 
 	var (
 		optType  reflect.Type
@@ -111,7 +113,7 @@ func buildMethodCommand(serviceName string, _ reflect.Type, method reflect.Metho
 	)
 
 	if hasOpt {
-		optType = methodType.In(1) // The option parameter type (should be *SomeOptions)
+		optType = methodType.In(2) //nolint:mnd // 2 = option param index (0=receiver, 1=ctx, 2=opt)
 		if optType.Kind() == reflect.Pointer {
 			optType = optType.Elem()
 		}

--- a/sonar/alm_integrations_service.go
+++ b/sonar/alm_integrations_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -481,13 +482,13 @@ type AlmIntegrationsSetPatOptions struct {
 
 // CheckPat checks the validity of a Personal Access Token for the given DevOps Platform setting.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) CheckPat(opt *AlmIntegrationsCheckPatOptions) (v *AlmIntegrationsCheckPat, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) CheckPat(ctx context.Context, opt *AlmIntegrationsCheckPatOptions) (v *AlmIntegrationsCheckPat, resp *http.Response, err error) {
 	err = s.ValidateCheckPatOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_integrations/check_pat", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_integrations/check_pat", opt)
 	if err != nil {
 		return
 	}
@@ -504,13 +505,13 @@ func (s *AlmIntegrationsService) CheckPat(opt *AlmIntegrationsCheckPatOptions) (
 
 // GetGithubClientID gets the client ID of a GitHub Integration.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) GetGithubClientID(opt *AlmIntegrationsGetGithubClientIDOptions) (v *AlmIntegrationsGetGithubClientID, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) GetGithubClientID(ctx context.Context, opt *AlmIntegrationsGetGithubClientIDOptions) (v *AlmIntegrationsGetGithubClientID, resp *http.Response, err error) {
 	err = s.ValidateGetGithubClientIDOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_integrations/get_github_client_id", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_integrations/get_github_client_id", opt)
 	if err != nil {
 		return
 	}
@@ -530,13 +531,13 @@ func (s *AlmIntegrationsService) GetGithubClientID(opt *AlmIntegrationsGetGithub
 // Requires the 'Create Projects' permission.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-func (s *AlmIntegrationsService) ImportAzureProject(opt *AlmIntegrationsImportAzureProjectOptions) (resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ImportAzureProject(ctx context.Context, opt *AlmIntegrationsImportAzureProjectOptions) (resp *http.Response, err error) {
 	err = s.ValidateImportAzureProjectOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_integrations/import_azure_project", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_integrations/import_azure_project", opt)
 	if err != nil {
 		return
 	}
@@ -554,13 +555,13 @@ func (s *AlmIntegrationsService) ImportAzureProject(opt *AlmIntegrationsImportAz
 // Requires the 'Create Projects' permission.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-func (s *AlmIntegrationsService) ImportBitbucketCloudRepo(opt *AlmIntegrationsImportBitbucketCloudRepoOptions) (resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ImportBitbucketCloudRepo(ctx context.Context, opt *AlmIntegrationsImportBitbucketCloudRepoOptions) (resp *http.Response, err error) {
 	err = s.ValidateImportBitbucketCloudRepoOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_integrations/import_bitbucketcloud_repo", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_integrations/import_bitbucketcloud_repo", opt)
 	if err != nil {
 		return
 	}
@@ -578,13 +579,13 @@ func (s *AlmIntegrationsService) ImportBitbucketCloudRepo(opt *AlmIntegrationsIm
 // Requires the 'Create Projects' permission.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-func (s *AlmIntegrationsService) ImportBitbucketServerProject(opt *AlmIntegrationsImportBitbucketServerProjectOptions) (resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ImportBitbucketServerProject(ctx context.Context, opt *AlmIntegrationsImportBitbucketServerProjectOptions) (resp *http.Response, err error) {
 	err = s.ValidateImportBitbucketServerProjectOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_integrations/import_bitbucketserver_project", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_integrations/import_bitbucketserver_project", opt)
 	if err != nil {
 		return
 	}
@@ -603,13 +604,13 @@ func (s *AlmIntegrationsService) ImportBitbucketServerProject(opt *AlmIntegratio
 // Requires the 'Create Projects' permission.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-func (s *AlmIntegrationsService) ImportGithubProject(opt *AlmIntegrationsImportGithubProjectOptions) (resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ImportGithubProject(ctx context.Context, opt *AlmIntegrationsImportGithubProjectOptions) (resp *http.Response, err error) {
 	err = s.ValidateImportGithubProjectOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_integrations/import_github_project", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_integrations/import_github_project", opt)
 	if err != nil {
 		return
 	}
@@ -626,13 +627,13 @@ func (s *AlmIntegrationsService) ImportGithubProject(opt *AlmIntegrationsImportG
 // Requires the 'Create Projects' permission.
 //
 // Deprecated: Since 10.5 - use /api/v2/dop-translation/bound-projects instead.
-func (s *AlmIntegrationsService) ImportGitlabProject(opt *AlmIntegrationsImportGitlabProjectOptions) (resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ImportGitlabProject(ctx context.Context, opt *AlmIntegrationsImportGitlabProjectOptions) (resp *http.Response, err error) {
 	err = s.ValidateImportGitlabProjectOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_integrations/import_gitlab_project", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_integrations/import_gitlab_project", opt)
 	if err != nil {
 		return
 	}
@@ -647,13 +648,13 @@ func (s *AlmIntegrationsService) ImportGitlabProject(opt *AlmIntegrationsImportG
 
 // ListAzureProjects lists Azure projects.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) ListAzureProjects(opt *AlmIntegrationsListAzureProjectsOptions) (v *AlmIntegrationsListAzureProjects, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ListAzureProjects(ctx context.Context, opt *AlmIntegrationsListAzureProjectsOptions) (v *AlmIntegrationsListAzureProjects, resp *http.Response, err error) {
 	err = s.ValidateListAzureProjectsOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_integrations/list_azure_projects", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_integrations/list_azure_projects", opt)
 	if err != nil {
 		return
 	}
@@ -670,13 +671,13 @@ func (s *AlmIntegrationsService) ListAzureProjects(opt *AlmIntegrationsListAzure
 
 // ListBitbucketServerProjects lists the Bitbucket Server projects.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) ListBitbucketServerProjects(opt *AlmIntegrationsListBitbucketServerProjectsOptions) (v *AlmIntegrationsListBitbucketServerProjects, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ListBitbucketServerProjects(ctx context.Context, opt *AlmIntegrationsListBitbucketServerProjectsOptions) (v *AlmIntegrationsListBitbucketServerProjects, resp *http.Response, err error) {
 	err = s.ValidateListBitbucketServerProjectsOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_integrations/list_bitbucketserver_projects", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_integrations/list_bitbucketserver_projects", opt)
 	if err != nil {
 		return
 	}
@@ -693,13 +694,13 @@ func (s *AlmIntegrationsService) ListBitbucketServerProjects(opt *AlmIntegration
 
 // ListGithubOrganizations lists GitHub organizations.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) ListGithubOrganizations(opt *AlmIntegrationsListGithubOrganizationsOptions) (v *AlmIntegrationsListGithubOrganizations, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ListGithubOrganizations(ctx context.Context, opt *AlmIntegrationsListGithubOrganizationsOptions) (v *AlmIntegrationsListGithubOrganizations, resp *http.Response, err error) {
 	err = s.ValidateListGithubOrganizationsOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_integrations/list_github_organizations", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_integrations/list_github_organizations", opt)
 	if err != nil {
 		return
 	}
@@ -716,13 +717,13 @@ func (s *AlmIntegrationsService) ListGithubOrganizations(opt *AlmIntegrationsLis
 
 // ListGithubRepositories lists the GitHub repositories for an organization.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) ListGithubRepositories(opt *AlmIntegrationsListGithubRepositoriesOptions) (v *AlmIntegrationsListGithubRepositories, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) ListGithubRepositories(ctx context.Context, opt *AlmIntegrationsListGithubRepositoriesOptions) (v *AlmIntegrationsListGithubRepositories, resp *http.Response, err error) {
 	err = s.ValidateListGithubRepositoriesOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_integrations/list_github_repositories", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_integrations/list_github_repositories", opt)
 	if err != nil {
 		return
 	}
@@ -739,13 +740,13 @@ func (s *AlmIntegrationsService) ListGithubRepositories(opt *AlmIntegrationsList
 
 // SearchAzureRepos searches the Azure repositories.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) SearchAzureRepos(opt *AlmIntegrationsSearchAzureReposOptions) (v *AlmIntegrationsSearchAzureRepos, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) SearchAzureRepos(ctx context.Context, opt *AlmIntegrationsSearchAzureReposOptions) (v *AlmIntegrationsSearchAzureRepos, resp *http.Response, err error) {
 	err = s.ValidateSearchAzureReposOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_integrations/search_azure_repos", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_integrations/search_azure_repos", opt)
 	if err != nil {
 		return
 	}
@@ -762,13 +763,13 @@ func (s *AlmIntegrationsService) SearchAzureRepos(opt *AlmIntegrationsSearchAzur
 
 // SearchBitbucketCloudRepos searches the Bitbucket Cloud repositories.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) SearchBitbucketCloudRepos(opt *AlmIntegrationsSearchBitbucketCloudReposOptions) (v *AlmIntegrationsSearchBitbucketCloudRepos, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) SearchBitbucketCloudRepos(ctx context.Context, opt *AlmIntegrationsSearchBitbucketCloudReposOptions) (v *AlmIntegrationsSearchBitbucketCloudRepos, resp *http.Response, err error) {
 	err = s.ValidateSearchBitbucketCloudReposOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_integrations/search_bitbucketcloud_repos", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_integrations/search_bitbucketcloud_repos", opt)
 	if err != nil {
 		return
 	}
@@ -785,13 +786,13 @@ func (s *AlmIntegrationsService) SearchBitbucketCloudRepos(opt *AlmIntegrationsS
 
 // SearchBitbucketServerRepos searches the Bitbucket Server repositories with REPO_ADMIN access.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) SearchBitbucketServerRepos(opt *AlmIntegrationsSearchBitbucketServerReposOptions) (v *AlmIntegrationsSearchBitbucketServerRepos, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) SearchBitbucketServerRepos(ctx context.Context, opt *AlmIntegrationsSearchBitbucketServerReposOptions) (v *AlmIntegrationsSearchBitbucketServerRepos, resp *http.Response, err error) {
 	err = s.ValidateSearchBitbucketServerReposOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_integrations/search_bitbucketserver_repos", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_integrations/search_bitbucketserver_repos", opt)
 	if err != nil {
 		return
 	}
@@ -808,13 +809,13 @@ func (s *AlmIntegrationsService) SearchBitbucketServerRepos(opt *AlmIntegrations
 
 // SearchGitlabRepos searches the GitLab projects.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) SearchGitlabRepos(opt *AlmIntegrationsSearchGitlabReposOptions) (v *AlmIntegrationsSearchGitlabRepos, resp *http.Response, err error) {
+func (s *AlmIntegrationsService) SearchGitlabRepos(ctx context.Context, opt *AlmIntegrationsSearchGitlabReposOptions) (v *AlmIntegrationsSearchGitlabRepos, resp *http.Response, err error) {
 	err = s.ValidateSearchGitlabReposOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_integrations/search_gitlab_repos", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_integrations/search_gitlab_repos", opt)
 	if err != nil {
 		return
 	}
@@ -831,13 +832,13 @@ func (s *AlmIntegrationsService) SearchGitlabRepos(opt *AlmIntegrationsSearchGit
 
 // SetPat sets a Personal Access Token for the given DevOps Platform setting.
 // Requires the 'Create Projects' permission.
-func (s *AlmIntegrationsService) SetPat(opt *AlmIntegrationsSetPatOptions) (resp *http.Response, err error) {
+func (s *AlmIntegrationsService) SetPat(ctx context.Context, opt *AlmIntegrationsSetPatOptions) (resp *http.Response, err error) {
 	err = s.ValidateSetPatOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_integrations/set_pat", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_integrations/set_pat", opt)
 	if err != nil {
 		return
 	}

--- a/sonar/alm_integrations_service_test.go
+++ b/sonar/alm_integrations_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -22,7 +23,7 @@ func TestAlmIntegrations_CheckPat(t *testing.T) {
 		AlmSetting: "my-azure-setting",
 	}
 
-	_, resp, err := client.AlmIntegrations.CheckPat(opt)
+	_, resp, err := client.AlmIntegrations.CheckPat(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -31,15 +32,15 @@ func TestAlmIntegrations_CheckPat_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.AlmIntegrations.CheckPat(nil)
+	_, _, err := client.AlmIntegrations.CheckPat(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.CheckPat(&AlmIntegrationsCheckPatOptions{})
+	_, _, err = client.AlmIntegrations.CheckPat(context.Background(), &AlmIntegrationsCheckPatOptions{})
 	assert.Error(t, err)
 
 	// Test AlmSetting too long
-	_, _, err = client.AlmIntegrations.CheckPat(&AlmIntegrationsCheckPatOptions{
+	_, _, err = client.AlmIntegrations.CheckPat(context.Background(), &AlmIntegrationsCheckPatOptions{
 		AlmSetting: strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
 	assert.Error(t, err)
@@ -58,7 +59,7 @@ func TestAlmIntegrations_GetGithubClientID(t *testing.T) {
 		AlmSetting: "my-github-setting",
 	}
 
-	result, resp, err := client.AlmIntegrations.GetGithubClientID(opt)
+	result, resp, err := client.AlmIntegrations.GetGithubClientID(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotNil(t, result)
@@ -69,11 +70,11 @@ func TestAlmIntegrations_GetGithubClientID_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.AlmIntegrations.GetGithubClientID(nil)
+	_, _, err := client.AlmIntegrations.GetGithubClientID(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.GetGithubClientID(&AlmIntegrationsGetGithubClientIDOptions{})
+	_, _, err = client.AlmIntegrations.GetGithubClientID(context.Background(), &AlmIntegrationsGetGithubClientIDOptions{})
 	assert.Error(t, err)
 }
 
@@ -91,7 +92,7 @@ func TestAlmIntegrations_ImportAzureProject(t *testing.T) {
 		RepositoryName: "my-azure-repo",
 	}
 
-	resp, err := client.AlmIntegrations.ImportAzureProject(opt)
+	resp, err := client.AlmIntegrations.ImportAzureProject(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -100,23 +101,23 @@ func TestAlmIntegrations_ImportAzureProject_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmIntegrations.ImportAzureProject(nil)
+	_, err := client.AlmIntegrations.ImportAzureProject(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing ProjectName
-	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOptions{
+	_, err = client.AlmIntegrations.ImportAzureProject(context.Background(), &AlmIntegrationsImportAzureProjectOptions{
 		RepositoryName: "repo",
 	})
 	assert.Error(t, err)
 
 	// Test missing RepositoryName
-	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOptions{
+	_, err = client.AlmIntegrations.ImportAzureProject(context.Background(), &AlmIntegrationsImportAzureProjectOptions{
 		ProjectName: "project",
 	})
 	assert.Error(t, err)
 
 	// Test invalid NewCodeDefinitionType
-	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOptions{
+	_, err = client.AlmIntegrations.ImportAzureProject(context.Background(), &AlmIntegrationsImportAzureProjectOptions{
 		ProjectName:           "project",
 		RepositoryName:        "repo",
 		NewCodeDefinitionType: "INVALID_TYPE",
@@ -124,7 +125,7 @@ func TestAlmIntegrations_ImportAzureProject_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test NUMBER_OF_DAYS without value
-	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOptions{
+	_, err = client.AlmIntegrations.ImportAzureProject(context.Background(), &AlmIntegrationsImportAzureProjectOptions{
 		ProjectName:           "project",
 		RepositoryName:        "repo",
 		NewCodeDefinitionType: NewCodePeriodTypeNumberOfDays,
@@ -132,7 +133,7 @@ func TestAlmIntegrations_ImportAzureProject_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test PREVIOUS_VERSION with value
-	_, err = client.AlmIntegrations.ImportAzureProject(&AlmIntegrationsImportAzureProjectOptions{
+	_, err = client.AlmIntegrations.ImportAzureProject(context.Background(), &AlmIntegrationsImportAzureProjectOptions{
 		ProjectName:            "project",
 		RepositoryName:         "repo",
 		NewCodeDefinitionType:  NewCodePeriodTypePreviousVersion,
@@ -153,7 +154,7 @@ func TestAlmIntegrations_ImportAzureProject_WithNewCodeDefinition(t *testing.T) 
 		NewCodeDefinitionType: NewCodePeriodTypePreviousVersion,
 	}
 
-	resp, err := client.AlmIntegrations.ImportAzureProject(opt)
+	resp, err := client.AlmIntegrations.ImportAzureProject(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 
@@ -165,7 +166,7 @@ func TestAlmIntegrations_ImportAzureProject_WithNewCodeDefinition(t *testing.T) 
 		NewCodeDefinitionValue: 30,
 	}
 
-	resp, err = client.AlmIntegrations.ImportAzureProject(opt)
+	resp, err = client.AlmIntegrations.ImportAzureProject(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -183,7 +184,7 @@ func TestAlmIntegrations_ImportBitbucketCloudRepo(t *testing.T) {
 		RepositorySlug: "my-repo",
 	}
 
-	resp, err := client.AlmIntegrations.ImportBitbucketCloudRepo(opt)
+	resp, err := client.AlmIntegrations.ImportBitbucketCloudRepo(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -192,11 +193,11 @@ func TestAlmIntegrations_ImportBitbucketCloudRepo_ValidationError(t *testing.T) 
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmIntegrations.ImportBitbucketCloudRepo(nil)
+	_, err := client.AlmIntegrations.ImportBitbucketCloudRepo(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing RepositorySlug
-	_, err = client.AlmIntegrations.ImportBitbucketCloudRepo(&AlmIntegrationsImportBitbucketCloudRepoOptions{})
+	_, err = client.AlmIntegrations.ImportBitbucketCloudRepo(context.Background(), &AlmIntegrationsImportBitbucketCloudRepoOptions{})
 	assert.Error(t, err)
 }
 
@@ -214,7 +215,7 @@ func TestAlmIntegrations_ImportBitbucketServerProject(t *testing.T) {
 		RepositorySlug: "my-repo",
 	}
 
-	resp, err := client.AlmIntegrations.ImportBitbucketServerProject(opt)
+	resp, err := client.AlmIntegrations.ImportBitbucketServerProject(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -223,17 +224,17 @@ func TestAlmIntegrations_ImportBitbucketServerProject_ValidationError(t *testing
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmIntegrations.ImportBitbucketServerProject(nil)
+	_, err := client.AlmIntegrations.ImportBitbucketServerProject(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing ProjectKey
-	_, err = client.AlmIntegrations.ImportBitbucketServerProject(&AlmIntegrationsImportBitbucketServerProjectOptions{
+	_, err = client.AlmIntegrations.ImportBitbucketServerProject(context.Background(), &AlmIntegrationsImportBitbucketServerProjectOptions{
 		RepositorySlug: "repo",
 	})
 	assert.Error(t, err)
 
 	// Test missing RepositorySlug
-	_, err = client.AlmIntegrations.ImportBitbucketServerProject(&AlmIntegrationsImportBitbucketServerProjectOptions{
+	_, err = client.AlmIntegrations.ImportBitbucketServerProject(context.Background(), &AlmIntegrationsImportBitbucketServerProjectOptions{
 		ProjectKey: "PRJ",
 	})
 	assert.Error(t, err)
@@ -252,7 +253,7 @@ func TestAlmIntegrations_ImportGithubProject(t *testing.T) {
 		RepositoryKey: "octocat/hello-world",
 	}
 
-	resp, err := client.AlmIntegrations.ImportGithubProject(opt)
+	resp, err := client.AlmIntegrations.ImportGithubProject(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -261,15 +262,15 @@ func TestAlmIntegrations_ImportGithubProject_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmIntegrations.ImportGithubProject(nil)
+	_, err := client.AlmIntegrations.ImportGithubProject(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing RepositoryKey
-	_, err = client.AlmIntegrations.ImportGithubProject(&AlmIntegrationsImportGithubProjectOptions{})
+	_, err = client.AlmIntegrations.ImportGithubProject(context.Background(), &AlmIntegrationsImportGithubProjectOptions{})
 	assert.Error(t, err)
 
 	// Test RepositoryKey too long
-	_, err = client.AlmIntegrations.ImportGithubProject(&AlmIntegrationsImportGithubProjectOptions{
+	_, err = client.AlmIntegrations.ImportGithubProject(context.Background(), &AlmIntegrationsImportGithubProjectOptions{
 		RepositoryKey: strings.Repeat("a", MaxGitHubRepoKeyLength+1),
 	})
 	assert.Error(t, err)
@@ -288,7 +289,7 @@ func TestAlmIntegrations_ImportGitlabProject(t *testing.T) {
 		GitlabProjectId: "12345",
 	}
 
-	resp, err := client.AlmIntegrations.ImportGitlabProject(opt)
+	resp, err := client.AlmIntegrations.ImportGitlabProject(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -297,11 +298,11 @@ func TestAlmIntegrations_ImportGitlabProject_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmIntegrations.ImportGitlabProject(nil)
+	_, err := client.AlmIntegrations.ImportGitlabProject(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing GitlabProjectId
-	_, err = client.AlmIntegrations.ImportGitlabProject(&AlmIntegrationsImportGitlabProjectOptions{})
+	_, err = client.AlmIntegrations.ImportGitlabProject(context.Background(), &AlmIntegrationsImportGitlabProjectOptions{})
 	assert.Error(t, err)
 }
 
@@ -318,7 +319,7 @@ func TestAlmIntegrations_ListAzureProjects(t *testing.T) {
 		AlmSetting: "my-azure-setting",
 	}
 
-	result, resp, err := client.AlmIntegrations.ListAzureProjects(opt)
+	result, resp, err := client.AlmIntegrations.ListAzureProjects(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotNil(t, result)
@@ -329,11 +330,11 @@ func TestAlmIntegrations_ListAzureProjects_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.AlmIntegrations.ListAzureProjects(nil)
+	_, _, err := client.AlmIntegrations.ListAzureProjects(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.ListAzureProjects(&AlmIntegrationsListAzureProjectsOptions{})
+	_, _, err = client.AlmIntegrations.ListAzureProjects(context.Background(), &AlmIntegrationsListAzureProjectsOptions{})
 	assert.Error(t, err)
 }
 
@@ -351,7 +352,7 @@ func TestAlmIntegrations_ListBitbucketServerProjects(t *testing.T) {
 		PageSize:   25,
 	}
 
-	result, resp, err := client.AlmIntegrations.ListBitbucketServerProjects(opt)
+	result, resp, err := client.AlmIntegrations.ListBitbucketServerProjects(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotNil(t, result)
@@ -362,15 +363,15 @@ func TestAlmIntegrations_ListBitbucketServerProjects_ValidationError(t *testing.
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.AlmIntegrations.ListBitbucketServerProjects(nil)
+	_, _, err := client.AlmIntegrations.ListBitbucketServerProjects(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.ListBitbucketServerProjects(&AlmIntegrationsListBitbucketServerProjectsOptions{})
+	_, _, err = client.AlmIntegrations.ListBitbucketServerProjects(context.Background(), &AlmIntegrationsListBitbucketServerProjectsOptions{})
 	assert.Error(t, err)
 
 	// Test PageSize out of range
-	_, _, err = client.AlmIntegrations.ListBitbucketServerProjects(&AlmIntegrationsListBitbucketServerProjectsOptions{
+	_, _, err = client.AlmIntegrations.ListBitbucketServerProjects(context.Background(), &AlmIntegrationsListBitbucketServerProjectsOptions{
 		AlmSetting: "setting",
 		PageSize:   MaxPageSizeAlmIntegrations + 1,
 	})
@@ -390,7 +391,7 @@ func TestAlmIntegrations_ListGithubOrganizations(t *testing.T) {
 		AlmSetting: "my-github-setting",
 	}
 
-	result, resp, err := client.AlmIntegrations.ListGithubOrganizations(opt)
+	result, resp, err := client.AlmIntegrations.ListGithubOrganizations(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotNil(t, result)
@@ -401,15 +402,15 @@ func TestAlmIntegrations_ListGithubOrganizations_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.AlmIntegrations.ListGithubOrganizations(nil)
+	_, _, err := client.AlmIntegrations.ListGithubOrganizations(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.ListGithubOrganizations(&AlmIntegrationsListGithubOrganizationsOptions{})
+	_, _, err = client.AlmIntegrations.ListGithubOrganizations(context.Background(), &AlmIntegrationsListGithubOrganizationsOptions{})
 	assert.Error(t, err)
 
 	// Test Token too long
-	_, _, err = client.AlmIntegrations.ListGithubOrganizations(&AlmIntegrationsListGithubOrganizationsOptions{
+	_, _, err = client.AlmIntegrations.ListGithubOrganizations(context.Background(), &AlmIntegrationsListGithubOrganizationsOptions{
 		AlmSetting: "setting",
 		Token:      strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
@@ -430,7 +431,7 @@ func TestAlmIntegrations_ListGithubRepositories(t *testing.T) {
 		Organization: "octocat",
 	}
 
-	result, resp, err := client.AlmIntegrations.ListGithubRepositories(opt)
+	result, resp, err := client.AlmIntegrations.ListGithubRepositories(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotNil(t, result)
@@ -441,17 +442,17 @@ func TestAlmIntegrations_ListGithubRepositories_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.AlmIntegrations.ListGithubRepositories(nil)
+	_, _, err := client.AlmIntegrations.ListGithubRepositories(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.ListGithubRepositories(&AlmIntegrationsListGithubRepositoriesOptions{
+	_, _, err = client.AlmIntegrations.ListGithubRepositories(context.Background(), &AlmIntegrationsListGithubRepositoriesOptions{
 		Organization: "octocat",
 	})
 	assert.Error(t, err)
 
 	// Test missing Organization
-	_, _, err = client.AlmIntegrations.ListGithubRepositories(&AlmIntegrationsListGithubRepositoriesOptions{
+	_, _, err = client.AlmIntegrations.ListGithubRepositories(context.Background(), &AlmIntegrationsListGithubRepositoriesOptions{
 		AlmSetting: "setting",
 	})
 	assert.Error(t, err)
@@ -470,7 +471,7 @@ func TestAlmIntegrations_SearchAzureRepos(t *testing.T) {
 		AlmSetting: "my-azure-setting",
 	}
 
-	result, resp, err := client.AlmIntegrations.SearchAzureRepos(opt)
+	result, resp, err := client.AlmIntegrations.SearchAzureRepos(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotNil(t, result)
@@ -481,22 +482,22 @@ func TestAlmIntegrations_SearchAzureRepos_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.AlmIntegrations.SearchAzureRepos(nil)
+	_, _, err := client.AlmIntegrations.SearchAzureRepos(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.SearchAzureRepos(&AlmIntegrationsSearchAzureReposOptions{})
+	_, _, err = client.AlmIntegrations.SearchAzureRepos(context.Background(), &AlmIntegrationsSearchAzureReposOptions{})
 	assert.Error(t, err)
 
 	// Test ProjectName too long
-	_, _, err = client.AlmIntegrations.SearchAzureRepos(&AlmIntegrationsSearchAzureReposOptions{
+	_, _, err = client.AlmIntegrations.SearchAzureRepos(context.Background(), &AlmIntegrationsSearchAzureReposOptions{
 		AlmSetting:  "setting",
 		ProjectName: strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
 	assert.Error(t, err)
 
 	// Test SearchQuery too long
-	_, _, err = client.AlmIntegrations.SearchAzureRepos(&AlmIntegrationsSearchAzureReposOptions{
+	_, _, err = client.AlmIntegrations.SearchAzureRepos(context.Background(), &AlmIntegrationsSearchAzureReposOptions{
 		AlmSetting:  "setting",
 		SearchQuery: strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
@@ -516,7 +517,7 @@ func TestAlmIntegrations_SearchBitbucketCloudRepos(t *testing.T) {
 		AlmSetting: "my-bitbucket-setting",
 	}
 
-	result, resp, err := client.AlmIntegrations.SearchBitbucketCloudRepos(opt)
+	result, resp, err := client.AlmIntegrations.SearchBitbucketCloudRepos(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotNil(t, result)
@@ -528,15 +529,15 @@ func TestAlmIntegrations_SearchBitbucketCloudRepos_ValidationError(t *testing.T)
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.AlmIntegrations.SearchBitbucketCloudRepos(nil)
+	_, _, err := client.AlmIntegrations.SearchBitbucketCloudRepos(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.SearchBitbucketCloudRepos(&AlmIntegrationsSearchBitbucketCloudReposOptions{})
+	_, _, err = client.AlmIntegrations.SearchBitbucketCloudRepos(context.Background(), &AlmIntegrationsSearchBitbucketCloudReposOptions{})
 	assert.Error(t, err)
 
 	// Test PageSize out of range
-	_, _, err = client.AlmIntegrations.SearchBitbucketCloudRepos(&AlmIntegrationsSearchBitbucketCloudReposOptions{
+	_, _, err = client.AlmIntegrations.SearchBitbucketCloudRepos(context.Background(), &AlmIntegrationsSearchBitbucketCloudReposOptions{
 		AlmSetting: "setting",
 		PaginationArgs: PaginationArgs{
 			PageSize: MaxPageSizeAlmIntegrations + 1,
@@ -545,7 +546,7 @@ func TestAlmIntegrations_SearchBitbucketCloudRepos_ValidationError(t *testing.T)
 	assert.Error(t, err)
 
 	// Test RepositoryName too long
-	_, _, err = client.AlmIntegrations.SearchBitbucketCloudRepos(&AlmIntegrationsSearchBitbucketCloudReposOptions{
+	_, _, err = client.AlmIntegrations.SearchBitbucketCloudRepos(context.Background(), &AlmIntegrationsSearchBitbucketCloudReposOptions{
 		AlmSetting:     "setting",
 		RepositoryName: strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
@@ -565,7 +566,7 @@ func TestAlmIntegrations_SearchBitbucketServerRepos(t *testing.T) {
 		AlmSetting: "my-bitbucket-setting",
 	}
 
-	result, resp, err := client.AlmIntegrations.SearchBitbucketServerRepos(opt)
+	result, resp, err := client.AlmIntegrations.SearchBitbucketServerRepos(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotNil(t, result)
@@ -576,29 +577,29 @@ func TestAlmIntegrations_SearchBitbucketServerRepos_ValidationError(t *testing.T
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.AlmIntegrations.SearchBitbucketServerRepos(nil)
+	_, _, err := client.AlmIntegrations.SearchBitbucketServerRepos(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(&AlmIntegrationsSearchBitbucketServerReposOptions{})
+	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(context.Background(), &AlmIntegrationsSearchBitbucketServerReposOptions{})
 	assert.Error(t, err)
 
 	// Test PageSize out of range
-	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(&AlmIntegrationsSearchBitbucketServerReposOptions{
+	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(context.Background(), &AlmIntegrationsSearchBitbucketServerReposOptions{
 		AlmSetting: "setting",
 		PageSize:   MaxPageSizeAlmIntegrations + 1,
 	})
 	assert.Error(t, err)
 
 	// Test ProjectName too long
-	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(&AlmIntegrationsSearchBitbucketServerReposOptions{
+	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(context.Background(), &AlmIntegrationsSearchBitbucketServerReposOptions{
 		AlmSetting:  "setting",
 		ProjectName: strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
 	assert.Error(t, err)
 
 	// Test RepositoryName too long
-	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(&AlmIntegrationsSearchBitbucketServerReposOptions{
+	_, _, err = client.AlmIntegrations.SearchBitbucketServerRepos(context.Background(), &AlmIntegrationsSearchBitbucketServerReposOptions{
 		AlmSetting:     "setting",
 		RepositoryName: strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
@@ -618,7 +619,7 @@ func TestAlmIntegrations_SearchGitlabRepos(t *testing.T) {
 		AlmSetting: "my-gitlab-setting",
 	}
 
-	result, resp, err := client.AlmIntegrations.SearchGitlabRepos(opt)
+	result, resp, err := client.AlmIntegrations.SearchGitlabRepos(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotNil(t, result)
@@ -629,15 +630,15 @@ func TestAlmIntegrations_SearchGitlabRepos_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.AlmIntegrations.SearchGitlabRepos(nil)
+	_, _, err := client.AlmIntegrations.SearchGitlabRepos(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmIntegrations.SearchGitlabRepos(&AlmIntegrationsSearchGitlabReposOptions{})
+	_, _, err = client.AlmIntegrations.SearchGitlabRepos(context.Background(), &AlmIntegrationsSearchGitlabReposOptions{})
 	assert.Error(t, err)
 
 	// Test PageSize out of range
-	_, _, err = client.AlmIntegrations.SearchGitlabRepos(&AlmIntegrationsSearchGitlabReposOptions{
+	_, _, err = client.AlmIntegrations.SearchGitlabRepos(context.Background(), &AlmIntegrationsSearchGitlabReposOptions{
 		AlmSetting: "setting",
 		PaginationArgs: PaginationArgs{
 			PageSize: MaxPageSizeAlmIntegrations + 1,
@@ -646,7 +647,7 @@ func TestAlmIntegrations_SearchGitlabRepos_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test ProjectName too long
-	_, _, err = client.AlmIntegrations.SearchGitlabRepos(&AlmIntegrationsSearchGitlabReposOptions{
+	_, _, err = client.AlmIntegrations.SearchGitlabRepos(context.Background(), &AlmIntegrationsSearchGitlabReposOptions{
 		AlmSetting:  "setting",
 		ProjectName: strings.Repeat("a", MaxAlmSettingKeyLength+1),
 	})
@@ -667,7 +668,7 @@ func TestAlmIntegrations_SetPat(t *testing.T) {
 		Pat:        "my-personal-access-token",
 	}
 
-	resp, err := client.AlmIntegrations.SetPat(opt)
+	resp, err := client.AlmIntegrations.SetPat(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -684,7 +685,7 @@ func TestAlmIntegrations_SetPat_WithUsername(t *testing.T) {
 		Username:   "my-username",
 	}
 
-	resp, err := client.AlmIntegrations.SetPat(opt)
+	resp, err := client.AlmIntegrations.SetPat(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -693,23 +694,23 @@ func TestAlmIntegrations_SetPat_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmIntegrations.SetPat(nil)
+	_, err := client.AlmIntegrations.SetPat(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Pat
-	_, err = client.AlmIntegrations.SetPat(&AlmIntegrationsSetPatOptions{
+	_, err = client.AlmIntegrations.SetPat(context.Background(), &AlmIntegrationsSetPatOptions{
 		AlmSetting: "setting",
 	})
 	assert.Error(t, err)
 
 	// Test Pat too long
-	_, err = client.AlmIntegrations.SetPat(&AlmIntegrationsSetPatOptions{
+	_, err = client.AlmIntegrations.SetPat(context.Background(), &AlmIntegrationsSetPatOptions{
 		Pat: strings.Repeat("a", MaxPatLength+1),
 	})
 	assert.Error(t, err)
 
 	// Test Username too long
-	_, err = client.AlmIntegrations.SetPat(&AlmIntegrationsSetPatOptions{
+	_, err = client.AlmIntegrations.SetPat(context.Background(), &AlmIntegrationsSetPatOptions{
 		Pat:      "token",
 		Username: strings.Repeat("a", MaxUsernameLength+1),
 	})

--- a/sonar/alm_settings_service.go
+++ b/sonar/alm_settings_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 const (
 	// MaxAlmKeyLength is the maximum length for DevOps Platform setting keys.
@@ -960,13 +963,13 @@ func (s *AlmSettingsService) ValidateValidateOpt(opt *AlmSettingsValidateOptions
 //
 // API endpoint: GET /api/alm_settings/count_binding.
 // Since: 8.1.
-func (s *AlmSettingsService) CountBinding(opt *AlmSettingsCountBindingOptions) (*AlmSettingsCountBinding, *http.Response, error) {
+func (s *AlmSettingsService) CountBinding(ctx context.Context, opt *AlmSettingsCountBindingOptions) (*AlmSettingsCountBinding, *http.Response, error) {
 	err := s.ValidateCountBindingOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_settings/count_binding", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_settings/count_binding", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -986,13 +989,13 @@ func (s *AlmSettingsService) CountBinding(opt *AlmSettingsCountBindingOptions) (
 //
 // API endpoint: POST /api/alm_settings/create_azure.
 // Since: 8.1.
-func (s *AlmSettingsService) CreateAzure(opt *AlmSettingsCreateAzureOptions) (*http.Response, error) {
+func (s *AlmSettingsService) CreateAzure(ctx context.Context, opt *AlmSettingsCreateAzureOptions) (*http.Response, error) {
 	err := s.ValidateCreateAzureOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_settings/create_azure", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_settings/create_azure", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1010,13 +1013,13 @@ func (s *AlmSettingsService) CreateAzure(opt *AlmSettingsCreateAzureOptions) (*h
 //
 // API endpoint: POST /api/alm_settings/create_bitbucket.
 // Since: 8.1.
-func (s *AlmSettingsService) CreateBitbucket(opt *AlmSettingsCreateBitbucketOptions) (*http.Response, error) {
+func (s *AlmSettingsService) CreateBitbucket(ctx context.Context, opt *AlmSettingsCreateBitbucketOptions) (*http.Response, error) {
 	err := s.ValidateCreateBitbucketOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_settings/create_bitbucket", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_settings/create_bitbucket", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1034,13 +1037,13 @@ func (s *AlmSettingsService) CreateBitbucket(opt *AlmSettingsCreateBitbucketOpti
 //
 // API endpoint: POST /api/alm_settings/create_bitbucketcloud.
 // Since: 8.7.
-func (s *AlmSettingsService) CreateBitbucketCloud(opt *AlmSettingsCreateBitbucketCloudOptions) (*http.Response, error) {
+func (s *AlmSettingsService) CreateBitbucketCloud(ctx context.Context, opt *AlmSettingsCreateBitbucketCloudOptions) (*http.Response, error) {
 	err := s.ValidateCreateBitbucketCloudOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_settings/create_bitbucketcloud", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_settings/create_bitbucketcloud", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1058,13 +1061,13 @@ func (s *AlmSettingsService) CreateBitbucketCloud(opt *AlmSettingsCreateBitbucke
 //
 // API endpoint: POST /api/alm_settings/create_github.
 // Since: 8.1.
-func (s *AlmSettingsService) CreateGithub(opt *AlmSettingsCreateGithubOptions) (*http.Response, error) {
+func (s *AlmSettingsService) CreateGithub(ctx context.Context, opt *AlmSettingsCreateGithubOptions) (*http.Response, error) {
 	err := s.ValidateCreateGithubOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_settings/create_github", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_settings/create_github", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1082,13 +1085,13 @@ func (s *AlmSettingsService) CreateGithub(opt *AlmSettingsCreateGithubOptions) (
 //
 // API endpoint: POST /api/alm_settings/create_gitlab.
 // Since: 8.1.
-func (s *AlmSettingsService) CreateGitlab(opt *AlmSettingsCreateGitlabOptions) (*http.Response, error) {
+func (s *AlmSettingsService) CreateGitlab(ctx context.Context, opt *AlmSettingsCreateGitlabOptions) (*http.Response, error) {
 	err := s.ValidateCreateGitlabOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_settings/create_gitlab", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_settings/create_gitlab", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1106,13 +1109,13 @@ func (s *AlmSettingsService) CreateGitlab(opt *AlmSettingsCreateGitlabOptions) (
 //
 // API endpoint: POST /api/alm_settings/delete.
 // Since: 8.1.
-func (s *AlmSettingsService) Delete(opt *AlmSettingsDeleteOptions) (*http.Response, error) {
+func (s *AlmSettingsService) Delete(ctx context.Context, opt *AlmSettingsDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_settings/delete", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_settings/delete", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1130,13 +1133,13 @@ func (s *AlmSettingsService) Delete(opt *AlmSettingsDeleteOptions) (*http.Respon
 //
 // API endpoint: GET /api/alm_settings/get_binding.
 // Since: 8.1.
-func (s *AlmSettingsService) GetBinding(opt *AlmSettingsGetBindingOptions) (*AlmSettingsGetBinding, *http.Response, error) {
+func (s *AlmSettingsService) GetBinding(ctx context.Context, opt *AlmSettingsGetBindingOptions) (*AlmSettingsGetBinding, *http.Response, error) {
 	err := s.ValidateGetBindingOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_settings/get_binding", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_settings/get_binding", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1157,13 +1160,13 @@ func (s *AlmSettingsService) GetBinding(opt *AlmSettingsGetBindingOptions) (*Alm
 //
 // API endpoint: GET /api/alm_settings/list.
 // Since: 8.1.
-func (s *AlmSettingsService) List(opt *AlmSettingsListOptions) (*AlmSettingsList, *http.Response, error) {
+func (s *AlmSettingsService) List(ctx context.Context, opt *AlmSettingsListOptions) (*AlmSettingsList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_settings/list", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_settings/list", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1183,8 +1186,8 @@ func (s *AlmSettingsService) List(opt *AlmSettingsListOptions) (*AlmSettingsList
 //
 // API endpoint: GET /api/alm_settings/list_definitions.
 // Since: 8.1.
-func (s *AlmSettingsService) ListDefinitions() (*AlmSettingsListDefinitions, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_settings/list_definitions", nil)
+func (s *AlmSettingsService) ListDefinitions(ctx context.Context) (*AlmSettingsListDefinitions, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_settings/list_definitions", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1204,13 +1207,13 @@ func (s *AlmSettingsService) ListDefinitions() (*AlmSettingsListDefinitions, *ht
 //
 // API endpoint: POST /api/alm_settings/update_azure.
 // Since: 8.1.
-func (s *AlmSettingsService) UpdateAzure(opt *AlmSettingsUpdateAzureOptions) (*http.Response, error) {
+func (s *AlmSettingsService) UpdateAzure(ctx context.Context, opt *AlmSettingsUpdateAzureOptions) (*http.Response, error) {
 	err := s.ValidateUpdateAzureOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_settings/update_azure", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_settings/update_azure", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1228,13 +1231,13 @@ func (s *AlmSettingsService) UpdateAzure(opt *AlmSettingsUpdateAzureOptions) (*h
 //
 // API endpoint: POST /api/alm_settings/update_bitbucket.
 // Since: 8.1.
-func (s *AlmSettingsService) UpdateBitbucket(opt *AlmSettingsUpdateBitbucketOptions) (*http.Response, error) {
+func (s *AlmSettingsService) UpdateBitbucket(ctx context.Context, opt *AlmSettingsUpdateBitbucketOptions) (*http.Response, error) {
 	err := s.ValidateUpdateBitbucketOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_settings/update_bitbucket", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_settings/update_bitbucket", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1252,13 +1255,13 @@ func (s *AlmSettingsService) UpdateBitbucket(opt *AlmSettingsUpdateBitbucketOpti
 //
 // API endpoint: POST /api/alm_settings/update_bitbucketcloud.
 // Since: 8.7.
-func (s *AlmSettingsService) UpdateBitbucketCloud(opt *AlmSettingsUpdateBitbucketCloudOptions) (*http.Response, error) {
+func (s *AlmSettingsService) UpdateBitbucketCloud(ctx context.Context, opt *AlmSettingsUpdateBitbucketCloudOptions) (*http.Response, error) {
 	err := s.ValidateUpdateBitbucketCloudOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_settings/update_bitbucketcloud", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_settings/update_bitbucketcloud", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1276,13 +1279,13 @@ func (s *AlmSettingsService) UpdateBitbucketCloud(opt *AlmSettingsUpdateBitbucke
 //
 // API endpoint: POST /api/alm_settings/update_github.
 // Since: 8.1.
-func (s *AlmSettingsService) UpdateGithub(opt *AlmSettingsUpdateGithubOptions) (*http.Response, error) {
+func (s *AlmSettingsService) UpdateGithub(ctx context.Context, opt *AlmSettingsUpdateGithubOptions) (*http.Response, error) {
 	err := s.ValidateUpdateGithubOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_settings/update_github", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_settings/update_github", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1300,13 +1303,13 @@ func (s *AlmSettingsService) UpdateGithub(opt *AlmSettingsUpdateGithubOptions) (
 //
 // API endpoint: POST /api/alm_settings/update_gitlab.
 // Since: 8.1.
-func (s *AlmSettingsService) UpdateGitlab(opt *AlmSettingsUpdateGitlabOptions) (*http.Response, error) {
+func (s *AlmSettingsService) UpdateGitlab(ctx context.Context, opt *AlmSettingsUpdateGitlabOptions) (*http.Response, error) {
 	err := s.ValidateUpdateGitlabOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "alm_settings/update_gitlab", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "alm_settings/update_gitlab", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1324,13 +1327,13 @@ func (s *AlmSettingsService) UpdateGitlab(opt *AlmSettingsUpdateGitlabOptions) (
 //
 // API endpoint: GET /api/alm_settings/validate.
 // Since: 8.6.
-func (s *AlmSettingsService) Validate(opt *AlmSettingsValidateOptions) (*AlmSettingsValidation, *http.Response, error) {
+func (s *AlmSettingsService) Validate(ctx context.Context, opt *AlmSettingsValidateOptions) (*AlmSettingsValidation, *http.Response, error) {
 	err := s.ValidateValidateOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "alm_settings/validate", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "alm_settings/validate", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/alm_settings_service_test.go
+++ b/sonar/alm_settings_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -25,7 +26,7 @@ func TestAlmSettings_CountBinding(t *testing.T) {
 		AlmSetting: "my-alm-setting",
 	}
 
-	result, resp, err := client.AlmSettings.CountBinding(opt)
+	result, resp, err := client.AlmSettings.CountBinding(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -37,11 +38,11 @@ func TestAlmSettings_CountBinding_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.AlmSettings.CountBinding(nil)
+	_, _, err := client.AlmSettings.CountBinding(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing AlmSetting
-	_, _, err = client.AlmSettings.CountBinding(&AlmSettingsCountBindingOptions{})
+	_, _, err = client.AlmSettings.CountBinding(context.Background(), &AlmSettingsCountBindingOptions{})
 	assert.Error(t, err)
 }
 
@@ -59,7 +60,7 @@ func TestAlmSettings_CreateAzure(t *testing.T) {
 		URL:                 "https://dev.azure.com/myorg",
 	}
 
-	resp, err := client.AlmSettings.CreateAzure(opt)
+	resp, err := client.AlmSettings.CreateAzure(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -68,18 +69,18 @@ func TestAlmSettings_CreateAzure_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmSettings.CreateAzure(nil)
+	_, err := client.AlmSettings.CreateAzure(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOptions{
+	_, err = client.AlmSettings.CreateAzure(context.Background(), &AlmSettingsCreateAzureOptions{
 		PersonalAccessToken: "pat",
 		URL:                 "https://dev.azure.com",
 	})
 	assert.Error(t, err)
 
 	// Test Key too long
-	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOptions{
+	_, err = client.AlmSettings.CreateAzure(context.Background(), &AlmSettingsCreateAzureOptions{
 		Key:                 strings.Repeat("a", MaxAlmKeyLength+1),
 		PersonalAccessToken: "pat",
 		URL:                 "https://dev.azure.com",
@@ -87,14 +88,14 @@ func TestAlmSettings_CreateAzure_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing PersonalAccessToken
-	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOptions{
+	_, err = client.AlmSettings.CreateAzure(context.Background(), &AlmSettingsCreateAzureOptions{
 		Key: "my-key",
 		URL: "https://dev.azure.com",
 	})
 	assert.Error(t, err)
 
 	// Test PersonalAccessToken too long
-	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOptions{
+	_, err = client.AlmSettings.CreateAzure(context.Background(), &AlmSettingsCreateAzureOptions{
 		Key:                 "my-key",
 		PersonalAccessToken: strings.Repeat("a", MaxPersonalAccessTokenLength+1),
 		URL:                 "https://dev.azure.com",
@@ -102,14 +103,14 @@ func TestAlmSettings_CreateAzure_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOptions{
+	_, err = client.AlmSettings.CreateAzure(context.Background(), &AlmSettingsCreateAzureOptions{
 		Key:                 "my-key",
 		PersonalAccessToken: "pat",
 	})
 	assert.Error(t, err)
 
 	// Test URL too long
-	_, err = client.AlmSettings.CreateAzure(&AlmSettingsCreateAzureOptions{
+	_, err = client.AlmSettings.CreateAzure(context.Background(), &AlmSettingsCreateAzureOptions{
 		Key:                 "my-key",
 		PersonalAccessToken: "pat",
 		URL:                 strings.Repeat("a", MaxAlmURLLength+1),
@@ -131,7 +132,7 @@ func TestAlmSettings_CreateBitbucket(t *testing.T) {
 		URL:                 "https://bitbucket.example.com",
 	}
 
-	resp, err := client.AlmSettings.CreateBitbucket(opt)
+	resp, err := client.AlmSettings.CreateBitbucket(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -140,18 +141,18 @@ func TestAlmSettings_CreateBitbucket_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmSettings.CreateBitbucket(nil)
+	_, err := client.AlmSettings.CreateBitbucket(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.CreateBitbucket(&AlmSettingsCreateBitbucketOptions{
+	_, err = client.AlmSettings.CreateBitbucket(context.Background(), &AlmSettingsCreateBitbucketOptions{
 		PersonalAccessToken: "pat",
 		URL:                 "https://bitbucket.example.com",
 	})
 	assert.Error(t, err)
 
 	// Test Key too long
-	_, err = client.AlmSettings.CreateBitbucket(&AlmSettingsCreateBitbucketOptions{
+	_, err = client.AlmSettings.CreateBitbucket(context.Background(), &AlmSettingsCreateBitbucketOptions{
 		Key:                 strings.Repeat("a", MaxAlmKeyLength+1),
 		PersonalAccessToken: "pat",
 		URL:                 "https://bitbucket.example.com",
@@ -159,14 +160,14 @@ func TestAlmSettings_CreateBitbucket_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing PersonalAccessToken
-	_, err = client.AlmSettings.CreateBitbucket(&AlmSettingsCreateBitbucketOptions{
+	_, err = client.AlmSettings.CreateBitbucket(context.Background(), &AlmSettingsCreateBitbucketOptions{
 		Key: "my-key",
 		URL: "https://bitbucket.example.com",
 	})
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.CreateBitbucket(&AlmSettingsCreateBitbucketOptions{
+	_, err = client.AlmSettings.CreateBitbucket(context.Background(), &AlmSettingsCreateBitbucketOptions{
 		Key:                 "my-key",
 		PersonalAccessToken: "pat",
 	})
@@ -188,7 +189,7 @@ func TestAlmSettings_CreateBitbucketCloud(t *testing.T) {
 		Workspace:    "my-workspace",
 	}
 
-	resp, err := client.AlmSettings.CreateBitbucketCloud(opt)
+	resp, err := client.AlmSettings.CreateBitbucketCloud(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -197,11 +198,11 @@ func TestAlmSettings_CreateBitbucketCloud_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmSettings.CreateBitbucketCloud(nil)
+	_, err := client.AlmSettings.CreateBitbucketCloud(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing ClientID
-	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOptions{
+	_, err = client.AlmSettings.CreateBitbucketCloud(context.Background(), &AlmSettingsCreateBitbucketCloudOptions{
 		ClientSecret: "secret",
 		Key:          "my-key",
 		Workspace:    "workspace",
@@ -209,7 +210,7 @@ func TestAlmSettings_CreateBitbucketCloud_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test ClientID too long
-	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOptions{
+	_, err = client.AlmSettings.CreateBitbucketCloud(context.Background(), &AlmSettingsCreateBitbucketCloudOptions{
 		ClientID:     strings.Repeat("a", MaxBitbucketCloudClientIDLength+1),
 		ClientSecret: "secret",
 		Key:          "my-key",
@@ -218,7 +219,7 @@ func TestAlmSettings_CreateBitbucketCloud_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing ClientSecret
-	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOptions{
+	_, err = client.AlmSettings.CreateBitbucketCloud(context.Background(), &AlmSettingsCreateBitbucketCloudOptions{
 		ClientID:  "client-id",
 		Key:       "my-key",
 		Workspace: "workspace",
@@ -226,7 +227,7 @@ func TestAlmSettings_CreateBitbucketCloud_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOptions{
+	_, err = client.AlmSettings.CreateBitbucketCloud(context.Background(), &AlmSettingsCreateBitbucketCloudOptions{
 		ClientID:     "client-id",
 		ClientSecret: "secret",
 		Workspace:    "workspace",
@@ -234,7 +235,7 @@ func TestAlmSettings_CreateBitbucketCloud_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Workspace
-	_, err = client.AlmSettings.CreateBitbucketCloud(&AlmSettingsCreateBitbucketCloudOptions{
+	_, err = client.AlmSettings.CreateBitbucketCloud(context.Background(), &AlmSettingsCreateBitbucketCloudOptions{
 		ClientID:     "client-id",
 		ClientSecret: "secret",
 		Key:          "my-key",
@@ -259,7 +260,7 @@ func TestAlmSettings_CreateGithub(t *testing.T) {
 		URL:          "https://api.github.com",
 	}
 
-	resp, err := client.AlmSettings.CreateGithub(opt)
+	resp, err := client.AlmSettings.CreateGithub(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -278,7 +279,7 @@ func TestAlmSettings_CreateGithub_WithOptionalWebhookSecret(t *testing.T) {
 		WebhookSecret: "my-webhook-secret",
 	}
 
-	resp, err := client.AlmSettings.CreateGithub(opt)
+	resp, err := client.AlmSettings.CreateGithub(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -287,11 +288,11 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmSettings.CreateGithub(nil)
+	_, err := client.AlmSettings.CreateGithub(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing AppID
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
+	_, err = client.AlmSettings.CreateGithub(context.Background(), &AlmSettingsCreateGithubOptions{
 		ClientID:     "client-id",
 		ClientSecret: "secret",
 		Key:          "my-key",
@@ -301,7 +302,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test AppID too long
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
+	_, err = client.AlmSettings.CreateGithub(context.Background(), &AlmSettingsCreateGithubOptions{
 		AppID:        strings.Repeat("a", MaxGitHubAppIDLength+1),
 		ClientID:     "client-id",
 		ClientSecret: "secret",
@@ -312,7 +313,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing ClientID
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
+	_, err = client.AlmSettings.CreateGithub(context.Background(), &AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientSecret: "secret",
 		Key:          "my-key",
@@ -322,7 +323,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test ClientID too long
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
+	_, err = client.AlmSettings.CreateGithub(context.Background(), &AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientID:     strings.Repeat("a", MaxGitHubClientIDLength+1),
 		ClientSecret: "secret",
@@ -333,7 +334,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing ClientSecret
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
+	_, err = client.AlmSettings.CreateGithub(context.Background(), &AlmSettingsCreateGithubOptions{
 		AppID:      "12345",
 		ClientID:   "client-id",
 		Key:        "my-key",
@@ -343,7 +344,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test ClientSecret too long
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
+	_, err = client.AlmSettings.CreateGithub(context.Background(), &AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientID:     "client-id",
 		ClientSecret: strings.Repeat("a", MaxGitHubClientSecretLength+1),
@@ -354,7 +355,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
+	_, err = client.AlmSettings.CreateGithub(context.Background(), &AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientID:     "client-id",
 		ClientSecret: "secret",
@@ -364,7 +365,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing PrivateKey
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
+	_, err = client.AlmSettings.CreateGithub(context.Background(), &AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientID:     "client-id",
 		ClientSecret: "secret",
@@ -374,7 +375,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test PrivateKey too long
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
+	_, err = client.AlmSettings.CreateGithub(context.Background(), &AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientID:     "client-id",
 		ClientSecret: "secret",
@@ -385,7 +386,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
+	_, err = client.AlmSettings.CreateGithub(context.Background(), &AlmSettingsCreateGithubOptions{
 		AppID:        "12345",
 		ClientID:     "client-id",
 		ClientSecret: "secret",
@@ -395,7 +396,7 @@ func TestAlmSettings_CreateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test WebhookSecret too long
-	_, err = client.AlmSettings.CreateGithub(&AlmSettingsCreateGithubOptions{
+	_, err = client.AlmSettings.CreateGithub(context.Background(), &AlmSettingsCreateGithubOptions{
 		AppID:         "12345",
 		ClientID:      "client-id",
 		ClientSecret:  "secret",
@@ -421,7 +422,7 @@ func TestAlmSettings_CreateGitlab(t *testing.T) {
 		URL:                 "https://gitlab.example.com",
 	}
 
-	resp, err := client.AlmSettings.CreateGitlab(opt)
+	resp, err := client.AlmSettings.CreateGitlab(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -430,25 +431,25 @@ func TestAlmSettings_CreateGitlab_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmSettings.CreateGitlab(nil)
+	_, err := client.AlmSettings.CreateGitlab(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.CreateGitlab(&AlmSettingsCreateGitlabOptions{
+	_, err = client.AlmSettings.CreateGitlab(context.Background(), &AlmSettingsCreateGitlabOptions{
 		PersonalAccessToken: "pat",
 		URL:                 "https://gitlab.example.com",
 	})
 	assert.Error(t, err)
 
 	// Test missing PersonalAccessToken
-	_, err = client.AlmSettings.CreateGitlab(&AlmSettingsCreateGitlabOptions{
+	_, err = client.AlmSettings.CreateGitlab(context.Background(), &AlmSettingsCreateGitlabOptions{
 		Key: "my-key",
 		URL: "https://gitlab.example.com",
 	})
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.CreateGitlab(&AlmSettingsCreateGitlabOptions{
+	_, err = client.AlmSettings.CreateGitlab(context.Background(), &AlmSettingsCreateGitlabOptions{
 		Key:                 "my-key",
 		PersonalAccessToken: "pat",
 	})
@@ -467,7 +468,7 @@ func TestAlmSettings_Delete(t *testing.T) {
 		Key: "my-alm-setting",
 	}
 
-	resp, err := client.AlmSettings.Delete(opt)
+	resp, err := client.AlmSettings.Delete(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -476,11 +477,11 @@ func TestAlmSettings_Delete_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmSettings.Delete(nil)
+	_, err := client.AlmSettings.Delete(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.Delete(&AlmSettingsDeleteOptions{})
+	_, err = client.AlmSettings.Delete(context.Background(), &AlmSettingsDeleteOptions{})
 	assert.Error(t, err)
 }
 
@@ -504,7 +505,7 @@ func TestAlmSettings_GetBinding(t *testing.T) {
 		Project: "my-project",
 	}
 
-	result, resp, err := client.AlmSettings.GetBinding(opt)
+	result, resp, err := client.AlmSettings.GetBinding(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -517,11 +518,11 @@ func TestAlmSettings_GetBinding_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.AlmSettings.GetBinding(nil)
+	_, _, err := client.AlmSettings.GetBinding(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Project
-	_, _, err = client.AlmSettings.GetBinding(&AlmSettingsGetBindingOptions{})
+	_, _, err = client.AlmSettings.GetBinding(context.Background(), &AlmSettingsGetBindingOptions{})
 	assert.Error(t, err)
 }
 
@@ -539,7 +540,7 @@ func TestAlmSettings_List(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/alm_settings/list", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.AlmSettings.List(&AlmSettingsListOptions{})
+	result, resp, err := client.AlmSettings.List(context.Background(), &AlmSettingsListOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -561,7 +562,7 @@ func TestAlmSettings_List_WithProject(t *testing.T) {
 		Project: "my-project",
 	}
 
-	_, _, err := client.AlmSettings.List(opt)
+	_, _, err := client.AlmSettings.List(context.Background(), opt)
 	require.NoError(t, err)
 }
 
@@ -570,7 +571,7 @@ func TestAlmSettings_List_NilOption(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/alm_settings/list", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, _, err := client.AlmSettings.List(nil)
+	result, _, err := client.AlmSettings.List(context.Background(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 }
@@ -590,7 +591,7 @@ func TestAlmSettings_ListDefinitions(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/alm_settings/list_definitions", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.AlmSettings.ListDefinitions()
+	result, resp, err := client.AlmSettings.ListDefinitions(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -612,7 +613,7 @@ func TestAlmSettings_UpdateAzure(t *testing.T) {
 		URL: "https://dev.azure.com",
 	}
 
-	resp, err := client.AlmSettings.UpdateAzure(opt)
+	resp, err := client.AlmSettings.UpdateAzure(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -628,7 +629,7 @@ func TestAlmSettings_UpdateAzure_WithOptionalFields(t *testing.T) {
 		URL:                 "https://dev.azure.com",
 	}
 
-	resp, err := client.AlmSettings.UpdateAzure(opt)
+	resp, err := client.AlmSettings.UpdateAzure(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -637,24 +638,24 @@ func TestAlmSettings_UpdateAzure_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmSettings.UpdateAzure(nil)
+	_, err := client.AlmSettings.UpdateAzure(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOptions{
+	_, err = client.AlmSettings.UpdateAzure(context.Background(), &AlmSettingsUpdateAzureOptions{
 		URL: "https://dev.azure.com",
 	})
 	assert.Error(t, err)
 
 	// Test Key too long
-	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOptions{
+	_, err = client.AlmSettings.UpdateAzure(context.Background(), &AlmSettingsUpdateAzureOptions{
 		Key: strings.Repeat("a", MaxAlmKeyLength+1),
 		URL: "https://dev.azure.com",
 	})
 	assert.Error(t, err)
 
 	// Test NewKey too long
-	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOptions{
+	_, err = client.AlmSettings.UpdateAzure(context.Background(), &AlmSettingsUpdateAzureOptions{
 		Key:    "my-key",
 		NewKey: strings.Repeat("a", MaxAlmKeyLength+1),
 		URL:    "https://dev.azure.com",
@@ -662,7 +663,7 @@ func TestAlmSettings_UpdateAzure_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test PersonalAccessToken too long
-	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOptions{
+	_, err = client.AlmSettings.UpdateAzure(context.Background(), &AlmSettingsUpdateAzureOptions{
 		Key:                 "my-key",
 		PersonalAccessToken: strings.Repeat("a", MaxPersonalAccessTokenLength+1),
 		URL:                 "https://dev.azure.com",
@@ -670,13 +671,13 @@ func TestAlmSettings_UpdateAzure_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOptions{
+	_, err = client.AlmSettings.UpdateAzure(context.Background(), &AlmSettingsUpdateAzureOptions{
 		Key: "my-key",
 	})
 	assert.Error(t, err)
 
 	// Test URL too long
-	_, err = client.AlmSettings.UpdateAzure(&AlmSettingsUpdateAzureOptions{
+	_, err = client.AlmSettings.UpdateAzure(context.Background(), &AlmSettingsUpdateAzureOptions{
 		Key: "my-key",
 		URL: strings.Repeat("a", MaxAlmURLLength+1),
 	})
@@ -696,7 +697,7 @@ func TestAlmSettings_UpdateBitbucket(t *testing.T) {
 		URL: "https://bitbucket.example.com",
 	}
 
-	resp, err := client.AlmSettings.UpdateBitbucket(opt)
+	resp, err := client.AlmSettings.UpdateBitbucket(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -705,17 +706,17 @@ func TestAlmSettings_UpdateBitbucket_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmSettings.UpdateBitbucket(nil)
+	_, err := client.AlmSettings.UpdateBitbucket(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.UpdateBitbucket(&AlmSettingsUpdateBitbucketOptions{
+	_, err = client.AlmSettings.UpdateBitbucket(context.Background(), &AlmSettingsUpdateBitbucketOptions{
 		URL: "https://bitbucket.example.com",
 	})
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.UpdateBitbucket(&AlmSettingsUpdateBitbucketOptions{
+	_, err = client.AlmSettings.UpdateBitbucket(context.Background(), &AlmSettingsUpdateBitbucketOptions{
 		Key: "my-key",
 	})
 	assert.Error(t, err)
@@ -735,7 +736,7 @@ func TestAlmSettings_UpdateBitbucketCloud(t *testing.T) {
 		Workspace: "my-workspace",
 	}
 
-	resp, err := client.AlmSettings.UpdateBitbucketCloud(opt)
+	resp, err := client.AlmSettings.UpdateBitbucketCloud(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -744,18 +745,18 @@ func TestAlmSettings_UpdateBitbucketCloud_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmSettings.UpdateBitbucketCloud(nil)
+	_, err := client.AlmSettings.UpdateBitbucketCloud(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing ClientID
-	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOptions{
+	_, err = client.AlmSettings.UpdateBitbucketCloud(context.Background(), &AlmSettingsUpdateBitbucketCloudOptions{
 		Key:       "my-key",
 		Workspace: "workspace",
 	})
 	assert.Error(t, err)
 
 	// Test ClientID too long
-	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOptions{
+	_, err = client.AlmSettings.UpdateBitbucketCloud(context.Background(), &AlmSettingsUpdateBitbucketCloudOptions{
 		ClientID:  strings.Repeat("a", MaxBitbucketCloudClientIDUpdateLength+1),
 		Key:       "my-key",
 		Workspace: "workspace",
@@ -763,7 +764,7 @@ func TestAlmSettings_UpdateBitbucketCloud_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test ClientSecret too long
-	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOptions{
+	_, err = client.AlmSettings.UpdateBitbucketCloud(context.Background(), &AlmSettingsUpdateBitbucketCloudOptions{
 		ClientID:     "client-id",
 		ClientSecret: strings.Repeat("a", MaxBitbucketCloudClientSecretUpdateLength+1),
 		Key:          "my-key",
@@ -772,21 +773,21 @@ func TestAlmSettings_UpdateBitbucketCloud_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOptions{
+	_, err = client.AlmSettings.UpdateBitbucketCloud(context.Background(), &AlmSettingsUpdateBitbucketCloudOptions{
 		ClientID:  "client-id",
 		Workspace: "workspace",
 	})
 	assert.Error(t, err)
 
 	// Test missing Workspace
-	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOptions{
+	_, err = client.AlmSettings.UpdateBitbucketCloud(context.Background(), &AlmSettingsUpdateBitbucketCloudOptions{
 		ClientID: "client-id",
 		Key:      "my-key",
 	})
 	assert.Error(t, err)
 
 	// Test Workspace too long
-	_, err = client.AlmSettings.UpdateBitbucketCloud(&AlmSettingsUpdateBitbucketCloudOptions{
+	_, err = client.AlmSettings.UpdateBitbucketCloud(context.Background(), &AlmSettingsUpdateBitbucketCloudOptions{
 		ClientID:  "client-id",
 		Key:       "my-key",
 		Workspace: strings.Repeat("a", MaxBitbucketCloudWorkspaceUpdateLength+1),
@@ -809,7 +810,7 @@ func TestAlmSettings_UpdateGithub(t *testing.T) {
 		URL:      "https://api.github.com",
 	}
 
-	resp, err := client.AlmSettings.UpdateGithub(opt)
+	resp, err := client.AlmSettings.UpdateGithub(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -829,7 +830,7 @@ func TestAlmSettings_UpdateGithub_WithOptionalFields(t *testing.T) {
 		WebhookSecret: "new-webhook-secret",
 	}
 
-	resp, err := client.AlmSettings.UpdateGithub(opt)
+	resp, err := client.AlmSettings.UpdateGithub(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -838,11 +839,11 @@ func TestAlmSettings_UpdateGithub_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmSettings.UpdateGithub(nil)
+	_, err := client.AlmSettings.UpdateGithub(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing AppID
-	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOptions{
+	_, err = client.AlmSettings.UpdateGithub(context.Background(), &AlmSettingsUpdateGithubOptions{
 		ClientID: "client-id",
 		Key:      "my-key",
 		URL:      "https://api.github.com",
@@ -850,7 +851,7 @@ func TestAlmSettings_UpdateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test AppID too long
-	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOptions{
+	_, err = client.AlmSettings.UpdateGithub(context.Background(), &AlmSettingsUpdateGithubOptions{
 		AppID:    strings.Repeat("a", MaxGitHubAppIDLength+1),
 		ClientID: "client-id",
 		Key:      "my-key",
@@ -859,7 +860,7 @@ func TestAlmSettings_UpdateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing ClientID
-	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOptions{
+	_, err = client.AlmSettings.UpdateGithub(context.Background(), &AlmSettingsUpdateGithubOptions{
 		AppID: "12345",
 		Key:   "my-key",
 		URL:   "https://api.github.com",
@@ -867,7 +868,7 @@ func TestAlmSettings_UpdateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOptions{
+	_, err = client.AlmSettings.UpdateGithub(context.Background(), &AlmSettingsUpdateGithubOptions{
 		AppID:    "12345",
 		ClientID: "client-id",
 		URL:      "https://api.github.com",
@@ -875,7 +876,7 @@ func TestAlmSettings_UpdateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOptions{
+	_, err = client.AlmSettings.UpdateGithub(context.Background(), &AlmSettingsUpdateGithubOptions{
 		AppID:    "12345",
 		ClientID: "client-id",
 		Key:      "my-key",
@@ -883,7 +884,7 @@ func TestAlmSettings_UpdateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test PrivateKey too long
-	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOptions{
+	_, err = client.AlmSettings.UpdateGithub(context.Background(), &AlmSettingsUpdateGithubOptions{
 		AppID:      "12345",
 		ClientID:   "client-id",
 		Key:        "my-key",
@@ -893,7 +894,7 @@ func TestAlmSettings_UpdateGithub_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test WebhookSecret too long
-	_, err = client.AlmSettings.UpdateGithub(&AlmSettingsUpdateGithubOptions{
+	_, err = client.AlmSettings.UpdateGithub(context.Background(), &AlmSettingsUpdateGithubOptions{
 		AppID:         "12345",
 		ClientID:      "client-id",
 		Key:           "my-key",
@@ -916,7 +917,7 @@ func TestAlmSettings_UpdateGitlab(t *testing.T) {
 		URL: "https://gitlab.example.com",
 	}
 
-	resp, err := client.AlmSettings.UpdateGitlab(opt)
+	resp, err := client.AlmSettings.UpdateGitlab(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -925,17 +926,17 @@ func TestAlmSettings_UpdateGitlab_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.AlmSettings.UpdateGitlab(nil)
+	_, err := client.AlmSettings.UpdateGitlab(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.AlmSettings.UpdateGitlab(&AlmSettingsUpdateGitlabOptions{
+	_, err = client.AlmSettings.UpdateGitlab(context.Background(), &AlmSettingsUpdateGitlabOptions{
 		URL: "https://gitlab.example.com",
 	})
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.AlmSettings.UpdateGitlab(&AlmSettingsUpdateGitlabOptions{
+	_, err = client.AlmSettings.UpdateGitlab(context.Background(), &AlmSettingsUpdateGitlabOptions{
 		Key: "my-key",
 	})
 	assert.Error(t, err)
@@ -954,7 +955,7 @@ func TestAlmSettings_Validate(t *testing.T) {
 		Key: "my-alm-setting",
 	}
 
-	result, resp, err := client.AlmSettings.Validate(opt)
+	result, resp, err := client.AlmSettings.Validate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -975,7 +976,7 @@ func TestAlmSettings_Validate_WithErrors(t *testing.T) {
 		Key: "my-alm-setting",
 	}
 
-	result, _, err := client.AlmSettings.Validate(opt)
+	result, _, err := client.AlmSettings.Validate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Len(t, result.Errors, 2)
 	assert.Equal(t, "Invalid token", result.Errors[0].Msg)
@@ -985,15 +986,15 @@ func TestAlmSettings_Validate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.AlmSettings.Validate(nil)
+	_, _, err := client.AlmSettings.Validate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, _, err = client.AlmSettings.Validate(&AlmSettingsValidateOptions{})
+	_, _, err = client.AlmSettings.Validate(context.Background(), &AlmSettingsValidateOptions{})
 	assert.Error(t, err)
 
 	// Test Key too long
-	_, _, err = client.AlmSettings.Validate(&AlmSettingsValidateOptions{
+	_, _, err = client.AlmSettings.Validate(context.Background(), &AlmSettingsValidateOptions{
 		Key: strings.Repeat("a", MaxAlmKeyLength+1),
 	})
 	assert.Error(t, err)

--- a/sonar/analysis_cache_service.go
+++ b/sonar/analysis_cache_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -74,13 +75,13 @@ func (s *AnalysisCacheService) ValidateGetOpt(opt *AnalysisCacheGetOptions) erro
 //
 // API endpoint: POST /api/analysis_cache/clear.
 // WARNING: This is an internal API and may change without notice.
-func (s *AnalysisCacheService) Clear(opt *AnalysisCacheClearOptions) (*http.Response, error) {
+func (s *AnalysisCacheService) Clear(ctx context.Context, opt *AnalysisCacheClearOptions) (*http.Response, error) {
 	err := s.ValidateClearOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "analysis_cache/clear", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "analysis_cache/clear", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -99,13 +100,13 @@ func (s *AnalysisCacheService) Clear(opt *AnalysisCacheClearOptions) (*http.Resp
 // The response body contains the raw binary data; the caller is responsible for reading and closing it.
 //
 // API endpoint: GET /api/analysis_cache/get.
-func (s *AnalysisCacheService) Get(opt *AnalysisCacheGetOptions) (*http.Response, error) {
+func (s *AnalysisCacheService) Get(ctx context.Context, opt *AnalysisCacheGetOptions) (*http.Response, error) {
 	err := s.ValidateGetOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "analysis_cache/get", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "analysis_cache/get", opt)
 	if err != nil {
 		return nil, err
 	}

--- a/sonar/analysis_cache_service_test.go
+++ b/sonar/analysis_cache_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"bytes"
 	"io"
 	"net/http"
@@ -16,7 +17,7 @@ func TestAnalysisCache_Clear(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	resp, err := client.AnalysisCache.Clear(nil)
+	resp, err := client.AnalysisCache.Clear(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -35,7 +36,7 @@ func TestAnalysisCache_Clear_WithOptions(t *testing.T) {
 		Branch:  "feature",
 	}
 
-	resp, err := client.AnalysisCache.Clear(opt)
+	resp, err := client.AnalysisCache.Clear(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -60,7 +61,7 @@ func TestAnalysisCache_Get(t *testing.T) {
 		Project: "my-project",
 	}
 
-	resp, err := client.AnalysisCache.Get(opt)
+	resp, err := client.AnalysisCache.Get(context.Background(), opt)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -93,7 +94,7 @@ func TestAnalysisCache_Get_WithOptions(t *testing.T) {
 		Branch:  "main",
 	}
 
-	resp, err := client.AnalysisCache.Get(opt)
+	resp, err := client.AnalysisCache.Get(context.Background(), opt)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/sonar/analysis_reports_service.go
+++ b/sonar/analysis_reports_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // AnalysisReportsService handles communication with the analysis reports related methods
 // of the SonarQube API.
@@ -29,8 +32,8 @@ type AnalysisReportsQueueStatus struct {
 //
 // API endpoint: GET /api/analysis_reports/is_queue_empty.
 // WARNING: this is an internal API and may change without notice.
-func (s *AnalysisReportsService) QueueStatus() (*AnalysisReportsQueueStatus, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "analysis_reports/is_queue_empty", nil)
+func (s *AnalysisReportsService) QueueStatus(ctx context.Context) (*AnalysisReportsQueueStatus, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "analysis_reports/is_queue_empty", nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/analysis_reports_service_test.go
+++ b/sonar/analysis_reports_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -24,7 +25,7 @@ func TestAnalysisReports_QueueStatus(t *testing.T) {
 			server := newTestServer(t, handler)
 			client := newTestClient(t, server.url())
 
-			result, resp, err := client.AnalysisReports.QueueStatus()
+			result, resp, err := client.AnalysisReports.QueueStatus(context.Background(), )
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			require.NotNil(t, result)

--- a/sonar/analysis_v2_service.go
+++ b/sonar/analysis_v2_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -132,8 +133,8 @@ func validateAnalysisWriter(writer io.Writer) error {
 // -----------------------------------------------------------------------------
 
 // GetVersion returns the Scanner Engine version as a plain text string.
-func (s *AnalysisService) GetVersion() (*string, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "analysis/version", nil, nil)
+func (s *AnalysisService) GetVersion(ctx context.Context) (*string, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "analysis/version", nil, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -150,8 +151,8 @@ func (s *AnalysisService) GetVersion() (*string, *http.Response, error) {
 
 // GetJresMetadata returns metadata for all available JREs, optionally filtered
 // by operating system and CPU architecture.
-func (s *AnalysisService) GetJresMetadata(opt *AnalysisJresOptions) ([]AnalysisJre, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "analysis/jres", opt, nil)
+func (s *AnalysisService) GetJresMetadata(ctx context.Context, opt *AnalysisJresOptions) ([]AnalysisJre, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "analysis/jres", opt, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -168,7 +169,7 @@ func (s *AnalysisService) GetJresMetadata(opt *AnalysisJresOptions) ([]AnalysisJ
 
 // DownloadJre downloads a JRE binary by ID into the provided writer.
 // Set the Accept header to "application/octet-stream" to receive the binary.
-func (s *AnalysisService) DownloadJre(jreID string, writer io.Writer) (*http.Response, error) {
+func (s *AnalysisService) DownloadJre(ctx context.Context, jreID string, writer io.Writer) (*http.Response, error) {
 	err := ValidateRequired(jreID, "Id")
 	if err != nil {
 		return nil, err
@@ -179,7 +180,7 @@ func (s *AnalysisService) DownloadJre(jreID string, writer io.Writer) (*http.Res
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "analysis/jres/"+jreID, nil, nil)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "analysis/jres/"+jreID, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -195,13 +196,13 @@ func (s *AnalysisService) DownloadJre(jreID string, writer io.Writer) (*http.Res
 }
 
 // GetJreMetadata returns metadata for a single JRE by ID.
-func (s *AnalysisService) GetJreMetadata(jreID string) (*AnalysisJre, *http.Response, error) {
+func (s *AnalysisService) GetJreMetadata(ctx context.Context, jreID string) (*AnalysisJre, *http.Response, error) {
 	err := ValidateRequired(jreID, "Id")
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "analysis/jres/"+jreID, nil, nil)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "analysis/jres/"+jreID, nil, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -217,13 +218,13 @@ func (s *AnalysisService) GetJreMetadata(jreID string) (*AnalysisJre, *http.Resp
 }
 
 // DownloadScannerEngine downloads the Scanner Engine binary into the provided writer.
-func (s *AnalysisService) DownloadScannerEngine(writer io.Writer) (*http.Response, error) {
+func (s *AnalysisService) DownloadScannerEngine(ctx context.Context, writer io.Writer) (*http.Response, error) {
 	err := validateAnalysisWriter(writer)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "analysis/engine", nil, nil)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "analysis/engine", nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -239,8 +240,8 @@ func (s *AnalysisService) DownloadScannerEngine(writer io.Writer) (*http.Respons
 }
 
 // GetScannerEngineMetadata returns metadata for the Scanner Engine.
-func (s *AnalysisService) GetScannerEngineMetadata() (*AnalysisEngineInfo, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "analysis/engine", nil, nil)
+func (s *AnalysisService) GetScannerEngineMetadata(ctx context.Context) (*AnalysisEngineInfo, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "analysis/engine", nil, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -257,13 +258,13 @@ func (s *AnalysisService) GetScannerEngineMetadata() (*AnalysisEngineInfo, *http
 
 // GetActiveRules returns all active rules for a specific project.
 // Used by the scanner-engine.
-func (s *AnalysisService) GetActiveRules(opt *AnalysisActiveRuleOptions) ([]AnalysisActiveRule, *http.Response, error) {
+func (s *AnalysisService) GetActiveRules(ctx context.Context, opt *AnalysisActiveRuleOptions) ([]AnalysisActiveRule, *http.Response, error) {
 	err := s.ValidateActiveRulesOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "analysis/active_rules", opt, nil)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "analysis/active_rules", opt, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/sonar/analysis_v2_service_test.go
+++ b/sonar/analysis_v2_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"bytes"
 	"io"
 	"net/http"
@@ -18,7 +19,7 @@ func TestAnalysisV2_GetVersion(t *testing.T) {
 	server := newTestServer(t, mockTextHandler(t, http.MethodGet, "/v2/analysis/version", http.StatusOK, "10.5.0.12345"))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Analysis.GetVersion()
+	result, resp, err := client.V2.Analysis.GetVersion(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "10.5.0.12345", *result)
@@ -36,7 +37,7 @@ func TestAnalysisV2_GetJresMetadata(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/analysis/jres", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Analysis.GetJresMetadata(nil)
+	result, resp, err := client.V2.Analysis.GetJresMetadata(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result, 2)
@@ -53,7 +54,7 @@ func TestAnalysisV2_GetJresMetadata_WithFilter(t *testing.T) {
 		response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Analysis.GetJresMetadata(&AnalysisJresOptions{
+	result, resp, err := client.V2.Analysis.GetJresMetadata(context.Background(), &AnalysisJresOptions{
 		Os:   "linux",
 		Arch: "x64",
 	})
@@ -73,7 +74,7 @@ func TestAnalysisV2_DownloadJre(t *testing.T) {
 	client := newTestClient(t, server.url())
 
 	var buf bytes.Buffer
-	resp, err := client.V2.Analysis.DownloadJre("jre-1", &buf)
+	resp, err := client.V2.Analysis.DownloadJre(context.Background(), "jre-1", &buf)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, binaryData, buf.Bytes())
@@ -93,7 +94,7 @@ func TestAnalysisV2_DownloadJre_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp, err := client.V2.Analysis.DownloadJre(tt.jreID, tt.writer)
+			resp, err := client.V2.Analysis.DownloadJre(context.Background(), tt.jreID, tt.writer)
 			assert.Error(t, err)
 			assert.Nil(t, resp)
 		})
@@ -116,7 +117,7 @@ func TestAnalysisV2_GetJreMetadata(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/analysis/jres/jre-1", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Analysis.GetJreMetadata("jre-1")
+	result, resp, err := client.V2.Analysis.GetJreMetadata(context.Background(), "jre-1")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "jre-1", result.Id)
@@ -126,7 +127,7 @@ func TestAnalysisV2_GetJreMetadata(t *testing.T) {
 func TestAnalysisV2_GetJreMetadata_Validation(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.V2.Analysis.GetJreMetadata("")
+	_, _, err := client.V2.Analysis.GetJreMetadata(context.Background(), "")
 	assert.Error(t, err)
 }
 
@@ -141,7 +142,7 @@ func TestAnalysisV2_DownloadScannerEngine(t *testing.T) {
 	client := newTestClient(t, server.url())
 
 	var buf bytes.Buffer
-	resp, err := client.V2.Analysis.DownloadScannerEngine(&buf)
+	resp, err := client.V2.Analysis.DownloadScannerEngine(context.Background(), &buf)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, binaryData, buf.Bytes())
@@ -150,7 +151,7 @@ func TestAnalysisV2_DownloadScannerEngine(t *testing.T) {
 func TestAnalysisV2_DownloadScannerEngine_Validation(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.V2.Analysis.DownloadScannerEngine(nil)
+	resp, err := client.V2.Analysis.DownloadScannerEngine(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -167,7 +168,7 @@ func TestAnalysisV2_GetScannerEngineMetadata(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/analysis/engine", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Analysis.GetScannerEngineMetadata()
+	result, resp, err := client.V2.Analysis.GetScannerEngineMetadata(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "scanner-engine.jar", result.Filename)
@@ -195,7 +196,7 @@ func TestAnalysisV2_GetActiveRules(t *testing.T) {
 		response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Analysis.GetActiveRules(&AnalysisActiveRuleOptions{
+	result, resp, err := client.V2.Analysis.GetActiveRules(context.Background(), &AnalysisActiveRuleOptions{
 		ProjectKey: "my-project",
 	})
 	require.NoError(t, err)
@@ -219,7 +220,7 @@ func TestAnalysisV2_GetActiveRules_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.V2.Analysis.GetActiveRules(tt.opt)
+			_, _, err := client.V2.Analysis.GetActiveRules(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}

--- a/sonar/authentication_service.go
+++ b/sonar/authentication_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // AuthenticationService handles communication with the authentication related methods
 // of the SonarQube API.
@@ -64,13 +67,13 @@ func (s *AuthenticationService) ValidateLoginOpt(opt *AuthenticationLoginOptions
 // Login authenticates a user.
 //
 // API endpoint: POST /api/authentication/login.
-func (s *AuthenticationService) Login(opt *AuthenticationLoginOptions) (*http.Response, error) {
+func (s *AuthenticationService) Login(ctx context.Context, opt *AuthenticationLoginOptions) (*http.Response, error) {
 	err := s.ValidateLoginOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "authentication/login", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "authentication/login", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +89,8 @@ func (s *AuthenticationService) Login(opt *AuthenticationLoginOptions) (*http.Re
 // Logout logs out the current user.
 //
 // API endpoint: POST /api/authentication/logout.
-func (s *AuthenticationService) Logout() (*http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "authentication/logout", nil)
+func (s *AuthenticationService) Logout(ctx context.Context) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "authentication/logout", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -103,8 +106,8 @@ func (s *AuthenticationService) Logout() (*http.Response, error) {
 // Validate checks if the current credentials are valid.
 //
 // API endpoint: GET /api/authentication/validate.
-func (s *AuthenticationService) Validate() (*AuthenticationValidation, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "authentication/validate", nil)
+func (s *AuthenticationService) Validate(ctx context.Context) (*AuthenticationValidation, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "authentication/validate", nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/authentication_service_test.go
+++ b/sonar/authentication_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -18,7 +19,7 @@ func TestAuthentication_Login(t *testing.T) {
 		Password: "secret",
 	}
 
-	resp, err := client.Authentication.Login(opt)
+	resp, err := client.Authentication.Login(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -37,7 +38,7 @@ func TestAuthentication_Login_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.Authentication.Login(tt.opt)
+			_, err := client.Authentication.Login(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -48,7 +49,7 @@ func TestAuthentication_Logout(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	resp, err := client.Authentication.Logout()
+	resp, err := client.Authentication.Logout(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -69,7 +70,7 @@ func TestAuthentication_Validate(t *testing.T) {
 			server := newTestServer(t, handler)
 			client := newTestClient(t, server.url())
 
-			result, resp, err := client.Authentication.Validate()
+			result, resp, err := client.Authentication.Validate(context.Background(), )
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			require.NotNil(t, result)

--- a/sonar/authorizations_v2_service.go
+++ b/sonar/authorizations_v2_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -226,13 +227,13 @@ func (s *AuthorizationsService) ValidateCreateGroupMembershipRequest(opt *Author
 
 // SearchGroups returns a list of groups matching the search criteria.
 // The results are sorted alphabetically by group name.
-func (s *AuthorizationsService) SearchGroups(opt *AuthorizationsSearchGroupsOptions) (*AuthorizationsGroupsSearch, *http.Response, error) {
+func (s *AuthorizationsService) SearchGroups(ctx context.Context, opt *AuthorizationsSearchGroupsOptions) (*AuthorizationsGroupsSearch, *http.Response, error) {
 	err := s.ValidateSearchGroupsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "authorizations/groups", opt, nil)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "authorizations/groups", opt, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -248,13 +249,13 @@ func (s *AuthorizationsService) SearchGroups(opt *AuthorizationsSearchGroupsOpti
 }
 
 // CreateGroup creates a new group.
-func (s *AuthorizationsService) CreateGroup(opt *AuthorizationsCreateGroupOptions) (*AuthorizationsGroup, *http.Response, error) {
+func (s *AuthorizationsService) CreateGroup(ctx context.Context, opt *AuthorizationsCreateGroupOptions) (*AuthorizationsGroup, *http.Response, error) {
 	err := s.ValidateCreateGroupRequest(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodPost, "authorizations/groups", nil, opt)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPost, "authorizations/groups", nil, opt)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -270,13 +271,13 @@ func (s *AuthorizationsService) CreateGroup(opt *AuthorizationsCreateGroupOption
 }
 
 // GetGroup retrieves a single group by ID.
-func (s *AuthorizationsService) GetGroup(groupID string) (*AuthorizationsGroup, *http.Response, error) {
+func (s *AuthorizationsService) GetGroup(ctx context.Context, groupID string) (*AuthorizationsGroup, *http.Response, error) {
 	err := ValidateRequired(groupID, "Id")
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "authorizations/groups/"+groupID, nil, nil)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "authorizations/groups/"+groupID, nil, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -292,13 +293,13 @@ func (s *AuthorizationsService) GetGroup(groupID string) (*AuthorizationsGroup, 
 }
 
 // DeleteGroup deletes a group by ID.
-func (s *AuthorizationsService) DeleteGroup(groupID string) (*http.Response, error) {
+func (s *AuthorizationsService) DeleteGroup(ctx context.Context, groupID string) (*http.Response, error) {
 	err := ValidateRequired(groupID, "Id")
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodDelete, "authorizations/groups/"+groupID, nil, nil)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodDelete, "authorizations/groups/"+groupID, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -312,13 +313,13 @@ func (s *AuthorizationsService) DeleteGroup(groupID string) (*http.Response, err
 }
 
 // UpdateGroup updates a group's name or description.
-func (s *AuthorizationsService) UpdateGroup(groupID string, opt *AuthorizationsUpdateGroupOptions) (*AuthorizationsGroup, *http.Response, error) {
+func (s *AuthorizationsService) UpdateGroup(ctx context.Context, groupID string, opt *AuthorizationsUpdateGroupOptions) (*AuthorizationsGroup, *http.Response, error) {
 	err := s.ValidateUpdateGroupRequest(groupID, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodPatch, "authorizations/groups/"+groupID, nil, opt)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPatch, "authorizations/groups/"+groupID, nil, opt)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -334,13 +335,13 @@ func (s *AuthorizationsService) UpdateGroup(groupID string, opt *AuthorizationsU
 }
 
 // SearchGroupMemberships returns a list of group memberships matching the search criteria.
-func (s *AuthorizationsService) SearchGroupMemberships(opt *AuthorizationsSearchGroupMembershipsOptions) (*AuthorizationsGroupMembershipsSearch, *http.Response, error) {
+func (s *AuthorizationsService) SearchGroupMemberships(ctx context.Context, opt *AuthorizationsSearchGroupMembershipsOptions) (*AuthorizationsGroupMembershipsSearch, *http.Response, error) {
 	err := s.ValidateSearchGroupMembershipsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "authorizations/group-memberships", opt, nil)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "authorizations/group-memberships", opt, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -356,13 +357,13 @@ func (s *AuthorizationsService) SearchGroupMemberships(opt *AuthorizationsSearch
 }
 
 // CreateGroupMembership adds a user to a group.
-func (s *AuthorizationsService) CreateGroupMembership(opt *AuthorizationsCreateGroupMembershipOptions) (*AuthorizationsGroupMembership, *http.Response, error) {
+func (s *AuthorizationsService) CreateGroupMembership(ctx context.Context, opt *AuthorizationsCreateGroupMembershipOptions) (*AuthorizationsGroupMembership, *http.Response, error) {
 	err := s.ValidateCreateGroupMembershipRequest(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodPost, "authorizations/group-memberships", nil, opt)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPost, "authorizations/group-memberships", nil, opt)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -378,13 +379,13 @@ func (s *AuthorizationsService) CreateGroupMembership(opt *AuthorizationsCreateG
 }
 
 // DeleteGroupMembership removes a user from a group.
-func (s *AuthorizationsService) DeleteGroupMembership(membershipID string) (*http.Response, error) {
+func (s *AuthorizationsService) DeleteGroupMembership(ctx context.Context, membershipID string) (*http.Response, error) {
 	err := ValidateRequired(membershipID, "Id")
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodDelete, "authorizations/group-memberships/"+membershipID, nil, nil)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodDelete, "authorizations/group-memberships/"+membershipID, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/sonar/authorizations_v2_service_test.go
+++ b/sonar/authorizations_v2_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -28,7 +29,7 @@ func TestAuthorizationsV2_SearchGroups(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/authorizations/groups", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Authorizations.SearchGroups(nil)
+	result, resp, err := client.V2.Authorizations.SearchGroups(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Groups, 2)
@@ -52,7 +53,7 @@ func TestAuthorizationsV2_SearchGroups_WithOptions(t *testing.T) {
 		response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Authorizations.SearchGroups(&AuthorizationsSearchGroupsOptions{
+	result, resp, err := client.V2.Authorizations.SearchGroups(context.Background(), &AuthorizationsSearchGroupsOptions{
 		PaginationParamsV2: PaginationParamsV2{PageIndex: 2, PageSize: 10},
 		Managed:            &managed,
 		Query:              "admins",
@@ -66,7 +67,7 @@ func TestAuthorizationsV2_SearchGroups_WithOptions(t *testing.T) {
 func TestAuthorizationsV2_SearchGroups_Validation(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.V2.Authorizations.SearchGroups(&AuthorizationsSearchGroupsOptions{
+	_, _, err := client.V2.Authorizations.SearchGroups(context.Background(), &AuthorizationsSearchGroupsOptions{
 		PaginationParamsV2: PaginationParamsV2{PageSize: 600},
 	})
 	assert.Error(t, err)
@@ -89,7 +90,7 @@ func TestAuthorizationsV2_CreateGroup(t *testing.T) {
 		}, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Authorizations.CreateGroup(&AuthorizationsCreateGroupOptions{
+	result, resp, err := client.V2.Authorizations.CreateGroup(context.Background(), &AuthorizationsCreateGroupOptions{
 		Name:        "new-group",
 		Description: "A new group",
 	})
@@ -113,7 +114,7 @@ func TestAuthorizationsV2_CreateGroup_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.V2.Authorizations.CreateGroup(tt.opt)
+			_, _, err := client.V2.Authorizations.CreateGroup(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -131,7 +132,7 @@ func TestAuthorizationsV2_GetGroup(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/authorizations/groups/g1", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Authorizations.GetGroup("g1")
+	result, resp, err := client.V2.Authorizations.GetGroup(context.Background(), "g1")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "admins", result.Name)
@@ -140,7 +141,7 @@ func TestAuthorizationsV2_GetGroup(t *testing.T) {
 func TestAuthorizationsV2_GetGroup_Validation(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.V2.Authorizations.GetGroup("")
+	_, _, err := client.V2.Authorizations.GetGroup(context.Background(), "")
 	assert.Error(t, err)
 }
 
@@ -152,7 +153,7 @@ func TestAuthorizationsV2_DeleteGroup(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodDelete, "/v2/authorizations/groups/g1", http.StatusNoContent))
 	client := newTestClient(t, server.url())
 
-	resp, err := client.V2.Authorizations.DeleteGroup("g1")
+	resp, err := client.V2.Authorizations.DeleteGroup(context.Background(), "g1")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -160,7 +161,7 @@ func TestAuthorizationsV2_DeleteGroup(t *testing.T) {
 func TestAuthorizationsV2_DeleteGroup_Validation(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, err := client.V2.Authorizations.DeleteGroup("")
+	_, err := client.V2.Authorizations.DeleteGroup(context.Background(), "")
 	assert.Error(t, err)
 }
 
@@ -181,7 +182,7 @@ func TestAuthorizationsV2_UpdateGroup(t *testing.T) {
 		}, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Authorizations.UpdateGroup("g1", &AuthorizationsUpdateGroupOptions{
+	result, resp, err := client.V2.Authorizations.UpdateGroup(context.Background(), "g1", &AuthorizationsUpdateGroupOptions{
 		Name:        "renamed-group",
 		Description: stringPtr("Updated description"),
 	})
@@ -206,7 +207,7 @@ func TestAuthorizationsV2_UpdateGroup_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.V2.Authorizations.UpdateGroup(tt.id, tt.opt)
+			_, _, err := client.V2.Authorizations.UpdateGroup(context.Background(), tt.id, tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -226,7 +227,7 @@ func TestAuthorizationsV2_SearchGroupMemberships(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/authorizations/group-memberships", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Authorizations.SearchGroupMemberships(nil)
+	result, resp, err := client.V2.Authorizations.SearchGroupMemberships(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.GroupMemberships, 1)
@@ -248,7 +249,7 @@ func TestAuthorizationsV2_SearchGroupMemberships_WithOptions(t *testing.T) {
 		response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Authorizations.SearchGroupMemberships(&AuthorizationsSearchGroupMembershipsOptions{
+	result, resp, err := client.V2.Authorizations.SearchGroupMemberships(context.Background(), &AuthorizationsSearchGroupMembershipsOptions{
 		PaginationParamsV2: PaginationParamsV2{PageIndex: 2, PageSize: 10},
 		GroupId:            "g1",
 		UserId:             "u1",
@@ -261,7 +262,7 @@ func TestAuthorizationsV2_SearchGroupMemberships_WithOptions(t *testing.T) {
 func TestAuthorizationsV2_SearchGroupMemberships_Validation(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.V2.Authorizations.SearchGroupMemberships(&AuthorizationsSearchGroupMembershipsOptions{
+	_, _, err := client.V2.Authorizations.SearchGroupMemberships(context.Background(), &AuthorizationsSearchGroupMembershipsOptions{
 		PaginationParamsV2: PaginationParamsV2{PageSize: 600},
 	})
 	assert.Error(t, err)
@@ -284,7 +285,7 @@ func TestAuthorizationsV2_CreateGroupMembership(t *testing.T) {
 		}, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Authorizations.CreateGroupMembership(&AuthorizationsCreateGroupMembershipOptions{
+	result, resp, err := client.V2.Authorizations.CreateGroupMembership(context.Background(), &AuthorizationsCreateGroupMembershipOptions{
 		GroupId: "g1",
 		UserId:  "u1",
 	})
@@ -309,7 +310,7 @@ func TestAuthorizationsV2_CreateGroupMembership_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.V2.Authorizations.CreateGroupMembership(tt.opt)
+			_, _, err := client.V2.Authorizations.CreateGroupMembership(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -323,7 +324,7 @@ func TestAuthorizationsV2_DeleteGroupMembership(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodDelete, "/v2/authorizations/group-memberships/m1", http.StatusNoContent))
 	client := newTestClient(t, server.url())
 
-	resp, err := client.V2.Authorizations.DeleteGroupMembership("m1")
+	resp, err := client.V2.Authorizations.DeleteGroupMembership(context.Background(), "m1")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -331,6 +332,6 @@ func TestAuthorizationsV2_DeleteGroupMembership(t *testing.T) {
 func TestAuthorizationsV2_DeleteGroupMembership_Validation(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, err := client.V2.Authorizations.DeleteGroupMembership("")
+	_, err := client.V2.Authorizations.DeleteGroupMembership(context.Background(), "")
 	assert.Error(t, err)
 }

--- a/sonar/batch_service.go
+++ b/sonar/batch_service.go
@@ -2,6 +2,7 @@ package sonar
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 )
 
@@ -56,13 +57,13 @@ func (s *BatchService) ValidateGetProjectOpt(opt *BatchProjectOptions) error {
 
 // GetFile downloads a JAR file listed in the index (see batch/index).
 // This endpoint returns binary data for the requested JAR file.
-func (s *BatchService) GetFile(opt *BatchFileOptions) (v []byte, resp *http.Response, err error) {
+func (s *BatchService) GetFile(ctx context.Context, opt *BatchFileOptions) (v []byte, resp *http.Response, err error) {
 	err = s.ValidateGetFileOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "batch/file", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "batch/file", opt)
 	if err != nil {
 		return
 	}
@@ -81,8 +82,8 @@ func (s *BatchService) GetFile(opt *BatchFileOptions) (v []byte, resp *http.Resp
 
 // GetIndex lists the JAR files to be downloaded by scanners.
 // Returns a list of JAR file names and their hashes.
-func (s *BatchService) GetIndex() (v *string, resp *http.Response, err error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "batch/index", nil)
+func (s *BatchService) GetIndex(ctx context.Context) (v *string, resp *http.Response, err error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "batch/index", nil)
 	if err != nil {
 		return
 	}
@@ -99,13 +100,13 @@ func (s *BatchService) GetIndex() (v *string, resp *http.Response, err error) {
 
 // GetProject returns project repository information including file hashes
 // for incremental analysis.
-func (s *BatchService) GetProject(opt *BatchProjectOptions) (v *BatchProject, resp *http.Response, err error) {
+func (s *BatchService) GetProject(ctx context.Context, opt *BatchProjectOptions) (v *BatchProject, resp *http.Response, err error) {
 	err = s.ValidateGetProjectOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "batch/project", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "batch/project", opt)
 	if err != nil {
 		return
 	}

--- a/sonar/batch_service_test.go
+++ b/sonar/batch_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -14,7 +15,7 @@ func TestBatchService_GetFile(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Batch.GetFile(&BatchFileOptions{
+		result, resp, err := client.Batch.GetFile(context.Background(), &BatchFileOptions{
 			Name: "batch-library-2.3.jar",
 		})
 
@@ -28,7 +29,7 @@ func TestBatchService_GetFile(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Batch.GetFile(nil)
+		_, _, err := client.Batch.GetFile(context.Background(), nil)
 
 		require.NoError(t, err)
 	})
@@ -38,7 +39,7 @@ func TestBatchService_GetFile(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Batch.GetFile(&BatchFileOptions{})
+		_, _, err := client.Batch.GetFile(context.Background(), &BatchFileOptions{})
 
 		require.NoError(t, err)
 	})
@@ -50,7 +51,7 @@ func TestBatchService_GetIndex(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Batch.GetIndex()
+		result, resp, err := client.Batch.GetIndex(context.Background(), )
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -77,7 +78,7 @@ func TestBatchService_GetProject(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Batch.GetProject(&BatchProjectOptions{
+		result, resp, err := client.Batch.GetProject(context.Background(), &BatchProjectOptions{
 			Key: "my-project",
 		})
 
@@ -92,7 +93,7 @@ func TestBatchService_GetProject(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Batch.GetProject(&BatchProjectOptions{
+		_, _, err := client.Batch.GetProject(context.Background(), &BatchProjectOptions{
 			Key:    "my-project",
 			Branch: "feature/my-branch",
 		})
@@ -105,7 +106,7 @@ func TestBatchService_GetProject(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Batch.GetProject(&BatchProjectOptions{
+		_, _, err := client.Batch.GetProject(context.Background(), &BatchProjectOptions{
 			Key:         "my-project",
 			PullRequest: "5461",
 		})
@@ -118,7 +119,7 @@ func TestBatchService_GetProject(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Batch.GetProject(nil)
+		_, _, err := client.Batch.GetProject(context.Background(), nil)
 
 		require.NoError(t, err)
 	})

--- a/sonar/ce_service.go
+++ b/sonar/ce_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 const (
 	// MaxCePageSize is the maximum page size for CE activity queries.
@@ -556,13 +559,13 @@ func (s *CeService) ValidateTaskOpt(opt *CeTaskOptions) error {
 //
 // API endpoint: GET /api/ce/activity.
 // Since: 5.2.
-func (s *CeService) Activity(opt *CeActivityOptions) (*CeActivity, *http.Response, error) {
+func (s *CeService) Activity(ctx context.Context, opt *CeActivityOptions) (*CeActivity, *http.Response, error) {
 	err := s.ValidateActivityOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "ce/activity", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "ce/activity", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -582,13 +585,13 @@ func (s *CeService) Activity(opt *CeActivityOptions) (*CeActivity, *http.Respons
 //
 // API endpoint: GET /api/ce/activity_status.
 // Since: 5.5.
-func (s *CeService) ActivityStatus(opt *CeActivityStatusOptions) (*CeActivityStatus, *http.Response, error) {
+func (s *CeService) ActivityStatus(ctx context.Context, opt *CeActivityStatusOptions) (*CeActivityStatus, *http.Response, error) {
 	err := s.ValidateActivityStatusOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "ce/activity_status", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "ce/activity_status", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -608,13 +611,13 @@ func (s *CeService) ActivityStatus(opt *CeActivityStatusOptions) (*CeActivitySta
 //
 // API endpoint: GET /api/ce/analysis_status.
 // Since: 7.4.
-func (s *CeService) AnalysisStatus(opt *CeAnalysisStatusOptions) (*CeAnalysisStatus, *http.Response, error) {
+func (s *CeService) AnalysisStatus(ctx context.Context, opt *CeAnalysisStatusOptions) (*CeAnalysisStatus, *http.Response, error) {
 	err := s.ValidateAnalysisStatusOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "ce/analysis_status", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "ce/analysis_status", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -635,13 +638,13 @@ func (s *CeService) AnalysisStatus(opt *CeAnalysisStatusOptions) (*CeAnalysisSta
 //
 // API endpoint: POST /api/ce/cancel.
 // Since: 5.2.
-func (s *CeService) Cancel(opt *CeCancelOptions) (*http.Response, error) {
+func (s *CeService) Cancel(ctx context.Context, opt *CeCancelOptions) (*http.Response, error) {
 	err := s.ValidateCancelOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "ce/cancel", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "ce/cancel", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -659,8 +662,8 @@ func (s *CeService) Cancel(opt *CeCancelOptions) (*http.Response, error) {
 //
 // API endpoint: POST /api/ce/cancel_all.
 // Since: 5.2.
-func (s *CeService) CancelAll() (*http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "ce/cancel_all", nil)
+func (s *CeService) CancelAll(ctx context.Context) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "ce/cancel_all", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -679,13 +682,13 @@ func (s *CeService) CancelAll() (*http.Response, error) {
 //
 // API endpoint: GET /api/ce/component.
 // Since: 5.2.
-func (s *CeService) Component(opt *CeComponentOptions) (*CeComponent, *http.Response, error) {
+func (s *CeService) Component(ctx context.Context, opt *CeComponentOptions) (*CeComponent, *http.Response, error) {
 	err := s.ValidateComponentOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "ce/component", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "ce/component", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -705,13 +708,13 @@ func (s *CeService) Component(opt *CeComponentOptions) (*CeComponent, *http.Resp
 //
 // API endpoint: POST /api/ce/dismiss_analysis_warning.
 // Since: 8.5.
-func (s *CeService) DismissAnalysisWarning(opt *CeDismissAnalysisWarningOptions) (*http.Response, error) {
+func (s *CeService) DismissAnalysisWarning(ctx context.Context, opt *CeDismissAnalysisWarningOptions) (*http.Response, error) {
 	err := s.ValidateDismissAnalysisWarningOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "ce/dismiss_analysis_warning", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "ce/dismiss_analysis_warning", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -728,8 +731,8 @@ func (s *CeService) DismissAnalysisWarning(opt *CeDismissAnalysisWarningOptions)
 //
 // API endpoint: GET /api/ce/indexation_status.
 // Since: 8.4.
-func (s *CeService) IndexationStatus() (*CeIndexationStatus, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "ce/indexation_status", nil)
+func (s *CeService) IndexationStatus(ctx context.Context) (*CeIndexationStatus, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "ce/indexation_status", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -749,8 +752,8 @@ func (s *CeService) IndexationStatus() (*CeIndexationStatus, *http.Response, err
 //
 // API endpoint: GET /api/ce/info.
 // Since: 7.2.
-func (s *CeService) Info() (*CeInfo, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "ce/info", nil)
+func (s *CeService) Info(ctx context.Context) (*CeInfo, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "ce/info", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -770,8 +773,8 @@ func (s *CeService) Info() (*CeInfo, *http.Response, error) {
 //
 // API endpoint: POST /api/ce/pause.
 // Since: 7.2.
-func (s *CeService) Pause() (*http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "ce/pause", nil)
+func (s *CeService) Pause(ctx context.Context) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "ce/pause", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -789,8 +792,8 @@ func (s *CeService) Pause() (*http.Response, error) {
 //
 // API endpoint: POST /api/ce/resume.
 // Since: 7.2.
-func (s *CeService) Resume() (*http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "ce/resume", nil)
+func (s *CeService) Resume(ctx context.Context) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "ce/resume", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -809,13 +812,13 @@ func (s *CeService) Resume() (*http.Response, error) {
 //
 // API endpoint: POST /api/ce/submit.
 // Since: 5.2.
-func (s *CeService) Submit(opt *CeSubmitOptions) (*CeSubmit, *http.Response, error) {
+func (s *CeService) Submit(ctx context.Context, opt *CeSubmitOptions) (*CeSubmit, *http.Response, error) {
 	err := s.ValidateSubmitOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "ce/submit", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "ce/submit", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -836,13 +839,13 @@ func (s *CeService) Submit(opt *CeSubmitOptions) (*CeSubmit, *http.Response, err
 //
 // API endpoint: GET /api/ce/task.
 // Since: 5.2.
-func (s *CeService) Task(opt *CeTaskOptions) (*CeTaskDetails, *http.Response, error) {
+func (s *CeService) Task(ctx context.Context, opt *CeTaskOptions) (*CeTaskDetails, *http.Response, error) {
 	err := s.ValidateTaskOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "ce/task", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "ce/task", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -861,8 +864,8 @@ func (s *CeService) Task(opt *CeTaskOptions) (*CeTaskDetails, *http.Response, er
 //
 // API endpoint: GET /api/ce/task_types.
 // Since: 5.5.
-func (s *CeService) TaskTypes() (*CeTaskTypes, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "ce/task_types", nil)
+func (s *CeService) TaskTypes(ctx context.Context) (*CeTaskTypes, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "ce/task_types", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -882,8 +885,8 @@ func (s *CeService) TaskTypes() (*CeTaskTypes, *http.Response, error) {
 //
 // API endpoint: GET /api/ce/worker_count.
 // Since: 6.5.
-func (s *CeService) WorkerCount() (*CeWorkerCount, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "ce/worker_count", nil)
+func (s *CeService) WorkerCount(ctx context.Context) (*CeWorkerCount, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "ce/worker_count", nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/ce_service_test.go
+++ b/sonar/ce_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -54,7 +55,7 @@ func TestCe_Activity(t *testing.T) {
 		Statuses:  []string{TaskStatusSuccess},
 	}
 
-	result, resp, err := client.Ce.Activity(opt)
+	result, resp, err := client.Ce.Activity(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -92,7 +93,7 @@ func TestCe_Activity_WithPagination(t *testing.T) {
 		},
 	}
 
-	result, resp, err := client.Ce.Activity(opt)
+	result, resp, err := client.Ce.Activity(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, int64(2), result.Paging.PageIndex)
@@ -108,7 +109,7 @@ func TestCe_Activity_WithNilOption(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Ce.Activity(nil)
+	result, resp, err := client.Ce.Activity(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -145,7 +146,7 @@ func TestCe_Activity_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Ce.Activity(tt.opt)
+			_, _, err := client.Ce.Activity(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -173,7 +174,7 @@ func TestCe_ActivityStatus(t *testing.T) {
 		Component: "my-project",
 	}
 
-	result, resp, err := client.Ce.ActivityStatus(opt)
+	result, resp, err := client.Ce.ActivityStatus(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -192,7 +193,7 @@ func TestCe_ActivityStatus_WithNilOption(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Ce.ActivityStatus(nil)
+	result, resp, err := client.Ce.ActivityStatus(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -229,7 +230,7 @@ func TestCe_AnalysisStatus(t *testing.T) {
 		Branch:    "main",
 	}
 
-	result, resp, err := client.Ce.AnalysisStatus(opt)
+	result, resp, err := client.Ce.AnalysisStatus(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -243,11 +244,11 @@ func TestCe_AnalysisStatus_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.Ce.AnalysisStatus(nil)
+	_, _, err := client.Ce.AnalysisStatus(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Component should fail validation.
-	_, _, err = client.Ce.AnalysisStatus(&CeAnalysisStatusOptions{})
+	_, _, err = client.Ce.AnalysisStatus(context.Background(), &CeAnalysisStatusOptions{})
 	assert.Error(t, err)
 }
 
@@ -266,7 +267,7 @@ func TestCe_Cancel(t *testing.T) {
 		ID: "task-123",
 	}
 
-	resp, err := client.Ce.Cancel(opt)
+	resp, err := client.Ce.Cancel(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -275,11 +276,11 @@ func TestCe_Cancel_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Ce.Cancel(nil)
+	_, err := client.Ce.Cancel(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing ID should fail validation.
-	_, err = client.Ce.Cancel(&CeCancelOptions{})
+	_, err = client.Ce.Cancel(context.Background(), &CeCancelOptions{})
 	assert.Error(t, err)
 }
 
@@ -288,7 +289,7 @@ func TestCe_CancelAll(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Ce.CancelAll()
+	resp, err := client.Ce.CancelAll(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -326,7 +327,7 @@ func TestCe_Component(t *testing.T) {
 		Component: "my-project",
 	}
 
-	result, resp, err := client.Ce.Component(opt)
+	result, resp, err := client.Ce.Component(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -341,11 +342,11 @@ func TestCe_Component_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.Ce.Component(nil)
+	_, _, err := client.Ce.Component(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Component should fail validation.
-	_, _, err = client.Ce.Component(&CeComponentOptions{})
+	_, _, err = client.Ce.Component(context.Background(), &CeComponentOptions{})
 	assert.Error(t, err)
 }
 
@@ -366,7 +367,7 @@ func TestCe_DismissAnalysisWarning(t *testing.T) {
 		Warning:   "warning-key-1",
 	}
 
-	resp, err := client.Ce.DismissAnalysisWarning(opt)
+	resp, err := client.Ce.DismissAnalysisWarning(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -394,7 +395,7 @@ func TestCe_DismissAnalysisWarning_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.Ce.DismissAnalysisWarning(tt.opt)
+			_, err := client.Ce.DismissAnalysisWarning(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -410,7 +411,7 @@ func TestCe_IndexationStatus(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Ce.IndexationStatus()
+	result, resp, err := client.Ce.IndexationStatus(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -427,7 +428,7 @@ func TestCe_Info(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Ce.Info()
+	result, resp, err := client.Ce.Info(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -439,7 +440,7 @@ func TestCe_Pause(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Ce.Pause()
+	resp, err := client.Ce.Pause(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -449,7 +450,7 @@ func TestCe_Resume(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Ce.Resume()
+	resp, err := client.Ce.Resume(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -478,7 +479,7 @@ func TestCe_Submit(t *testing.T) {
 		Report:      "base64-encoded-report",
 	}
 
-	result, resp, err := client.Ce.Submit(opt)
+	result, resp, err := client.Ce.Submit(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -516,7 +517,7 @@ func TestCe_Submit_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Ce.Submit(tt.opt)
+			_, _, err := client.Ce.Submit(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -555,7 +556,7 @@ func TestCe_Task(t *testing.T) {
 		AdditionalFields: []string{TaskFieldStacktrace},
 	}
 
-	result, resp, err := client.Ce.Task(opt)
+	result, resp, err := client.Ce.Task(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -590,7 +591,7 @@ func TestCe_Task_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Ce.Task(tt.opt)
+			_, _, err := client.Ce.Task(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -603,7 +604,7 @@ func TestCe_TaskTypes(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Ce.TaskTypes()
+	result, resp, err := client.Ce.TaskTypes(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -621,7 +622,7 @@ func TestCe_WorkerCount(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Ce.WorkerCount()
+	result, resp, err := client.Ce.WorkerCount(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/clean_code_policy_v2_service.go
+++ b/sonar/clean_code_policy_v2_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -254,13 +255,13 @@ func (s *CleanCodePolicyService) ValidateCreateRuleRequest(opt *CleanCodePolicyC
 
 // CreateRule creates a custom rule based on a template.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *CleanCodePolicyService) CreateRule(opt *CleanCodePolicyCreateRuleOptions) (*RuleV2, *http.Response, error) {
+func (s *CleanCodePolicyService) CreateRule(ctx context.Context, opt *CleanCodePolicyCreateRuleOptions) (*RuleV2, *http.Response, error) {
 	err := s.ValidateCreateRuleRequest(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodPost, "clean-code-policy/rules", nil, opt)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPost, "clean-code-policy/rules", nil, opt)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/sonar/clean_code_policy_v2_service_test.go
+++ b/sonar/clean_code_policy_v2_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -46,7 +47,7 @@ func TestCleanCodePolicyV2_CreateRule(t *testing.T) {
 	server := newTestServer(t, mockJSONBodyHandler(t, http.MethodPost, "/v2/clean-code-policy/rules", http.StatusOK, request, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.CleanCodePolicy.CreateRule(request)
+	result, resp, err := client.V2.CleanCodePolicy.CreateRule(context.Background(), request)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "custom:my_rule", result.Key)
@@ -80,7 +81,7 @@ func TestCleanCodePolicyV2_CreateRule_MinimalRequest(t *testing.T) {
 	server := newTestServer(t, mockJSONBodyHandler(t, http.MethodPost, "/v2/clean-code-policy/rules", http.StatusOK, request, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.CleanCodePolicy.CreateRule(request)
+	result, resp, err := client.V2.CleanCodePolicy.CreateRule(context.Background(), request)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "custom:min_rule", result.Key)
@@ -111,7 +112,7 @@ func TestCleanCodePolicyV2_CreateRule_MultipleImpacts(t *testing.T) {
 	server := newTestServer(t, mockJSONBodyHandler(t, http.MethodPost, "/v2/clean-code-policy/rules", http.StatusOK, request, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.CleanCodePolicy.CreateRule(request)
+	result, resp, err := client.V2.CleanCodePolicy.CreateRule(context.Background(), request)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Impacts, 3)
@@ -142,7 +143,7 @@ func TestCleanCodePolicyV2_CreateRule_WithParameters(t *testing.T) {
 	server := newTestServer(t, mockJSONBodyHandler(t, http.MethodPost, "/v2/clean-code-policy/rules", http.StatusOK, request, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.CleanCodePolicy.CreateRule(request)
+	result, resp, err := client.V2.CleanCodePolicy.CreateRule(context.Background(), request)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Parameters, 2)
@@ -276,7 +277,7 @@ func TestCleanCodePolicyV2_CreateRule_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.V2.CleanCodePolicy.CreateRule(tt.opt)
+			_, _, err := client.V2.CleanCodePolicy.CreateRule(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -433,7 +433,7 @@ type SonarAPIRequestParameters struct {
 // For most use cases, prefer the version-specific helpers:
 //   - NewSonarQubeV1APIRequest for V1 API endpoints (go-querystring encoding).
 //   - NewSonarQubeV2APIRequest for V2 API endpoints (JSON-tag encoding, body support).
-func (c *Client) NewSonarQubeAPIRequest(params SonarAPIRequestParameters) (*http.Request, error) {
+func (c *Client) NewSonarQubeAPIRequest(ctx context.Context, params SonarAPIRequestParameters) (*http.Request, error) {
 	method := http.MethodGet
 	if params.Method != "" {
 		method = params.Method
@@ -450,7 +450,7 @@ func (c *Client) NewSonarQubeAPIRequest(params SonarAPIRequestParameters) (*http
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), method, requestURL, bodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, bodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -464,7 +464,7 @@ func (c *Client) NewSonarQubeAPIRequest(params SonarAPIRequestParameters) (*http
 // relative to the client base URL. If opt is non-nil, it is encoded as URL
 // query parameters using go-querystring struct tags and appended to the
 // request URL.
-func (c *Client) NewSonarQubeV1APIRequest(method, path string, opt any) (*http.Request, error) {
+func (c *Client) NewSonarQubeV1APIRequest(ctx context.Context, method, path string, opt any) (*http.Request, error) {
 	var rawQuery url.Values
 
 	if opt != nil {
@@ -477,7 +477,7 @@ func (c *Client) NewSonarQubeV1APIRequest(method, path string, opt any) (*http.R
 	}
 
 	//nolint:exhaustruct // Headers and Body intentionally unset for V1 requests
-	return c.NewSonarQubeAPIRequest(SonarAPIRequestParameters{
+	return c.NewSonarQubeAPIRequest(ctx, SonarAPIRequestParameters{
 		Method:   method,
 		Path:     path,
 		RawQuery: rawQuery,
@@ -489,7 +489,7 @@ func (c *Client) NewSonarQubeV1APIRequest(method, path string, opt any) (*http.R
 // prepended. If queryOpt is non-nil, it is encoded as URL query parameters
 // using JSON struct tags. If body is non-nil, it is JSON-marshaled and used
 // as the request body.
-func (c *Client) NewSonarQubeV2APIRequest(method, path string, queryOpt any, body any) (*http.Request, error) {
+func (c *Client) NewSonarQubeV2APIRequest(ctx context.Context, method, path string, queryOpt any, body any) (*http.Request, error) {
 	var rawQuery url.Values
 
 	if queryOpt != nil {
@@ -502,7 +502,7 @@ func (c *Client) NewSonarQubeV2APIRequest(method, path string, queryOpt any, bod
 	}
 
 	//nolint:exhaustruct // Headers intentionally unset for V2 requests
-	return c.NewSonarQubeAPIRequest(SonarAPIRequestParameters{
+	return c.NewSonarQubeAPIRequest(ctx, SonarAPIRequestParameters{
 		Method:   method,
 		Path:     v2BasePath + path,
 		RawQuery: rawQuery,

--- a/sonar/components_service.go
+++ b/sonar/components_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 const (
 	// MaxComponentSearchQueryLength is the maximum length for search queries (truncated by API if exceeded).
@@ -697,13 +700,13 @@ func (s *ComponentsService) ValidateTreeOpt(opt *ComponentsTreeOptions) error {
 // This is an internal API and may change without notice.
 //
 // Since: 4.4.
-func (s *ComponentsService) App(opt *ComponentsAppOptions) (*ComponentsApp, *http.Response, error) {
+func (s *ComponentsService) App(ctx context.Context, opt *ComponentsAppOptions) (*ComponentsApp, *http.Response, error) {
 	err := s.ValidateAppOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "components/app", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "components/app", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -721,13 +724,13 @@ func (s *ComponentsService) App(opt *ComponentsAppOptions) (*ComponentsApp, *htt
 // Search searches for components.
 //
 // Since: 6.3.
-func (s *ComponentsService) Search(opt *ComponentsSearchOptions) (*ComponentsSearch, *http.Response, error) {
+func (s *ComponentsService) Search(ctx context.Context, opt *ComponentsSearchOptions) (*ComponentsSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "components/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "components/search", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -747,13 +750,13 @@ func (s *ComponentsService) Search(opt *ComponentsSearchOptions) (*ComponentsSea
 // This is an internal API and may change without notice.
 //
 // Since: 6.2.
-func (s *ComponentsService) SearchProjects(opt *ComponentsSearchProjectsOptions) (*ComponentsSearchProjects, *http.Response, error) {
+func (s *ComponentsService) SearchProjects(ctx context.Context, opt *ComponentsSearchProjectsOptions) (*ComponentsSearchProjects, *http.Response, error) {
 	err := s.ValidateSearchProjectsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "components/search_projects", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "components/search_projects", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -773,13 +776,13 @@ func (s *ComponentsService) SearchProjects(opt *ComponentsSearchProjectsOptions)
 // Requires the following permission: 'Browse' on the project of the specified component.
 //
 // Since: 5.4.
-func (s *ComponentsService) Show(opt *ComponentsShowOptions) (*ComponentsShow, *http.Response, error) {
+func (s *ComponentsService) Show(ctx context.Context, opt *ComponentsShowOptions) (*ComponentsShow, *http.Response, error) {
 	err := s.ValidateShowOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "components/show", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "components/show", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -802,13 +805,13 @@ func (s *ComponentsService) Show(opt *ComponentsShowOptions) (*ComponentsShow, *
 // This is an internal API and may change without notice.
 //
 // Since: 4.2.
-func (s *ComponentsService) Suggestions(opt *ComponentsSuggestionsOptions) (*ComponentsSuggestions, *http.Response, error) {
+func (s *ComponentsService) Suggestions(ctx context.Context, opt *ComponentsSuggestionsOptions) (*ComponentsSuggestions, *http.Response, error) {
 	err := s.ValidateSuggestionsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "components/suggestions", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "components/suggestions", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -828,13 +831,13 @@ func (s *ComponentsService) Suggestions(opt *ComponentsSuggestionsOptions) (*Com
 // When limiting search with the q parameter, directories are not returned.
 //
 // Since: 5.4.
-func (s *ComponentsService) Tree(opt *ComponentsTreeOptions) (*ComponentsTree, *http.Response, error) {
+func (s *ComponentsService) Tree(ctx context.Context, opt *ComponentsTreeOptions) (*ComponentsTree, *http.Response, error) {
 	err := s.ValidateTreeOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "components/tree", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "components/tree", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/components_service_test.go
+++ b/sonar/components_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -40,7 +41,7 @@ func TestComponents_App(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Components.App(&ComponentsAppOptions{
+	result, resp, err := client.Components.App(context.Background(), &ComponentsAppOptions{
 		Component: "my_project:src/file.go",
 		Branch:    "feature/my_branch",
 	})
@@ -77,7 +78,7 @@ func TestComponents_App_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Components.App(tt.opt)
+			_, _, err := client.Components.App(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -111,7 +112,7 @@ func TestComponents_Search(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Components.Search(&ComponentsSearchOptions{
+	result, resp, err := client.Components.Search(context.Background(), &ComponentsSearchOptions{
 		Qualifiers: []string{ProjectQualifierTRK},
 		Query:      "sonar",
 	})
@@ -155,7 +156,7 @@ func TestComponents_Search_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Components.Search(tt.opt)
+			_, _, err := client.Components.Search(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -201,7 +202,7 @@ func TestComponents_SearchProjects(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Components.SearchProjects(&ComponentsSearchProjectsOptions{
+	result, resp, err := client.Components.SearchProjects(context.Background(), &ComponentsSearchProjectsOptions{
 		Facets: []string{"alert_status"},
 		Filter: "coverage >= 80",
 	})
@@ -243,7 +244,7 @@ func TestComponents_SearchProjects_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Components.SearchProjects(tt.opt)
+			_, _, err := client.Components.SearchProjects(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -286,7 +287,7 @@ func TestComponents_Show(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Components.Show(&ComponentsShowOptions{
+	result, resp, err := client.Components.Show(context.Background(), &ComponentsShowOptions{
 		Component: "my_project:src/file.go",
 	})
 	require.NoError(t, err)
@@ -315,7 +316,7 @@ func TestComponents_Show_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Components.Show(tt.opt)
+			_, _, err := client.Components.Show(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -353,7 +354,7 @@ func TestComponents_Suggestions(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Components.Suggestions(&ComponentsSuggestionsOptions{
+	result, resp, err := client.Components.Suggestions(context.Background(), &ComponentsSuggestionsOptions{
 		Search: "sonar",
 	})
 	require.NoError(t, err)
@@ -392,7 +393,7 @@ func TestComponents_Suggestions_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Components.Suggestions(tt.opt)
+			_, _, err := client.Components.Suggestions(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -442,7 +443,7 @@ func TestComponents_Tree(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Components.Tree(&ComponentsTreeOptions{
+	result, resp, err := client.Components.Tree(context.Background(), &ComponentsTreeOptions{
 		Component: "my_project",
 		Strategy:  MeasureStrategyChildren,
 	})
@@ -470,7 +471,7 @@ func TestComponents_Tree_WithQualifiers(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	_, resp, err := client.Components.Tree(&ComponentsTreeOptions{
+	_, resp, err := client.Components.Tree(context.Background(), &ComponentsTreeOptions{
 		Component:  "my_project",
 		Qualifiers: []string{"FIL", "UTS"},
 		Sort:       []string{"name", "path"},
@@ -526,7 +527,7 @@ func TestComponents_Tree_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Components.Tree(tt.opt)
+			_, _, err := client.Components.Tree(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -551,7 +552,7 @@ func TestComponents_Search_WithPagination(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, _, err := client.Components.Search(&ComponentsSearchOptions{
+	result, _, err := client.Components.Search(context.Background(), &ComponentsSearchOptions{
 		Qualifiers: []string{ProjectQualifierTRK},
 		PaginationArgs: PaginationArgs{
 			Page:     2,

--- a/sonar/developers_service.go
+++ b/sonar/developers_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // DevelopersService handles communication with the developers related methods
 // of the SonarQube API.
@@ -78,13 +81,13 @@ func (s *DevelopersService) ValidateSearchEventsOpt(opt *DevelopersSearchEventsO
 //
 // API endpoint: GET /api/developers/search_events.
 // WARNING: This is an internal API and may change without notice.
-func (s *DevelopersService) SearchEvents(opt *DevelopersSearchEventsOptions) (*DevelopersSearchEvents, *http.Response, error) {
+func (s *DevelopersService) SearchEvents(ctx context.Context, opt *DevelopersSearchEventsOptions) (*DevelopersSearchEvents, *http.Response, error) {
 	err := s.ValidateSearchEventsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "developers/search_events", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "developers/search_events", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/developers_service_test.go
+++ b/sonar/developers_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -28,7 +29,7 @@ func TestDevelopers_SearchEvents(t *testing.T) {
 		Projects: []string{"my-project"},
 	}
 
-	result, resp, err := client.Developers.SearchEvents(opt)
+	result, resp, err := client.Developers.SearchEvents(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -70,7 +71,7 @@ func TestDevelopers_SearchEvents_ValidationErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			client := newLocalhostClient(t)
 
-			_, _, err := client.Developers.SearchEvents(tt.opt)
+			_, _, err := client.Developers.SearchEvents(context.Background(), tt.opt)
 			require.Error(t, err)
 
 			var validationErr *ValidationError

--- a/sonar/dismiss_message_service.go
+++ b/sonar/dismiss_message_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // DismissMessageService handles communication with the message dismissal related methods
 // of the SonarQube API.
@@ -94,13 +97,13 @@ func (s *DismissMessageService) ValidateDismissOpt(opt *DismissMessageDismissOpt
 //
 // API endpoint: GET /api/dismiss_message/check.
 // Since: 10.2.
-func (s *DismissMessageService) Check(opt *DismissMessageCheckOptions) (*DismissMessageCheck, *http.Response, error) {
+func (s *DismissMessageService) Check(ctx context.Context, opt *DismissMessageCheckOptions) (*DismissMessageCheck, *http.Response, error) {
 	err := s.ValidateCheckOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "dismiss_message/check", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "dismiss_message/check", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -119,13 +122,13 @@ func (s *DismissMessageService) Check(opt *DismissMessageCheckOptions) (*Dismiss
 //
 // API endpoint: POST /api/dismiss_message/dismiss.
 // Since: 10.2.
-func (s *DismissMessageService) Dismiss(opt *DismissMessageDismissOptions) (*http.Response, error) {
+func (s *DismissMessageService) Dismiss(ctx context.Context, opt *DismissMessageDismissOptions) (*http.Response, error) {
 	err := s.ValidateDismissOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "dismiss_message/dismiss", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "dismiss_message/dismiss", opt)
 	if err != nil {
 		return nil, err
 	}

--- a/sonar/dismiss_message_service_test.go
+++ b/sonar/dismiss_message_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestDismissMessage_Check(t *testing.T) {
 		ProjectKey:  "my-project",
 	}
 
-	result, resp, err := client.DismissMessage.Check(opt)
+	result, resp, err := client.DismissMessage.Check(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -53,7 +54,7 @@ func TestDismissMessage_Check_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.DismissMessage.Check(tt.opt)
+			_, _, err := client.DismissMessage.Check(context.Background(), tt.opt)
 			require.Error(t, err)
 		})
 	}
@@ -68,7 +69,7 @@ func TestDismissMessage_Dismiss(t *testing.T) {
 		ProjectKey:  "my-project",
 	}
 
-	resp, err := client.DismissMessage.Dismiss(opt)
+	resp, err := client.DismissMessage.Dismiss(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -100,7 +101,7 @@ func TestDismissMessage_Dismiss_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.DismissMessage.Dismiss(tt.opt)
+			_, err := client.DismissMessage.Dismiss(context.Background(), tt.opt)
 			require.Error(t, err)
 		})
 	}

--- a/sonar/dop_translation_v2_service.go
+++ b/sonar/dop_translation_v2_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -128,13 +129,13 @@ func (s *DopTranslationService) ValidateCreateBoundProjectRequest(opt *DopTransl
 // repository, or updates the binding if the project already exists.
 // This is an idempotent operation.
 // Requires the 'Create Projects' permission and a configured Personal Access Token.
-func (s *DopTranslationService) CreateOrUpdateBoundProject(opt *DopTranslationBoundProjectOptions) (*DopTranslationBoundProject, *http.Response, error) {
+func (s *DopTranslationService) CreateOrUpdateBoundProject(ctx context.Context, opt *DopTranslationBoundProjectOptions) (*DopTranslationBoundProject, *http.Response, error) {
 	err := s.ValidateCreateBoundProjectRequest(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodPut, "dop-translation/bound-projects", nil, opt)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPut, "dop-translation/bound-projects", nil, opt)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -152,13 +153,13 @@ func (s *DopTranslationService) CreateOrUpdateBoundProject(opt *DopTranslationBo
 // CreateBoundProject creates a SonarQube project with the information from the
 // provided DevOps platform project.
 // Requires the 'Create Projects' permission and a configured Personal Access Token.
-func (s *DopTranslationService) CreateBoundProject(opt *DopTranslationBoundProjectOptions) (*DopTranslationBoundProject, *http.Response, error) {
+func (s *DopTranslationService) CreateBoundProject(ctx context.Context, opt *DopTranslationBoundProjectOptions) (*DopTranslationBoundProject, *http.Response, error) {
 	err := s.ValidateCreateBoundProjectRequest(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodPost, "dop-translation/bound-projects", nil, opt)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPost, "dop-translation/bound-projects", nil, opt)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -175,8 +176,8 @@ func (s *DopTranslationService) CreateBoundProject(opt *DopTranslationBoundProje
 
 // GetDopSettings lists all DevOps Platform Integration settings.
 // Requires the 'Create Projects' permission.
-func (s *DopTranslationService) GetDopSettings() (*DopTranslationDopSettings, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "dop-translation/dop-settings", nil, nil)
+func (s *DopTranslationService) GetDopSettings(ctx context.Context) (*DopTranslationDopSettings, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "dop-translation/dop-settings", nil, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/sonar/dop_translation_v2_service_test.go
+++ b/sonar/dop_translation_v2_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -28,7 +29,7 @@ func TestDopTranslationV2_CreateOrUpdateBoundProject(t *testing.T) {
 		}, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.DopTranslation.CreateOrUpdateBoundProject(&DopTranslationBoundProjectOptions{
+	result, resp, err := client.V2.DopTranslation.CreateOrUpdateBoundProject(context.Background(), &DopTranslationBoundProjectOptions{
 		DevOpsPlatformSettingId: "dop-1",
 		Monorepo:                false,
 		ProjectKey:              "my-project",
@@ -58,7 +59,7 @@ func TestDopTranslationV2_CreateOrUpdateBoundProject_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.V2.DopTranslation.CreateOrUpdateBoundProject(tt.opt)
+			_, _, err := client.V2.DopTranslation.CreateOrUpdateBoundProject(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -84,7 +85,7 @@ func TestDopTranslationV2_CreateBoundProject(t *testing.T) {
 		}, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.DopTranslation.CreateBoundProject(&DopTranslationBoundProjectOptions{
+	result, resp, err := client.V2.DopTranslation.CreateBoundProject(context.Background(), &DopTranslationBoundProjectOptions{
 		DevOpsPlatformSettingId: "dop-1",
 		Monorepo:                true,
 		ProjectKey:              "mono-project",
@@ -100,7 +101,7 @@ func TestDopTranslationV2_CreateBoundProject(t *testing.T) {
 func TestDopTranslationV2_CreateBoundProject_Validation(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.V2.DopTranslation.CreateBoundProject(nil)
+	_, _, err := client.V2.DopTranslation.CreateBoundProject(context.Background(), nil)
 	assert.Error(t, err)
 }
 
@@ -119,7 +120,7 @@ func TestDopTranslationV2_GetDopSettings(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/dop-translation/dop-settings", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.DopTranslation.GetDopSettings()
+	result, resp, err := client.V2.DopTranslation.GetDopSettings(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.DopSettings, 2)

--- a/sonar/duplications_service.go
+++ b/sonar/duplications_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // DuplicationsService handles communication with the duplications related methods
 // of the SonarQube API.
@@ -96,13 +99,13 @@ func (s *DuplicationsService) ValidateShowOpt(opt *DuplicationsShowOptions) erro
 //
 // API endpoint: GET /api/duplications/show.
 // Since: 4.4.
-func (s *DuplicationsService) Show(opt *DuplicationsShowOptions) (*DuplicationsShow, *http.Response, error) {
+func (s *DuplicationsService) Show(ctx context.Context, opt *DuplicationsShowOptions) (*DuplicationsShow, *http.Response, error) {
 	err := s.ValidateShowOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "duplications/show", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "duplications/show", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/duplications_service_test.go
+++ b/sonar/duplications_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -30,7 +31,7 @@ func TestDuplications_Show(t *testing.T) {
 		Key: "com.example:MyFile.java",
 	}
 
-	result, resp, err := client.Duplications.Show(opt)
+	result, resp, err := client.Duplications.Show(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -55,7 +56,7 @@ func TestDuplications_Show_WithBranch(t *testing.T) {
 		Branch: "feature",
 	}
 
-	_, resp, err := client.Duplications.Show(opt)
+	_, resp, err := client.Duplications.Show(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -70,7 +71,7 @@ func TestDuplications_Show_WithPullRequest(t *testing.T) {
 		PullRequest: "123",
 	}
 
-	_, resp, err := client.Duplications.Show(opt)
+	_, resp, err := client.Duplications.Show(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -94,7 +95,7 @@ func TestDuplications_Show_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Duplications.Show(tt.opt)
+			_, _, err := client.Duplications.Show(context.Background(), tt.opt)
 			require.Error(t, err)
 		})
 	}

--- a/sonar/editions_service.go
+++ b/sonar/editions_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // EditionsService handles communication with the editions related methods of the
 // SonarQube API. This service is only available in Enterprise Edition.
@@ -94,8 +97,8 @@ func (s *EditionsService) ValidateSetOpt(opt *LicenseSetOptions) error {
 // API endpoint: POST /api/editions/activate_grace_period.
 // Since: 10.3.
 // Enterprise Edition only.
-func (s *EditionsService) ActivateGracePeriod() (*http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "editions/activate_grace_period", nil)
+func (s *EditionsService) ActivateGracePeriod(ctx context.Context) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "editions/activate_grace_period", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -109,8 +112,8 @@ func (s *EditionsService) ActivateGracePeriod() (*http.Response, error) {
 // API endpoint: GET /api/editions/show_license.
 // Since: 7.2.
 // Enterprise Edition only.
-func (s *EditionsService) Get() (*LicenseGet, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "editions/show_license", nil)
+func (s *EditionsService) Get(ctx context.Context) (*LicenseGet, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "editions/show_license", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -130,8 +133,8 @@ func (s *EditionsService) Get() (*LicenseGet, *http.Response, error) {
 // API endpoint: GET /api/editions/is_valid_license.
 // Since: 7.3.
 // Enterprise Edition only.
-func (s *EditionsService) IsValidLicense() (*LicenseIsValid, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "editions/is_valid_license", nil)
+func (s *EditionsService) IsValidLicense(ctx context.Context) (*LicenseIsValid, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "editions/is_valid_license", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -152,13 +155,13 @@ func (s *EditionsService) IsValidLicense() (*LicenseIsValid, *http.Response, err
 // API endpoint: POST /api/editions/set_license.
 // Since: 7.2.
 // Enterprise Edition only.
-func (s *EditionsService) Set(opt *LicenseSetOptions) (*http.Response, error) {
+func (s *EditionsService) Set(ctx context.Context, opt *LicenseSetOptions) (*http.Response, error) {
 	err := s.ValidateSetOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "editions/set_license", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "editions/set_license", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -172,8 +175,8 @@ func (s *EditionsService) Set(opt *LicenseSetOptions) (*http.Response, error) {
 // API endpoint: POST /api/editions/unset_license.
 // Since: 7.2.
 // Enterprise Edition only.
-func (s *EditionsService) UnsetLicense() (*http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "editions/unset_license", nil)
+func (s *EditionsService) UnsetLicense(ctx context.Context) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "editions/unset_license", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/sonar/editions_service_test.go
+++ b/sonar/editions_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -13,7 +14,7 @@ func TestEditionsService_ActivateGracePeriod(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Editions.ActivateGracePeriod()
+	resp, err := client.Editions.ActivateGracePeriod(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -40,7 +41,7 @@ func TestEditionsService_Get(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Editions.Get()
+	result, resp, err := client.Editions.Get(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -58,7 +59,7 @@ func TestEditionsService_Get_Empty(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Editions.Get()
+	result, resp, err := client.Editions.Get(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -70,7 +71,7 @@ func TestEditionsService_IsValidLicense(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Editions.IsValidLicense()
+	result, resp, err := client.Editions.IsValidLicense(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -83,7 +84,7 @@ func TestEditionsService_IsValidLicense_Invalid(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Editions.IsValidLicense()
+	result, resp, err := client.Editions.IsValidLicense(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -95,7 +96,7 @@ func TestEditionsService_Set(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Editions.Set(&LicenseSetOptions{
+	resp, err := client.Editions.Set(context.Background(), &LicenseSetOptions{
 		License: "my-license-key",
 	})
 	require.NoError(t, err)
@@ -106,12 +107,12 @@ func TestEditionsService_Set_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	resp, err := client.Editions.Set(nil)
+	resp, err := client.Editions.Set(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
 	// Missing License key should fail validation.
-	resp, err = client.Editions.Set(&LicenseSetOptions{})
+	resp, err = client.Editions.Set(context.Background(), &LicenseSetOptions{})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -121,7 +122,7 @@ func TestEditionsService_UnsetLicense(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Editions.UnsetLicense()
+	resp, err := client.Editions.UnsetLicense(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }

--- a/sonar/emails_service.go
+++ b/sonar/emails_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // EmailsService handles communication with the email related methods
 // of the SonarQube API.
@@ -59,13 +62,13 @@ func (s *EmailsService) ValidateSendOpt(opt *EmailsSendOptions) error {
 //
 // API endpoint: POST /api/emails/send.
 // WARNING: This is an internal API and may change without notice.
-func (s *EmailsService) Send(opt *EmailsSendOptions) (*http.Response, error) {
+func (s *EmailsService) Send(ctx context.Context, opt *EmailsSendOptions) (*http.Response, error) {
 	err := s.ValidateSendOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "emails/send", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "emails/send", opt)
 	if err != nil {
 		return nil, err
 	}

--- a/sonar/emails_service_test.go
+++ b/sonar/emails_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -19,7 +20,7 @@ func TestEmails_Send(t *testing.T) {
 		To:      "test@example.com",
 	}
 
-	resp, err := client.Emails.Send(opt)
+	resp, err := client.Emails.Send(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -55,7 +56,7 @@ func TestEmails_Send_ValidationErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			client := newLocalhostClient(t)
 
-			_, err := client.Emails.Send(tt.opt)
+			_, err := client.Emails.Send(context.Background(), tt.opt)
 			require.Error(t, err)
 
 			var validationErr *ValidationError

--- a/sonar/favorites_service.go
+++ b/sonar/favorites_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // FavoritesService handles communication with the favorites related methods
 // of the SonarQube API.
@@ -108,13 +111,13 @@ func (s *FavoritesService) ValidateSearchOpt(opt *FavoritesSearchOptions) error 
 //
 // API endpoint: POST /api/favorites/add.
 // Since: 6.3.
-func (s *FavoritesService) Add(opt *FavoritesAddOptions) (*http.Response, error) {
+func (s *FavoritesService) Add(ctx context.Context, opt *FavoritesAddOptions) (*http.Response, error) {
 	err := s.ValidateAddOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "favorites/add", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "favorites/add", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -132,13 +135,13 @@ func (s *FavoritesService) Add(opt *FavoritesAddOptions) (*http.Response, error)
 //
 // API endpoint: POST /api/favorites/remove.
 // Since: 6.3.
-func (s *FavoritesService) Remove(opt *FavoritesRemoveOptions) (*http.Response, error) {
+func (s *FavoritesService) Remove(ctx context.Context, opt *FavoritesRemoveOptions) (*http.Response, error) {
 	err := s.ValidateRemoveOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "favorites/remove", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "favorites/remove", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -156,13 +159,13 @@ func (s *FavoritesService) Remove(opt *FavoritesRemoveOptions) (*http.Response, 
 //
 // API endpoint: GET /api/favorites/search.
 // Since: 6.3.
-func (s *FavoritesService) Search(opt *FavoritesSearchOptions) (*FavoritesSearch, *http.Response, error) {
+func (s *FavoritesService) Search(ctx context.Context, opt *FavoritesSearchOptions) (*FavoritesSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "favorites/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "favorites/search", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/favorites_service_test.go
+++ b/sonar/favorites_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestFavorites_Add(t *testing.T) {
 		Component: "my-project",
 	}
 
-	resp, err := client.Favorites.Add(opt)
+	resp, err := client.Favorites.Add(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -25,11 +26,11 @@ func TestFavorites_Add_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Favorites.Add(nil)
+	_, err := client.Favorites.Add(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Component should fail validation.
-	_, err = client.Favorites.Add(&FavoritesAddOptions{})
+	_, err = client.Favorites.Add(context.Background(), &FavoritesAddOptions{})
 	assert.Error(t, err)
 }
 
@@ -41,7 +42,7 @@ func TestFavorites_Remove(t *testing.T) {
 		Component: "my-project",
 	}
 
-	resp, err := client.Favorites.Remove(opt)
+	resp, err := client.Favorites.Remove(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -50,11 +51,11 @@ func TestFavorites_Remove_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Favorites.Remove(nil)
+	_, err := client.Favorites.Remove(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Component should fail validation.
-	_, err = client.Favorites.Remove(&FavoritesRemoveOptions{})
+	_, err = client.Favorites.Remove(context.Background(), &FavoritesRemoveOptions{})
 	assert.Error(t, err)
 }
 
@@ -72,7 +73,7 @@ func TestFavorites_Search(t *testing.T) {
 	}))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Favorites.Search(nil)
+	result, resp, err := client.Favorites.Search(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -100,7 +101,7 @@ func TestFavorites_Search_WithPagination(t *testing.T) {
 		},
 	}
 
-	_, resp, err := client.Favorites.Search(opt)
+	_, resp, err := client.Favorites.Search(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }

--- a/sonar/features_service.go
+++ b/sonar/features_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // FeaturesService handles communication with the features related methods
 // of the SonarQube API.
@@ -26,8 +29,8 @@ type FeaturesList []string
 //
 // API endpoint: GET /api/features/list.
 // WARNING: This is an internal API and may change without notice.
-func (s *FeaturesService) List() (*FeaturesList, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "features/list", nil)
+func (s *FeaturesService) List(ctx context.Context) (*FeaturesList, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "features/list", nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/features_service_test.go
+++ b/sonar/features_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -13,7 +14,7 @@ func TestFeatures_List(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.Features.List()
+	result, resp, err := client.Features.List(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -27,7 +28,7 @@ func TestFeatures_List_Empty(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.Features.List()
+	result, resp, err := client.Features.List(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/github_provisioning_service.go
+++ b/sonar/github_provisioning_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // GithubProvisioningService handles communication with the GitHub provisioning related methods
 // of the SonarQube API.
@@ -62,8 +65,8 @@ type GithubProvisioningJitStatus struct {
 //
 // API endpoint: POST /api/github_provisioning/check.
 // WARNING: This is an internal API and may change without notice.
-func (s *GithubProvisioningService) Check() (*GithubProvisioningCheck, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "github_provisioning/check", nil)
+func (s *GithubProvisioningService) Check(ctx context.Context) (*GithubProvisioningCheck, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "github_provisioning/check", nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/github_provisioning_service_test.go
+++ b/sonar/github_provisioning_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -26,7 +27,7 @@ func TestGithubProvisioning_Check(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.GithubProvisioning.Check()
+	result, resp, err := client.GithubProvisioning.Check(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -48,7 +49,7 @@ func TestGithubProvisioning_Check_WithError(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.GithubProvisioning.Check()
+	result, resp, err := client.GithubProvisioning.Check(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "failed", result.Application.AutoProvisioning.Status)
@@ -60,7 +61,7 @@ func TestGithubProvisioning_Check_EmptyResponse(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.GithubProvisioning.Check()
+	result, resp, err := client.GithubProvisioning.Check(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/hotspots_service.go
+++ b/sonar/hotspots_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 const (
 	// MaxHotspotCommentLength is the maximum length for a hotspot comment.
@@ -733,13 +736,13 @@ func (s *HotspotsService) ValidateShowOpt(opt *HotspotsShowOptions) error {
 // API endpoint: POST /api/hotspots/add_comment.
 // Since: 8.1.
 // Internal: true.
-func (s *HotspotsService) AddComment(opt *HotspotsAddCommentOptions) (*http.Response, error) {
+func (s *HotspotsService) AddComment(ctx context.Context, opt *HotspotsAddCommentOptions) (*http.Response, error) {
 	err := s.ValidateAddCommentOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "hotspots/add_comment", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "hotspots/add_comment", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -758,13 +761,13 @@ func (s *HotspotsService) AddComment(opt *HotspotsAddCommentOptions) (*http.Resp
 // API endpoint: POST /api/hotspots/assign.
 // Since: 8.2.
 // Internal: true.
-func (s *HotspotsService) Assign(opt *HotspotsAssignOptions) (*http.Response, error) {
+func (s *HotspotsService) Assign(ctx context.Context, opt *HotspotsAssignOptions) (*http.Response, error) {
 	err := s.ValidateAssignOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "hotspots/assign", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "hotspots/assign", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -782,13 +785,13 @@ func (s *HotspotsService) Assign(opt *HotspotsAssignOptions) (*http.Response, er
 //
 // API endpoint: POST /api/hotspots/change_status.
 // Since: 8.1.
-func (s *HotspotsService) ChangeStatus(opt *HotspotsChangeStatusOptions) (*http.Response, error) {
+func (s *HotspotsService) ChangeStatus(ctx context.Context, opt *HotspotsChangeStatusOptions) (*http.Response, error) {
 	err := s.ValidateChangeStatusOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "hotspots/change_status", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "hotspots/change_status", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -807,13 +810,13 @@ func (s *HotspotsService) ChangeStatus(opt *HotspotsChangeStatusOptions) (*http.
 // API endpoint: POST /api/hotspots/delete_comment.
 // Since: 8.2.
 // Internal: true.
-func (s *HotspotsService) DeleteComment(opt *HotspotsDeleteCommentOptions) (*http.Response, error) {
+func (s *HotspotsService) DeleteComment(ctx context.Context, opt *HotspotsDeleteCommentOptions) (*http.Response, error) {
 	err := s.ValidateDeleteCommentOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "hotspots/delete_comment", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "hotspots/delete_comment", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -832,13 +835,13 @@ func (s *HotspotsService) DeleteComment(opt *HotspotsDeleteCommentOptions) (*htt
 // API endpoint: POST /api/hotspots/edit_comment.
 // Since: 8.2.
 // Internal: true.
-func (s *HotspotsService) EditComment(opt *HotspotsEditCommentOptions) (*HotspotsEditComment, *http.Response, error) {
+func (s *HotspotsService) EditComment(ctx context.Context, opt *HotspotsEditCommentOptions) (*HotspotsEditComment, *http.Response, error) {
 	err := s.ValidateEditCommentOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "hotspots/edit_comment", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "hotspots/edit_comment", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -863,13 +866,13 @@ func (s *HotspotsService) EditComment(opt *HotspotsEditCommentOptions) (*Hotspot
 // API endpoint: GET /api/hotspots/list.
 // Since: 10.2.
 // Internal: true.
-func (s *HotspotsService) List(opt *HotspotsListOptions) (*HotspotsList, *http.Response, error) {
+func (s *HotspotsService) List(ctx context.Context, opt *HotspotsListOptions) (*HotspotsList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "hotspots/list", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "hotspots/list", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -891,13 +894,13 @@ func (s *HotspotsService) List(opt *HotspotsListOptions) (*HotspotsList, *http.R
 // API endpoint: GET /api/hotspots/pull.
 // Since: 10.1.
 // Internal: true.
-func (s *HotspotsService) Pull(opt *HotspotsPullOptions) ([]byte, *http.Response, error) {
+func (s *HotspotsService) Pull(ctx context.Context, opt *HotspotsPullOptions) ([]byte, *http.Response, error) {
 	err := s.ValidatePullOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "hotspots/pull", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "hotspots/pull", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -919,13 +922,13 @@ func (s *HotspotsService) Pull(opt *HotspotsPullOptions) ([]byte, *http.Response
 //
 // API endpoint: GET /api/hotspots/search.
 // Since: 8.1.
-func (s *HotspotsService) Search(opt *HotspotsSearchOptions) (*HotspotsSearch, *http.Response, error) {
+func (s *HotspotsService) Search(ctx context.Context, opt *HotspotsSearchOptions) (*HotspotsSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "hotspots/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "hotspots/search", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -944,13 +947,13 @@ func (s *HotspotsService) Search(opt *HotspotsSearchOptions) (*HotspotsSearch, *
 //
 // API endpoint: GET /api/hotspots/show.
 // Since: 8.1.
-func (s *HotspotsService) Show(opt *HotspotsShowOptions) (*HotspotsShow, *http.Response, error) {
+func (s *HotspotsService) Show(ctx context.Context, opt *HotspotsShowOptions) (*HotspotsShow, *http.Response, error) {
 	err := s.ValidateShowOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "hotspots/show", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "hotspots/show", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/hotspots_service_test.go
+++ b/sonar/hotspots_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -24,7 +25,7 @@ func TestHotspots_AddComment(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Hotspots.AddComment(&HotspotsAddCommentOptions{
+	resp, err := client.Hotspots.AddComment(context.Background(), &HotspotsAddCommentOptions{
 		Hotspot: "hotspot123",
 		Comment: "This is a comment",
 	})
@@ -62,7 +63,7 @@ func TestHotspots_AddComment_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.Hotspots.AddComment(tt.opt)
+			_, err := client.Hotspots.AddComment(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -84,7 +85,7 @@ func TestHotspots_Assign(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Hotspots.Assign(&HotspotsAssignOptions{
+	resp, err := client.Hotspots.Assign(context.Background(), &HotspotsAssignOptions{
 		Hotspot:  "hotspot123",
 		Assignee: "john.doe",
 	})
@@ -111,7 +112,7 @@ func TestHotspots_Assign_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.Hotspots.Assign(tt.opt)
+			_, err := client.Hotspots.Assign(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -134,7 +135,7 @@ func TestHotspots_ChangeStatus(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Hotspots.ChangeStatus(&HotspotsChangeStatusOptions{
+	resp, err := client.Hotspots.ChangeStatus(context.Background(), &HotspotsChangeStatusOptions{
 		Hotspot:    "hotspot123",
 		Status:     HotspotStatusReviewed,
 		Resolution: HotspotResolutionSafe,
@@ -174,7 +175,7 @@ func TestHotspots_ChangeStatus_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.Hotspots.ChangeStatus(tt.opt)
+			_, err := client.Hotspots.ChangeStatus(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -195,7 +196,7 @@ func TestHotspots_DeleteComment(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Hotspots.DeleteComment(&HotspotsDeleteCommentOptions{
+	resp, err := client.Hotspots.DeleteComment(context.Background(), &HotspotsDeleteCommentOptions{
 		Comment: "comment123",
 	})
 	require.NoError(t, err)
@@ -221,7 +222,7 @@ func TestHotspots_DeleteComment_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.Hotspots.DeleteComment(tt.opt)
+			_, err := client.Hotspots.DeleteComment(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -243,7 +244,7 @@ func TestHotspots_EditComment(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Hotspots.EditComment(&HotspotsEditCommentOptions{
+	result, resp, err := client.Hotspots.EditComment(context.Background(), &HotspotsEditCommentOptions{
 		Comment: "comment123",
 		Text:    "Updated comment",
 	})
@@ -284,7 +285,7 @@ func TestHotspots_EditComment_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Hotspots.EditComment(tt.opt)
+			_, _, err := client.Hotspots.EditComment(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -320,7 +321,7 @@ func TestHotspots_List(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Hotspots.List(&HotspotsListOptions{
+	result, resp, err := client.Hotspots.List(context.Background(), &HotspotsListOptions{
 		Project: "my-project",
 	})
 	require.NoError(t, err)
@@ -361,7 +362,7 @@ func TestHotspots_List_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Hotspots.List(tt.opt)
+			_, _, err := client.Hotspots.List(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -385,7 +386,7 @@ func TestHotspots_Pull(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Hotspots.Pull(&HotspotsPullOptions{
+	result, resp, err := client.Hotspots.Pull(context.Background(), &HotspotsPullOptions{
 		ProjectKey: "my-project",
 		BranchName: "main",
 	})
@@ -417,7 +418,7 @@ func TestHotspots_Pull_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Hotspots.Pull(tt.opt)
+			_, _, err := client.Hotspots.Pull(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -453,7 +454,7 @@ func TestHotspots_Search_WithProject(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Hotspots.Search(&HotspotsSearchOptions{
+	result, resp, err := client.Hotspots.Search(context.Background(), &HotspotsSearchOptions{
 		Project: "my-project",
 	})
 	require.NoError(t, err)
@@ -475,7 +476,7 @@ func TestHotspots_Search_WithHotspots(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	_, resp, err := client.Hotspots.Search(&HotspotsSearchOptions{
+	_, resp, err := client.Hotspots.Search(context.Background(), &HotspotsSearchOptions{
 		Hotspots: []string{"hotspot1", "hotspot2"},
 	})
 	require.NoError(t, err)
@@ -498,7 +499,7 @@ func TestHotspots_Search_WithFilters(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	_, resp, err := client.Hotspots.Search(&HotspotsSearchOptions{
+	_, resp, err := client.Hotspots.Search(context.Background(), &HotspotsSearchOptions{
 		Project:         "my-project",
 		Status:          HotspotStatusReviewed,
 		Resolution:      HotspotResolutionSafe,
@@ -548,7 +549,7 @@ func TestHotspots_Search_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Hotspots.Search(tt.opt)
+			_, _, err := client.Hotspots.Search(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -607,7 +608,7 @@ func TestHotspots_Show(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Hotspots.Show(&HotspotsShowOptions{
+	result, resp, err := client.Hotspots.Show(context.Background(), &HotspotsShowOptions{
 		Hotspot: "hotspot123",
 	})
 	require.NoError(t, err)
@@ -643,7 +644,7 @@ func TestHotspots_Show_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Hotspots.Show(tt.opt)
+			_, _, err := client.Hotspots.Show(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}

--- a/sonar/issues_service.go
+++ b/sonar/issues_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -785,13 +786,13 @@ type IssuesTagsOptions struct {
 
 // AddComment adds a comment to an issue.
 // Requires authentication and 'Browse' permission on the project of the specified issue.
-func (s *IssuesService) AddComment(opt *IssuesAddCommentOptions) (v *IssuesAddComment, resp *http.Response, err error) {
+func (s *IssuesService) AddComment(ctx context.Context, opt *IssuesAddCommentOptions) (v *IssuesAddComment, resp *http.Response, err error) {
 	err = s.ValidateAddCommentOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "issues/add_comment", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "issues/add_comment", opt)
 	if err != nil {
 		return
 	}
@@ -810,13 +811,13 @@ func (s *IssuesService) AddComment(opt *IssuesAddCommentOptions) (v *IssuesAddCo
 // Requires 'Administer Issues' permission on the specified project.
 // Only 'falsepositive', 'wontfix' and 'accept' transitions are supported.
 // Upon successful execution, the HTTP status code returned is 202 (Accepted).
-func (s *IssuesService) AnticipatedTransitions(opt *IssuesAnticipatedTransitionsOptions) (resp *http.Response, err error) {
+func (s *IssuesService) AnticipatedTransitions(ctx context.Context, opt *IssuesAnticipatedTransitionsOptions) (resp *http.Response, err error) {
 	err = s.ValidateAnticipatedTransitionsOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "issues/anticipated_transitions", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "issues/anticipated_transitions", opt)
 	if err != nil {
 		return
 	}
@@ -831,13 +832,13 @@ func (s *IssuesService) AnticipatedTransitions(opt *IssuesAnticipatedTransitions
 
 // Assign assigns or unassigns an issue.
 // Requires authentication and 'Browse' permission on the project.
-func (s *IssuesService) Assign(opt *IssuesAssignOptions) (v *IssuesAssign, resp *http.Response, err error) {
+func (s *IssuesService) Assign(ctx context.Context, opt *IssuesAssignOptions) (v *IssuesAssign, resp *http.Response, err error) {
 	err = s.ValidateAssignOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "issues/assign", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "issues/assign", opt)
 	if err != nil {
 		return
 	}
@@ -854,13 +855,13 @@ func (s *IssuesService) Assign(opt *IssuesAssignOptions) (v *IssuesAssign, resp 
 
 // Authors searches SCM accounts which match a given query.
 // Requires authentication. Returns 503 when issue indexing is in progress.
-func (s *IssuesService) Authors(opt *IssuesAuthorsOptions) (v *IssuesAuthors, resp *http.Response, err error) {
+func (s *IssuesService) Authors(ctx context.Context, opt *IssuesAuthorsOptions) (v *IssuesAuthors, resp *http.Response, err error) {
 	err = s.ValidateAuthorsOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "issues/authors", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "issues/authors", opt)
 	if err != nil {
 		return
 	}
@@ -877,13 +878,13 @@ func (s *IssuesService) Authors(opt *IssuesAuthorsOptions) (v *IssuesAuthors, re
 
 // BulkChange performs bulk changes on issues. Up to 500 issues can be updated.
 // Requires authentication.
-func (s *IssuesService) BulkChange(opt *IssuesBulkChangeOptions) (v *IssuesBulkChange, resp *http.Response, err error) {
+func (s *IssuesService) BulkChange(ctx context.Context, opt *IssuesBulkChangeOptions) (v *IssuesBulkChange, resp *http.Response, err error) {
 	err = s.ValidateBulkChangeOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "issues/bulk_change", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "issues/bulk_change", opt)
 	if err != nil {
 		return
 	}
@@ -900,13 +901,13 @@ func (s *IssuesService) BulkChange(opt *IssuesBulkChangeOptions) (v *IssuesBulkC
 
 // Changelog displays the changelog of an issue.
 // Requires 'Browse' permission on the project of the specified issue.
-func (s *IssuesService) Changelog(opt *IssuesChangelogOptions) (v *IssuesChangelog, resp *http.Response, err error) {
+func (s *IssuesService) Changelog(ctx context.Context, opt *IssuesChangelogOptions) (v *IssuesChangelog, resp *http.Response, err error) {
 	err = s.ValidateChangelogOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "issues/changelog", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "issues/changelog", opt)
 	if err != nil {
 		return
 	}
@@ -923,13 +924,13 @@ func (s *IssuesService) Changelog(opt *IssuesChangelogOptions) (v *IssuesChangel
 
 // ComponentTags lists tags for issues under a given component.
 // Returns 503 when issue indexing is in progress.
-func (s *IssuesService) ComponentTags(opt *IssuesComponentTagsOptions) (v *IssuesComponentTags, resp *http.Response, err error) {
+func (s *IssuesService) ComponentTags(ctx context.Context, opt *IssuesComponentTagsOptions) (v *IssuesComponentTags, resp *http.Response, err error) {
 	err = s.ValidateComponentTagsOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "issues/component_tags", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "issues/component_tags", opt)
 	if err != nil {
 		return
 	}
@@ -946,13 +947,13 @@ func (s *IssuesService) ComponentTags(opt *IssuesComponentTagsOptions) (v *Issue
 
 // DeleteComment deletes a comment.
 // Requires authentication and 'Browse' permission on the project of the specified issue.
-func (s *IssuesService) DeleteComment(opt *IssuesDeleteCommentOptions) (v *IssuesDeleteComment, resp *http.Response, err error) {
+func (s *IssuesService) DeleteComment(ctx context.Context, opt *IssuesDeleteCommentOptions) (v *IssuesDeleteComment, resp *http.Response, err error) {
 	err = s.ValidateDeleteCommentOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "issues/delete_comment", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "issues/delete_comment", opt)
 	if err != nil {
 		return
 	}
@@ -971,13 +972,13 @@ func (s *IssuesService) DeleteComment(opt *IssuesDeleteCommentOptions) (v *Issue
 // Requires authentication and 'Browse' permission on the project.
 // Transitions 'accept', 'wontfix', and 'falsepositive' require 'Administer Issues' permission.
 // Security hotspot transitions require 'Administer Security Hotspot' permission.
-func (s *IssuesService) DoTransition(opt *IssuesDoTransitionOptions) (v *IssuesDoTransition, resp *http.Response, err error) {
+func (s *IssuesService) DoTransition(ctx context.Context, opt *IssuesDoTransitionOptions) (v *IssuesDoTransition, resp *http.Response, err error) {
 	err = s.ValidateDoTransitionOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "issues/do_transition", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "issues/do_transition", opt)
 	if err != nil {
 		return
 	}
@@ -994,13 +995,13 @@ func (s *IssuesService) DoTransition(opt *IssuesDoTransitionOptions) (v *IssuesD
 
 // EditComment edits a comment.
 // Requires authentication and 'Browse' permission on the project of the specified issue.
-func (s *IssuesService) EditComment(opt *IssuesEditCommentOptions) (v *IssuesEditComment, resp *http.Response, err error) {
+func (s *IssuesService) EditComment(ctx context.Context, opt *IssuesEditCommentOptions) (v *IssuesEditComment, resp *http.Response, err error) {
 	err = s.ValidateEditCommentOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "issues/edit_comment", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "issues/edit_comment", opt)
 	if err != nil {
 		return
 	}
@@ -1018,13 +1019,13 @@ func (s *IssuesService) EditComment(opt *IssuesEditCommentOptions) (v *IssuesEdi
 // List lists issues in degraded mode when issue indexing is running.
 // Either 'project' or 'component' parameter is required.
 // Requires 'Browse' permission on the specified project.
-func (s *IssuesService) List(opt *IssuesListOptions) (v *IssuesList, resp *http.Response, err error) {
+func (s *IssuesService) List(ctx context.Context, opt *IssuesListOptions) (v *IssuesList, resp *http.Response, err error) {
 	err = s.ValidateListOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "issues/list", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "issues/list", opt)
 	if err != nil {
 		return
 	}
@@ -1042,13 +1043,13 @@ func (s *IssuesService) List(opt *IssuesListOptions) (v *IssuesList, resp *http.
 // Pull fetches all issues for a given branch.
 // The issues returned are not paginated, so the response size can be big.
 // Requires 'Browse' permission on the project.
-func (s *IssuesService) Pull(opt *IssuesPullOptions) (v []byte, resp *http.Response, err error) {
+func (s *IssuesService) Pull(ctx context.Context, opt *IssuesPullOptions) (v []byte, resp *http.Response, err error) {
 	err = s.ValidatePullOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "issues/pull", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "issues/pull", opt)
 	if err != nil {
 		return
 	}
@@ -1064,13 +1065,13 @@ func (s *IssuesService) Pull(opt *IssuesPullOptions) (v []byte, resp *http.Respo
 // PullTaint fetches all taint vulnerabilities for a given branch.
 // The vulnerabilities returned are not paginated, so the response size can be big.
 // Requires 'Browse' permission on the project.
-func (s *IssuesService) PullTaint(opt *IssuesPullTaintOptions) (v []byte, resp *http.Response, err error) {
+func (s *IssuesService) PullTaint(ctx context.Context, opt *IssuesPullTaintOptions) (v []byte, resp *http.Response, err error) {
 	err = s.ValidatePullTaintOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "issues/pull_taint", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "issues/pull_taint", opt)
 	if err != nil {
 		return
 	}
@@ -1085,13 +1086,13 @@ func (s *IssuesService) PullTaint(opt *IssuesPullTaintOptions) (v []byte, resp *
 
 // Reindex triggers reindexing of issues for a project.
 // Requires 'Administer System' permission.
-func (s *IssuesService) Reindex(opt *IssuesReindexOptions) (resp *http.Response, err error) {
+func (s *IssuesService) Reindex(ctx context.Context, opt *IssuesReindexOptions) (resp *http.Response, err error) {
 	err = s.ValidateReindexOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "issues/reindex", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "issues/reindex", opt)
 	if err != nil {
 		return
 	}
@@ -1108,13 +1109,13 @@ func (s *IssuesService) Reindex(opt *IssuesReindexOptions) (resp *http.Response,
 // Requires 'Browse' permission on the specified project(s).
 // For applications, it also requires 'Browse' permission on child projects.
 // Returns 503 when issue indexing is in progress.
-func (s *IssuesService) Search(opt *IssuesSearchOptions) (v *IssuesSearch, resp *http.Response, err error) {
+func (s *IssuesService) Search(ctx context.Context, opt *IssuesSearchOptions) (v *IssuesSearch, resp *http.Response, err error) {
 	err = s.ValidateSearchOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "issues/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "issues/search", opt)
 	if err != nil {
 		return
 	}
@@ -1131,13 +1132,13 @@ func (s *IssuesService) Search(opt *IssuesSearchOptions) (v *IssuesSearch, resp 
 
 // SetSeverity changes the severity of an issue.
 // Requires authentication, 'Browse' and 'Administer Issues' permissions on the project.
-func (s *IssuesService) SetSeverity(opt *IssuesSetSeverityOptions) (v *IssuesSetSeverity, resp *http.Response, err error) {
+func (s *IssuesService) SetSeverity(ctx context.Context, opt *IssuesSetSeverityOptions) (v *IssuesSetSeverity, resp *http.Response, err error) {
 	err = s.ValidateSetSeverityOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "issues/set_severity", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "issues/set_severity", opt)
 	if err != nil {
 		return
 	}
@@ -1154,13 +1155,13 @@ func (s *IssuesService) SetSeverity(opt *IssuesSetSeverityOptions) (v *IssuesSet
 
 // SetTags sets tags on an issue.
 // Requires authentication and 'Browse' permission on the project.
-func (s *IssuesService) SetTags(opt *IssuesSetTagsOptions) (v *IssuesSetTags, resp *http.Response, err error) {
+func (s *IssuesService) SetTags(ctx context.Context, opt *IssuesSetTagsOptions) (v *IssuesSetTags, resp *http.Response, err error) {
 	err = s.ValidateSetTagsOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "issues/set_tags", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "issues/set_tags", opt)
 	if err != nil {
 		return
 	}
@@ -1177,13 +1178,13 @@ func (s *IssuesService) SetTags(opt *IssuesSetTagsOptions) (v *IssuesSetTags, re
 
 // SetType changes the type of an issue.
 // Requires authentication, 'Browse' and 'Administer Issues' permissions on the project.
-func (s *IssuesService) SetType(opt *IssuesSetTypeOptions) (v *IssuesSetType, resp *http.Response, err error) {
+func (s *IssuesService) SetType(ctx context.Context, opt *IssuesSetTypeOptions) (v *IssuesSetType, resp *http.Response, err error) {
 	err = s.ValidateSetTypeOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "issues/set_type", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "issues/set_type", opt)
 	if err != nil {
 		return
 	}
@@ -1199,13 +1200,13 @@ func (s *IssuesService) SetType(opt *IssuesSetTypeOptions) (v *IssuesSetType, re
 }
 
 // Tags lists tags matching a given query.
-func (s *IssuesService) Tags(opt *IssuesTagsOptions) (v *IssuesTags, resp *http.Response, err error) {
+func (s *IssuesService) Tags(ctx context.Context, opt *IssuesTagsOptions) (v *IssuesTags, resp *http.Response, err error) {
 	err = s.ValidateTagsOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "issues/tags", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "issues/tags", opt)
 	if err != nil {
 		return
 	}

--- a/sonar/issues_service_test.go
+++ b/sonar/issues_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -33,7 +34,7 @@ func TestIssues_AddComment(t *testing.T) {
 		Issue: "AU-Tpxb--iU5OvuD2FLy",
 		Text:  "This is a comment",
 	}
-	result, resp, err := client.Issues.AddComment(opt)
+	result, resp, err := client.Issues.AddComment(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "AU-Tpxb--iU5OvuD2FLy", result.Issue.Key)
@@ -62,7 +63,7 @@ func TestIssues_AddComment_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Issues.AddComment(tt.opt)
+			_, _, err := client.Issues.AddComment(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -93,7 +94,7 @@ func TestIssues_Assign(t *testing.T) {
 		Issue:    "test-key",
 		Assignee: "admin",
 	}
-	result, resp, err := client.Issues.Assign(opt)
+	result, resp, err := client.Issues.Assign(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "admin", result.Issue.Assignee)
@@ -119,7 +120,7 @@ func TestIssues_Authors(t *testing.T) {
 		Project:  "my-project",
 		PageSize: 50,
 	}
-	result, resp, err := client.Issues.Authors(opt)
+	result, resp, err := client.Issues.Authors(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Authors, 2)
@@ -128,7 +129,7 @@ func TestIssues_Authors(t *testing.T) {
 func TestIssues_Authors_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.Issues.Authors(&IssuesAuthorsOptions{PageSize: 150})
+	_, _, err := client.Issues.Authors(context.Background(), &IssuesAuthorsOptions{PageSize: 150})
 	assert.Error(t, err)
 }
 
@@ -153,7 +154,7 @@ func TestIssues_BulkChange(t *testing.T) {
 		SetSeverity: RuleSeverityMajor,
 		AddTags:     []string{"tag1", "tag2"},
 	}
-	result, resp, err := client.Issues.BulkChange(opt)
+	result, resp, err := client.Issues.BulkChange(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, int64(8), result.Success)
@@ -199,7 +200,7 @@ func TestIssues_BulkChange_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Issues.BulkChange(tt.opt)
+			_, _, err := client.Issues.BulkChange(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -233,7 +234,7 @@ func TestIssues_Changelog(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	opt := &IssuesChangelogOptions{Issue: "test-key"}
-	result, resp, err := client.Issues.Changelog(opt)
+	result, resp, err := client.Issues.Changelog(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Changelog, 1)
@@ -256,7 +257,7 @@ func TestIssues_ComponentTags(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	opt := &IssuesComponentTagsOptions{ComponentUuid: "uuid-123"}
-	result, resp, err := client.Issues.ComponentTags(opt)
+	result, resp, err := client.Issues.ComponentTags(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Tags, 1)
@@ -279,7 +280,7 @@ func TestIssues_DeleteComment(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	opt := &IssuesDeleteCommentOptions{Comment: "comment-key"}
-	result, resp, err := client.Issues.DeleteComment(opt)
+	result, resp, err := client.Issues.DeleteComment(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "test-key", result.Issue.Key)
@@ -305,7 +306,7 @@ func TestIssues_DoTransition(t *testing.T) {
 		Issue:      "test-key",
 		Transition: IssueTransitionConfirm,
 	}
-	result, resp, err := client.Issues.DoTransition(opt)
+	result, resp, err := client.Issues.DoTransition(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "test-key", result.Issue.Key)
@@ -314,7 +315,7 @@ func TestIssues_DoTransition(t *testing.T) {
 func TestIssues_DoTransition_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.Issues.DoTransition(&IssuesDoTransitionOptions{
+	_, _, err := client.Issues.DoTransition(context.Background(), &IssuesDoTransitionOptions{
 		Issue:      "test-key",
 		Transition: "invalid",
 	})
@@ -341,7 +342,7 @@ func TestIssues_EditComment(t *testing.T) {
 		Comment: "comment-key",
 		Text:    "Updated comment",
 	}
-	result, resp, err := client.Issues.EditComment(opt)
+	result, resp, err := client.Issues.EditComment(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "test-key", result.Issue.Key)
@@ -370,7 +371,7 @@ func TestIssues_List(t *testing.T) {
 	opt := &IssuesListOptions{
 		Project: "my-project",
 	}
-	result, resp, err := client.Issues.List(opt)
+	result, resp, err := client.Issues.List(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Issues, 1)
@@ -402,7 +403,7 @@ func TestIssues_List_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Issues.List(tt.opt)
+			_, _, err := client.Issues.List(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -437,7 +438,7 @@ func TestIssues_Search(t *testing.T) {
 		Types:            []string{RuleTypeBug},
 		ImpactSeverities: []string{RuleImpactSeverityHigh},
 	}
-	result, resp, err := client.Issues.Search(opt)
+	result, resp, err := client.Issues.Search(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Issues, 1)
@@ -484,7 +485,7 @@ func TestIssues_Search_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Issues.Search(tt.opt)
+			_, _, err := client.Issues.Search(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -510,7 +511,7 @@ func TestIssues_SetSeverity(t *testing.T) {
 		Issue:    "test-key",
 		Severity: RuleSeverityBlocker,
 	}
-	result, resp, err := client.Issues.SetSeverity(opt)
+	result, resp, err := client.Issues.SetSeverity(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, RuleSeverityBlocker, result.Issue.Severity)
@@ -519,7 +520,7 @@ func TestIssues_SetSeverity(t *testing.T) {
 func TestIssues_SetSeverity_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.Issues.SetSeverity(&IssuesSetSeverityOptions{
+	_, _, err := client.Issues.SetSeverity(context.Background(), &IssuesSetSeverityOptions{
 		Issue:    "test-key",
 		Severity: "INVALID",
 	})
@@ -546,7 +547,7 @@ func TestIssues_SetTags(t *testing.T) {
 		Issue: "test-key",
 		Tags:  []string{"security", "cwe"},
 	}
-	result, resp, err := client.Issues.SetTags(opt)
+	result, resp, err := client.Issues.SetTags(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Issue.Tags, 2)
@@ -572,7 +573,7 @@ func TestIssues_SetType(t *testing.T) {
 		Issue: "test-key",
 		Type:  RuleTypeBug,
 	}
-	result, resp, err := client.Issues.SetType(opt)
+	result, resp, err := client.Issues.SetType(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, RuleTypeBug, result.Issue.Type)
@@ -604,7 +605,7 @@ func TestIssues_SetType_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Issues.SetType(tt.opt)
+			_, _, err := client.Issues.SetType(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -630,7 +631,7 @@ func TestIssues_Tags(t *testing.T) {
 		Project:  "my-project",
 		PageSize: 100,
 	}
-	result, resp, err := client.Issues.Tags(opt)
+	result, resp, err := client.Issues.Tags(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Tags, 3)
@@ -656,7 +657,7 @@ func TestIssues_Pull(t *testing.T) {
 		ProjectKey: "my-project",
 		BranchName: "main",
 	}
-	result, resp, err := client.Issues.Pull(opt)
+	result, resp, err := client.Issues.Pull(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotNil(t, result)
@@ -688,7 +689,7 @@ func TestIssues_Pull_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Issues.Pull(tt.opt)
+			_, _, err := client.Issues.Pull(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -714,7 +715,7 @@ func TestIssues_PullTaint(t *testing.T) {
 		ProjectKey: "my-project",
 		BranchName: "main",
 	}
-	result, resp, err := client.Issues.PullTaint(opt)
+	result, resp, err := client.Issues.PullTaint(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotNil(t, result)
@@ -735,7 +736,7 @@ func TestIssues_Reindex(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	opt := &IssuesReindexOptions{Project: "my-project"}
-	resp, err := client.Issues.Reindex(opt)
+	resp, err := client.Issues.Reindex(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -755,7 +756,7 @@ func TestIssues_AnticipatedTransitions(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	opt := &IssuesAnticipatedTransitionsOptions{ProjectKey: "my-project"}
-	resp, err := client.Issues.AnticipatedTransitions(opt)
+	resp, err := client.Issues.AnticipatedTransitions(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
 }
@@ -779,7 +780,7 @@ func TestIssues_AnticipatedTransitions_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.Issues.AnticipatedTransitions(tt.opt)
+			_, err := client.Issues.AnticipatedTransitions(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}

--- a/sonar/l10n_service.go
+++ b/sonar/l10n_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // L10NService handles communication with the localization related methods
 // of the SonarQube API.
@@ -54,13 +57,13 @@ func (s *L10NService) ValidateGetIndexOpt(opt *L10NIndexOptions) error {
 //
 // API endpoint: GET /api/l10n/index.
 // Warning: This API is internal and may change without notice.
-func (s *L10NService) GetIndex(opt *L10NIndexOptions) (*L10NIndex, *http.Response, error) {
+func (s *L10NService) GetIndex(ctx context.Context, opt *L10NIndexOptions) (*L10NIndex, *http.Response, error) {
 	err := s.ValidateGetIndexOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "l10n/index", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "l10n/index", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/l10n_service_test.go
+++ b/sonar/l10n_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -22,7 +23,7 @@ func TestL10N_Index(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.L10N.GetIndex(nil)
+	result, resp, err := client.L10N.GetIndex(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -44,7 +45,7 @@ func TestL10N_Index_WithLocale(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.L10N.GetIndex(&L10NIndexOptions{Locale: "fr"})
+	result, resp, err := client.L10N.GetIndex(context.Background(), &L10NIndexOptions{Locale: "fr"})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "fr", result.Locale)
@@ -56,7 +57,7 @@ func TestL10N_Index_WithTimestamp(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	_, _, err := client.L10N.GetIndex(&L10NIndexOptions{Timestamp: "2024-01-01T00:00:00+0000"})
+	_, _, err := client.L10N.GetIndex(context.Background(), &L10NIndexOptions{Timestamp: "2024-01-01T00:00:00+0000"})
 	require.NoError(t, err)
 }
 
@@ -65,7 +66,7 @@ func TestL10N_Index_EmptyMessages(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, _, err := client.L10N.GetIndex(nil)
+	result, _, err := client.L10N.GetIndex(context.Background(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, result.Messages)
 	assert.Empty(t, result.Messages)

--- a/sonar/languages_service.go
+++ b/sonar/languages_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // LanguagesService handles communication with the languages related methods
 // of the SonarQube API.
@@ -61,13 +64,13 @@ func (s *LanguagesService) ValidateListOpt(opt *LanguagesListOptions) error {
 //
 // API endpoint: GET /api/languages/list.
 // Since: 5.1.
-func (s *LanguagesService) List(opt *LanguagesListOptions) (*LanguagesList, *http.Response, error) {
+func (s *LanguagesService) List(ctx context.Context, opt *LanguagesListOptions) (*LanguagesList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "languages/list", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "languages/list", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/languages_service_test.go
+++ b/sonar/languages_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -20,7 +21,7 @@ func TestLanguages_List(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.Languages.List(&LanguagesListOptions{})
+	result, resp, err := client.Languages.List(context.Background(), &LanguagesListOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -35,7 +36,7 @@ func TestLanguages_List_WithQuery(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.Languages.List(&LanguagesListOptions{Query: "java"})
+	result, resp, err := client.Languages.List(context.Background(), &LanguagesListOptions{Query: "java"})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Languages, 1)
@@ -46,7 +47,7 @@ func TestLanguages_List_NilOption(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.Languages.List(nil)
+	result, resp, err := client.Languages.List(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/marketplace_v2_service.go
+++ b/sonar/marketplace_v2_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -30,8 +31,8 @@ type MarketplaceAzureBillingV2 struct {
 
 // BillAzureAccount bills the user's Azure account with the cost of the
 // SonarQube Server license. Used by admins.
-func (s *MarketplaceService) BillAzureAccount() (*MarketplaceAzureBillingV2, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodPost, "marketplace/azure/billing", nil, nil)
+func (s *MarketplaceService) BillAzureAccount(ctx context.Context) (*MarketplaceAzureBillingV2, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPost, "marketplace/azure/billing", nil, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/sonar/marketplace_v2_service_test.go
+++ b/sonar/marketplace_v2_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -20,7 +21,7 @@ func TestMarketplaceV2_BillAzureAccount(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/v2/marketplace/azure/billing", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Marketplace.BillAzureAccount()
+	result, resp, err := client.V2.Marketplace.BillAzureAccount(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.True(t, result.Success)

--- a/sonar/measures_service.go
+++ b/sonar/measures_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -389,13 +390,13 @@ func (s *MeasuresService) ValidateSearchHistoryOpt(opt *MeasuresSearchHistoryOpt
 // Requires the following permission: 'Browse' on the project of specified component.
 //
 // Since: 5.4.
-func (s *MeasuresService) Component(opt *MeasuresComponentOptions) (*MeasuresComponent, *http.Response, error) {
+func (s *MeasuresService) Component(ctx context.Context, opt *MeasuresComponentOptions) (*MeasuresComponent, *http.Response, error) {
 	err := s.ValidateComponentOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "measures/component", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "measures/component", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -416,13 +417,13 @@ func (s *MeasuresService) Component(opt *MeasuresComponentOptions) (*MeasuresCom
 // When limiting search with the q parameter, directories are not returned.
 //
 // Since: 5.4.
-func (s *MeasuresService) ComponentTree(opt *MeasuresComponentTreeOptions) (*MeasuresComponentTree, *http.Response, error) {
+func (s *MeasuresService) ComponentTree(ctx context.Context, opt *MeasuresComponentTreeOptions) (*MeasuresComponentTree, *http.Response, error) {
 	err := s.ValidateComponentTreeOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "measures/component_tree", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "measures/component_tree", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -442,13 +443,13 @@ func (s *MeasuresService) ComponentTree(opt *MeasuresComponentTreeOptions) (*Mea
 // At most 100 projects can be provided.
 //
 // Since: 6.2.
-func (s *MeasuresService) Search(opt *MeasuresSearchOptions) (*MeasuresSearch, *http.Response, error) {
+func (s *MeasuresService) Search(ctx context.Context, opt *MeasuresSearchOptions) (*MeasuresSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "measures/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "measures/search", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -468,13 +469,13 @@ func (s *MeasuresService) Search(opt *MeasuresSearchOptions) (*MeasuresSearch, *
 // Requires the following permission: 'Browse' on the specified component.
 //
 // Since: 6.3.
-func (s *MeasuresService) SearchHistory(opt *MeasuresSearchHistoryOptions) (*MeasuresSearchHistory, *http.Response, error) {
+func (s *MeasuresService) SearchHistory(ctx context.Context, opt *MeasuresSearchHistoryOptions) (*MeasuresSearchHistory, *http.Response, error) {
 	err := s.ValidateSearchHistoryOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "measures/search_history", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "measures/search_history", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/measures_service_test.go
+++ b/sonar/measures_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -38,7 +39,7 @@ func TestMeasuresService_Component(t *testing.T) {
 		MetricKeys: []string{"coverage", "bugs", "vulnerabilities"},
 	}
 
-	result, resp, err := client.Measures.Component(opt)
+	result, resp, err := client.Measures.Component(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "my-project", result.Component.Key)
@@ -53,14 +54,14 @@ func TestMeasuresService_Component_ValidationError(t *testing.T) {
 	opt := &MeasuresComponentOptions{
 		MetricKeys: []string{"coverage"},
 	}
-	_, _, err := client.Measures.Component(opt)
+	_, _, err := client.Measures.Component(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test missing MetricKeys
 	opt = &MeasuresComponentOptions{
 		Component: "my-project",
 	}
-	_, _, err = client.Measures.Component(opt)
+	_, _, err = client.Measures.Component(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -99,7 +100,7 @@ func TestMeasuresService_ComponentTree(t *testing.T) {
 		Strategy:   MeasureStrategyAll,
 	}
 
-	result, resp, err := client.Measures.ComponentTree(opt)
+	result, resp, err := client.Measures.ComponentTree(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "my-project", result.BaseComponent.Key)
@@ -114,14 +115,14 @@ func TestMeasuresService_ComponentTree_ValidationError(t *testing.T) {
 	opt := &MeasuresComponentTreeOptions{
 		MetricKeys: []string{"coverage"},
 	}
-	_, _, err := client.Measures.ComponentTree(opt)
+	_, _, err := client.Measures.ComponentTree(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test missing MetricKeys
 	opt = &MeasuresComponentTreeOptions{
 		Component: "my-project",
 	}
-	_, _, err = client.Measures.ComponentTree(opt)
+	_, _, err = client.Measures.ComponentTree(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test invalid Strategy
@@ -130,7 +131,7 @@ func TestMeasuresService_ComponentTree_ValidationError(t *testing.T) {
 		MetricKeys: []string{"coverage"},
 		Strategy:   "invalid",
 	}
-	_, _, err = client.Measures.ComponentTree(opt)
+	_, _, err = client.Measures.ComponentTree(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test invalid MetricSortFilter
@@ -139,7 +140,7 @@ func TestMeasuresService_ComponentTree_ValidationError(t *testing.T) {
 		MetricKeys:       []string{"coverage"},
 		MetricSortFilter: "invalid",
 	}
-	_, _, err = client.Measures.ComponentTree(opt)
+	_, _, err = client.Measures.ComponentTree(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -160,7 +161,7 @@ func TestMeasuresService_Search(t *testing.T) {
 		ProjectKeys: []string{"project1", "project2"},
 	}
 
-	result, resp, err := client.Measures.Search(opt)
+	result, resp, err := client.Measures.Search(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Measures, 2)
@@ -174,14 +175,14 @@ func TestMeasuresService_Search_ValidationError(t *testing.T) {
 	opt := &MeasuresSearchOptions{
 		ProjectKeys: []string{"project1"},
 	}
-	_, _, err := client.Measures.Search(opt)
+	_, _, err := client.Measures.Search(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test missing ProjectKeys
 	opt = &MeasuresSearchOptions{
 		MetricKeys: []string{"coverage"},
 	}
-	_, _, err = client.Measures.Search(opt)
+	_, _, err = client.Measures.Search(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -211,7 +212,7 @@ func TestMeasuresService_SearchHistory(t *testing.T) {
 		To:        "2024-03-01",
 	}
 
-	result, resp, err := client.Measures.SearchHistory(opt)
+	result, resp, err := client.Measures.SearchHistory(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Measures, 1)
@@ -226,13 +227,13 @@ func TestMeasuresService_SearchHistory_ValidationError(t *testing.T) {
 	opt := &MeasuresSearchHistoryOptions{
 		Metrics: []string{"coverage"},
 	}
-	_, _, err := client.Measures.SearchHistory(opt)
+	_, _, err := client.Measures.SearchHistory(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test missing Metrics
 	opt = &MeasuresSearchHistoryOptions{
 		Component: "my-project",
 	}
-	_, _, err = client.Measures.SearchHistory(opt)
+	_, _, err = client.Measures.SearchHistory(context.Background(), opt)
 	assert.Error(t, err)
 }

--- a/sonar/metrics_service.go
+++ b/sonar/metrics_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // MetricsService handles communication with the metrics related methods
 // of the SonarQube API.
@@ -85,13 +88,13 @@ func (s *MetricsService) ValidateSearchOpt(opt *MetricsSearchOptions) error {
 //
 // API endpoint: GET /api/metrics/search.
 // Since: 2.6.
-func (s *MetricsService) Search(opt *MetricsSearchOptions) (*MetricsSearch, *http.Response, error) {
+func (s *MetricsService) Search(ctx context.Context, opt *MetricsSearchOptions) (*MetricsSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "metrics/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "metrics/search", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -110,8 +113,8 @@ func (s *MetricsService) Search(opt *MetricsSearchOptions) (*MetricsSearch, *htt
 //
 // API endpoint: GET /api/metrics/types.
 // Since: 2.6.
-func (s *MetricsService) Types() (*MetricsTypes, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "metrics/types", nil)
+func (s *MetricsService) Types(ctx context.Context) (*MetricsTypes, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "metrics/types", nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/metrics_service_test.go
+++ b/sonar/metrics_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -46,7 +47,7 @@ func TestMetrics_Search(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.Metrics.Search(nil)
+	result, resp, err := client.Metrics.Search(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -69,7 +70,7 @@ func TestMetrics_Search_WithPagination(t *testing.T) {
 		},
 	}
 
-	_, resp, err := client.Metrics.Search(opt)
+	_, resp, err := client.Metrics.Search(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -80,7 +81,7 @@ func TestMetrics_Types(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.Metrics.Types()
+	result, resp, err := client.Metrics.Types(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/monitoring_service.go
+++ b/sonar/monitoring_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // MonitoringService handles communication with the monitoring related methods
 // of the SonarQube API.
@@ -21,8 +24,8 @@ type MonitoringService struct {
 //
 // API endpoint: GET /api/monitoring/metrics.
 // Since: 9.3.
-func (s *MonitoringService) Metrics() (*string, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "monitoring/metrics", nil)
+func (s *MonitoringService) Metrics(ctx context.Context) (*string, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "monitoring/metrics", nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/monitoring_service_test.go
+++ b/sonar/monitoring_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -17,7 +18,7 @@ sonarqube_health 1`
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.Monitoring.Metrics()
+	result, resp, err := client.Monitoring.Metrics(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/navigation_service.go
+++ b/sonar/navigation_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // NavigationService handles communication with the navigation related methods
 // of the SonarQube API.
@@ -227,13 +230,13 @@ func (s *NavigationService) ValidateComponentOpt(opt *NavigationComponentOptions
 // API endpoint: GET /api/navigation/component.
 // Since: 5.2.
 // Internal: true.
-func (s *NavigationService) Component(opt *NavigationComponentOptions) (*NavigationComponent, *http.Response, error) {
+func (s *NavigationService) Component(ctx context.Context, opt *NavigationComponentOptions) (*NavigationComponent, *http.Response, error) {
 	err := s.ValidateComponentOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "navigation/component", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "navigation/component", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -253,8 +256,8 @@ func (s *NavigationService) Component(opt *NavigationComponentOptions) (*Navigat
 // API endpoint: GET /api/navigation/global.
 // Since: 5.2.
 // Internal: true.
-func (s *NavigationService) Global() (*NavigationGlobal, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "navigation/global", nil)
+func (s *NavigationService) Global(ctx context.Context) (*NavigationGlobal, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "navigation/global", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -275,8 +278,8 @@ func (s *NavigationService) Global() (*NavigationGlobal, *http.Response, error) 
 // API endpoint: GET /api/navigation/marketplace.
 // Since: 7.2.
 // Internal: true.
-func (s *NavigationService) Marketplace() (*NavigationMarketplace, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "navigation/marketplace", nil)
+func (s *NavigationService) Marketplace(ctx context.Context) (*NavigationMarketplace, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "navigation/marketplace", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -297,8 +300,8 @@ func (s *NavigationService) Marketplace() (*NavigationMarketplace, *http.Respons
 // API endpoint: GET /api/navigation/settings.
 // Since: 5.2.
 // Internal: true.
-func (s *NavigationService) Settings() (*NavigationSettings, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "navigation/settings", nil)
+func (s *NavigationService) Settings(ctx context.Context) (*NavigationSettings, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "navigation/settings", nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/navigation_service_test.go
+++ b/sonar/navigation_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -35,7 +36,7 @@ func TestNavigationService_Component(t *testing.T) {
 			Component: "my-project",
 		}
 
-		result, resp, err := client.Navigation.Component(opt)
+		result, resp, err := client.Navigation.Component(context.Background(), opt)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, "my-project", result.Key)
@@ -60,7 +61,7 @@ func TestNavigationService_Component(t *testing.T) {
 			Branch:    "feature/my-branch",
 		}
 
-		_, _, err := client.Navigation.Component(opt)
+		_, _, err := client.Navigation.Component(context.Background(), opt)
 		require.NoError(t, err)
 	})
 
@@ -68,7 +69,7 @@ func TestNavigationService_Component(t *testing.T) {
 		server := newTestServer(t, mockHandler(t, http.MethodGet, "/navigation/component", http.StatusOK, NavigationComponent{}))
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Navigation.Component(nil)
+		_, _, err := client.Navigation.Component(context.Background(), nil)
 		require.NoError(t, err)
 	})
 }
@@ -90,7 +91,7 @@ func TestNavigationService_Global(t *testing.T) {
 		server := newTestServer(t, mockHandler(t, http.MethodGet, "/navigation/global", http.StatusOK, response))
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Navigation.Global()
+		result, resp, err := client.Navigation.Global(context.Background(), )
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, "10.5.0", result.Version)
@@ -108,7 +109,7 @@ func TestNavigationService_Marketplace(t *testing.T) {
 		server := newTestServer(t, mockHandler(t, http.MethodGet, "/navigation/marketplace", http.StatusOK, response))
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Navigation.Marketplace()
+		result, resp, err := client.Navigation.Marketplace(context.Background(), )
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, int64(1000000), result.Ncloc)
@@ -127,7 +128,7 @@ func TestNavigationService_Settings(t *testing.T) {
 		server := newTestServer(t, mockHandler(t, http.MethodGet, "/navigation/settings", http.StatusOK, response))
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Navigation.Settings()
+		result, resp, err := client.Navigation.Settings(context.Background(), )
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.True(t, result.ShowUpdateCenter)

--- a/sonar/new_code_periods_service.go
+++ b/sonar/new_code_periods_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 )
@@ -206,13 +207,13 @@ func (s *NewCodePeriodsService) ValidateUnsetOpt(opt *NewCodePeriodsUnsetOptions
 //
 // API endpoint: GET /api/new_code_periods/list.
 // Since: 8.0.
-func (s *NewCodePeriodsService) List(opt *NewCodePeriodsListOptions) (*NewCodePeriodsList, *http.Response, error) {
+func (s *NewCodePeriodsService) List(ctx context.Context, opt *NewCodePeriodsListOptions) (*NewCodePeriodsList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "new_code_periods/list", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "new_code_periods/list", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -238,13 +239,13 @@ func (s *NewCodePeriodsService) List(opt *NewCodePeriodsListOptions) (*NewCodePe
 //
 // API endpoint: POST /api/new_code_periods/set.
 // Since: 8.0.
-func (s *NewCodePeriodsService) Set(opt *NewCodePeriodsSetOptions) (*http.Response, error) {
+func (s *NewCodePeriodsService) Set(ctx context.Context, opt *NewCodePeriodsSetOptions) (*http.Response, error) {
 	err := s.ValidateSetOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "new_code_periods/set", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "new_code_periods/set", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -267,13 +268,13 @@ func (s *NewCodePeriodsService) Set(opt *NewCodePeriodsSetOptions) (*http.Respon
 //
 // API endpoint: GET /api/new_code_periods/show.
 // Since: 8.0.
-func (s *NewCodePeriodsService) Show(opt *NewCodePeriodsShowOptions) (*NewCodePeriodsShow, *http.Response, error) {
+func (s *NewCodePeriodsService) Show(ctx context.Context, opt *NewCodePeriodsShowOptions) (*NewCodePeriodsShow, *http.Response, error) {
 	err := s.ValidateShowOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "new_code_periods/show", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "new_code_periods/show", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -297,13 +298,13 @@ func (s *NewCodePeriodsService) Show(opt *NewCodePeriodsShowOptions) (*NewCodePe
 //
 // API endpoint: POST /api/new_code_periods/unset.
 // Since: 8.0.
-func (s *NewCodePeriodsService) Unset(opt *NewCodePeriodsUnsetOptions) (*http.Response, error) {
+func (s *NewCodePeriodsService) Unset(ctx context.Context, opt *NewCodePeriodsUnsetOptions) (*http.Response, error) {
 	err := s.ValidateUnsetOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "new_code_periods/unset", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "new_code_periods/unset", opt)
 	if err != nil {
 		return nil, err
 	}

--- a/sonar/new_code_periods_service_test.go
+++ b/sonar/new_code_periods_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -43,7 +44,7 @@ func TestNewCodePeriods_List(t *testing.T) {
 		Project: "my-project",
 	}
 
-	result, resp, err := client.NewCodePeriods.List(opt)
+	result, resp, err := client.NewCodePeriods.List(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -56,11 +57,11 @@ func TestNewCodePeriods_List_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.NewCodePeriods.List(nil)
+	_, _, err := client.NewCodePeriods.List(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, _, err = client.NewCodePeriods.List(&NewCodePeriodsListOptions{})
+	_, _, err = client.NewCodePeriods.List(context.Background(), &NewCodePeriodsListOptions{})
 	assert.Error(t, err)
 }
 
@@ -81,7 +82,7 @@ func TestNewCodePeriods_Set(t *testing.T) {
 		Value: "30",
 	}
 
-	resp, err := client.NewCodePeriods.Set(opt)
+	resp, err := client.NewCodePeriods.Set(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -90,27 +91,27 @@ func TestNewCodePeriods_Set_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.NewCodePeriods.Set(nil)
+	_, err := client.NewCodePeriods.Set(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Type should fail validation.
-	_, err = client.NewCodePeriods.Set(&NewCodePeriodsSetOptions{})
+	_, err = client.NewCodePeriods.Set(context.Background(), &NewCodePeriodsSetOptions{})
 	assert.Error(t, err)
 
 	// Invalid Type should fail validation.
-	_, err = client.NewCodePeriods.Set(&NewCodePeriodsSetOptions{
+	_, err = client.NewCodePeriods.Set(context.Background(), &NewCodePeriodsSetOptions{
 		Type: "INVALID_TYPE",
 	})
 	assert.Error(t, err)
 
 	// SPECIFIC_ANALYSIS without Branch should fail validation.
-	_, err = client.NewCodePeriods.Set(&NewCodePeriodsSetOptions{
+	_, err = client.NewCodePeriods.Set(context.Background(), &NewCodePeriodsSetOptions{
 		Type: NewCodePeriodTypeSpecificAnalysis,
 	})
 	assert.Error(t, err)
 
 	// REFERENCE_BRANCH without Project should fail validation.
-	_, err = client.NewCodePeriods.Set(&NewCodePeriodsSetOptions{
+	_, err = client.NewCodePeriods.Set(context.Background(), &NewCodePeriodsSetOptions{
 		Type: NewCodePeriodTypeReferenceBranch,
 	})
 	assert.Error(t, err)
@@ -126,7 +127,7 @@ func TestNewCodePeriods_Show(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/new_code_periods/show", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.NewCodePeriods.Show(nil)
+	result, resp, err := client.NewCodePeriods.Show(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -161,7 +162,7 @@ func TestNewCodePeriods_Show_WithOptions(t *testing.T) {
 		Branch:  "main",
 	}
 
-	result, _, err := client.NewCodePeriods.Show(opt)
+	result, _, err := client.NewCodePeriods.Show(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, "my-project", result.ProjectKey)
 	assert.Equal(t, NewCodePeriodTypeReferenceBranch, result.Type)
@@ -172,7 +173,7 @@ func TestNewCodePeriods_Unset(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/new_code_periods/unset", http.StatusOK))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.NewCodePeriods.Unset(nil)
+	resp, err := client.NewCodePeriods.Unset(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -192,7 +193,7 @@ func TestNewCodePeriods_Unset_WithOptions(t *testing.T) {
 		Project: "my-project",
 	}
 
-	resp, err := client.NewCodePeriods.Unset(opt)
+	resp, err := client.NewCodePeriods.Unset(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }

--- a/sonar/notifications_service.go
+++ b/sonar/notifications_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // NotificationsService handles communication with the notifications related methods
 // of the SonarQube API.
@@ -127,13 +130,13 @@ func (s *NotificationsService) ValidateRemoveOpt(opt *NotificationsRemoveOptions
 //
 // API endpoint: POST /api/notifications/add.
 // Since: 6.3.
-func (s *NotificationsService) Add(opt *NotificationsAddOptions) (*http.Response, error) {
+func (s *NotificationsService) Add(ctx context.Context, opt *NotificationsAddOptions) (*http.Response, error) {
 	err := s.ValidateAddOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "notifications/add", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "notifications/add", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -152,13 +155,13 @@ func (s *NotificationsService) Add(opt *NotificationsAddOptions) (*http.Response
 //
 // API endpoint: GET /api/notifications/list.
 // Since: 6.3.
-func (s *NotificationsService) List(opt *NotificationsListOptions) (*NotificationsList, *http.Response, error) {
+func (s *NotificationsService) List(ctx context.Context, opt *NotificationsListOptions) (*NotificationsList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "notifications/list", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "notifications/list", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -179,13 +182,13 @@ func (s *NotificationsService) List(opt *NotificationsListOptions) (*Notificatio
 //
 // API endpoint: POST /api/notifications/remove.
 // Since: 6.3.
-func (s *NotificationsService) Remove(opt *NotificationsRemoveOptions) (*http.Response, error) {
+func (s *NotificationsService) Remove(ctx context.Context, opt *NotificationsRemoveOptions) (*http.Response, error) {
 	err := s.ValidateRemoveOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "notifications/remove", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "notifications/remove", opt)
 	if err != nil {
 		return nil, err
 	}

--- a/sonar/notifications_service_test.go
+++ b/sonar/notifications_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -22,7 +23,7 @@ func TestNotifications_Add(t *testing.T) {
 		Type: "NewIssues",
 	}
 
-	resp, err := client.Notifications.Add(opt)
+	resp, err := client.Notifications.Add(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -45,7 +46,7 @@ func TestNotifications_Add_WithAllOptions(t *testing.T) {
 		Login:   "admin",
 	}
 
-	resp, err := client.Notifications.Add(opt)
+	resp, err := client.Notifications.Add(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -54,11 +55,11 @@ func TestNotifications_Add_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Notifications.Add(nil)
+	_, err := client.Notifications.Add(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Type should fail validation.
-	_, err = client.Notifications.Add(&NotificationsAddOptions{})
+	_, err = client.Notifications.Add(context.Background(), &NotificationsAddOptions{})
 	assert.Error(t, err)
 }
 
@@ -79,7 +80,7 @@ func TestNotifications_List(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Notifications.List(nil)
+	result, resp, err := client.Notifications.List(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -104,7 +105,7 @@ func TestNotifications_List_WithLogin(t *testing.T) {
 		Login: "admin",
 	}
 
-	_, resp, err := client.Notifications.List(opt)
+	_, resp, err := client.Notifications.List(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -123,7 +124,7 @@ func TestNotifications_Remove(t *testing.T) {
 		Type: "NewIssues",
 	}
 
-	resp, err := client.Notifications.Remove(opt)
+	resp, err := client.Notifications.Remove(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -132,11 +133,11 @@ func TestNotifications_Remove_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Notifications.Remove(nil)
+	_, err := client.Notifications.Remove(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Type should fail validation.
-	_, err = client.Notifications.Remove(&NotificationsRemoveOptions{})
+	_, err = client.Notifications.Remove(context.Background(), &NotificationsRemoveOptions{})
 	assert.Error(t, err)
 }
 

--- a/sonar/permissions_service.go
+++ b/sonar/permissions_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 const (
 	// MinPermissionQueryLength is the minimum required length for permission query strings.
@@ -1109,13 +1112,13 @@ func (s *PermissionsService) ValidateUsersOpt(opt *PermissionsUsersOptions) erro
 //
 // API endpoint: POST /api/permissions/add_group.
 // Since: 5.2.
-func (s *PermissionsService) AddGroup(opt *PermissionsAddGroupOptions) (*http.Response, error) {
+func (s *PermissionsService) AddGroup(ctx context.Context, opt *PermissionsAddGroupOptions) (*http.Response, error) {
 	err := s.ValidateAddGroupOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/add_group", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/add_group", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1134,13 +1137,13 @@ func (s *PermissionsService) AddGroup(opt *PermissionsAddGroupOptions) (*http.Re
 //
 // API endpoint: POST /api/permissions/add_group_to_template.
 // Since: 5.2.
-func (s *PermissionsService) AddGroupToTemplate(opt *PermissionsAddGroupToTemplateOptions) (*http.Response, error) {
+func (s *PermissionsService) AddGroupToTemplate(ctx context.Context, opt *PermissionsAddGroupToTemplateOptions) (*http.Response, error) {
 	err := s.ValidateAddGroupToTemplateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/add_group_to_template", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/add_group_to_template", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1158,13 +1161,13 @@ func (s *PermissionsService) AddGroupToTemplate(opt *PermissionsAddGroupToTempla
 //
 // API endpoint: POST /api/permissions/add_project_creator_to_template.
 // Since: 6.0.
-func (s *PermissionsService) AddProjectCreatorToTemplate(opt *PermissionsAddProjectCreatorToTemplateOptions) (*http.Response, error) {
+func (s *PermissionsService) AddProjectCreatorToTemplate(ctx context.Context, opt *PermissionsAddProjectCreatorToTemplateOptions) (*http.Response, error) {
 	err := s.ValidateAddProjectCreatorToTemplateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/add_project_creator_to_template", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/add_project_creator_to_template", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1186,13 +1189,13 @@ func (s *PermissionsService) AddProjectCreatorToTemplate(opt *PermissionsAddProj
 //
 // API endpoint: POST /api/permissions/add_user.
 // Since: 5.2.
-func (s *PermissionsService) AddUser(opt *PermissionsAddUserOptions) (*http.Response, error) {
+func (s *PermissionsService) AddUser(ctx context.Context, opt *PermissionsAddUserOptions) (*http.Response, error) {
 	err := s.ValidateAddUserOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/add_user", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/add_user", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1210,13 +1213,13 @@ func (s *PermissionsService) AddUser(opt *PermissionsAddUserOptions) (*http.Resp
 //
 // API endpoint: POST /api/permissions/add_user_to_template.
 // Since: 5.2.
-func (s *PermissionsService) AddUserToTemplate(opt *PermissionsAddUserToTemplateOptions) (*http.Response, error) {
+func (s *PermissionsService) AddUserToTemplate(ctx context.Context, opt *PermissionsAddUserToTemplateOptions) (*http.Response, error) {
 	err := s.ValidateAddUserToTemplateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/add_user_to_template", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/add_user_to_template", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1236,13 +1239,13 @@ func (s *PermissionsService) AddUserToTemplate(opt *PermissionsAddUserToTemplate
 //
 // API endpoint: POST /api/permissions/apply_template.
 // Since: 5.2.
-func (s *PermissionsService) ApplyTemplate(opt *PermissionsApplyTemplateOptions) (*http.Response, error) {
+func (s *PermissionsService) ApplyTemplate(ctx context.Context, opt *PermissionsApplyTemplateOptions) (*http.Response, error) {
 	err := s.ValidateApplyTemplateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/apply_template", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/apply_template", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1262,13 +1265,13 @@ func (s *PermissionsService) ApplyTemplate(opt *PermissionsApplyTemplateOptions)
 //
 // API endpoint: POST /api/permissions/bulk_apply_template.
 // Since: 5.5.
-func (s *PermissionsService) BulkApplyTemplate(opt *PermissionsBulkApplyTemplateOptions) (*http.Response, error) {
+func (s *PermissionsService) BulkApplyTemplate(ctx context.Context, opt *PermissionsBulkApplyTemplateOptions) (*http.Response, error) {
 	err := s.ValidateBulkApplyTemplateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/bulk_apply_template", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/bulk_apply_template", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1286,13 +1289,13 @@ func (s *PermissionsService) BulkApplyTemplate(opt *PermissionsBulkApplyTemplate
 //
 // API endpoint: POST /api/permissions/create_template.
 // Since: 5.2.
-func (s *PermissionsService) CreateTemplate(opt *PermissionsCreateTemplateOptions) (*PermissionsCreateTemplate, *http.Response, error) {
+func (s *PermissionsService) CreateTemplate(ctx context.Context, opt *PermissionsCreateTemplateOptions) (*PermissionsCreateTemplate, *http.Response, error) {
 	err := s.ValidateCreateTemplateOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/create_template", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/create_template", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1312,13 +1315,13 @@ func (s *PermissionsService) CreateTemplate(opt *PermissionsCreateTemplateOption
 //
 // API endpoint: POST /api/permissions/delete_template.
 // Since: 5.2.
-func (s *PermissionsService) DeleteTemplate(opt *PermissionsDeleteTemplateOptions) (*http.Response, error) {
+func (s *PermissionsService) DeleteTemplate(ctx context.Context, opt *PermissionsDeleteTemplateOptions) (*http.Response, error) {
 	err := s.ValidateDeleteTemplateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/delete_template", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/delete_template", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1344,13 +1347,13 @@ func (s *PermissionsService) DeleteTemplate(opt *PermissionsDeleteTemplateOption
 //
 // API endpoint: GET /api/permissions/groups.
 // Since: 5.2.
-func (s *PermissionsService) Groups(opt *PermissionsGroupsOptions) (*PermissionsGroups, *http.Response, error) {
+func (s *PermissionsService) Groups(ctx context.Context, opt *PermissionsGroupsOptions) (*PermissionsGroups, *http.Response, error) {
 	err := s.ValidateGroupsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "permissions/groups", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "permissions/groups", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1375,13 +1378,13 @@ func (s *PermissionsService) Groups(opt *PermissionsGroupsOptions) (*Permissions
 //
 // API endpoint: POST /api/permissions/remove_group.
 // Since: 5.2.
-func (s *PermissionsService) RemoveGroup(opt *PermissionsRemoveGroupOptions) (*http.Response, error) {
+func (s *PermissionsService) RemoveGroup(ctx context.Context, opt *PermissionsRemoveGroupOptions) (*http.Response, error) {
 	err := s.ValidateRemoveGroupOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/remove_group", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/remove_group", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1400,13 +1403,13 @@ func (s *PermissionsService) RemoveGroup(opt *PermissionsRemoveGroupOptions) (*h
 //
 // API endpoint: POST /api/permissions/remove_group_from_template.
 // Since: 5.2.
-func (s *PermissionsService) RemoveGroupFromTemplate(opt *PermissionsRemoveGroupFromTemplateOptions) (*http.Response, error) {
+func (s *PermissionsService) RemoveGroupFromTemplate(ctx context.Context, opt *PermissionsRemoveGroupFromTemplateOptions) (*http.Response, error) {
 	err := s.ValidateRemoveGroupFromTemplateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/remove_group_from_template", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/remove_group_from_template", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1424,13 +1427,13 @@ func (s *PermissionsService) RemoveGroupFromTemplate(opt *PermissionsRemoveGroup
 //
 // API endpoint: POST /api/permissions/remove_project_creator_from_template.
 // Since: 6.0.
-func (s *PermissionsService) RemoveProjectCreatorFromTemplate(opt *PermissionsRemoveProjectCreatorFromTemplateOptions) (*http.Response, error) {
+func (s *PermissionsService) RemoveProjectCreatorFromTemplate(ctx context.Context, opt *PermissionsRemoveProjectCreatorFromTemplateOptions) (*http.Response, error) {
 	err := s.ValidateRemoveProjectCreatorFromTemplateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/remove_project_creator_from_template", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/remove_project_creator_from_template", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1452,13 +1455,13 @@ func (s *PermissionsService) RemoveProjectCreatorFromTemplate(opt *PermissionsRe
 //
 // API endpoint: POST /api/permissions/remove_user.
 // Since: 5.2.
-func (s *PermissionsService) RemoveUser(opt *PermissionsRemoveUserOptions) (*http.Response, error) {
+func (s *PermissionsService) RemoveUser(ctx context.Context, opt *PermissionsRemoveUserOptions) (*http.Response, error) {
 	err := s.ValidateRemoveUserOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/remove_user", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/remove_user", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1476,13 +1479,13 @@ func (s *PermissionsService) RemoveUser(opt *PermissionsRemoveUserOptions) (*htt
 //
 // API endpoint: POST /api/permissions/remove_user_from_template.
 // Since: 5.2.
-func (s *PermissionsService) RemoveUserFromTemplate(opt *PermissionsRemoveUserFromTemplateOptions) (*http.Response, error) {
+func (s *PermissionsService) RemoveUserFromTemplate(ctx context.Context, opt *PermissionsRemoveUserFromTemplateOptions) (*http.Response, error) {
 	err := s.ValidateRemoveUserFromTemplateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/remove_user_from_template", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/remove_user_from_template", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1501,13 +1504,13 @@ func (s *PermissionsService) RemoveUserFromTemplate(opt *PermissionsRemoveUserFr
 //
 // API endpoint: GET /api/permissions/search_templates.
 // Since: 5.2.
-func (s *PermissionsService) SearchTemplates(opt *PermissionsSearchTemplatesOptions) (*PermissionsSearchTemplates, *http.Response, error) {
+func (s *PermissionsService) SearchTemplates(ctx context.Context, opt *PermissionsSearchTemplatesOptions) (*PermissionsSearchTemplates, *http.Response, error) {
 	err := s.ValidateSearchTemplatesOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "permissions/search_templates", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "permissions/search_templates", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1527,13 +1530,13 @@ func (s *PermissionsService) SearchTemplates(opt *PermissionsSearchTemplatesOpti
 //
 // API endpoint: POST /api/permissions/set_default_template.
 // Since: 5.2.
-func (s *PermissionsService) SetDefaultTemplate(opt *PermissionsSetDefaultTemplateOptions) (*http.Response, error) {
+func (s *PermissionsService) SetDefaultTemplate(ctx context.Context, opt *PermissionsSetDefaultTemplateOptions) (*http.Response, error) {
 	err := s.ValidateSetDefaultTemplateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/set_default_template", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/set_default_template", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1556,13 +1559,13 @@ func (s *PermissionsService) SetDefaultTemplate(opt *PermissionsSetDefaultTempla
 //
 // API endpoint: GET /api/permissions/template_groups.
 // Since: 5.2.
-func (s *PermissionsService) TemplateGroups(opt *PermissionsTemplateGroupsOptions) (*PermissionsTemplateGroups, *http.Response, error) {
+func (s *PermissionsService) TemplateGroups(ctx context.Context, opt *PermissionsTemplateGroupsOptions) (*PermissionsTemplateGroups, *http.Response, error) {
 	err := s.ValidateTemplateGroupsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "permissions/template_groups", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "permissions/template_groups", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1587,13 +1590,13 @@ func (s *PermissionsService) TemplateGroups(opt *PermissionsTemplateGroupsOption
 //
 // API endpoint: GET /api/permissions/template_users.
 // Since: 5.2.
-func (s *PermissionsService) TemplateUsers(opt *PermissionsTemplateUsersOptions) (*PermissionsTemplateUsers, *http.Response, error) {
+func (s *PermissionsService) TemplateUsers(ctx context.Context, opt *PermissionsTemplateUsersOptions) (*PermissionsTemplateUsers, *http.Response, error) {
 	err := s.ValidateTemplateUsersOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "permissions/template_users", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "permissions/template_users", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1613,13 +1616,13 @@ func (s *PermissionsService) TemplateUsers(opt *PermissionsTemplateUsersOptions)
 //
 // API endpoint: POST /api/permissions/update_template.
 // Since: 5.2.
-func (s *PermissionsService) UpdateTemplate(opt *PermissionsUpdateTemplateOptions) (*PermissionsUpdateTemplate, *http.Response, error) {
+func (s *PermissionsService) UpdateTemplate(ctx context.Context, opt *PermissionsUpdateTemplateOptions) (*PermissionsUpdateTemplate, *http.Response, error) {
 	err := s.ValidateUpdateTemplateOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "permissions/update_template", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "permissions/update_template", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1648,13 +1651,13 @@ func (s *PermissionsService) UpdateTemplate(opt *PermissionsUpdateTemplateOption
 //
 // API endpoint: GET /api/permissions/users.
 // Since: 5.2.
-func (s *PermissionsService) Users(opt *PermissionsUsersOptions) (*PermissionsUsers, *http.Response, error) {
+func (s *PermissionsService) Users(ctx context.Context, opt *PermissionsUsersOptions) (*PermissionsUsers, *http.Response, error) {
 	err := s.ValidateUsersOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "permissions/users", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "permissions/users", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/permissions_service_test.go
+++ b/sonar/permissions_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -21,7 +22,7 @@ func TestPermissions_AddGroup(t *testing.T) {
 		Permission: "admin",
 	}
 
-	resp, err := client.Permissions.AddGroup(opt)
+	resp, err := client.Permissions.AddGroup(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -36,7 +37,7 @@ func TestPermissions_AddGroup_WithProject(t *testing.T) {
 		ProjectKey: "my-project",
 	}
 
-	resp, err := client.Permissions.AddGroup(opt)
+	resp, err := client.Permissions.AddGroup(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -45,23 +46,23 @@ func TestPermissions_AddGroup_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Permissions.AddGroup(nil)
+	_, err := client.Permissions.AddGroup(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing GroupName should fail validation.
-	_, err = client.Permissions.AddGroup(&PermissionsAddGroupOptions{
+	_, err = client.Permissions.AddGroup(context.Background(), &PermissionsAddGroupOptions{
 		Permission: "admin",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.AddGroup(&PermissionsAddGroupOptions{
+	_, err = client.Permissions.AddGroup(context.Background(), &PermissionsAddGroupOptions{
 		GroupName: "developers",
 	})
 	assert.Error(t, err)
 
 	// Invalid permission should fail validation.
-	_, err = client.Permissions.AddGroup(&PermissionsAddGroupOptions{
+	_, err = client.Permissions.AddGroup(context.Background(), &PermissionsAddGroupOptions{
 		GroupName:  "developers",
 		Permission: "invalid",
 	})
@@ -82,7 +83,7 @@ func TestPermissions_AddGroupToTemplate(t *testing.T) {
 		TemplateName: "my-template",
 	}
 
-	resp, err := client.Permissions.AddGroupToTemplate(opt)
+	resp, err := client.Permissions.AddGroupToTemplate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -91,25 +92,25 @@ func TestPermissions_AddGroupToTemplate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Permissions.AddGroupToTemplate(nil)
+	_, err := client.Permissions.AddGroupToTemplate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing GroupName should fail validation.
-	_, err = client.Permissions.AddGroupToTemplate(&PermissionsAddGroupToTemplateOptions{
+	_, err = client.Permissions.AddGroupToTemplate(context.Background(), &PermissionsAddGroupToTemplateOptions{
 		Permission:   "admin",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.AddGroupToTemplate(&PermissionsAddGroupToTemplateOptions{
+	_, err = client.Permissions.AddGroupToTemplate(context.Background(), &PermissionsAddGroupToTemplateOptions{
 		GroupName:    "developers",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Invalid permission should fail validation.
-	_, err = client.Permissions.AddGroupToTemplate(&PermissionsAddGroupToTemplateOptions{
+	_, err = client.Permissions.AddGroupToTemplate(context.Background(), &PermissionsAddGroupToTemplateOptions{
 		GroupName:    "developers",
 		Permission:   "gateadmin", // Not a project permission
 		TemplateName: "my-template",
@@ -117,7 +118,7 @@ func TestPermissions_AddGroupToTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.AddGroupToTemplate(&PermissionsAddGroupToTemplateOptions{
+	_, err = client.Permissions.AddGroupToTemplate(context.Background(), &PermissionsAddGroupToTemplateOptions{
 		GroupName:  "developers",
 		Permission: "admin",
 	})
@@ -137,7 +138,7 @@ func TestPermissions_AddProjectCreatorToTemplate(t *testing.T) {
 		TemplateName: "my-template",
 	}
 
-	resp, err := client.Permissions.AddProjectCreatorToTemplate(opt)
+	resp, err := client.Permissions.AddProjectCreatorToTemplate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -146,24 +147,24 @@ func TestPermissions_AddProjectCreatorToTemplate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Permissions.AddProjectCreatorToTemplate(nil)
+	_, err := client.Permissions.AddProjectCreatorToTemplate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.AddProjectCreatorToTemplate(&PermissionsAddProjectCreatorToTemplateOptions{
+	_, err = client.Permissions.AddProjectCreatorToTemplate(context.Background(), &PermissionsAddProjectCreatorToTemplateOptions{
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Invalid permission should fail validation.
-	_, err = client.Permissions.AddProjectCreatorToTemplate(&PermissionsAddProjectCreatorToTemplateOptions{
+	_, err = client.Permissions.AddProjectCreatorToTemplate(context.Background(), &PermissionsAddProjectCreatorToTemplateOptions{
 		Permission:   "provisioning", // Not a project permission
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.AddProjectCreatorToTemplate(&PermissionsAddProjectCreatorToTemplateOptions{
+	_, err = client.Permissions.AddProjectCreatorToTemplate(context.Background(), &PermissionsAddProjectCreatorToTemplateOptions{
 		Permission: "admin",
 	})
 	assert.Error(t, err)
@@ -182,7 +183,7 @@ func TestPermissions_AddUser(t *testing.T) {
 		Permission: "admin",
 	}
 
-	resp, err := client.Permissions.AddUser(opt)
+	resp, err := client.Permissions.AddUser(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -191,23 +192,23 @@ func TestPermissions_AddUser_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Permissions.AddUser(nil)
+	_, err := client.Permissions.AddUser(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Login should fail validation.
-	_, err = client.Permissions.AddUser(&PermissionsAddUserOptions{
+	_, err = client.Permissions.AddUser(context.Background(), &PermissionsAddUserOptions{
 		Permission: "admin",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.AddUser(&PermissionsAddUserOptions{
+	_, err = client.Permissions.AddUser(context.Background(), &PermissionsAddUserOptions{
 		Login: "john.doe",
 	})
 	assert.Error(t, err)
 
 	// Invalid permission should fail validation.
-	_, err = client.Permissions.AddUser(&PermissionsAddUserOptions{
+	_, err = client.Permissions.AddUser(context.Background(), &PermissionsAddUserOptions{
 		Login:      "john.doe",
 		Permission: "invalid",
 	})
@@ -228,7 +229,7 @@ func TestPermissions_AddUserToTemplate(t *testing.T) {
 		TemplateName: "my-template",
 	}
 
-	resp, err := client.Permissions.AddUserToTemplate(opt)
+	resp, err := client.Permissions.AddUserToTemplate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -237,25 +238,25 @@ func TestPermissions_AddUserToTemplate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Permissions.AddUserToTemplate(nil)
+	_, err := client.Permissions.AddUserToTemplate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Login should fail validation.
-	_, err = client.Permissions.AddUserToTemplate(&PermissionsAddUserToTemplateOptions{
+	_, err = client.Permissions.AddUserToTemplate(context.Background(), &PermissionsAddUserToTemplateOptions{
 		Permission:   "admin",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.AddUserToTemplate(&PermissionsAddUserToTemplateOptions{
+	_, err = client.Permissions.AddUserToTemplate(context.Background(), &PermissionsAddUserToTemplateOptions{
 		Login:        "john.doe",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Invalid permission should fail validation.
-	_, err = client.Permissions.AddUserToTemplate(&PermissionsAddUserToTemplateOptions{
+	_, err = client.Permissions.AddUserToTemplate(context.Background(), &PermissionsAddUserToTemplateOptions{
 		Login:        "john.doe",
 		Permission:   "profileadmin", // Not a project permission
 		TemplateName: "my-template",
@@ -263,7 +264,7 @@ func TestPermissions_AddUserToTemplate_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.AddUserToTemplate(&PermissionsAddUserToTemplateOptions{
+	_, err = client.Permissions.AddUserToTemplate(context.Background(), &PermissionsAddUserToTemplateOptions{
 		Login:      "john.doe",
 		Permission: "admin",
 	})
@@ -283,7 +284,7 @@ func TestPermissions_ApplyTemplate(t *testing.T) {
 		TemplateName: "my-template",
 	}
 
-	resp, err := client.Permissions.ApplyTemplate(opt)
+	resp, err := client.Permissions.ApplyTemplate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -292,17 +293,17 @@ func TestPermissions_ApplyTemplate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Permissions.ApplyTemplate(nil)
+	_, err := client.Permissions.ApplyTemplate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing ProjectID and ProjectKey should fail validation.
-	_, err = client.Permissions.ApplyTemplate(&PermissionsApplyTemplateOptions{
+	_, err = client.Permissions.ApplyTemplate(context.Background(), &PermissionsApplyTemplateOptions{
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.ApplyTemplate(&PermissionsApplyTemplateOptions{
+	_, err = client.Permissions.ApplyTemplate(context.Background(), &PermissionsApplyTemplateOptions{
 		ProjectKey: "my-project",
 	})
 	assert.Error(t, err)
@@ -320,7 +321,7 @@ func TestPermissions_BulkApplyTemplate(t *testing.T) {
 		TemplateName: "my-template",
 	}
 
-	resp, err := client.Permissions.BulkApplyTemplate(opt)
+	resp, err := client.Permissions.BulkApplyTemplate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -334,7 +335,7 @@ func TestPermissions_BulkApplyTemplate_WithProjects(t *testing.T) {
 		Projects:     []string{"project1", "project2"},
 	}
 
-	resp, err := client.Permissions.BulkApplyTemplate(opt)
+	resp, err := client.Permissions.BulkApplyTemplate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -343,15 +344,15 @@ func TestPermissions_BulkApplyTemplate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Permissions.BulkApplyTemplate(nil)
+	_, err := client.Permissions.BulkApplyTemplate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.BulkApplyTemplate(&PermissionsBulkApplyTemplateOptions{})
+	_, err = client.Permissions.BulkApplyTemplate(context.Background(), &PermissionsBulkApplyTemplateOptions{})
 	assert.Error(t, err)
 
 	// Invalid qualifier should fail validation.
-	_, err = client.Permissions.BulkApplyTemplate(&PermissionsBulkApplyTemplateOptions{
+	_, err = client.Permissions.BulkApplyTemplate(context.Background(), &PermissionsBulkApplyTemplateOptions{
 		TemplateName: "my-template",
 		Qualifiers:   "INVALID",
 	})
@@ -379,7 +380,7 @@ func TestPermissions_CreateTemplate(t *testing.T) {
 		ProjectKeyPattern: "my-.*",
 	}
 
-	result, resp, err := client.Permissions.CreateTemplate(opt)
+	result, resp, err := client.Permissions.CreateTemplate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -390,11 +391,11 @@ func TestPermissions_CreateTemplate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.Permissions.CreateTemplate(nil)
+	_, _, err := client.Permissions.CreateTemplate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Name should fail validation.
-	_, _, err = client.Permissions.CreateTemplate(&PermissionsCreateTemplateOptions{})
+	_, _, err = client.Permissions.CreateTemplate(context.Background(), &PermissionsCreateTemplateOptions{})
 	assert.Error(t, err)
 }
 
@@ -410,7 +411,7 @@ func TestPermissions_DeleteTemplate(t *testing.T) {
 		TemplateName: "my-template",
 	}
 
-	resp, err := client.Permissions.DeleteTemplate(opt)
+	resp, err := client.Permissions.DeleteTemplate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -419,11 +420,11 @@ func TestPermissions_DeleteTemplate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Permissions.DeleteTemplate(nil)
+	_, err := client.Permissions.DeleteTemplate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.DeleteTemplate(&PermissionsDeleteTemplateOptions{})
+	_, err = client.Permissions.DeleteTemplate(context.Background(), &PermissionsDeleteTemplateOptions{})
 	assert.Error(t, err)
 }
 
@@ -454,7 +455,7 @@ func TestPermissions_Groups(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/permissions/groups", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Permissions.Groups(nil)
+	result, resp, err := client.Permissions.Groups(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -480,7 +481,7 @@ func TestPermissions_Groups_WithOptions(t *testing.T) {
 		Permission: "admin",
 	}
 
-	_, resp, err := client.Permissions.Groups(opt)
+	_, resp, err := client.Permissions.Groups(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -489,13 +490,13 @@ func TestPermissions_Groups_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Invalid permission should fail validation.
-	_, _, err := client.Permissions.Groups(&PermissionsGroupsOptions{
+	_, _, err := client.Permissions.Groups(context.Background(), &PermissionsGroupsOptions{
 		Permission: "invalid",
 	})
 	assert.Error(t, err)
 
 	// Query too short should fail validation.
-	_, _, err = client.Permissions.Groups(&PermissionsGroupsOptions{
+	_, _, err = client.Permissions.Groups(context.Background(), &PermissionsGroupsOptions{
 		Query: "ab",
 	})
 	assert.Error(t, err)
@@ -514,7 +515,7 @@ func TestPermissions_RemoveGroup(t *testing.T) {
 		Permission: "admin",
 	}
 
-	resp, err := client.Permissions.RemoveGroup(opt)
+	resp, err := client.Permissions.RemoveGroup(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -523,17 +524,17 @@ func TestPermissions_RemoveGroup_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Permissions.RemoveGroup(nil)
+	_, err := client.Permissions.RemoveGroup(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing GroupName should fail validation.
-	_, err = client.Permissions.RemoveGroup(&PermissionsRemoveGroupOptions{
+	_, err = client.Permissions.RemoveGroup(context.Background(), &PermissionsRemoveGroupOptions{
 		Permission: "admin",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.RemoveGroup(&PermissionsRemoveGroupOptions{
+	_, err = client.Permissions.RemoveGroup(context.Background(), &PermissionsRemoveGroupOptions{
 		GroupName: "developers",
 	})
 	assert.Error(t, err)
@@ -553,7 +554,7 @@ func TestPermissions_RemoveGroupFromTemplate(t *testing.T) {
 		TemplateName: "my-template",
 	}
 
-	resp, err := client.Permissions.RemoveGroupFromTemplate(opt)
+	resp, err := client.Permissions.RemoveGroupFromTemplate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -562,25 +563,25 @@ func TestPermissions_RemoveGroupFromTemplate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Permissions.RemoveGroupFromTemplate(nil)
+	_, err := client.Permissions.RemoveGroupFromTemplate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing GroupName should fail validation.
-	_, err = client.Permissions.RemoveGroupFromTemplate(&PermissionsRemoveGroupFromTemplateOptions{
+	_, err = client.Permissions.RemoveGroupFromTemplate(context.Background(), &PermissionsRemoveGroupFromTemplateOptions{
 		Permission:   "admin",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.RemoveGroupFromTemplate(&PermissionsRemoveGroupFromTemplateOptions{
+	_, err = client.Permissions.RemoveGroupFromTemplate(context.Background(), &PermissionsRemoveGroupFromTemplateOptions{
 		GroupName:    "developers",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.RemoveGroupFromTemplate(&PermissionsRemoveGroupFromTemplateOptions{
+	_, err = client.Permissions.RemoveGroupFromTemplate(context.Background(), &PermissionsRemoveGroupFromTemplateOptions{
 		GroupName:  "developers",
 		Permission: "admin",
 	})
@@ -600,7 +601,7 @@ func TestPermissions_RemoveProjectCreatorFromTemplate(t *testing.T) {
 		TemplateName: "my-template",
 	}
 
-	resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(opt)
+	resp, err := client.Permissions.RemoveProjectCreatorFromTemplate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -609,17 +610,17 @@ func TestPermissions_RemoveProjectCreatorFromTemplate_ValidationError(t *testing
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Permissions.RemoveProjectCreatorFromTemplate(nil)
+	_, err := client.Permissions.RemoveProjectCreatorFromTemplate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.RemoveProjectCreatorFromTemplate(&PermissionsRemoveProjectCreatorFromTemplateOptions{
+	_, err = client.Permissions.RemoveProjectCreatorFromTemplate(context.Background(), &PermissionsRemoveProjectCreatorFromTemplateOptions{
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.RemoveProjectCreatorFromTemplate(&PermissionsRemoveProjectCreatorFromTemplateOptions{
+	_, err = client.Permissions.RemoveProjectCreatorFromTemplate(context.Background(), &PermissionsRemoveProjectCreatorFromTemplateOptions{
 		Permission: "admin",
 	})
 	assert.Error(t, err)
@@ -638,7 +639,7 @@ func TestPermissions_RemoveUser(t *testing.T) {
 		Permission: "admin",
 	}
 
-	resp, err := client.Permissions.RemoveUser(opt)
+	resp, err := client.Permissions.RemoveUser(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -647,17 +648,17 @@ func TestPermissions_RemoveUser_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Permissions.RemoveUser(nil)
+	_, err := client.Permissions.RemoveUser(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Login should fail validation.
-	_, err = client.Permissions.RemoveUser(&PermissionsRemoveUserOptions{
+	_, err = client.Permissions.RemoveUser(context.Background(), &PermissionsRemoveUserOptions{
 		Permission: "admin",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.RemoveUser(&PermissionsRemoveUserOptions{
+	_, err = client.Permissions.RemoveUser(context.Background(), &PermissionsRemoveUserOptions{
 		Login: "john.doe",
 	})
 	assert.Error(t, err)
@@ -677,7 +678,7 @@ func TestPermissions_RemoveUserFromTemplate(t *testing.T) {
 		TemplateName: "my-template",
 	}
 
-	resp, err := client.Permissions.RemoveUserFromTemplate(opt)
+	resp, err := client.Permissions.RemoveUserFromTemplate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -686,25 +687,25 @@ func TestPermissions_RemoveUserFromTemplate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Permissions.RemoveUserFromTemplate(nil)
+	_, err := client.Permissions.RemoveUserFromTemplate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Login should fail validation.
-	_, err = client.Permissions.RemoveUserFromTemplate(&PermissionsRemoveUserFromTemplateOptions{
+	_, err = client.Permissions.RemoveUserFromTemplate(context.Background(), &PermissionsRemoveUserFromTemplateOptions{
 		Permission:   "admin",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing Permission should fail validation.
-	_, err = client.Permissions.RemoveUserFromTemplate(&PermissionsRemoveUserFromTemplateOptions{
+	_, err = client.Permissions.RemoveUserFromTemplate(context.Background(), &PermissionsRemoveUserFromTemplateOptions{
 		Login:        "john.doe",
 		TemplateName: "my-template",
 	})
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.RemoveUserFromTemplate(&PermissionsRemoveUserFromTemplateOptions{
+	_, err = client.Permissions.RemoveUserFromTemplate(context.Background(), &PermissionsRemoveUserFromTemplateOptions{
 		Login:      "john.doe",
 		Permission: "admin",
 	})
@@ -734,7 +735,7 @@ func TestPermissions_SearchTemplates(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/permissions/search_templates", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Permissions.SearchTemplates(nil)
+	result, resp, err := client.Permissions.SearchTemplates(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -782,7 +783,7 @@ func TestPermissions_SetDefaultTemplate(t *testing.T) {
 		TemplateName: "my-template",
 	}
 
-	resp, err := client.Permissions.SetDefaultTemplate(opt)
+	resp, err := client.Permissions.SetDefaultTemplate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -791,15 +792,15 @@ func TestPermissions_SetDefaultTemplate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Permissions.SetDefaultTemplate(nil)
+	_, err := client.Permissions.SetDefaultTemplate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, err = client.Permissions.SetDefaultTemplate(&PermissionsSetDefaultTemplateOptions{})
+	_, err = client.Permissions.SetDefaultTemplate(context.Background(), &PermissionsSetDefaultTemplateOptions{})
 	assert.Error(t, err)
 
 	// Invalid qualifier should fail validation.
-	_, err = client.Permissions.SetDefaultTemplate(&PermissionsSetDefaultTemplateOptions{
+	_, err = client.Permissions.SetDefaultTemplate(context.Background(), &PermissionsSetDefaultTemplateOptions{
 		TemplateName: "my-template",
 		Qualifier:    "INVALID",
 	})
@@ -832,7 +833,7 @@ func TestPermissions_TemplateGroups(t *testing.T) {
 		TemplateName: "my-template",
 	}
 
-	result, resp, err := client.Permissions.TemplateGroups(opt)
+	result, resp, err := client.Permissions.TemplateGroups(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -844,22 +845,22 @@ func TestPermissions_TemplateGroups_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.Permissions.TemplateGroups(nil)
+	_, _, err := client.Permissions.TemplateGroups(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, _, err = client.Permissions.TemplateGroups(&PermissionsTemplateGroupsOptions{})
+	_, _, err = client.Permissions.TemplateGroups(context.Background(), &PermissionsTemplateGroupsOptions{})
 	assert.Error(t, err)
 
 	// Invalid permission should fail validation.
-	_, _, err = client.Permissions.TemplateGroups(&PermissionsTemplateGroupsOptions{
+	_, _, err = client.Permissions.TemplateGroups(context.Background(), &PermissionsTemplateGroupsOptions{
 		TemplateName: "my-template",
 		Permission:   "gateadmin", // Not a project permission
 	})
 	assert.Error(t, err)
 
 	// Query too short should fail validation.
-	_, _, err = client.Permissions.TemplateGroups(&PermissionsTemplateGroupsOptions{
+	_, _, err = client.Permissions.TemplateGroups(context.Background(), &PermissionsTemplateGroupsOptions{
 		TemplateName: "my-template",
 		Query:        "ab",
 	})
@@ -893,7 +894,7 @@ func TestPermissions_TemplateUsers(t *testing.T) {
 		TemplateName: "my-template",
 	}
 
-	result, resp, err := client.Permissions.TemplateUsers(opt)
+	result, resp, err := client.Permissions.TemplateUsers(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -905,22 +906,22 @@ func TestPermissions_TemplateUsers_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.Permissions.TemplateUsers(nil)
+	_, _, err := client.Permissions.TemplateUsers(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing TemplateID and TemplateName should fail validation.
-	_, _, err = client.Permissions.TemplateUsers(&PermissionsTemplateUsersOptions{})
+	_, _, err = client.Permissions.TemplateUsers(context.Background(), &PermissionsTemplateUsersOptions{})
 	assert.Error(t, err)
 
 	// Invalid permission should fail validation.
-	_, _, err = client.Permissions.TemplateUsers(&PermissionsTemplateUsersOptions{
+	_, _, err = client.Permissions.TemplateUsers(context.Background(), &PermissionsTemplateUsersOptions{
 		TemplateName: "my-template",
 		Permission:   "provisioning", // Not a project permission
 	})
 	assert.Error(t, err)
 
 	// Query too short should fail validation.
-	_, _, err = client.Permissions.TemplateUsers(&PermissionsTemplateUsersOptions{
+	_, _, err = client.Permissions.TemplateUsers(context.Background(), &PermissionsTemplateUsersOptions{
 		TemplateName: "my-template",
 		Query:        "ab",
 	})
@@ -948,7 +949,7 @@ func TestPermissions_UpdateTemplate(t *testing.T) {
 		ProjectKeyPattern: "new-.*",
 	}
 
-	result, resp, err := client.Permissions.UpdateTemplate(opt)
+	result, resp, err := client.Permissions.UpdateTemplate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -959,11 +960,11 @@ func TestPermissions_UpdateTemplate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.Permissions.UpdateTemplate(nil)
+	_, _, err := client.Permissions.UpdateTemplate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing ID should fail validation.
-	_, _, err = client.Permissions.UpdateTemplate(&PermissionsUpdateTemplateOptions{
+	_, _, err = client.Permissions.UpdateTemplate(context.Background(), &PermissionsUpdateTemplateOptions{
 		Name: "new-name",
 	})
 	assert.Error(t, err)
@@ -1000,7 +1001,7 @@ func TestPermissions_Users(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/permissions/users", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Permissions.Users(nil)
+	result, resp, err := client.Permissions.Users(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -1027,7 +1028,7 @@ func TestPermissions_Users_WithOptions(t *testing.T) {
 		Permission: "admin",
 	}
 
-	_, resp, err := client.Permissions.Users(opt)
+	_, resp, err := client.Permissions.Users(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -1036,13 +1037,13 @@ func TestPermissions_Users_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Invalid permission should fail validation.
-	_, _, err := client.Permissions.Users(&PermissionsUsersOptions{
+	_, _, err := client.Permissions.Users(context.Background(), &PermissionsUsersOptions{
 		Permission: "invalid",
 	})
 	assert.Error(t, err)
 
 	// Query too short should fail validation.
-	_, _, err = client.Permissions.Users(&PermissionsUsersOptions{
+	_, _, err = client.Permissions.Users(context.Background(), &PermissionsUsersOptions{
 		Query: "ab",
 	})
 	assert.Error(t, err)

--- a/sonar/plugins_service.go
+++ b/sonar/plugins_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // PluginsService handles communication with the plugins related methods
 // of the SonarQube API.
@@ -373,8 +376,8 @@ func (s *PluginsService) ValidateUpdateOpt(opt *PluginsUpdateOptions) error {
 //
 // API endpoint: GET /api/plugins/available.
 // Since: 5.2.
-func (s *PluginsService) Available() (*PluginsAvailable, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "plugins/available", nil)
+func (s *PluginsService) Available(ctx context.Context) (*PluginsAvailable, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "plugins/available", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -394,8 +397,8 @@ func (s *PluginsService) Available() (*PluginsAvailable, *http.Response, error) 
 //
 // API endpoint: POST /api/plugins/cancel_all.
 // Since: 5.2.
-func (s *PluginsService) CancelAll() (*http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "plugins/cancel_all", nil)
+func (s *PluginsService) CancelAll(ctx context.Context) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "plugins/cancel_all", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -413,13 +416,13 @@ func (s *PluginsService) CancelAll() (*http.Response, error) {
 // API endpoint: GET /api/plugins/download.
 // Since: 7.2.
 // Internal: true.
-func (s *PluginsService) Download(opt *PluginsDownloadOptions) (*string, *http.Response, error) {
+func (s *PluginsService) Download(ctx context.Context, opt *PluginsDownloadOptions) (*string, *http.Response, error) {
 	err := s.ValidateDownloadOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "plugins/download", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "plugins/download", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -441,13 +444,13 @@ func (s *PluginsService) Download(opt *PluginsDownloadOptions) (*string, *http.R
 //
 // API endpoint: POST /api/plugins/install.
 // Since: 5.2.
-func (s *PluginsService) Install(opt *PluginsInstallOptions) (*http.Response, error) {
+func (s *PluginsService) Install(ctx context.Context, opt *PluginsInstallOptions) (*http.Response, error) {
 	err := s.ValidateInstallOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "plugins/install", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "plugins/install", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -465,13 +468,13 @@ func (s *PluginsService) Install(opt *PluginsInstallOptions) (*http.Response, er
 //
 // API endpoint: GET /api/plugins/installed.
 // Since: 5.2.
-func (s *PluginsService) Installed(opt *PluginsInstalledOptions) (*PluginsInstalled, *http.Response, error) {
+func (s *PluginsService) Installed(ctx context.Context, opt *PluginsInstalledOptions) (*PluginsInstalled, *http.Response, error) {
 	err := s.ValidateInstalledOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "plugins/installed", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "plugins/installed", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -491,8 +494,8 @@ func (s *PluginsService) Installed(opt *PluginsInstalledOptions) (*PluginsInstal
 //
 // API endpoint: GET /api/plugins/pending.
 // Since: 5.2.
-func (s *PluginsService) Pending() (*PluginsPending, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "plugins/pending", nil)
+func (s *PluginsService) Pending(ctx context.Context) (*PluginsPending, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "plugins/pending", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -512,13 +515,13 @@ func (s *PluginsService) Pending() (*PluginsPending, *http.Response, error) {
 //
 // API endpoint: POST /api/plugins/uninstall.
 // Since: 5.2.
-func (s *PluginsService) Uninstall(opt *PluginsUninstallOptions) (*http.Response, error) {
+func (s *PluginsService) Uninstall(ctx context.Context, opt *PluginsUninstallOptions) (*http.Response, error) {
 	err := s.ValidateUninstallOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "plugins/uninstall", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "plugins/uninstall", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -537,13 +540,13 @@ func (s *PluginsService) Uninstall(opt *PluginsUninstallOptions) (*http.Response
 //
 // API endpoint: POST /api/plugins/update.
 // Since: 5.2.
-func (s *PluginsService) Update(opt *PluginsUpdateOptions) (*http.Response, error) {
+func (s *PluginsService) Update(ctx context.Context, opt *PluginsUpdateOptions) (*http.Response, error) {
 	err := s.ValidateUpdateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "plugins/update", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "plugins/update", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -562,8 +565,8 @@ func (s *PluginsService) Update(opt *PluginsUpdateOptions) (*http.Response, erro
 //
 // API endpoint: GET /api/plugins/updates.
 // Since: 5.2.
-func (s *PluginsService) Updates() (*PluginsUpdates, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "plugins/updates", nil)
+func (s *PluginsService) Updates(ctx context.Context) (*PluginsUpdates, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "plugins/updates", nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/plugins_service_test.go
+++ b/sonar/plugins_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestPluginsService_Available(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/plugins/available", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Plugins.Available()
+	result, resp, err := client.Plugins.Available(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -49,7 +50,7 @@ func TestPluginsService_CancelAll(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/plugins/cancel_all", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Plugins.CancelAll()
+	resp, err := client.Plugins.CancelAll(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -64,7 +65,7 @@ func TestPluginsService_Download(t *testing.T) {
 		})
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Plugins.Download(&PluginsDownloadOptions{
+		result, resp, err := client.Plugins.Download(context.Background(), &PluginsDownloadOptions{
 			Plugin: "sonar-java",
 		})
 		require.NoError(t, err)
@@ -75,14 +76,14 @@ func TestPluginsService_Download(t *testing.T) {
 	t.Run("nil option", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.Plugins.Download(nil)
+		_, _, err := client.Plugins.Download(context.Background(), nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("missing plugin", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.Plugins.Download(&PluginsDownloadOptions{})
+		_, _, err := client.Plugins.Download(context.Background(), &PluginsDownloadOptions{})
 		assert.Error(t, err)
 	})
 }
@@ -97,7 +98,7 @@ func TestPluginsService_Install(t *testing.T) {
 		})
 		client := newTestClient(t, server.URL)
 
-		resp, err := client.Plugins.Install(&PluginsInstallOptions{
+		resp, err := client.Plugins.Install(context.Background(), &PluginsInstallOptions{
 			Key: "sonar-java",
 		})
 		require.NoError(t, err)
@@ -107,14 +108,14 @@ func TestPluginsService_Install(t *testing.T) {
 	t.Run("nil option", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.Plugins.Install(nil)
+		_, err := client.Plugins.Install(context.Background(), nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("missing key", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.Plugins.Install(&PluginsInstallOptions{})
+		_, err := client.Plugins.Install(context.Background(), &PluginsInstallOptions{})
 		assert.Error(t, err)
 	})
 }
@@ -141,7 +142,7 @@ func TestPluginsService_Installed(t *testing.T) {
 		server := newTestServer(t, mockHandler(t, http.MethodGet, "/plugins/installed", http.StatusOK, response))
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Plugins.Installed(nil)
+		result, resp, err := client.Plugins.Installed(context.Background(), nil)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		require.NotNil(t, result)
@@ -158,7 +159,7 @@ func TestPluginsService_Installed(t *testing.T) {
 		})
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Plugins.Installed(&PluginsInstalledOptions{
+		_, _, err := client.Plugins.Installed(context.Background(), &PluginsInstalledOptions{
 			Fields: []string{"category"},
 		})
 		require.NoError(t, err)
@@ -172,7 +173,7 @@ func TestPluginsService_Installed(t *testing.T) {
 		})
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Plugins.Installed(&PluginsInstalledOptions{
+		_, _, err := client.Plugins.Installed(context.Background(), &PluginsInstalledOptions{
 			Type: "BUNDLED",
 		})
 		require.NoError(t, err)
@@ -181,7 +182,7 @@ func TestPluginsService_Installed(t *testing.T) {
 	t.Run("invalid field", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.Plugins.Installed(&PluginsInstalledOptions{
+		_, _, err := client.Plugins.Installed(context.Background(), &PluginsInstalledOptions{
 			Fields: []string{"invalid"},
 		})
 		assert.Error(t, err)
@@ -190,7 +191,7 @@ func TestPluginsService_Installed(t *testing.T) {
 	t.Run("invalid type", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.Plugins.Installed(&PluginsInstalledOptions{
+		_, _, err := client.Plugins.Installed(context.Background(), &PluginsInstalledOptions{
 			Type: "INVALID",
 		})
 		assert.Error(t, err)
@@ -212,7 +213,7 @@ func TestPluginsService_Pending(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/plugins/pending", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Plugins.Pending()
+	result, resp, err := client.Plugins.Pending(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -230,7 +231,7 @@ func TestPluginsService_Uninstall(t *testing.T) {
 		})
 		client := newTestClient(t, server.URL)
 
-		resp, err := client.Plugins.Uninstall(&PluginsUninstallOptions{
+		resp, err := client.Plugins.Uninstall(context.Background(), &PluginsUninstallOptions{
 			Key: "sonar-java",
 		})
 		require.NoError(t, err)
@@ -240,14 +241,14 @@ func TestPluginsService_Uninstall(t *testing.T) {
 	t.Run("nil option", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.Plugins.Uninstall(nil)
+		_, err := client.Plugins.Uninstall(context.Background(), nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("missing key", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.Plugins.Uninstall(&PluginsUninstallOptions{})
+		_, err := client.Plugins.Uninstall(context.Background(), &PluginsUninstallOptions{})
 		assert.Error(t, err)
 	})
 }
@@ -262,7 +263,7 @@ func TestPluginsService_Update(t *testing.T) {
 		})
 		client := newTestClient(t, server.URL)
 
-		resp, err := client.Plugins.Update(&PluginsUpdateOptions{
+		resp, err := client.Plugins.Update(context.Background(), &PluginsUpdateOptions{
 			Key: "sonar-java",
 		})
 		require.NoError(t, err)
@@ -272,14 +273,14 @@ func TestPluginsService_Update(t *testing.T) {
 	t.Run("nil option", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.Plugins.Update(nil)
+		_, err := client.Plugins.Update(context.Background(), nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("missing key", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.Plugins.Update(&PluginsUpdateOptions{})
+		_, err := client.Plugins.Update(context.Background(), &PluginsUpdateOptions{})
 		assert.Error(t, err)
 	})
 }
@@ -311,7 +312,7 @@ func TestPluginsService_Updates(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/plugins/updates", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Plugins.Updates()
+	result, resp, err := client.Plugins.Updates(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/project_analyses_service.go
+++ b/sonar/project_analyses_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"strings"
 )
@@ -327,13 +328,13 @@ func isValidDateTime(dateTimeStr string) bool {
 //
 // API endpoint: POST /api/project_analyses/create_event.
 // Since: 6.3.
-func (s *ProjectAnalysesService) CreateEvent(opt *ProjectAnalysesCreateEventOptions) (*ProjectAnalysesEvent, *http.Response, error) {
+func (s *ProjectAnalysesService) CreateEvent(ctx context.Context, opt *ProjectAnalysesCreateEventOptions) (*ProjectAnalysesEvent, *http.Response, error) {
 	err := s.ValidateCreateEventOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "project_analyses/create_event", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_analyses/create_event", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -353,13 +354,13 @@ func (s *ProjectAnalysesService) CreateEvent(opt *ProjectAnalysesCreateEventOpti
 //
 // API endpoint: POST /api/project_analyses/delete.
 // Since: 6.3.
-func (s *ProjectAnalysesService) Delete(opt *ProjectAnalysesDeleteOptions) (*http.Response, error) {
+func (s *ProjectAnalysesService) Delete(ctx context.Context, opt *ProjectAnalysesDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "project_analyses/delete", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_analyses/delete", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -378,13 +379,13 @@ func (s *ProjectAnalysesService) Delete(opt *ProjectAnalysesDeleteOptions) (*htt
 //
 // API endpoint: POST /api/project_analyses/delete_event.
 // Since: 6.3.
-func (s *ProjectAnalysesService) DeleteEvent(opt *ProjectAnalysesDeleteEventOptions) (*http.Response, error) {
+func (s *ProjectAnalysesService) DeleteEvent(ctx context.Context, opt *ProjectAnalysesDeleteEventOptions) (*http.Response, error) {
 	err := s.ValidateDeleteEventOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "project_analyses/delete_event", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_analyses/delete_event", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -402,13 +403,13 @@ func (s *ProjectAnalysesService) DeleteEvent(opt *ProjectAnalysesDeleteEventOpti
 //
 // API endpoint: GET /api/project_analyses/search.
 // Since: 6.3.
-func (s *ProjectAnalysesService) Search(opt *ProjectAnalysesSearchOptions) (*ProjectAnalysesSearch, *http.Response, error) {
+func (s *ProjectAnalysesService) Search(ctx context.Context, opt *ProjectAnalysesSearchOptions) (*ProjectAnalysesSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "project_analyses/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "project_analyses/search", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -425,7 +426,7 @@ func (s *ProjectAnalysesService) Search(opt *ProjectAnalysesSearchOptions) (*Pro
 
 // SearchAll is a convenience method to iterate over all analyses.
 // It handles pagination automatically.
-func (s *ProjectAnalysesService) SearchAll(opt *ProjectAnalysesSearchOptions) ([]ProjectAnalysis, *http.Response, error) {
+func (s *ProjectAnalysesService) SearchAll(ctx context.Context, opt *ProjectAnalysesSearchOptions) ([]ProjectAnalysis, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -442,7 +443,7 @@ func (s *ProjectAnalysesService) SearchAll(opt *ProjectAnalysesSearchOptions) ([
 	}
 
 	for {
-		result, resp, err := s.Search(&searchOpt)
+		result, resp, err := s.Search(ctx, &searchOpt)
 		if err != nil {
 			return nil, resp, err
 		}
@@ -463,13 +464,13 @@ func (s *ProjectAnalysesService) SearchAll(opt *ProjectAnalysesSearchOptions) ([
 //
 // API endpoint: POST /api/project_analyses/update_event.
 // Since: 6.3.
-func (s *ProjectAnalysesService) UpdateEvent(opt *ProjectAnalysesUpdateEventOptions) (*ProjectAnalysesEvent, *http.Response, error) {
+func (s *ProjectAnalysesService) UpdateEvent(ctx context.Context, opt *ProjectAnalysesUpdateEventOptions) (*ProjectAnalysesEvent, *http.Response, error) {
 	err := s.ValidateUpdateEventOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "project_analyses/update_event", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_analyses/update_event", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/project_analyses_service_test.go
+++ b/sonar/project_analyses_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -30,7 +31,7 @@ func TestProjectAnalysesService_CreateEvent(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.ProjectAnalyses.CreateEvent(&ProjectAnalysesCreateEventOptions{
+		result, resp, err := client.ProjectAnalyses.CreateEvent(context.Background(), &ProjectAnalysesCreateEventOptions{
 			Analysis: "AU-TpxcA-iU5OvuD2FL0",
 			Category: "VERSION",
 			Name:     "1.0",
@@ -43,14 +44,14 @@ func TestProjectAnalysesService_CreateEvent(t *testing.T) {
 	t.Run("nil option", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.CreateEvent(nil)
+		_, _, err := client.ProjectAnalyses.CreateEvent(context.Background(), nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("missing analysis", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.CreateEvent(&ProjectAnalysesCreateEventOptions{
+		_, _, err := client.ProjectAnalyses.CreateEvent(context.Background(), &ProjectAnalysesCreateEventOptions{
 			Name: "1.0",
 		})
 		assert.Error(t, err)
@@ -59,7 +60,7 @@ func TestProjectAnalysesService_CreateEvent(t *testing.T) {
 	t.Run("missing name", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.CreateEvent(&ProjectAnalysesCreateEventOptions{
+		_, _, err := client.ProjectAnalyses.CreateEvent(context.Background(), &ProjectAnalysesCreateEventOptions{
 			Analysis: "AU-TpxcA-iU5OvuD2FL0",
 		})
 		assert.Error(t, err)
@@ -68,7 +69,7 @@ func TestProjectAnalysesService_CreateEvent(t *testing.T) {
 	t.Run("invalid category", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.CreateEvent(&ProjectAnalysesCreateEventOptions{
+		_, _, err := client.ProjectAnalyses.CreateEvent(context.Background(), &ProjectAnalysesCreateEventOptions{
 			Analysis: "AU-TpxcA-iU5OvuD2FL0",
 			Category: "INVALID",
 			Name:     "1.0",
@@ -88,7 +89,7 @@ func TestProjectAnalysesService_Delete(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		resp, err := client.ProjectAnalyses.Delete(&ProjectAnalysesDeleteOptions{
+		resp, err := client.ProjectAnalyses.Delete(context.Background(), &ProjectAnalysesDeleteOptions{
 			Analysis: "AU-TpxcA-iU5OvuD2FL0",
 		})
 		require.NoError(t, err)
@@ -98,14 +99,14 @@ func TestProjectAnalysesService_Delete(t *testing.T) {
 	t.Run("nil option", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.ProjectAnalyses.Delete(nil)
+		_, err := client.ProjectAnalyses.Delete(context.Background(), nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("missing analysis", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.ProjectAnalyses.Delete(&ProjectAnalysesDeleteOptions{})
+		_, err := client.ProjectAnalyses.Delete(context.Background(), &ProjectAnalysesDeleteOptions{})
 		assert.Error(t, err)
 	})
 }
@@ -121,7 +122,7 @@ func TestProjectAnalysesService_DeleteEvent(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		resp, err := client.ProjectAnalyses.DeleteEvent(&ProjectAnalysesDeleteEventOptions{
+		resp, err := client.ProjectAnalyses.DeleteEvent(context.Background(), &ProjectAnalysesDeleteEventOptions{
 			Event: "AU-TpxcA-iU5OvuD2FL1",
 		})
 		require.NoError(t, err)
@@ -131,14 +132,14 @@ func TestProjectAnalysesService_DeleteEvent(t *testing.T) {
 	t.Run("nil option", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.ProjectAnalyses.DeleteEvent(nil)
+		_, err := client.ProjectAnalyses.DeleteEvent(context.Background(), nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("missing event", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.ProjectAnalyses.DeleteEvent(&ProjectAnalysesDeleteEventOptions{})
+		_, err := client.ProjectAnalyses.DeleteEvent(context.Background(), &ProjectAnalysesDeleteEventOptions{})
 		assert.Error(t, err)
 	})
 }
@@ -176,7 +177,7 @@ func TestProjectAnalysesService_Search(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOptions{
+		result, resp, err := client.ProjectAnalyses.Search(context.Background(), &ProjectAnalysesSearchOptions{
 			Project: "my-project",
 		})
 		require.NoError(t, err)
@@ -200,7 +201,7 @@ func TestProjectAnalysesService_Search(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOptions{
+		_, _, err := client.ProjectAnalyses.Search(context.Background(), &ProjectAnalysesSearchOptions{
 			Project:  "my-project",
 			Branch:   "main",
 			Category: "VERSION",
@@ -218,7 +219,7 @@ func TestProjectAnalysesService_Search(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOptions{
+		_, _, err := client.ProjectAnalyses.Search(context.Background(), &ProjectAnalysesSearchOptions{
 			Project: "my-project",
 			From:    "2022-01-01T00:00:00Z",
 			To:      "2022-12-31T23:59:59Z",
@@ -229,21 +230,21 @@ func TestProjectAnalysesService_Search(t *testing.T) {
 	t.Run("nil option", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.Search(nil)
+		_, _, err := client.ProjectAnalyses.Search(context.Background(), nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("missing project", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOptions{})
+		_, _, err := client.ProjectAnalyses.Search(context.Background(), &ProjectAnalysesSearchOptions{})
 		assert.Error(t, err)
 	})
 
 	t.Run("invalid category", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOptions{
+		_, _, err := client.ProjectAnalyses.Search(context.Background(), &ProjectAnalysesSearchOptions{
 			Project:  "my-project",
 			Category: "INVALID",
 		})
@@ -253,7 +254,7 @@ func TestProjectAnalysesService_Search(t *testing.T) {
 	t.Run("invalid from date", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOptions{
+		_, _, err := client.ProjectAnalyses.Search(context.Background(), &ProjectAnalysesSearchOptions{
 			Project: "my-project",
 			From:    "invalid-date",
 		})
@@ -263,7 +264,7 @@ func TestProjectAnalysesService_Search(t *testing.T) {
 	t.Run("invalid to date", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.Search(&ProjectAnalysesSearchOptions{
+		_, _, err := client.ProjectAnalyses.Search(context.Background(), &ProjectAnalysesSearchOptions{
 			Project: "my-project",
 			To:      "invalid-date",
 		})
@@ -297,7 +298,7 @@ func TestProjectAnalysesService_SearchAll(t *testing.T) {
 		}
 		opt.PageSize = 1
 
-		result, _, err := client.ProjectAnalyses.SearchAll(opt)
+		result, _, err := client.ProjectAnalyses.SearchAll(context.Background(), opt)
 		require.NoError(t, err)
 		assert.Len(t, result, 2)
 		assert.Equal(t, 2, callCount)
@@ -306,7 +307,7 @@ func TestProjectAnalysesService_SearchAll(t *testing.T) {
 	t.Run("nil option", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.SearchAll(nil)
+		_, _, err := client.ProjectAnalyses.SearchAll(context.Background(), nil)
 		assert.Error(t, err)
 	})
 }
@@ -331,7 +332,7 @@ func TestProjectAnalysesService_UpdateEvent(t *testing.T) {
 
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.ProjectAnalyses.UpdateEvent(&ProjectAnalysesUpdateEventOptions{
+		result, resp, err := client.ProjectAnalyses.UpdateEvent(context.Background(), &ProjectAnalysesUpdateEventOptions{
 			Event: "AU-TpxcA-iU5OvuD2FL1",
 			Name:  "2.0",
 		})
@@ -343,14 +344,14 @@ func TestProjectAnalysesService_UpdateEvent(t *testing.T) {
 	t.Run("nil option", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.UpdateEvent(nil)
+		_, _, err := client.ProjectAnalyses.UpdateEvent(context.Background(), nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("missing event", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.UpdateEvent(&ProjectAnalysesUpdateEventOptions{
+		_, _, err := client.ProjectAnalyses.UpdateEvent(context.Background(), &ProjectAnalysesUpdateEventOptions{
 			Name: "2.0",
 		})
 		assert.Error(t, err)
@@ -359,7 +360,7 @@ func TestProjectAnalysesService_UpdateEvent(t *testing.T) {
 	t.Run("missing name", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.ProjectAnalyses.UpdateEvent(&ProjectAnalysesUpdateEventOptions{
+		_, _, err := client.ProjectAnalyses.UpdateEvent(context.Background(), &ProjectAnalysesUpdateEventOptions{
 			Event: "AU-TpxcA-iU5OvuD2FL1",
 		})
 		assert.Error(t, err)

--- a/sonar/project_badges_service.go
+++ b/sonar/project_badges_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 const (
 	// BadgeMetricCoverage represents the coverage metric for badges.
@@ -215,13 +218,13 @@ func (s *ProjectBadgesService) ValidateTokenOpt(opt *ProjectBadgesTokenOptions) 
 //
 // API endpoint: GET /api/project_badges/measure.
 // Since: 7.1.
-func (s *ProjectBadgesService) Measure(opt *ProjectBadgesMeasureOptions) (*string, *http.Response, error) {
+func (s *ProjectBadgesService) Measure(ctx context.Context, opt *ProjectBadgesMeasureOptions) (*string, *http.Response, error) {
 	err := s.ValidateMeasureOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "project_badges/measure", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "project_badges/measure", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -241,13 +244,13 @@ func (s *ProjectBadgesService) Measure(opt *ProjectBadgesMeasureOptions) (*strin
 //
 // API endpoint: GET /api/project_badges/quality_gate.
 // Since: 7.1.
-func (s *ProjectBadgesService) QualityGate(opt *ProjectBadgesQualityGateOptions) (*string, *http.Response, error) {
+func (s *ProjectBadgesService) QualityGate(ctx context.Context, opt *ProjectBadgesQualityGateOptions) (*string, *http.Response, error) {
 	err := s.ValidateQualityGateOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "project_badges/quality_gate", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "project_badges/quality_gate", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -268,13 +271,13 @@ func (s *ProjectBadgesService) QualityGate(opt *ProjectBadgesQualityGateOptions)
 //
 // API endpoint: POST /api/project_badges/renew_token.
 // Since: 9.2.
-func (s *ProjectBadgesService) RenewToken(opt *ProjectBadgesRenewTokenOptions) (*http.Response, error) {
+func (s *ProjectBadgesService) RenewToken(ctx context.Context, opt *ProjectBadgesRenewTokenOptions) (*http.Response, error) {
 	err := s.ValidateRenewTokenOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "project_badges/renew_token", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_badges/renew_token", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -293,13 +296,13 @@ func (s *ProjectBadgesService) RenewToken(opt *ProjectBadgesRenewTokenOptions) (
 //
 // API endpoint: GET /api/project_badges/token.
 // Since: 9.2.
-func (s *ProjectBadgesService) Token(opt *ProjectBadgesTokenOptions) (*ProjectBadgesToken, *http.Response, error) {
+func (s *ProjectBadgesService) Token(ctx context.Context, opt *ProjectBadgesTokenOptions) (*ProjectBadgesToken, *http.Response, error) {
 	err := s.ValidateTokenOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "project_badges/token", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "project_badges/token", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/project_badges_service_test.go
+++ b/sonar/project_badges_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -17,7 +18,7 @@ func TestProjectBadges_Measure(t *testing.T) {
 		Metric:  "coverage",
 	}
 
-	result, resp, err := client.ProjectBadges.Measure(opt)
+	result, resp, err := client.ProjectBadges.Measure(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -28,23 +29,23 @@ func TestProjectBadges_Measure_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.ProjectBadges.Measure(nil)
+	_, _, err := client.ProjectBadges.Measure(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, _, err = client.ProjectBadges.Measure(&ProjectBadgesMeasureOptions{
+	_, _, err = client.ProjectBadges.Measure(context.Background(), &ProjectBadgesMeasureOptions{
 		Metric: "coverage",
 	})
 	assert.Error(t, err)
 
 	// Missing Metric should fail validation.
-	_, _, err = client.ProjectBadges.Measure(&ProjectBadgesMeasureOptions{
+	_, _, err = client.ProjectBadges.Measure(context.Background(), &ProjectBadgesMeasureOptions{
 		Project: "my-project",
 	})
 	assert.Error(t, err)
 
 	// Invalid Metric should fail validation.
-	_, _, err = client.ProjectBadges.Measure(&ProjectBadgesMeasureOptions{
+	_, _, err = client.ProjectBadges.Measure(context.Background(), &ProjectBadgesMeasureOptions{
 		Project: "my-project",
 		Metric:  "invalid_metric",
 	})
@@ -59,7 +60,7 @@ func TestProjectBadges_QualityGate(t *testing.T) {
 		Project: "my-project",
 	}
 
-	result, resp, err := client.ProjectBadges.QualityGate(opt)
+	result, resp, err := client.ProjectBadges.QualityGate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -69,11 +70,11 @@ func TestProjectBadges_QualityGate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.ProjectBadges.QualityGate(nil)
+	_, _, err := client.ProjectBadges.QualityGate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, _, err = client.ProjectBadges.QualityGate(&ProjectBadgesQualityGateOptions{})
+	_, _, err = client.ProjectBadges.QualityGate(context.Background(), &ProjectBadgesQualityGateOptions{})
 	assert.Error(t, err)
 }
 
@@ -85,7 +86,7 @@ func TestProjectBadges_RenewToken(t *testing.T) {
 		Project: "my-project",
 	}
 
-	resp, err := client.ProjectBadges.RenewToken(opt)
+	resp, err := client.ProjectBadges.RenewToken(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -94,11 +95,11 @@ func TestProjectBadges_RenewToken_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.ProjectBadges.RenewToken(nil)
+	_, err := client.ProjectBadges.RenewToken(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, err = client.ProjectBadges.RenewToken(&ProjectBadgesRenewTokenOptions{})
+	_, err = client.ProjectBadges.RenewToken(context.Background(), &ProjectBadgesRenewTokenOptions{})
 	assert.Error(t, err)
 }
 
@@ -112,7 +113,7 @@ func TestProjectBadges_Token(t *testing.T) {
 		Project: "my-project",
 	}
 
-	result, resp, err := client.ProjectBadges.Token(opt)
+	result, resp, err := client.ProjectBadges.Token(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -123,11 +124,11 @@ func TestProjectBadges_Token_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.ProjectBadges.Token(nil)
+	_, _, err := client.ProjectBadges.Token(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, _, err = client.ProjectBadges.Token(&ProjectBadgesTokenOptions{})
+	_, _, err = client.ProjectBadges.Token(context.Background(), &ProjectBadgesTokenOptions{})
 	assert.Error(t, err)
 }
 

--- a/sonar/project_branches_service.go
+++ b/sonar/project_branches_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // ProjectBranchesService handles communication with the project branches related methods
 // of the SonarQube API.
@@ -214,13 +217,13 @@ func (s *ProjectBranchesService) ValidateSetMainOpt(opt *ProjectBranchesSetMainO
 //
 // API endpoint: POST /api/project_branches/delete.
 // Since: 6.6.
-func (s *ProjectBranchesService) Delete(opt *ProjectBranchesDeleteOptions) (*http.Response, error) {
+func (s *ProjectBranchesService) Delete(ctx context.Context, opt *ProjectBranchesDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "project_branches/delete", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_branches/delete", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -238,13 +241,13 @@ func (s *ProjectBranchesService) Delete(opt *ProjectBranchesDeleteOptions) (*htt
 //
 // API endpoint: GET /api/project_branches/list.
 // Since: 6.6.
-func (s *ProjectBranchesService) List(opt *ProjectBranchesListOptions) (*ProjectBranchesList, *http.Response, error) {
+func (s *ProjectBranchesService) List(ctx context.Context, opt *ProjectBranchesListOptions) (*ProjectBranchesList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "project_branches/list", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "project_branches/list", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -264,13 +267,13 @@ func (s *ProjectBranchesService) List(opt *ProjectBranchesListOptions) (*Project
 //
 // API endpoint: POST /api/project_branches/rename.
 // Since: 6.6.
-func (s *ProjectBranchesService) Rename(opt *ProjectBranchesRenameOptions) (*http.Response, error) {
+func (s *ProjectBranchesService) Rename(ctx context.Context, opt *ProjectBranchesRenameOptions) (*http.Response, error) {
 	err := s.ValidateRenameOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "project_branches/rename", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_branches/rename", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -289,13 +292,13 @@ func (s *ProjectBranchesService) Rename(opt *ProjectBranchesRenameOptions) (*htt
 //
 // API endpoint: POST /api/project_branches/set_automatic_deletion_protection.
 // Since: 8.1.
-func (s *ProjectBranchesService) SetAutomaticDeletionProtection(opt *ProjectBranchesSetAutomaticDeletionProtectionOptions) (*http.Response, error) {
+func (s *ProjectBranchesService) SetAutomaticDeletionProtection(ctx context.Context, opt *ProjectBranchesSetAutomaticDeletionProtectionOptions) (*http.Response, error) {
 	err := s.ValidateSetAutomaticDeletionProtectionOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "project_branches/set_automatic_deletion_protection", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_branches/set_automatic_deletion_protection", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -314,13 +317,13 @@ func (s *ProjectBranchesService) SetAutomaticDeletionProtection(opt *ProjectBran
 //
 // API endpoint: POST /api/project_branches/set_main.
 // Since: 10.2.
-func (s *ProjectBranchesService) SetMain(opt *ProjectBranchesSetMainOptions) (*http.Response, error) {
+func (s *ProjectBranchesService) SetMain(ctx context.Context, opt *ProjectBranchesSetMainOptions) (*http.Response, error) {
 	err := s.ValidateSetMainOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "project_branches/set_main", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_branches/set_main", opt)
 	if err != nil {
 		return nil, err
 	}

--- a/sonar/project_branches_service_test.go
+++ b/sonar/project_branches_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestProjectBranches_Delete(t *testing.T) {
 		Project: "my-project",
 	}
 
-	resp, err := client.ProjectBranches.Delete(opt)
+	resp, err := client.ProjectBranches.Delete(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -28,17 +29,17 @@ func TestProjectBranches_Delete_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.ProjectBranches.Delete(nil)
+	_, err := client.ProjectBranches.Delete(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Branch should fail validation.
-	_, err = client.ProjectBranches.Delete(&ProjectBranchesDeleteOptions{
+	_, err = client.ProjectBranches.Delete(context.Background(), &ProjectBranchesDeleteOptions{
 		Project: "my-project",
 	})
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, err = client.ProjectBranches.Delete(&ProjectBranchesDeleteOptions{
+	_, err = client.ProjectBranches.Delete(context.Background(), &ProjectBranchesDeleteOptions{
 		Branch: "feature-1",
 	})
 	assert.Error(t, err)
@@ -74,7 +75,7 @@ func TestProjectBranches_List(t *testing.T) {
 		Project: "my-project",
 	}
 
-	result, resp, err := client.ProjectBranches.List(opt)
+	result, resp, err := client.ProjectBranches.List(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -89,11 +90,11 @@ func TestProjectBranches_List_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.ProjectBranches.List(nil)
+	_, _, err := client.ProjectBranches.List(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, _, err = client.ProjectBranches.List(&ProjectBranchesListOptions{})
+	_, _, err = client.ProjectBranches.List(context.Background(), &ProjectBranchesListOptions{})
 	assert.Error(t, err)
 }
 
@@ -108,7 +109,7 @@ func TestProjectBranches_Rename(t *testing.T) {
 		Project: "my-project",
 	}
 
-	resp, err := client.ProjectBranches.Rename(opt)
+	resp, err := client.ProjectBranches.Rename(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -117,17 +118,17 @@ func TestProjectBranches_Rename_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.ProjectBranches.Rename(nil)
+	_, err := client.ProjectBranches.Rename(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Name should fail validation.
-	_, err = client.ProjectBranches.Rename(&ProjectBranchesRenameOptions{
+	_, err = client.ProjectBranches.Rename(context.Background(), &ProjectBranchesRenameOptions{
 		Project: "my-project",
 	})
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, err = client.ProjectBranches.Rename(&ProjectBranchesRenameOptions{
+	_, err = client.ProjectBranches.Rename(context.Background(), &ProjectBranchesRenameOptions{
 		Name: "main",
 	})
 	assert.Error(t, err)
@@ -137,7 +138,7 @@ func TestProjectBranches_Rename_ValidationError(t *testing.T) {
 	for i := 0; i < MaxBranchNameLength+1; i++ {
 		longName += "a"
 	}
-	_, err = client.ProjectBranches.Rename(&ProjectBranchesRenameOptions{
+	_, err = client.ProjectBranches.Rename(context.Background(), &ProjectBranchesRenameOptions{
 		Name:    longName,
 		Project: "my-project",
 	})
@@ -156,7 +157,7 @@ func TestProjectBranches_SetAutomaticDeletionProtection(t *testing.T) {
 		Value:   true,
 	}
 
-	resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(opt)
+	resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -173,7 +174,7 @@ func TestProjectBranches_SetAutomaticDeletionProtection_False(t *testing.T) {
 		Value:   false,
 	}
 
-	resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(opt)
+	resp, err := client.ProjectBranches.SetAutomaticDeletionProtection(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -182,18 +183,18 @@ func TestProjectBranches_SetAutomaticDeletionProtection_ValidationError(t *testi
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.ProjectBranches.SetAutomaticDeletionProtection(nil)
+	_, err := client.ProjectBranches.SetAutomaticDeletionProtection(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Branch should fail validation.
-	_, err = client.ProjectBranches.SetAutomaticDeletionProtection(&ProjectBranchesSetAutomaticDeletionProtectionOptions{
+	_, err = client.ProjectBranches.SetAutomaticDeletionProtection(context.Background(), &ProjectBranchesSetAutomaticDeletionProtectionOptions{
 		Project: "my-project",
 		Value:   true,
 	})
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, err = client.ProjectBranches.SetAutomaticDeletionProtection(&ProjectBranchesSetAutomaticDeletionProtectionOptions{
+	_, err = client.ProjectBranches.SetAutomaticDeletionProtection(context.Background(), &ProjectBranchesSetAutomaticDeletionProtectionOptions{
 		Branch: "feature-1",
 		Value:  true,
 	})
@@ -211,7 +212,7 @@ func TestProjectBranches_SetMain(t *testing.T) {
 		Project: "my-project",
 	}
 
-	resp, err := client.ProjectBranches.SetMain(opt)
+	resp, err := client.ProjectBranches.SetMain(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -220,17 +221,17 @@ func TestProjectBranches_SetMain_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.ProjectBranches.SetMain(nil)
+	_, err := client.ProjectBranches.SetMain(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Branch should fail validation.
-	_, err = client.ProjectBranches.SetMain(&ProjectBranchesSetMainOptions{
+	_, err = client.ProjectBranches.SetMain(context.Background(), &ProjectBranchesSetMainOptions{
 		Project: "my-project",
 	})
 	assert.Error(t, err)
 
 	// Missing Project should fail validation.
-	_, err = client.ProjectBranches.SetMain(&ProjectBranchesSetMainOptions{
+	_, err = client.ProjectBranches.SetMain(context.Background(), &ProjectBranchesSetMainOptions{
 		Branch: "main",
 	})
 	assert.Error(t, err)

--- a/sonar/project_dump_service.go
+++ b/sonar/project_dump_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // ProjectDumpService handles communication with the project dump related methods
 // of the SonarQube API.
@@ -100,13 +103,13 @@ func (s *ProjectDumpService) ValidateStatusOpt(opt *ProjectDumpStatusOptions) er
 //
 // API endpoint: POST /api/project_dump/export.
 // Since: 1.0.
-func (s *ProjectDumpService) Export(opt *ProjectDumpExportOptions) (*ProjectDumpExport, *http.Response, error) {
+func (s *ProjectDumpService) Export(ctx context.Context, opt *ProjectDumpExportOptions) (*ProjectDumpExport, *http.Response, error) {
 	err := s.ValidateExportOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "project_dump/export", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_dump/export", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,13 +129,13 @@ func (s *ProjectDumpService) Export(opt *ProjectDumpExportOptions) (*ProjectDump
 //
 // API endpoint: GET /api/project_dump/status.
 // Since: 1.0.
-func (s *ProjectDumpService) Status(opt *ProjectDumpStatusOptions) (*ProjectDumpStatus, *http.Response, error) {
+func (s *ProjectDumpService) Status(ctx context.Context, opt *ProjectDumpStatusOptions) (*ProjectDumpStatus, *http.Response, error) {
 	err := s.ValidateStatusOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "project_dump/status", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "project_dump/status", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/project_dump_service_test.go
+++ b/sonar/project_dump_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestProjectDump_Export(t *testing.T) {
 		Key: "my-project",
 	}
 
-	result, resp, err := client.ProjectDump.Export(opt)
+	result, resp, err := client.ProjectDump.Export(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -36,11 +37,11 @@ func TestProjectDump_Export_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.ProjectDump.Export(nil)
+	_, _, err := client.ProjectDump.Export(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Key should fail validation.
-	_, _, err = client.ProjectDump.Export(&ProjectDumpExportOptions{})
+	_, _, err = client.ProjectDump.Export(context.Background(), &ProjectDumpExportOptions{})
 	assert.Error(t, err)
 }
 
@@ -59,7 +60,7 @@ func TestProjectDump_Status(t *testing.T) {
 		Key: "my-project",
 	}
 
-	result, resp, err := client.ProjectDump.Status(opt)
+	result, resp, err := client.ProjectDump.Status(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -81,7 +82,7 @@ func TestProjectDump_Status_WithID(t *testing.T) {
 		ID: "proj-123",
 	}
 
-	result, resp, err := client.ProjectDump.Status(opt)
+	result, resp, err := client.ProjectDump.Status(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -91,11 +92,11 @@ func TestProjectDump_Status_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.ProjectDump.Status(nil)
+	_, _, err := client.ProjectDump.Status(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing both ID and Key should fail validation.
-	_, _, err = client.ProjectDump.Status(&ProjectDumpStatusOptions{})
+	_, _, err = client.ProjectDump.Status(context.Background(), &ProjectDumpStatusOptions{})
 	assert.Error(t, err)
 }
 

--- a/sonar/project_links_service.go
+++ b/sonar/project_links_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // ProjectLinksService handles communication with the project links related methods
 // of the SonarQube API.
@@ -154,13 +157,13 @@ func (s *ProjectLinksService) ValidateSearchOpt(opt *ProjectLinksSearchOptions) 
 //
 // API endpoint: POST /api/project_links/create.
 // Since: 6.1.
-func (s *ProjectLinksService) Create(opt *ProjectLinksCreateOptions) (*ProjectLinksCreate, *http.Response, error) {
+func (s *ProjectLinksService) Create(ctx context.Context, opt *ProjectLinksCreateOptions) (*ProjectLinksCreate, *http.Response, error) {
 	err := s.ValidateCreateOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "project_links/create", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_links/create", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -180,13 +183,13 @@ func (s *ProjectLinksService) Create(opt *ProjectLinksCreateOptions) (*ProjectLi
 //
 // API endpoint: POST /api/project_links/delete.
 // Since: 6.1.
-func (s *ProjectLinksService) Delete(opt *ProjectLinksDeleteOptions) (*http.Response, error) {
+func (s *ProjectLinksService) Delete(ctx context.Context, opt *ProjectLinksDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "project_links/delete", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_links/delete", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -208,13 +211,13 @@ func (s *ProjectLinksService) Delete(opt *ProjectLinksDeleteOptions) (*http.Resp
 //
 // API endpoint: GET /api/project_links/search.
 // Since: 6.1.
-func (s *ProjectLinksService) Search(opt *ProjectLinksSearchOptions) (*ProjectLinksSearch, *http.Response, error) {
+func (s *ProjectLinksService) Search(ctx context.Context, opt *ProjectLinksSearchOptions) (*ProjectLinksSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "project_links/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "project_links/search", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/project_links_service_test.go
+++ b/sonar/project_links_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -29,7 +30,7 @@ func TestProjectLinks_Create(t *testing.T) {
 		URL:        "https://example.com",
 	}
 
-	result, resp, err := client.ProjectLinks.Create(opt)
+	result, resp, err := client.ProjectLinks.Create(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -41,25 +42,25 @@ func TestProjectLinks_Create_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.ProjectLinks.Create(nil)
+	_, _, err := client.ProjectLinks.Create(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Name should fail validation.
-	_, _, err = client.ProjectLinks.Create(&ProjectLinksCreateOptions{
+	_, _, err = client.ProjectLinks.Create(context.Background(), &ProjectLinksCreateOptions{
 		ProjectKey: "my-project",
 		URL:        "https://example.com",
 	})
 	assert.Error(t, err)
 
 	// Missing URL should fail validation.
-	_, _, err = client.ProjectLinks.Create(&ProjectLinksCreateOptions{
+	_, _, err = client.ProjectLinks.Create(context.Background(), &ProjectLinksCreateOptions{
 		Name:       "Homepage",
 		ProjectKey: "my-project",
 	})
 	assert.Error(t, err)
 
 	// Missing ProjectID and ProjectKey should fail validation.
-	_, _, err = client.ProjectLinks.Create(&ProjectLinksCreateOptions{
+	_, _, err = client.ProjectLinks.Create(context.Background(), &ProjectLinksCreateOptions{
 		Name: "Homepage",
 		URL:  "https://example.com",
 	})
@@ -76,7 +77,7 @@ func TestProjectLinks_Delete(t *testing.T) {
 		ID: "1",
 	}
 
-	resp, err := client.ProjectLinks.Delete(opt)
+	resp, err := client.ProjectLinks.Delete(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -85,11 +86,11 @@ func TestProjectLinks_Delete_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.ProjectLinks.Delete(nil)
+	_, err := client.ProjectLinks.Delete(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing ID should fail validation.
-	_, err = client.ProjectLinks.Delete(&ProjectLinksDeleteOptions{})
+	_, err = client.ProjectLinks.Delete(context.Background(), &ProjectLinksDeleteOptions{})
 	assert.Error(t, err)
 }
 
@@ -110,7 +111,7 @@ func TestProjectLinks_Search(t *testing.T) {
 		ProjectKey: "my-project",
 	}
 
-	result, resp, err := client.ProjectLinks.Search(opt)
+	result, resp, err := client.ProjectLinks.Search(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -122,11 +123,11 @@ func TestProjectLinks_Search_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.ProjectLinks.Search(nil)
+	_, _, err := client.ProjectLinks.Search(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing ProjectID and ProjectKey should fail validation.
-	_, _, err = client.ProjectLinks.Search(&ProjectLinksSearchOptions{})
+	_, _, err = client.ProjectLinks.Search(context.Background(), &ProjectLinksSearchOptions{})
 	assert.Error(t, err)
 }
 

--- a/sonar/project_tags_service.go
+++ b/sonar/project_tags_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // ProjectTagsService handles communication with the project tags related methods
 // of the SonarQube API.
@@ -84,13 +87,13 @@ func (s *ProjectTagsService) ValidateSetOpt(opt *ProjectTagsSetOptions) error {
 //
 // API endpoint: GET /api/project_tags/search.
 // Since: 6.4.
-func (s *ProjectTagsService) Search(opt *ProjectTagsSearchOptions) (*ProjectTagsSearch, *http.Response, error) {
+func (s *ProjectTagsService) Search(ctx context.Context, opt *ProjectTagsSearchOptions) (*ProjectTagsSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "project_tags/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "project_tags/search", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -110,13 +113,13 @@ func (s *ProjectTagsService) Search(opt *ProjectTagsSearchOptions) (*ProjectTags
 //
 // API endpoint: POST /api/project_tags/set.
 // Since: 6.4.
-func (s *ProjectTagsService) Set(opt *ProjectTagsSetOptions) (*http.Response, error) {
+func (s *ProjectTagsService) Set(ctx context.Context, opt *ProjectTagsSetOptions) (*http.Response, error) {
 	err := s.ValidateSetOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "project_tags/set", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_tags/set", opt)
 	if err != nil {
 		return nil, err
 	}

--- a/sonar/project_tags_service_test.go
+++ b/sonar/project_tags_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestProjectTagsService_Search(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.ProjectTags.Search(nil)
+		result, resp, err := client.ProjectTags.Search(context.Background(), nil)
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -38,7 +39,7 @@ func TestProjectTagsService_Search(t *testing.T) {
 			Query: "sec",
 		}
 
-		result, resp, err := client.ProjectTags.Search(opt)
+		result, resp, err := client.ProjectTags.Search(context.Background(), opt)
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -57,7 +58,7 @@ func TestProjectTagsService_Set(t *testing.T) {
 			Tags:    []string{"security", "performance"},
 		}
 
-		resp, err := client.ProjectTags.Set(opt)
+		resp, err := client.ProjectTags.Set(context.Background(), opt)
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
@@ -80,7 +81,7 @@ func TestProjectTagsService_Set(t *testing.T) {
 			Tags:    []string{},
 		}
 
-		resp, err := client.ProjectTags.Set(opt)
+		resp, err := client.ProjectTags.Set(context.Background(), opt)
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
@@ -89,7 +90,7 @@ func TestProjectTagsService_Set(t *testing.T) {
 	t.Run("nil option fails validation", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.ProjectTags.Set(nil)
+		_, err := client.ProjectTags.Set(context.Background(), nil)
 
 		assert.Error(t, err)
 	})
@@ -97,7 +98,7 @@ func TestProjectTagsService_Set(t *testing.T) {
 	t.Run("missing project fails validation", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, err := client.ProjectTags.Set(&ProjectTagsSetOptions{
+		_, err := client.ProjectTags.Set(context.Background(), &ProjectTagsSetOptions{
 			Tags: []string{"tag1"},
 		})
 

--- a/sonar/projects_service.go
+++ b/sonar/projects_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -433,13 +434,13 @@ func (s *ProjectsService) ValidateUpdateVisibilityOpt(opt *ProjectsUpdateVisibil
 // Requires 'Administer System' permission.
 //
 // Since: 5.2.
-func (s *ProjectsService) BulkDelete(opt *ProjectsBulkDeleteOptions) (*http.Response, error) {
+func (s *ProjectsService) BulkDelete(ctx context.Context, opt *ProjectsBulkDeleteOptions) (*http.Response, error) {
 	err := s.ValidateBulkDeleteOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "projects/bulk_delete", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "projects/bulk_delete", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -456,13 +457,13 @@ func (s *ProjectsService) BulkDelete(opt *ProjectsBulkDeleteOptions) (*http.Resp
 // Requires 'Create Projects' permission.
 //
 // Since: 4.0.
-func (s *ProjectsService) Create(opt *ProjectsCreateOptions) (*ProjectsCreate, *http.Response, error) {
+func (s *ProjectsService) Create(ctx context.Context, opt *ProjectsCreateOptions) (*ProjectsCreate, *http.Response, error) {
 	err := s.ValidateCreateOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "projects/create", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "projects/create", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -481,13 +482,13 @@ func (s *ProjectsService) Create(opt *ProjectsCreateOptions) (*ProjectsCreate, *
 // Requires 'Administer System' permission or 'Administer' permission on the project.
 //
 // Since: 5.2.
-func (s *ProjectsService) Delete(opt *ProjectsDeleteOptions) (*http.Response, error) {
+func (s *ProjectsService) Delete(ctx context.Context, opt *ProjectsDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "projects/delete", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "projects/delete", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -504,13 +505,13 @@ func (s *ProjectsService) Delete(opt *ProjectsDeleteOptions) (*http.Response, er
 // Requires 'Browse' permission on the returned projects.
 //
 // Since: 6.3.
-func (s *ProjectsService) Search(opt *ProjectsSearchOptions) (*ProjectsSearch, *http.Response, error) {
+func (s *ProjectsService) Search(ctx context.Context, opt *ProjectsSearchOptions) (*ProjectsSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "projects/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "projects/search", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -529,13 +530,13 @@ func (s *ProjectsService) Search(opt *ProjectsSearchOptions) (*ProjectsSearch, *
 // Only the favorite and recently analyzed projects will be returned.
 //
 // Since: 6.4.
-func (s *ProjectsService) SearchMyProjects(opt *ProjectsSearchMyProjectsOptions) (*ProjectsSearchMyProjects, *http.Response, error) {
+func (s *ProjectsService) SearchMyProjects(ctx context.Context, opt *ProjectsSearchMyProjectsOptions) (*ProjectsSearchMyProjects, *http.Response, error) {
 	err := s.ValidateSearchMyProjectsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "projects/search_my_projects", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "projects/search_my_projects", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -554,8 +555,8 @@ func (s *ProjectsService) SearchMyProjects(opt *ProjectsSearchMyProjectsOptions)
 // Requires authentication.
 //
 // Since: 9.5.
-func (s *ProjectsService) SearchMyScannableProjects(opt *ProjectsSearchMyScannableProjectsOptions) (*ProjectsSearchMyScannableProjects, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "projects/search_my_scannable_projects", opt)
+func (s *ProjectsService) SearchMyScannableProjects(ctx context.Context, opt *ProjectsSearchMyScannableProjectsOptions) (*ProjectsSearchMyScannableProjects, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "projects/search_my_scannable_projects", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -574,13 +575,13 @@ func (s *ProjectsService) SearchMyScannableProjects(opt *ProjectsSearchMyScannab
 // Requires 'Administer System' permission.
 //
 // Since: 6.4.
-func (s *ProjectsService) UpdateDefaultVisibility(opt *ProjectsUpdateDefaultVisibilityOptions) (*http.Response, error) {
+func (s *ProjectsService) UpdateDefaultVisibility(ctx context.Context, opt *ProjectsUpdateDefaultVisibilityOptions) (*http.Response, error) {
 	err := s.ValidateUpdateDefaultVisibilityOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "projects/update_default_visibility", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "projects/update_default_visibility", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -597,13 +598,13 @@ func (s *ProjectsService) UpdateDefaultVisibility(opt *ProjectsUpdateDefaultVisi
 // Requires 'Administer' permission on the project.
 //
 // Since: 6.1.
-func (s *ProjectsService) UpdateKey(opt *ProjectsUpdateKeyOptions) (*http.Response, error) {
+func (s *ProjectsService) UpdateKey(ctx context.Context, opt *ProjectsUpdateKeyOptions) (*http.Response, error) {
 	err := s.ValidateUpdateKeyOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "projects/update_key", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "projects/update_key", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -620,13 +621,13 @@ func (s *ProjectsService) UpdateKey(opt *ProjectsUpdateKeyOptions) (*http.Respon
 // Requires 'Project administer' permission on the project.
 //
 // Since: 6.4.
-func (s *ProjectsService) UpdateVisibility(opt *ProjectsUpdateVisibilityOptions) (*http.Response, error) {
+func (s *ProjectsService) UpdateVisibility(ctx context.Context, opt *ProjectsUpdateVisibilityOptions) (*http.Response, error) {
 	err := s.ValidateUpdateVisibilityOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "projects/update_visibility", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "projects/update_visibility", opt)
 	if err != nil {
 		return nil, err
 	}

--- a/sonar/projects_service_test.go
+++ b/sonar/projects_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -24,7 +25,7 @@ func TestProjectsService_BulkDelete(t *testing.T) {
 		Projects: []string{"project1", "project2"},
 	}
 
-	resp, err := client.Projects.BulkDelete(opt)
+	resp, err := client.Projects.BulkDelete(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -35,7 +36,7 @@ func TestProjectsService_BulkDelete_ValidationError(t *testing.T) {
 
 	// Test no filter provided
 	opt := &ProjectsBulkDeleteOptions{}
-	_, err := client.Projects.BulkDelete(opt)
+	_, err := client.Projects.BulkDelete(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test invalid qualifier
@@ -43,7 +44,7 @@ func TestProjectsService_BulkDelete_ValidationError(t *testing.T) {
 		Query:      "test",
 		Qualifiers: []string{"INVALID"},
 	}
-	_, err = client.Projects.BulkDelete(opt)
+	_, err = client.Projects.BulkDelete(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -67,7 +68,7 @@ func TestProjectsService_Create(t *testing.T) {
 		Visibility: ProjectVisibilityPrivate,
 	}
 
-	result, resp, err := client.Projects.Create(opt)
+	result, resp, err := client.Projects.Create(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "my-project", result.Project.Key)
@@ -82,14 +83,14 @@ func TestProjectsService_Create_ValidationError(t *testing.T) {
 	opt := &ProjectsCreateOptions{
 		Project: "my-project",
 	}
-	_, _, err := client.Projects.Create(opt)
+	_, _, err := client.Projects.Create(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test missing Project
 	opt = &ProjectsCreateOptions{
 		Name: "My Project",
 	}
-	_, _, err = client.Projects.Create(opt)
+	_, _, err = client.Projects.Create(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test Name too long
@@ -97,7 +98,7 @@ func TestProjectsService_Create_ValidationError(t *testing.T) {
 		Name:    strings.Repeat("a", MaxProjectNameLength+1),
 		Project: "my-project",
 	}
-	_, _, err = client.Projects.Create(opt)
+	_, _, err = client.Projects.Create(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test Project key too long
@@ -105,7 +106,7 @@ func TestProjectsService_Create_ValidationError(t *testing.T) {
 		Name:    "My Project",
 		Project: strings.Repeat("a", MaxProjectKeyLength+1),
 	}
-	_, _, err = client.Projects.Create(opt)
+	_, _, err = client.Projects.Create(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test invalid visibility
@@ -114,7 +115,7 @@ func TestProjectsService_Create_ValidationError(t *testing.T) {
 		Project:    "my-project",
 		Visibility: "invalid",
 	}
-	_, _, err = client.Projects.Create(opt)
+	_, _, err = client.Projects.Create(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -129,7 +130,7 @@ func TestProjectsService_Delete(t *testing.T) {
 		Project: "my-project",
 	}
 
-	resp, err := client.Projects.Delete(opt)
+	resp, err := client.Projects.Delete(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -140,7 +141,7 @@ func TestProjectsService_Delete_ValidationError(t *testing.T) {
 
 	// Test missing Project
 	opt := &ProjectsDeleteOptions{}
-	_, err := client.Projects.Delete(opt)
+	_, err := client.Projects.Delete(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -174,7 +175,7 @@ func TestProjectsService_Search(t *testing.T) {
 		Qualifiers: []string{ProjectQualifierTRK},
 	}
 
-	result, resp, err := client.Projects.Search(opt)
+	result, resp, err := client.Projects.Search(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Components, 2)
@@ -189,7 +190,7 @@ func TestProjectsService_Search_ValidationError(t *testing.T) {
 	opt := &ProjectsSearchOptions{
 		Qualifiers: []string{"INVALID"},
 	}
-	_, _, err := client.Projects.Search(opt)
+	_, _, err := client.Projects.Search(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -212,7 +213,7 @@ func TestProjectsService_SearchMyProjects(t *testing.T) {
 
 	opt := &ProjectsSearchMyProjectsOptions{}
 
-	result, resp, err := client.Projects.SearchMyProjects(opt)
+	result, resp, err := client.Projects.SearchMyProjects(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Projects, 1)
@@ -230,7 +231,7 @@ func TestProjectsService_SearchMyScannableProjects(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Projects.SearchMyScannableProjects(&ProjectsSearchMyScannableProjectsOptions{})
+	result, resp, err := client.Projects.SearchMyScannableProjects(context.Background(), &ProjectsSearchMyScannableProjectsOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Projects, 2)
@@ -247,7 +248,7 @@ func TestProjectsService_UpdateDefaultVisibility(t *testing.T) {
 		ProjectVisibility: ProjectVisibilityPrivate,
 	}
 
-	resp, err := client.Projects.UpdateDefaultVisibility(opt)
+	resp, err := client.Projects.UpdateDefaultVisibility(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -258,14 +259,14 @@ func TestProjectsService_UpdateDefaultVisibility_ValidationError(t *testing.T) {
 
 	// Test missing ProjectVisibility
 	opt := &ProjectsUpdateDefaultVisibilityOptions{}
-	_, err := client.Projects.UpdateDefaultVisibility(opt)
+	_, err := client.Projects.UpdateDefaultVisibility(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test invalid visibility
 	opt = &ProjectsUpdateDefaultVisibilityOptions{
 		ProjectVisibility: "invalid",
 	}
-	_, err = client.Projects.UpdateDefaultVisibility(opt)
+	_, err = client.Projects.UpdateDefaultVisibility(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -281,7 +282,7 @@ func TestProjectsService_UpdateKey(t *testing.T) {
 		To:   "new-project-key",
 	}
 
-	resp, err := client.Projects.UpdateKey(opt)
+	resp, err := client.Projects.UpdateKey(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -294,14 +295,14 @@ func TestProjectsService_UpdateKey_ValidationError(t *testing.T) {
 	opt := &ProjectsUpdateKeyOptions{
 		To: "new-key",
 	}
-	_, err := client.Projects.UpdateKey(opt)
+	_, err := client.Projects.UpdateKey(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test missing To
 	opt = &ProjectsUpdateKeyOptions{
 		From: "old-key",
 	}
-	_, err = client.Projects.UpdateKey(opt)
+	_, err = client.Projects.UpdateKey(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -317,7 +318,7 @@ func TestProjectsService_UpdateVisibility(t *testing.T) {
 		Visibility: ProjectVisibilityPublic,
 	}
 
-	resp, err := client.Projects.UpdateVisibility(opt)
+	resp, err := client.Projects.UpdateVisibility(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -330,14 +331,14 @@ func TestProjectsService_UpdateVisibility_ValidationError(t *testing.T) {
 	opt := &ProjectsUpdateVisibilityOptions{
 		Visibility: ProjectVisibilityPublic,
 	}
-	_, err := client.Projects.UpdateVisibility(opt)
+	_, err := client.Projects.UpdateVisibility(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test missing Visibility
 	opt = &ProjectsUpdateVisibilityOptions{
 		Project: "my-project",
 	}
-	_, err = client.Projects.UpdateVisibility(opt)
+	_, err = client.Projects.UpdateVisibility(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test invalid visibility
@@ -345,6 +346,6 @@ func TestProjectsService_UpdateVisibility_ValidationError(t *testing.T) {
 		Project:    "my-project",
 		Visibility: "invalid",
 	}
-	_, err = client.Projects.UpdateVisibility(opt)
+	_, err = client.Projects.UpdateVisibility(context.Background(), opt)
 	assert.Error(t, err)
 }

--- a/sonar/push_service.go
+++ b/sonar/push_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -69,13 +70,13 @@ func (s *PushService) ValidateSonarlintEventsOpt(opt *PushSonarlintEventsOptions
 //
 // API endpoint: GET /api/push/sonarlint_events.
 // WARNING: This is an internal API and may change without notice.
-func (s *PushService) SonarlintEvents(opt *PushSonarlintEventsOptions) (*http.Response, error) {
+func (s *PushService) SonarlintEvents(ctx context.Context, opt *PushSonarlintEventsOptions) (*http.Response, error) {
 	err := s.ValidateSonarlintEventsOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "push/sonarlint_events", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "push/sonarlint_events", opt)
 	if err != nil {
 		return nil, err
 	}

--- a/sonar/push_service_test.go
+++ b/sonar/push_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -19,7 +20,7 @@ func TestPush_SonarlintEvents(t *testing.T) {
 		ProjectKeys: []string{"my-project"},
 	}
 
-	resp, err := client.Push.SonarlintEvents(opt)
+	resp, err := client.Push.SonarlintEvents(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -39,7 +40,7 @@ func TestPush_SonarlintEvents_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.Push.SonarlintEvents(tt.opt)
+			_, err := client.Push.SonarlintEvents(context.Background(), tt.opt)
 			require.Error(t, err)
 
 			var validationErr *ValidationError

--- a/sonar/qualitygates_service.go
+++ b/sonar/qualitygates_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -480,13 +481,13 @@ type QualitygatesUpdateConditionOptions struct {
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - Edit right on the specified quality gate
-func (s *QualitygatesService) AddGroup(opt *QualitygatesAddGroupOptions) (resp *http.Response, err error) {
+func (s *QualitygatesService) AddGroup(ctx context.Context, opt *QualitygatesAddGroupOptions) (resp *http.Response, err error) {
 	err = s.ValidateAddGroupOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualitygates/add_group", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualitygates/add_group", opt)
 	if err != nil {
 		return
 	}
@@ -503,13 +504,13 @@ func (s *QualitygatesService) AddGroup(opt *QualitygatesAddGroupOptions) (resp *
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - Edit right on the specified quality gate
-func (s *QualitygatesService) AddUser(opt *QualitygatesAddUserOptions) (resp *http.Response, err error) {
+func (s *QualitygatesService) AddUser(ctx context.Context, opt *QualitygatesAddUserOptions) (resp *http.Response, err error) {
 	err = s.ValidateAddUserOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualitygates/add_user", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualitygates/add_user", opt)
 	if err != nil {
 		return
 	}
@@ -524,13 +525,13 @@ func (s *QualitygatesService) AddUser(opt *QualitygatesAddUserOptions) (resp *ht
 
 // Copy copies a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) Copy(opt *QualitygatesCopyOptions) (resp *http.Response, err error) {
+func (s *QualitygatesService) Copy(ctx context.Context, opt *QualitygatesCopyOptions) (resp *http.Response, err error) {
 	err = s.ValidateCopyOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualitygates/copy", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualitygates/copy", opt)
 	if err != nil {
 		return
 	}
@@ -545,13 +546,13 @@ func (s *QualitygatesService) Copy(opt *QualitygatesCopyOptions) (resp *http.Res
 
 // Create creates a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) Create(opt *QualitygatesCreateOptions) (v *QualitygatesCreate, resp *http.Response, err error) {
+func (s *QualitygatesService) Create(ctx context.Context, opt *QualitygatesCreateOptions) (v *QualitygatesCreate, resp *http.Response, err error) {
 	err = s.ValidateCreateOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualitygates/create", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualitygates/create", opt)
 	if err != nil {
 		return
 	}
@@ -568,13 +569,13 @@ func (s *QualitygatesService) Create(opt *QualitygatesCreateOptions) (v *Quality
 
 // CreateCondition adds a new condition to a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) CreateCondition(opt *QualitygatesCreateConditionOptions) (v *QualitygatesCreateCondition, resp *http.Response, err error) {
+func (s *QualitygatesService) CreateCondition(ctx context.Context, opt *QualitygatesCreateConditionOptions) (v *QualitygatesCreateCondition, resp *http.Response, err error) {
 	err = s.ValidateCreateConditionOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualitygates/create_condition", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualitygates/create_condition", opt)
 	if err != nil {
 		return
 	}
@@ -591,13 +592,13 @@ func (s *QualitygatesService) CreateCondition(opt *QualitygatesCreateConditionOp
 
 // DeleteCondition deletes a condition from a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) DeleteCondition(opt *QualitygatesDeleteConditionOptions) (resp *http.Response, err error) {
+func (s *QualitygatesService) DeleteCondition(ctx context.Context, opt *QualitygatesDeleteConditionOptions) (resp *http.Response, err error) {
 	err = s.ValidateDeleteConditionOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualitygates/delete_condition", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualitygates/delete_condition", opt)
 	if err != nil {
 		return
 	}
@@ -614,13 +615,13 @@ func (s *QualitygatesService) DeleteCondition(opt *QualitygatesDeleteConditionOp
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - 'Administer' rights on the project
-func (s *QualitygatesService) Unassign(opt *QualitygatesUnassignOptions) (resp *http.Response, err error) {
+func (s *QualitygatesService) Unassign(ctx context.Context, opt *QualitygatesUnassignOptions) (resp *http.Response, err error) {
 	err = s.ValidateUnassignOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualitygates/deselect", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualitygates/deselect", opt)
 	if err != nil {
 		return
 	}
@@ -635,13 +636,13 @@ func (s *QualitygatesService) Unassign(opt *QualitygatesUnassignOptions) (resp *
 
 // Delete deletes a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) Delete(opt *QualitygatesDeleteOptions) (resp *http.Response, err error) {
+func (s *QualitygatesService) Delete(ctx context.Context, opt *QualitygatesDeleteOptions) (resp *http.Response, err error) {
 	err = s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualitygates/destroy", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualitygates/destroy", opt)
 	if err != nil {
 		return
 	}
@@ -659,13 +660,13 @@ func (s *QualitygatesService) Delete(opt *QualitygatesDeleteOptions) (resp *http
 //   - 'Administer System'
 //   - 'Administer' rights on the specified project
 //   - 'Browse' on the specified project
-func (s *QualitygatesService) GetByProject(opt *QualitygatesGetByProjectOptions) (v *QualitygatesGetByProject, resp *http.Response, err error) {
+func (s *QualitygatesService) GetByProject(ctx context.Context, opt *QualitygatesGetByProjectOptions) (v *QualitygatesGetByProject, resp *http.Response, err error) {
 	err = s.ValidateGetByProjectOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualitygates/get_by_project", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualitygates/get_by_project", opt)
 	if err != nil {
 		return
 	}
@@ -681,8 +682,8 @@ func (s *QualitygatesService) GetByProject(opt *QualitygatesGetByProjectOptions)
 }
 
 // List gets a list of quality gates.
-func (s *QualitygatesService) List() (v *QualitygatesList, resp *http.Response, err error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualitygates/list", nil)
+func (s *QualitygatesService) List(ctx context.Context) (v *QualitygatesList, resp *http.Response, err error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualitygates/list", nil)
 	if err != nil {
 		return
 	}
@@ -706,13 +707,13 @@ func (s *QualitygatesService) List() (v *QualitygatesList, resp *http.Response, 
 //   - 'Administer' rights on the specified project
 //   - 'Browse' on the specified project
 //   - 'Execute Analysis' on the specified project
-func (s *QualitygatesService) ProjectStatus(opt *QualitygatesProjectStatusOptions) (v *QualitygatesProjectStatus, resp *http.Response, err error) {
+func (s *QualitygatesService) ProjectStatus(ctx context.Context, opt *QualitygatesProjectStatusOptions) (v *QualitygatesProjectStatus, resp *http.Response, err error) {
 	err = s.ValidateProjectStatusOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualitygates/project_status", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualitygates/project_status", opt)
 	if err != nil {
 		return
 	}
@@ -731,13 +732,13 @@ func (s *QualitygatesService) ProjectStatus(opt *QualitygatesProjectStatusOption
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - Edit right on the specified quality gate
-func (s *QualitygatesService) RemoveGroup(opt *QualitygatesRemoveGroupOptions) (resp *http.Response, err error) {
+func (s *QualitygatesService) RemoveGroup(ctx context.Context, opt *QualitygatesRemoveGroupOptions) (resp *http.Response, err error) {
 	err = s.ValidateRemoveGroupOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualitygates/remove_group", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualitygates/remove_group", opt)
 	if err != nil {
 		return
 	}
@@ -754,13 +755,13 @@ func (s *QualitygatesService) RemoveGroup(opt *QualitygatesRemoveGroupOptions) (
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - Edit right on the specified quality gate
-func (s *QualitygatesService) RemoveUser(opt *QualitygatesRemoveUserOptions) (resp *http.Response, err error) {
+func (s *QualitygatesService) RemoveUser(ctx context.Context, opt *QualitygatesRemoveUserOptions) (resp *http.Response, err error) {
 	err = s.ValidateRemoveUserOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualitygates/remove_user", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualitygates/remove_user", opt)
 	if err != nil {
 		return
 	}
@@ -775,13 +776,13 @@ func (s *QualitygatesService) RemoveUser(opt *QualitygatesRemoveUserOptions) (re
 
 // Rename renames a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) Rename(opt *QualitygatesRenameOptions) (resp *http.Response, err error) {
+func (s *QualitygatesService) Rename(ctx context.Context, opt *QualitygatesRenameOptions) (resp *http.Response, err error) {
 	err = s.ValidateRenameOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualitygates/rename", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualitygates/rename", opt)
 	if err != nil {
 		return
 	}
@@ -796,13 +797,13 @@ func (s *QualitygatesService) Rename(opt *QualitygatesRenameOptions) (resp *http
 
 // Search searches for projects associated (or not) to a quality gate.
 // Only authorized projects for the current user will be returned.
-func (s *QualitygatesService) Search(opt *QualitygatesSearchOptions) (v *QualitygatesSearch, resp *http.Response, err error) {
+func (s *QualitygatesService) Search(ctx context.Context, opt *QualitygatesSearchOptions) (v *QualitygatesSearch, resp *http.Response, err error) {
 	err = s.ValidateSearchOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualitygates/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualitygates/search", opt)
 	if err != nil {
 		return
 	}
@@ -821,13 +822,13 @@ func (s *QualitygatesService) Search(opt *QualitygatesSearchOptions) (v *Quality
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - Edit right on the specified quality gate
-func (s *QualitygatesService) SearchGroups(opt *QualitygatesSearchGroupsOptions) (v *QualitygatesSearchGroups, resp *http.Response, err error) {
+func (s *QualitygatesService) SearchGroups(ctx context.Context, opt *QualitygatesSearchGroupsOptions) (v *QualitygatesSearchGroups, resp *http.Response, err error) {
 	err = s.ValidateSearchGroupsOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualitygates/search_groups", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualitygates/search_groups", opt)
 	if err != nil {
 		return
 	}
@@ -846,13 +847,13 @@ func (s *QualitygatesService) SearchGroups(opt *QualitygatesSearchGroupsOptions)
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - Edit right on the specified quality gate
-func (s *QualitygatesService) SearchUsers(opt *QualitygatesSearchUsersOptions) (v *QualitygatesSearchUsers, resp *http.Response, err error) {
+func (s *QualitygatesService) SearchUsers(ctx context.Context, opt *QualitygatesSearchUsersOptions) (v *QualitygatesSearchUsers, resp *http.Response, err error) {
 	err = s.ValidateSearchUsersOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualitygates/search_users", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualitygates/search_users", opt)
 	if err != nil {
 		return
 	}
@@ -871,13 +872,13 @@ func (s *QualitygatesService) SearchUsers(opt *QualitygatesSearchUsersOptions) (
 // Requires one of the following permissions:
 //   - 'Administer Quality Gates'
 //   - 'Administer' right on the specified project
-func (s *QualitygatesService) Assign(opt *QualitygatesAssignOptions) (resp *http.Response, err error) {
+func (s *QualitygatesService) Assign(ctx context.Context, opt *QualitygatesAssignOptions) (resp *http.Response, err error) {
 	err = s.ValidateAssignOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualitygates/select", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualitygates/select", opt)
 	if err != nil {
 		return
 	}
@@ -892,13 +893,13 @@ func (s *QualitygatesService) Assign(opt *QualitygatesAssignOptions) (resp *http
 
 // SetDefault sets a quality gate as the default quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) SetDefault(opt *QualitygatesSetDefaultOptions) (resp *http.Response, err error) {
+func (s *QualitygatesService) SetDefault(ctx context.Context, opt *QualitygatesSetDefaultOptions) (resp *http.Response, err error) {
 	err = s.ValidateSetDefaultOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualitygates/set_as_default", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualitygates/set_as_default", opt)
 	if err != nil {
 		return
 	}
@@ -912,13 +913,13 @@ func (s *QualitygatesService) SetDefault(opt *QualitygatesSetDefaultOptions) (re
 }
 
 // Show displays the details of a quality gate.
-func (s *QualitygatesService) Show(opt *QualitygatesShowOptions) (v *QualitygatesShow, resp *http.Response, err error) {
+func (s *QualitygatesService) Show(ctx context.Context, opt *QualitygatesShowOptions) (v *QualitygatesShow, resp *http.Response, err error) {
 	err = s.ValidateShowOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualitygates/show", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualitygates/show", opt)
 	if err != nil {
 		return
 	}
@@ -935,13 +936,13 @@ func (s *QualitygatesService) Show(opt *QualitygatesShowOptions) (v *Qualitygate
 
 // UpdateCondition updates a condition attached to a quality gate.
 // Requires the 'Administer Quality Gates' permission.
-func (s *QualitygatesService) UpdateCondition(opt *QualitygatesUpdateConditionOptions) (resp *http.Response, err error) {
+func (s *QualitygatesService) UpdateCondition(ctx context.Context, opt *QualitygatesUpdateConditionOptions) (resp *http.Response, err error) {
 	err = s.ValidateUpdateConditionOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualitygates/update_condition", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualitygates/update_condition", opt)
 	if err != nil {
 		return
 	}

--- a/sonar/qualitygates_service_test.go
+++ b/sonar/qualitygates_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -19,7 +20,7 @@ func TestQualityGates_AddGroup(t *testing.T) {
 		GroupName: "sonar-administrators",
 	}
 
-	resp, err := client.Qualitygates.AddGroup(opt)
+	resp, err := client.Qualitygates.AddGroup(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -28,23 +29,23 @@ func TestQualityGates_AddGroup_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualitygates.AddGroup(nil)
+	_, err := client.Qualitygates.AddGroup(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing GateName
-	_, err = client.Qualitygates.AddGroup(&QualitygatesAddGroupOptions{
+	_, err = client.Qualitygates.AddGroup(context.Background(), &QualitygatesAddGroupOptions{
 		GroupName: "group",
 	})
 	assert.Error(t, err)
 
 	// Test missing GroupName
-	_, err = client.Qualitygates.AddGroup(&QualitygatesAddGroupOptions{
+	_, err = client.Qualitygates.AddGroup(context.Background(), &QualitygatesAddGroupOptions{
 		GateName: "gate",
 	})
 	assert.Error(t, err)
 
 	// Test GateName too long
-	_, err = client.Qualitygates.AddGroup(&QualitygatesAddGroupOptions{
+	_, err = client.Qualitygates.AddGroup(context.Background(), &QualitygatesAddGroupOptions{
 		GateName:  strings.Repeat("a", MaxQualityGateNameLength+1),
 		GroupName: "group",
 	})
@@ -60,7 +61,7 @@ func TestQualityGates_AddUser(t *testing.T) {
 		Login:    "john.doe",
 	}
 
-	resp, err := client.Qualitygates.AddUser(opt)
+	resp, err := client.Qualitygates.AddUser(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -74,7 +75,7 @@ func TestQualityGates_Copy(t *testing.T) {
 		SourceName: "SonarSource Way",
 	}
 
-	resp, err := client.Qualitygates.Copy(opt)
+	resp, err := client.Qualitygates.Copy(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -87,7 +88,7 @@ func TestQualityGates_Create(t *testing.T) {
 		Name: "My Quality Gate",
 	}
 
-	result, resp, err := client.Qualitygates.Create(opt)
+	result, resp, err := client.Qualitygates.Create(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -105,7 +106,7 @@ func TestQualityGates_CreateCondition(t *testing.T) {
 		Op:       "LT",
 	}
 
-	result, resp, err := client.Qualitygates.CreateCondition(opt)
+	result, resp, err := client.Qualitygates.CreateCondition(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -116,7 +117,7 @@ func TestQualityGates_CreateCondition_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test invalid Op value
-	_, _, err := client.Qualitygates.CreateCondition(&QualitygatesCreateConditionOptions{
+	_, _, err := client.Qualitygates.CreateCondition(context.Background(), &QualitygatesCreateConditionOptions{
 		Error:    "80",
 		GateName: "gate",
 		Metric:   "coverage",
@@ -125,7 +126,7 @@ func TestQualityGates_CreateCondition_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing required fields
-	_, _, err = client.Qualitygates.CreateCondition(&QualitygatesCreateConditionOptions{
+	_, _, err = client.Qualitygates.CreateCondition(context.Background(), &QualitygatesCreateConditionOptions{
 		GateName: "gate",
 		Metric:   "coverage",
 	})
@@ -140,7 +141,7 @@ func TestQualityGates_DeleteCondition(t *testing.T) {
 		ID: "1",
 	}
 
-	resp, err := client.Qualitygates.DeleteCondition(opt)
+	resp, err := client.Qualitygates.DeleteCondition(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -153,7 +154,7 @@ func TestQualityGates_Unassign(t *testing.T) {
 		ProjectKey: "my_project",
 	}
 
-	resp, err := client.Qualitygates.Unassign(opt)
+	resp, err := client.Qualitygates.Unassign(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -166,7 +167,7 @@ func TestQualityGates_Delete(t *testing.T) {
 		Name: "My Quality Gate",
 	}
 
-	resp, err := client.Qualitygates.Delete(opt)
+	resp, err := client.Qualitygates.Delete(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -179,7 +180,7 @@ func TestQualityGates_GetByProject(t *testing.T) {
 		Project: "my_project",
 	}
 
-	result, resp, err := client.Qualitygates.GetByProject(opt)
+	result, resp, err := client.Qualitygates.GetByProject(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -198,7 +199,7 @@ func TestQualityGates_List(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualitygates/list", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Qualitygates.List()
+	result, resp, err := client.Qualitygates.List(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -225,7 +226,7 @@ func TestQualityGates_ProjectStatus(t *testing.T) {
 		ProjectKey: "my_project",
 	}
 
-	result, resp, err := client.Qualitygates.ProjectStatus(opt)
+	result, resp, err := client.Qualitygates.ProjectStatus(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -238,11 +239,11 @@ func TestQualityGates_ProjectStatus_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualitygates.ProjectStatus(nil)
+	_, _, err := client.Qualitygates.ProjectStatus(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing all required fields
-	_, _, err = client.Qualitygates.ProjectStatus(&QualitygatesProjectStatusOptions{})
+	_, _, err = client.Qualitygates.ProjectStatus(context.Background(), &QualitygatesProjectStatusOptions{})
 	assert.Error(t, err)
 }
 
@@ -255,7 +256,7 @@ func TestQualityGates_RemoveGroup(t *testing.T) {
 		GroupName: "sonar-administrators",
 	}
 
-	resp, err := client.Qualitygates.RemoveGroup(opt)
+	resp, err := client.Qualitygates.RemoveGroup(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -269,7 +270,7 @@ func TestQualityGates_RemoveUser(t *testing.T) {
 		Login:    "john.doe",
 	}
 
-	resp, err := client.Qualitygates.RemoveUser(opt)
+	resp, err := client.Qualitygates.RemoveUser(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -283,7 +284,7 @@ func TestQualityGates_Rename(t *testing.T) {
 		Name:        "New Name",
 	}
 
-	resp, err := client.Qualitygates.Rename(opt)
+	resp, err := client.Qualitygates.Rename(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -303,7 +304,7 @@ func TestQualityGates_Search(t *testing.T) {
 		GateName: "SonarSource Way",
 	}
 
-	result, resp, err := client.Qualitygates.Search(opt)
+	result, resp, err := client.Qualitygates.Search(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -315,7 +316,7 @@ func TestQualityGates_Search_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test invalid Selected value
-	_, _, err := client.Qualitygates.Search(&QualitygatesSearchOptions{
+	_, _, err := client.Qualitygates.Search(context.Background(), &QualitygatesSearchOptions{
 		GateName: "gate",
 		Selected: "invalid",
 	})
@@ -336,7 +337,7 @@ func TestQualityGates_SearchGroups(t *testing.T) {
 		GateName: "SonarSource Way",
 	}
 
-	result, resp, err := client.Qualitygates.SearchGroups(opt)
+	result, resp, err := client.Qualitygates.SearchGroups(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -358,7 +359,7 @@ func TestQualityGates_SearchUsers(t *testing.T) {
 		GateName: "SonarSource Way",
 	}
 
-	result, resp, err := client.Qualitygates.SearchUsers(opt)
+	result, resp, err := client.Qualitygates.SearchUsers(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -375,7 +376,7 @@ func TestQualityGates_Assign(t *testing.T) {
 		ProjectKey: "my_project",
 	}
 
-	resp, err := client.Qualitygates.Assign(opt)
+	resp, err := client.Qualitygates.Assign(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -388,7 +389,7 @@ func TestQualityGates_SetDefault(t *testing.T) {
 		Name: "SonarSource Way",
 	}
 
-	resp, err := client.Qualitygates.SetDefault(opt)
+	resp, err := client.Qualitygates.SetDefault(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -415,7 +416,7 @@ func TestQualityGates_Show(t *testing.T) {
 		Name: "SonarSource Way",
 	}
 
-	result, resp, err := client.Qualitygates.Show(opt)
+	result, resp, err := client.Qualitygates.Show(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -438,7 +439,7 @@ func TestQualityGates_UpdateCondition(t *testing.T) {
 		Op:     "LT",
 	}
 
-	resp, err := client.Qualitygates.UpdateCondition(opt)
+	resp, err := client.Qualitygates.UpdateCondition(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -447,11 +448,11 @@ func TestQualityGates_UpdateCondition_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualitygates.UpdateCondition(nil)
+	_, err := client.Qualitygates.UpdateCondition(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test invalid Op value
-	_, err = client.Qualitygates.UpdateCondition(&QualitygatesUpdateConditionOptions{
+	_, err = client.Qualitygates.UpdateCondition(context.Background(), &QualitygatesUpdateConditionOptions{
 		Error:  "80",
 		ID:     "1",
 		Metric: "coverage",
@@ -460,7 +461,7 @@ func TestQualityGates_UpdateCondition_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing required fields
-	_, err = client.Qualitygates.UpdateCondition(&QualitygatesUpdateConditionOptions{
+	_, err = client.Qualitygates.UpdateCondition(context.Background(), &QualitygatesUpdateConditionOptions{
 		ID:     "1",
 		Metric: "coverage",
 	})

--- a/sonar/qualityprofiles_service.go
+++ b/sonar/qualityprofiles_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -943,7 +944,7 @@ type QualityprofilesShowOptions struct {
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) ActivateRule(opt *QualityprofilesActivateRuleOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) ActivateRule(ctx context.Context, opt *QualityprofilesActivateRuleOptions) (resp *http.Response, err error) {
 	err = s.ValidateActivateRuleOpt(opt)
 	if err != nil {
 		return
@@ -952,7 +953,7 @@ func (s *QualityprofilesService) ActivateRule(opt *QualityprofilesActivateRuleOp
 	// Convert map fields to URL-encodable format
 	urlOpt := s.convertActivateRuleOptForURL(opt)
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/activate_rule", urlOpt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/activate_rule", urlOpt)
 	if err != nil {
 		return
 	}
@@ -969,13 +970,13 @@ func (s *QualityprofilesService) ActivateRule(opt *QualityprofilesActivateRuleOp
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) ActivateRules(opt *QualityprofilesActivateRulesOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) ActivateRules(ctx context.Context, opt *QualityprofilesActivateRulesOptions) (resp *http.Response, err error) {
 	err = s.ValidateActivateRulesOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/activate_rules", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/activate_rules", opt)
 	if err != nil {
 		return
 	}
@@ -992,13 +993,13 @@ func (s *QualityprofilesService) ActivateRules(opt *QualityprofilesActivateRules
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) AddGroup(opt *QualityprofilesAddGroupOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) AddGroup(ctx context.Context, opt *QualityprofilesAddGroupOptions) (resp *http.Response, err error) {
 	err = s.ValidateAddGroupOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/add_group", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/add_group", opt)
 	if err != nil {
 		return
 	}
@@ -1015,13 +1016,13 @@ func (s *QualityprofilesService) AddGroup(opt *QualityprofilesAddGroupOptions) (
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Administer right on the specified project
-func (s *QualityprofilesService) AddProject(opt *QualityprofilesAddProjectOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) AddProject(ctx context.Context, opt *QualityprofilesAddProjectOptions) (resp *http.Response, err error) {
 	err = s.ValidateAddProjectOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/add_project", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/add_project", opt)
 	if err != nil {
 		return
 	}
@@ -1038,13 +1039,13 @@ func (s *QualityprofilesService) AddProject(opt *QualityprofilesAddProjectOption
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) AddUser(opt *QualityprofilesAddUserOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) AddUser(ctx context.Context, opt *QualityprofilesAddUserOptions) (resp *http.Response, err error) {
 	err = s.ValidateAddUserOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/add_user", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/add_user", opt)
 	if err != nil {
 		return
 	}
@@ -1059,13 +1060,13 @@ func (s *QualityprofilesService) AddUser(opt *QualityprofilesAddUserOptions) (re
 
 // Backup backs up a quality profile in XML form.
 // The exported profile can be restored through Restore.
-func (s *QualityprofilesService) Backup(opt *QualityprofilesBackupOptions) (v *string, resp *http.Response, err error) {
+func (s *QualityprofilesService) Backup(ctx context.Context, opt *QualityprofilesBackupOptions) (v *string, resp *http.Response, err error) {
 	err = s.ValidateBackupOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualityprofiles/backup", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualityprofiles/backup", opt)
 	if err != nil {
 		return
 	}
@@ -1084,13 +1085,13 @@ func (s *QualityprofilesService) Backup(opt *QualityprofilesBackupOptions) (v *s
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) ChangeParent(opt *QualityprofilesChangeParentOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) ChangeParent(ctx context.Context, opt *QualityprofilesChangeParentOptions) (resp *http.Response, err error) {
 	err = s.ValidateChangeParentOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/change_parent", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/change_parent", opt)
 	if err != nil {
 		return
 	}
@@ -1105,13 +1106,13 @@ func (s *QualityprofilesService) ChangeParent(opt *QualityprofilesChangeParentOp
 
 // Changelog gets the history of changes on a quality profile.
 // Events are ordered by date in descending order (most recent first).
-func (s *QualityprofilesService) Changelog(opt *QualityprofilesChangelogOptions) (v *QualityprofilesChangelog, resp *http.Response, err error) {
+func (s *QualityprofilesService) Changelog(ctx context.Context, opt *QualityprofilesChangelogOptions) (v *QualityprofilesChangelog, resp *http.Response, err error) {
 	err = s.ValidateChangelogOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualityprofiles/changelog", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualityprofiles/changelog", opt)
 	if err != nil {
 		return
 	}
@@ -1127,13 +1128,13 @@ func (s *QualityprofilesService) Changelog(opt *QualityprofilesChangelogOptions)
 }
 
 // Compare compares two quality profiles.
-func (s *QualityprofilesService) Compare(opt *QualityprofilesCompareOptions) (v *QualityprofilesCompare, resp *http.Response, err error) {
+func (s *QualityprofilesService) Compare(ctx context.Context, opt *QualityprofilesCompareOptions) (v *QualityprofilesCompare, resp *http.Response, err error) {
 	err = s.ValidateCompareOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualityprofiles/compare", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualityprofiles/compare", opt)
 	if err != nil {
 		return
 	}
@@ -1150,13 +1151,13 @@ func (s *QualityprofilesService) Compare(opt *QualityprofilesCompareOptions) (v 
 
 // Copy copies a quality profile.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *QualityprofilesService) Copy(opt *QualityprofilesCopyOptions) (v *QualityprofilesCopy, resp *http.Response, err error) {
+func (s *QualityprofilesService) Copy(ctx context.Context, opt *QualityprofilesCopyOptions) (v *QualityprofilesCopy, resp *http.Response, err error) {
 	err = s.ValidateCopyOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/copy", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/copy", opt)
 	if err != nil {
 		return
 	}
@@ -1173,13 +1174,13 @@ func (s *QualityprofilesService) Copy(opt *QualityprofilesCopyOptions) (v *Quali
 
 // Create creates a quality profile.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *QualityprofilesService) Create(opt *QualityprofilesCreateOptions) (v *QualityprofilesCreate, resp *http.Response, err error) {
+func (s *QualityprofilesService) Create(ctx context.Context, opt *QualityprofilesCreateOptions) (v *QualityprofilesCreate, resp *http.Response, err error) {
 	err = s.ValidateCreateOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/create", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/create", opt)
 	if err != nil {
 		return
 	}
@@ -1198,13 +1199,13 @@ func (s *QualityprofilesService) Create(opt *QualityprofilesCreateOptions) (v *Q
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) DeactivateRule(opt *QualityprofilesDeactivateRuleOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) DeactivateRule(ctx context.Context, opt *QualityprofilesDeactivateRuleOptions) (resp *http.Response, err error) {
 	err = s.ValidateDeactivateRuleOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/deactivate_rule", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/deactivate_rule", opt)
 	if err != nil {
 		return
 	}
@@ -1221,13 +1222,13 @@ func (s *QualityprofilesService) DeactivateRule(opt *QualityprofilesDeactivateRu
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) DeactivateRules(opt *QualityprofilesDeactivateRulesOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) DeactivateRules(ctx context.Context, opt *QualityprofilesDeactivateRulesOptions) (resp *http.Response, err error) {
 	err = s.ValidateDeactivateRulesOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/deactivate_rules", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/deactivate_rules", opt)
 	if err != nil {
 		return
 	}
@@ -1245,13 +1246,13 @@ func (s *QualityprofilesService) DeactivateRules(opt *QualityprofilesDeactivateR
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) Delete(opt *QualityprofilesDeleteOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) Delete(ctx context.Context, opt *QualityprofilesDeleteOptions) (resp *http.Response, err error) {
 	err = s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/delete", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/delete", opt)
 	if err != nil {
 		return
 	}
@@ -1267,13 +1268,13 @@ func (s *QualityprofilesService) Delete(opt *QualityprofilesDeleteOptions) (resp
 // Export exports a quality profile.
 //
 // Deprecated: Since SonarQube 25.4. Use Backup instead.
-func (s *QualityprofilesService) Export(opt *QualityprofilesExportOptions) (v *string, resp *http.Response, err error) {
+func (s *QualityprofilesService) Export(ctx context.Context, opt *QualityprofilesExportOptions) (v *string, resp *http.Response, err error) {
 	err = s.ValidateExportOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualityprofiles/export", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualityprofiles/export", opt)
 	if err != nil {
 		return
 	}
@@ -1291,8 +1292,8 @@ func (s *QualityprofilesService) Export(opt *QualityprofilesExportOptions) (v *s
 // Exporters lists quality profile exporters.
 //
 // Deprecated: No more custom profile exporters since SonarQube 25.4.
-func (s *QualityprofilesService) Exporters() (v *QualityprofilesExporters, resp *http.Response, err error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualityprofiles/exporters", nil)
+func (s *QualityprofilesService) Exporters(ctx context.Context) (v *QualityprofilesExporters, resp *http.Response, err error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualityprofiles/exporters", nil)
 	if err != nil {
 		return
 	}
@@ -1310,8 +1311,8 @@ func (s *QualityprofilesService) Exporters() (v *QualityprofilesExporters, resp 
 // Importers lists supported quality profile importers.
 //
 // Deprecated: Since SonarQube 25.4.
-func (s *QualityprofilesService) Importers() (v *QualityprofilesImporters, resp *http.Response, err error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualityprofiles/importers", nil)
+func (s *QualityprofilesService) Importers(ctx context.Context) (v *QualityprofilesImporters, resp *http.Response, err error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualityprofiles/importers", nil)
 	if err != nil {
 		return
 	}
@@ -1327,13 +1328,13 @@ func (s *QualityprofilesService) Importers() (v *QualityprofilesImporters, resp 
 }
 
 // Inheritance shows a quality profile's ancestors and children.
-func (s *QualityprofilesService) Inheritance(opt *QualityprofilesInheritanceOptions) (v *QualityprofilesInheritance, resp *http.Response, err error) {
+func (s *QualityprofilesService) Inheritance(ctx context.Context, opt *QualityprofilesInheritanceOptions) (v *QualityprofilesInheritance, resp *http.Response, err error) {
 	err = s.ValidateInheritanceOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualityprofiles/inheritance", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualityprofiles/inheritance", opt)
 	if err != nil {
 		return
 	}
@@ -1350,13 +1351,13 @@ func (s *QualityprofilesService) Inheritance(opt *QualityprofilesInheritanceOpti
 
 // Projects lists projects with their association status regarding a quality profile.
 // Only projects explicitly bound to the profile are returned.
-func (s *QualityprofilesService) Projects(opt *QualityprofilesProjectsOptions) (v *QualityprofilesProjects, resp *http.Response, err error) {
+func (s *QualityprofilesService) Projects(ctx context.Context, opt *QualityprofilesProjectsOptions) (v *QualityprofilesProjects, resp *http.Response, err error) {
 	err = s.ValidateProjectsOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualityprofiles/projects", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualityprofiles/projects", opt)
 	if err != nil {
 		return
 	}
@@ -1375,13 +1376,13 @@ func (s *QualityprofilesService) Projects(opt *QualityprofilesProjectsOptions) (
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) RemoveGroup(opt *QualityprofilesRemoveGroupOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) RemoveGroup(ctx context.Context, opt *QualityprofilesRemoveGroupOptions) (resp *http.Response, err error) {
 	err = s.ValidateRemoveGroupOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/remove_group", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/remove_group", opt)
 	if err != nil {
 		return
 	}
@@ -1399,13 +1400,13 @@ func (s *QualityprofilesService) RemoveGroup(opt *QualityprofilesRemoveGroupOpti
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
 //   - Administer right on the specified project
-func (s *QualityprofilesService) RemoveProject(opt *QualityprofilesRemoveProjectOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) RemoveProject(ctx context.Context, opt *QualityprofilesRemoveProjectOptions) (resp *http.Response, err error) {
 	err = s.ValidateRemoveProjectOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/remove_project", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/remove_project", opt)
 	if err != nil {
 		return
 	}
@@ -1422,13 +1423,13 @@ func (s *QualityprofilesService) RemoveProject(opt *QualityprofilesRemoveProject
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) RemoveUser(opt *QualityprofilesRemoveUserOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) RemoveUser(ctx context.Context, opt *QualityprofilesRemoveUserOptions) (resp *http.Response, err error) {
 	err = s.ValidateRemoveUserOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/remove_user", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/remove_user", opt)
 	if err != nil {
 		return
 	}
@@ -1445,13 +1446,13 @@ func (s *QualityprofilesService) RemoveUser(opt *QualityprofilesRemoveUserOption
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) Rename(opt *QualityprofilesRenameOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) Rename(ctx context.Context, opt *QualityprofilesRenameOptions) (resp *http.Response, err error) {
 	err = s.ValidateRenameOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/rename", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/rename", opt)
 	if err != nil {
 		return
 	}
@@ -1468,13 +1469,13 @@ func (s *QualityprofilesService) Rename(opt *QualityprofilesRenameOptions) (resp
 // The restored profile name is taken from the backup file.
 // If a profile with the same name and language exists, it will be overwritten.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *QualityprofilesService) Restore(opt *QualityprofilesRestoreOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) Restore(ctx context.Context, opt *QualityprofilesRestoreOptions) (resp *http.Response, err error) {
 	err = s.ValidateRestoreOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/restore", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/restore", opt)
 	if err != nil {
 		return
 	}
@@ -1488,13 +1489,13 @@ func (s *QualityprofilesService) Restore(opt *QualityprofilesRestoreOptions) (re
 }
 
 // Search searches for quality profiles.
-func (s *QualityprofilesService) Search(opt *QualityprofilesSearchOptions) (v *QualityprofilesSearch, resp *http.Response, err error) {
+func (s *QualityprofilesService) Search(ctx context.Context, opt *QualityprofilesSearchOptions) (v *QualityprofilesSearch, resp *http.Response, err error) {
 	err = s.ValidateSearchOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualityprofiles/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualityprofiles/search", opt)
 	if err != nil {
 		return
 	}
@@ -1513,13 +1514,13 @@ func (s *QualityprofilesService) Search(opt *QualityprofilesSearchOptions) (v *Q
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) SearchGroups(opt *QualityprofilesSearchGroupsOptions) (v *QualityprofilesSearchGroups, resp *http.Response, err error) {
+func (s *QualityprofilesService) SearchGroups(ctx context.Context, opt *QualityprofilesSearchGroupsOptions) (v *QualityprofilesSearchGroups, resp *http.Response, err error) {
 	err = s.ValidateSearchGroupsOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualityprofiles/search_groups", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualityprofiles/search_groups", opt)
 	if err != nil {
 		return
 	}
@@ -1538,13 +1539,13 @@ func (s *QualityprofilesService) SearchGroups(opt *QualityprofilesSearchGroupsOp
 // Requires one of the following permissions:
 //   - 'Administer Quality Profiles'
 //   - Edit right on the specified quality profile
-func (s *QualityprofilesService) SearchUsers(opt *QualityprofilesSearchUsersOptions) (v *QualityprofilesSearchUsers, resp *http.Response, err error) {
+func (s *QualityprofilesService) SearchUsers(ctx context.Context, opt *QualityprofilesSearchUsersOptions) (v *QualityprofilesSearchUsers, resp *http.Response, err error) {
 	err = s.ValidateSearchUsersOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualityprofiles/search_users", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualityprofiles/search_users", opt)
 	if err != nil {
 		return
 	}
@@ -1561,13 +1562,13 @@ func (s *QualityprofilesService) SearchUsers(opt *QualityprofilesSearchUsersOpti
 
 // SetDefault selects the default profile for a given language.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *QualityprofilesService) SetDefault(opt *QualityprofilesSetDefaultOptions) (resp *http.Response, err error) {
+func (s *QualityprofilesService) SetDefault(ctx context.Context, opt *QualityprofilesSetDefaultOptions) (resp *http.Response, err error) {
 	err = s.ValidateSetDefaultOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "qualityprofiles/set_default", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "qualityprofiles/set_default", opt)
 	if err != nil {
 		return
 	}
@@ -1581,13 +1582,13 @@ func (s *QualityprofilesService) SetDefault(opt *QualityprofilesSetDefaultOption
 }
 
 // Show shows a quality profile.
-func (s *QualityprofilesService) Show(opt *QualityprofilesShowOptions) (v *QualityprofilesShow, resp *http.Response, err error) {
+func (s *QualityprofilesService) Show(ctx context.Context, opt *QualityprofilesShowOptions) (v *QualityprofilesShow, resp *http.Response, err error) {
 	err = s.ValidateShowOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "qualityprofiles/show", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "qualityprofiles/show", opt)
 	if err != nil {
 		return
 	}

--- a/sonar/qualityprofiles_service_test.go
+++ b/sonar/qualityprofiles_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -18,7 +19,7 @@ func TestQualityprofiles_ActivateRule(t *testing.T) {
 		Rule: "squid:AvoidCycles",
 	}
 
-	resp, err := client.Qualityprofiles.ActivateRule(opt)
+	resp, err := client.Qualityprofiles.ActivateRule(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -27,23 +28,23 @@ func TestQualityprofiles_ActivateRule_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.ActivateRule(nil)
+	_, err := client.Qualityprofiles.ActivateRule(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
+	_, err = client.Qualityprofiles.ActivateRule(context.Background(), &QualityprofilesActivateRuleOptions{
 		Rule: "squid:AvoidCycles",
 	})
 	assert.Error(t, err)
 
 	// Test missing Rule
-	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
+	_, err = client.Qualityprofiles.ActivateRule(context.Background(), &QualityprofilesActivateRuleOptions{
 		Key: "AU-TpxcA-iU5OvuD2FL0",
 	})
 	assert.Error(t, err)
 
 	// Test both Impacts and Severity set
-	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
+	_, err = client.Qualityprofiles.ActivateRule(context.Background(), &QualityprofilesActivateRuleOptions{
 		Key:      "AU-TpxcA-iU5OvuD2FL0",
 		Rule:     "squid:AvoidCycles",
 		Impacts:  map[string]string{SoftwareQualityMaintainability: RuleImpactSeverityHigh},
@@ -52,7 +53,7 @@ func TestQualityprofiles_ActivateRule_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test invalid Severity
-	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
+	_, err = client.Qualityprofiles.ActivateRule(context.Background(), &QualityprofilesActivateRuleOptions{
 		Key:      "AU-TpxcA-iU5OvuD2FL0",
 		Rule:     "squid:AvoidCycles",
 		Severity: "INVALID",
@@ -60,7 +61,7 @@ func TestQualityprofiles_ActivateRule_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test invalid Impacts map key (software quality)
-	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
+	_, err = client.Qualityprofiles.ActivateRule(context.Background(), &QualityprofilesActivateRuleOptions{
 		Key:     "AU-TpxcA-iU5OvuD2FL0",
 		Rule:    "squid:AvoidCycles",
 		Impacts: map[string]string{"INVALID_QUALITY": RuleImpactSeverityHigh},
@@ -68,7 +69,7 @@ func TestQualityprofiles_ActivateRule_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test invalid Impacts map value (severity)
-	_, err = client.Qualityprofiles.ActivateRule(&QualityprofilesActivateRuleOptions{
+	_, err = client.Qualityprofiles.ActivateRule(context.Background(), &QualityprofilesActivateRuleOptions{
 		Key:     "AU-TpxcA-iU5OvuD2FL0",
 		Rule:    "squid:AvoidCycles",
 		Impacts: map[string]string{SoftwareQualityMaintainability: "INVALID_SEVERITY"},
@@ -85,7 +86,7 @@ func TestQualityprofiles_ActivateRules(t *testing.T) {
 		Languages: []string{"java"},
 	}
 
-	resp, err := client.Qualityprofiles.ActivateRules(opt)
+	resp, err := client.Qualityprofiles.ActivateRules(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -94,43 +95,43 @@ func TestQualityprofiles_ActivateRules_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.ActivateRules(nil)
+	_, err := client.Qualityprofiles.ActivateRules(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing TargetKey
-	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOptions{})
+	_, err = client.Qualityprofiles.ActivateRules(context.Background(), &QualityprofilesActivateRulesOptions{})
 	assert.Error(t, err)
 
 	// Test invalid language
-	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOptions{
+	_, err = client.Qualityprofiles.ActivateRules(context.Background(), &QualityprofilesActivateRulesOptions{
 		TargetKey: "AU-TpxcA-iU5OvuD2FL0",
 		Languages: []string{"invalid_language"},
 	})
 	assert.Error(t, err)
 
 	// Test invalid severity
-	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOptions{
+	_, err = client.Qualityprofiles.ActivateRules(context.Background(), &QualityprofilesActivateRulesOptions{
 		TargetKey:  "AU-TpxcA-iU5OvuD2FL0",
 		Severities: []string{"INVALID_SEVERITY"},
 	})
 	assert.Error(t, err)
 
 	// Test invalid impact severity
-	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOptions{
+	_, err = client.Qualityprofiles.ActivateRules(context.Background(), &QualityprofilesActivateRulesOptions{
 		TargetKey:        "AU-TpxcA-iU5OvuD2FL0",
 		ImpactSeverities: []string{"INVALID"},
 	})
 	assert.Error(t, err)
 
 	// Test invalid software quality
-	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOptions{
+	_, err = client.Qualityprofiles.ActivateRules(context.Background(), &QualityprofilesActivateRulesOptions{
 		TargetKey:               "AU-TpxcA-iU5OvuD2FL0",
 		ImpactSoftwareQualities: []string{"INVALID"},
 	})
 	assert.Error(t, err)
 
 	// Test invalid sort field
-	_, err = client.Qualityprofiles.ActivateRules(&QualityprofilesActivateRulesOptions{
+	_, err = client.Qualityprofiles.ActivateRules(context.Background(), &QualityprofilesActivateRulesOptions{
 		TargetKey: "AU-TpxcA-iU5OvuD2FL0",
 		Sort:      "invalid_sort",
 	})
@@ -147,7 +148,7 @@ func TestQualityprofiles_AddGroup(t *testing.T) {
 		QualityProfile: "Sonar way",
 	}
 
-	resp, err := client.Qualityprofiles.AddGroup(opt)
+	resp, err := client.Qualityprofiles.AddGroup(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -156,25 +157,25 @@ func TestQualityprofiles_AddGroup_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.AddGroup(nil)
+	_, err := client.Qualityprofiles.AddGroup(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Group
-	_, err = client.Qualityprofiles.AddGroup(&QualityprofilesAddGroupOptions{
+	_, err = client.Qualityprofiles.AddGroup(context.Background(), &QualityprofilesAddGroupOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.AddGroup(&QualityprofilesAddGroupOptions{
+	_, err = client.Qualityprofiles.AddGroup(context.Background(), &QualityprofilesAddGroupOptions{
 		Group:          "sonar-administrators",
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test invalid Language
-	_, err = client.Qualityprofiles.AddGroup(&QualityprofilesAddGroupOptions{
+	_, err = client.Qualityprofiles.AddGroup(context.Background(), &QualityprofilesAddGroupOptions{
 		Group:          "sonar-administrators",
 		Language:       "invalid_lang",
 		QualityProfile: "Sonar way",
@@ -182,7 +183,7 @@ func TestQualityprofiles_AddGroup_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, err = client.Qualityprofiles.AddGroup(&QualityprofilesAddGroupOptions{
+	_, err = client.Qualityprofiles.AddGroup(context.Background(), &QualityprofilesAddGroupOptions{
 		Group:    "sonar-administrators",
 		Language: "java",
 	})
@@ -199,7 +200,7 @@ func TestQualityprofiles_AddProject(t *testing.T) {
 		QualityProfile: "Sonar way",
 	}
 
-	resp, err := client.Qualityprofiles.AddProject(opt)
+	resp, err := client.Qualityprofiles.AddProject(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -208,25 +209,25 @@ func TestQualityprofiles_AddProject_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.AddProject(nil)
+	_, err := client.Qualityprofiles.AddProject(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.AddProject(&QualityprofilesAddProjectOptions{
+	_, err = client.Qualityprofiles.AddProject(context.Background(), &QualityprofilesAddProjectOptions{
 		Project:        "my_project",
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing Project
-	_, err = client.Qualityprofiles.AddProject(&QualityprofilesAddProjectOptions{
+	_, err = client.Qualityprofiles.AddProject(context.Background(), &QualityprofilesAddProjectOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, err = client.Qualityprofiles.AddProject(&QualityprofilesAddProjectOptions{
+	_, err = client.Qualityprofiles.AddProject(context.Background(), &QualityprofilesAddProjectOptions{
 		Language: "java",
 		Project:  "my_project",
 	})
@@ -243,7 +244,7 @@ func TestQualityprofiles_AddUser(t *testing.T) {
 		QualityProfile: "Sonar way",
 	}
 
-	resp, err := client.Qualityprofiles.AddUser(opt)
+	resp, err := client.Qualityprofiles.AddUser(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -252,25 +253,25 @@ func TestQualityprofiles_AddUser_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.AddUser(nil)
+	_, err := client.Qualityprofiles.AddUser(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.AddUser(&QualityprofilesAddUserOptions{
+	_, err = client.Qualityprofiles.AddUser(context.Background(), &QualityprofilesAddUserOptions{
 		Login:          "john.doe",
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing Login
-	_, err = client.Qualityprofiles.AddUser(&QualityprofilesAddUserOptions{
+	_, err = client.Qualityprofiles.AddUser(context.Background(), &QualityprofilesAddUserOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, err = client.Qualityprofiles.AddUser(&QualityprofilesAddUserOptions{
+	_, err = client.Qualityprofiles.AddUser(context.Background(), &QualityprofilesAddUserOptions{
 		Language: "java",
 		Login:    "john.doe",
 	})
@@ -292,7 +293,7 @@ func TestQualityprofiles_Backup(t *testing.T) {
 		QualityProfile: "Sonar way",
 	}
 
-	result, resp, err := client.Qualityprofiles.Backup(opt)
+	result, resp, err := client.Qualityprofiles.Backup(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -303,17 +304,17 @@ func TestQualityprofiles_Backup_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualityprofiles.Backup(nil)
+	_, _, err := client.Qualityprofiles.Backup(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, _, err = client.Qualityprofiles.Backup(&QualityprofilesBackupOptions{
+	_, _, err = client.Qualityprofiles.Backup(context.Background(), &QualityprofilesBackupOptions{
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, _, err = client.Qualityprofiles.Backup(&QualityprofilesBackupOptions{
+	_, _, err = client.Qualityprofiles.Backup(context.Background(), &QualityprofilesBackupOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
@@ -329,7 +330,7 @@ func TestQualityprofiles_ChangeParent(t *testing.T) {
 		ParentQualityProfile: "Sonar way",
 	}
 
-	resp, err := client.Qualityprofiles.ChangeParent(opt)
+	resp, err := client.Qualityprofiles.ChangeParent(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -338,17 +339,17 @@ func TestQualityprofiles_ChangeParent_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.ChangeParent(nil)
+	_, err := client.Qualityprofiles.ChangeParent(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.ChangeParent(&QualityprofilesChangeParentOptions{
+	_, err = client.Qualityprofiles.ChangeParent(context.Background(), &QualityprofilesChangeParentOptions{
 		QualityProfile: "My Profile",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, err = client.Qualityprofiles.ChangeParent(&QualityprofilesChangeParentOptions{
+	_, err = client.Qualityprofiles.ChangeParent(context.Background(), &QualityprofilesChangeParentOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
@@ -375,7 +376,7 @@ func TestQualityprofiles_Changelog(t *testing.T) {
 		QualityProfile: "Sonar way",
 	}
 
-	result, resp, err := client.Qualityprofiles.Changelog(opt)
+	result, resp, err := client.Qualityprofiles.Changelog(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -387,23 +388,23 @@ func TestQualityprofiles_Changelog_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualityprofiles.Changelog(nil)
+	_, _, err := client.Qualityprofiles.Changelog(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, _, err = client.Qualityprofiles.Changelog(&QualityprofilesChangelogOptions{
+	_, _, err = client.Qualityprofiles.Changelog(context.Background(), &QualityprofilesChangelogOptions{
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, _, err = client.Qualityprofiles.Changelog(&QualityprofilesChangelogOptions{
+	_, _, err = client.Qualityprofiles.Changelog(context.Background(), &QualityprofilesChangelogOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
 
 	// Test invalid FilterMode
-	_, _, err = client.Qualityprofiles.Changelog(&QualityprofilesChangelogOptions{
+	_, _, err = client.Qualityprofiles.Changelog(context.Background(), &QualityprofilesChangelogOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 		FilterMode:     "INVALID",
@@ -431,7 +432,7 @@ func TestQualityprofiles_Compare(t *testing.T) {
 		RightKey: "profile2",
 	}
 
-	result, resp, err := client.Qualityprofiles.Compare(opt)
+	result, resp, err := client.Qualityprofiles.Compare(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -443,17 +444,17 @@ func TestQualityprofiles_Compare_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualityprofiles.Compare(nil)
+	_, _, err := client.Qualityprofiles.Compare(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing LeftKey
-	_, _, err = client.Qualityprofiles.Compare(&QualityprofilesCompareOptions{
+	_, _, err = client.Qualityprofiles.Compare(context.Background(), &QualityprofilesCompareOptions{
 		RightKey: "profile2",
 	})
 	assert.Error(t, err)
 
 	// Test missing RightKey
-	_, _, err = client.Qualityprofiles.Compare(&QualityprofilesCompareOptions{
+	_, _, err = client.Qualityprofiles.Compare(context.Background(), &QualityprofilesCompareOptions{
 		LeftKey: "profile1",
 	})
 	assert.Error(t, err)
@@ -477,7 +478,7 @@ func TestQualityprofiles_Copy(t *testing.T) {
 		ToName:  "My Profile Copy",
 	}
 
-	result, resp, err := client.Qualityprofiles.Copy(opt)
+	result, resp, err := client.Qualityprofiles.Copy(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -488,23 +489,23 @@ func TestQualityprofiles_Copy_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualityprofiles.Copy(nil)
+	_, _, err := client.Qualityprofiles.Copy(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing FromKey
-	_, _, err = client.Qualityprofiles.Copy(&QualityprofilesCopyOptions{
+	_, _, err = client.Qualityprofiles.Copy(context.Background(), &QualityprofilesCopyOptions{
 		ToName: "New Profile",
 	})
 	assert.Error(t, err)
 
 	// Test missing ToName
-	_, _, err = client.Qualityprofiles.Copy(&QualityprofilesCopyOptions{
+	_, _, err = client.Qualityprofiles.Copy(context.Background(), &QualityprofilesCopyOptions{
 		FromKey: "source-key",
 	})
 	assert.Error(t, err)
 
 	// Test ToName too long
-	_, _, err = client.Qualityprofiles.Copy(&QualityprofilesCopyOptions{
+	_, _, err = client.Qualityprofiles.Copy(context.Background(), &QualityprofilesCopyOptions{
 		FromKey: "source-key",
 		ToName:  strings.Repeat("a", MaxQualityProfileNameLength+1),
 	})
@@ -530,7 +531,7 @@ func TestQualityprofiles_Create(t *testing.T) {
 		Name:     "My New Profile",
 	}
 
-	result, resp, err := client.Qualityprofiles.Create(opt)
+	result, resp, err := client.Qualityprofiles.Create(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -541,23 +542,23 @@ func TestQualityprofiles_Create_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualityprofiles.Create(nil)
+	_, _, err := client.Qualityprofiles.Create(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, _, err = client.Qualityprofiles.Create(&QualityprofilesCreateOptions{
+	_, _, err = client.Qualityprofiles.Create(context.Background(), &QualityprofilesCreateOptions{
 		Name: "My Profile",
 	})
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, _, err = client.Qualityprofiles.Create(&QualityprofilesCreateOptions{
+	_, _, err = client.Qualityprofiles.Create(context.Background(), &QualityprofilesCreateOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
 
 	// Test Name too long
-	_, _, err = client.Qualityprofiles.Create(&QualityprofilesCreateOptions{
+	_, _, err = client.Qualityprofiles.Create(context.Background(), &QualityprofilesCreateOptions{
 		Language: "java",
 		Name:     strings.Repeat("a", MaxQualityProfileNameLength+1),
 	})
@@ -573,7 +574,7 @@ func TestQualityprofiles_DeactivateRule(t *testing.T) {
 		Rule: "squid:AvoidCycles",
 	}
 
-	resp, err := client.Qualityprofiles.DeactivateRule(opt)
+	resp, err := client.Qualityprofiles.DeactivateRule(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -582,17 +583,17 @@ func TestQualityprofiles_DeactivateRule_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.DeactivateRule(nil)
+	_, err := client.Qualityprofiles.DeactivateRule(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.Qualityprofiles.DeactivateRule(&QualityprofilesDeactivateRuleOptions{
+	_, err = client.Qualityprofiles.DeactivateRule(context.Background(), &QualityprofilesDeactivateRuleOptions{
 		Rule: "squid:AvoidCycles",
 	})
 	assert.Error(t, err)
 
 	// Test missing Rule
-	_, err = client.Qualityprofiles.DeactivateRule(&QualityprofilesDeactivateRuleOptions{
+	_, err = client.Qualityprofiles.DeactivateRule(context.Background(), &QualityprofilesDeactivateRuleOptions{
 		Key: "AU-TpxcA-iU5OvuD2FL0",
 	})
 	assert.Error(t, err)
@@ -607,7 +608,7 @@ func TestQualityprofiles_DeactivateRules(t *testing.T) {
 		Languages: []string{"java"},
 	}
 
-	resp, err := client.Qualityprofiles.DeactivateRules(opt)
+	resp, err := client.Qualityprofiles.DeactivateRules(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -616,11 +617,11 @@ func TestQualityprofiles_DeactivateRules_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.DeactivateRules(nil)
+	_, err := client.Qualityprofiles.DeactivateRules(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing TargetKey
-	_, err = client.Qualityprofiles.DeactivateRules(&QualityprofilesDeactivateRulesOptions{})
+	_, err = client.Qualityprofiles.DeactivateRules(context.Background(), &QualityprofilesDeactivateRulesOptions{})
 	assert.Error(t, err)
 }
 
@@ -633,7 +634,7 @@ func TestQualityprofiles_Delete(t *testing.T) {
 		QualityProfile: "My Profile",
 	}
 
-	resp, err := client.Qualityprofiles.Delete(opt)
+	resp, err := client.Qualityprofiles.Delete(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -642,17 +643,17 @@ func TestQualityprofiles_Delete_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.Delete(nil)
+	_, err := client.Qualityprofiles.Delete(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.Delete(&QualityprofilesDeleteOptions{
+	_, err = client.Qualityprofiles.Delete(context.Background(), &QualityprofilesDeleteOptions{
 		QualityProfile: "My Profile",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, err = client.Qualityprofiles.Delete(&QualityprofilesDeleteOptions{
+	_, err = client.Qualityprofiles.Delete(context.Background(), &QualityprofilesDeleteOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
@@ -673,7 +674,7 @@ func TestQualityprofiles_Export(t *testing.T) {
 		QualityProfile: "Sonar way",
 	}
 
-	result, resp, err := client.Qualityprofiles.Export(opt)
+	result, resp, err := client.Qualityprofiles.Export(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -684,11 +685,11 @@ func TestQualityprofiles_Export_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualityprofiles.Export(nil)
+	_, _, err := client.Qualityprofiles.Export(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, _, err = client.Qualityprofiles.Export(&QualityprofilesExportOptions{})
+	_, _, err = client.Qualityprofiles.Export(context.Background(), &QualityprofilesExportOptions{})
 	assert.Error(t, err)
 }
 
@@ -702,7 +703,7 @@ func TestQualityprofiles_Exporters(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualityprofiles/exporters", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Qualityprofiles.Exporters()
+	result, resp, err := client.Qualityprofiles.Exporters(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -720,7 +721,7 @@ func TestQualityprofiles_Importers(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualityprofiles/importers", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Qualityprofiles.Importers()
+	result, resp, err := client.Qualityprofiles.Importers(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -749,7 +750,7 @@ func TestQualityprofiles_Inheritance(t *testing.T) {
 		QualityProfile: "My Profile",
 	}
 
-	result, resp, err := client.Qualityprofiles.Inheritance(opt)
+	result, resp, err := client.Qualityprofiles.Inheritance(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -762,17 +763,17 @@ func TestQualityprofiles_Inheritance_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualityprofiles.Inheritance(nil)
+	_, _, err := client.Qualityprofiles.Inheritance(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, _, err = client.Qualityprofiles.Inheritance(&QualityprofilesInheritanceOptions{
+	_, _, err = client.Qualityprofiles.Inheritance(context.Background(), &QualityprofilesInheritanceOptions{
 		QualityProfile: "My Profile",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, _, err = client.Qualityprofiles.Inheritance(&QualityprofilesInheritanceOptions{
+	_, _, err = client.Qualityprofiles.Inheritance(context.Background(), &QualityprofilesInheritanceOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
@@ -794,7 +795,7 @@ func TestQualityprofiles_Projects(t *testing.T) {
 		Key: "profile-key",
 	}
 
-	result, resp, err := client.Qualityprofiles.Projects(opt)
+	result, resp, err := client.Qualityprofiles.Projects(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -806,15 +807,15 @@ func TestQualityprofiles_Projects_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualityprofiles.Projects(nil)
+	_, _, err := client.Qualityprofiles.Projects(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, _, err = client.Qualityprofiles.Projects(&QualityprofilesProjectsOptions{})
+	_, _, err = client.Qualityprofiles.Projects(context.Background(), &QualityprofilesProjectsOptions{})
 	assert.Error(t, err)
 
 	// Test invalid Selected
-	_, _, err = client.Qualityprofiles.Projects(&QualityprofilesProjectsOptions{
+	_, _, err = client.Qualityprofiles.Projects(context.Background(), &QualityprofilesProjectsOptions{
 		Key:      "profile-key",
 		Selected: "invalid",
 	})
@@ -831,7 +832,7 @@ func TestQualityprofiles_RemoveGroup(t *testing.T) {
 		QualityProfile: "Sonar way",
 	}
 
-	resp, err := client.Qualityprofiles.RemoveGroup(opt)
+	resp, err := client.Qualityprofiles.RemoveGroup(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -840,11 +841,11 @@ func TestQualityprofiles_RemoveGroup_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.RemoveGroup(nil)
+	_, err := client.Qualityprofiles.RemoveGroup(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Group
-	_, err = client.Qualityprofiles.RemoveGroup(&QualityprofilesRemoveGroupOptions{
+	_, err = client.Qualityprofiles.RemoveGroup(context.Background(), &QualityprofilesRemoveGroupOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 	})
@@ -861,7 +862,7 @@ func TestQualityprofiles_RemoveProject(t *testing.T) {
 		QualityProfile: "Sonar way",
 	}
 
-	resp, err := client.Qualityprofiles.RemoveProject(opt)
+	resp, err := client.Qualityprofiles.RemoveProject(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -870,11 +871,11 @@ func TestQualityprofiles_RemoveProject_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.RemoveProject(nil)
+	_, err := client.Qualityprofiles.RemoveProject(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.RemoveProject(&QualityprofilesRemoveProjectOptions{
+	_, err = client.Qualityprofiles.RemoveProject(context.Background(), &QualityprofilesRemoveProjectOptions{
 		Project:        "my_project",
 		QualityProfile: "Sonar way",
 	})
@@ -891,7 +892,7 @@ func TestQualityprofiles_RemoveUser(t *testing.T) {
 		QualityProfile: "Sonar way",
 	}
 
-	resp, err := client.Qualityprofiles.RemoveUser(opt)
+	resp, err := client.Qualityprofiles.RemoveUser(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -900,11 +901,11 @@ func TestQualityprofiles_RemoveUser_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.RemoveUser(nil)
+	_, err := client.Qualityprofiles.RemoveUser(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.RemoveUser(&QualityprofilesRemoveUserOptions{
+	_, err = client.Qualityprofiles.RemoveUser(context.Background(), &QualityprofilesRemoveUserOptions{
 		Login:          "john.doe",
 		QualityProfile: "Sonar way",
 	})
@@ -920,7 +921,7 @@ func TestQualityprofiles_Rename(t *testing.T) {
 		Name: "New Profile Name",
 	}
 
-	resp, err := client.Qualityprofiles.Rename(opt)
+	resp, err := client.Qualityprofiles.Rename(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -929,23 +930,23 @@ func TestQualityprofiles_Rename_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.Rename(nil)
+	_, err := client.Qualityprofiles.Rename(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, err = client.Qualityprofiles.Rename(&QualityprofilesRenameOptions{
+	_, err = client.Qualityprofiles.Rename(context.Background(), &QualityprofilesRenameOptions{
 		Name: "New Name",
 	})
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, err = client.Qualityprofiles.Rename(&QualityprofilesRenameOptions{
+	_, err = client.Qualityprofiles.Rename(context.Background(), &QualityprofilesRenameOptions{
 		Key: "profile-key",
 	})
 	assert.Error(t, err)
 
 	// Test Name too long
-	_, err = client.Qualityprofiles.Rename(&QualityprofilesRenameOptions{
+	_, err = client.Qualityprofiles.Rename(context.Background(), &QualityprofilesRenameOptions{
 		Key:  "profile-key",
 		Name: strings.Repeat("a", MaxQualityProfileNameLength+1),
 	})
@@ -960,7 +961,7 @@ func TestQualityprofiles_Restore(t *testing.T) {
 		Backup: `<?xml version='1.0'?><profile><name>My Profile</name></profile>`,
 	}
 
-	resp, err := client.Qualityprofiles.Restore(opt)
+	resp, err := client.Qualityprofiles.Restore(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -969,11 +970,11 @@ func TestQualityprofiles_Restore_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.Restore(nil)
+	_, err := client.Qualityprofiles.Restore(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Backup
-	_, err = client.Qualityprofiles.Restore(&QualityprofilesRestoreOptions{})
+	_, err = client.Qualityprofiles.Restore(context.Background(), &QualityprofilesRestoreOptions{})
 	assert.Error(t, err)
 }
 
@@ -1009,7 +1010,7 @@ func TestQualityprofiles_Search(t *testing.T) {
 		Language: "java",
 	}
 
-	result, resp, err := client.Qualityprofiles.Search(opt)
+	result, resp, err := client.Qualityprofiles.Search(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -1022,7 +1023,7 @@ func TestQualityprofiles_Search_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualityprofiles.Search(nil)
+	_, _, err := client.Qualityprofiles.Search(context.Background(), nil)
 	assert.Error(t, err)
 }
 
@@ -1042,7 +1043,7 @@ func TestQualityprofiles_SearchGroups(t *testing.T) {
 		QualityProfile: "Sonar way",
 	}
 
-	result, resp, err := client.Qualityprofiles.SearchGroups(opt)
+	result, resp, err := client.Qualityprofiles.SearchGroups(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -1054,23 +1055,23 @@ func TestQualityprofiles_SearchGroups_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualityprofiles.SearchGroups(nil)
+	_, _, err := client.Qualityprofiles.SearchGroups(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, _, err = client.Qualityprofiles.SearchGroups(&QualityprofilesSearchGroupsOptions{
+	_, _, err = client.Qualityprofiles.SearchGroups(context.Background(), &QualityprofilesSearchGroupsOptions{
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, _, err = client.Qualityprofiles.SearchGroups(&QualityprofilesSearchGroupsOptions{
+	_, _, err = client.Qualityprofiles.SearchGroups(context.Background(), &QualityprofilesSearchGroupsOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
 
 	// Test invalid Selected
-	_, _, err = client.Qualityprofiles.SearchGroups(&QualityprofilesSearchGroupsOptions{
+	_, _, err = client.Qualityprofiles.SearchGroups(context.Background(), &QualityprofilesSearchGroupsOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 		Selected:       "invalid",
@@ -1094,7 +1095,7 @@ func TestQualityprofiles_SearchUsers(t *testing.T) {
 		QualityProfile: "Sonar way",
 	}
 
-	result, resp, err := client.Qualityprofiles.SearchUsers(opt)
+	result, resp, err := client.Qualityprofiles.SearchUsers(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -1106,23 +1107,23 @@ func TestQualityprofiles_SearchUsers_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualityprofiles.SearchUsers(nil)
+	_, _, err := client.Qualityprofiles.SearchUsers(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, _, err = client.Qualityprofiles.SearchUsers(&QualityprofilesSearchUsersOptions{
+	_, _, err = client.Qualityprofiles.SearchUsers(context.Background(), &QualityprofilesSearchUsersOptions{
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, _, err = client.Qualityprofiles.SearchUsers(&QualityprofilesSearchUsersOptions{
+	_, _, err = client.Qualityprofiles.SearchUsers(context.Background(), &QualityprofilesSearchUsersOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
 
 	// Test invalid Selected
-	_, _, err = client.Qualityprofiles.SearchUsers(&QualityprofilesSearchUsersOptions{
+	_, _, err = client.Qualityprofiles.SearchUsers(context.Background(), &QualityprofilesSearchUsersOptions{
 		Language:       "java",
 		QualityProfile: "Sonar way",
 		Selected:       "invalid",
@@ -1139,7 +1140,7 @@ func TestQualityprofiles_SetDefault(t *testing.T) {
 		QualityProfile: "Sonar way",
 	}
 
-	resp, err := client.Qualityprofiles.SetDefault(opt)
+	resp, err := client.Qualityprofiles.SetDefault(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -1148,17 +1149,17 @@ func TestQualityprofiles_SetDefault_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Qualityprofiles.SetDefault(nil)
+	_, err := client.Qualityprofiles.SetDefault(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Language
-	_, err = client.Qualityprofiles.SetDefault(&QualityprofilesSetDefaultOptions{
+	_, err = client.Qualityprofiles.SetDefault(context.Background(), &QualityprofilesSetDefaultOptions{
 		QualityProfile: "Sonar way",
 	})
 	assert.Error(t, err)
 
 	// Test missing QualityProfile
-	_, err = client.Qualityprofiles.SetDefault(&QualityprofilesSetDefaultOptions{
+	_, err = client.Qualityprofiles.SetDefault(context.Background(), &QualityprofilesSetDefaultOptions{
 		Language: "java",
 	})
 	assert.Error(t, err)
@@ -1184,7 +1185,7 @@ func TestQualityprofiles_Show(t *testing.T) {
 		Key: "sonar-way-java",
 	}
 
-	result, resp, err := client.Qualityprofiles.Show(opt)
+	result, resp, err := client.Qualityprofiles.Show(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -1196,11 +1197,11 @@ func TestQualityprofiles_Show_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Qualityprofiles.Show(nil)
+	_, _, err := client.Qualityprofiles.Show(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Key
-	_, _, err = client.Qualityprofiles.Show(&QualityprofilesShowOptions{})
+	_, _, err = client.Qualityprofiles.Show(context.Background(), &QualityprofilesShowOptions{})
 	assert.Error(t, err)
 }
 

--- a/sonar/rules_service.go
+++ b/sonar/rules_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -566,8 +567,8 @@ type RulesUpdateOptions struct {
 
 // App retrieves data required for rendering the 'Coding Rules' page.
 // WARNING: This is an internal endpoint, may change without notice.
-func (s *RulesService) App() (v *RulesApp, resp *http.Response, err error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "rules/app", nil)
+func (s *RulesService) App(ctx context.Context) (v *RulesApp, resp *http.Response, err error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "rules/app", nil)
 	if err != nil {
 		return
 	}
@@ -584,7 +585,7 @@ func (s *RulesService) App() (v *RulesApp, resp *http.Response, err error) {
 
 // Create creates a custom rule.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *RulesService) Create(opt *RulesCreateOptions) (v *RulesCreate, resp *http.Response, err error) {
+func (s *RulesService) Create(ctx context.Context, opt *RulesCreateOptions) (v *RulesCreate, resp *http.Response, err error) {
 	err = s.ValidateCreateOpt(opt)
 	if err != nil {
 		return
@@ -593,7 +594,7 @@ func (s *RulesService) Create(opt *RulesCreateOptions) (v *RulesCreate, resp *ht
 	// Convert to URL-encodable format
 	urlOpt := s.convertCreateOptForURL(opt)
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "rules/create", urlOpt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "rules/create", urlOpt)
 	if err != nil {
 		return
 	}
@@ -610,13 +611,13 @@ func (s *RulesService) Create(opt *RulesCreateOptions) (v *RulesCreate, resp *ht
 
 // Delete deletes a custom rule.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *RulesService) Delete(opt *RulesDeleteOptions) (resp *http.Response, err error) {
+func (s *RulesService) Delete(ctx context.Context, opt *RulesDeleteOptions) (resp *http.Response, err error) {
 	err = s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "rules/delete", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "rules/delete", opt)
 	if err != nil {
 		return
 	}
@@ -630,13 +631,13 @@ func (s *RulesService) Delete(opt *RulesDeleteOptions) (resp *http.Response, err
 }
 
 // List lists rules, excluding external rules and rules with status REMOVED.
-func (s *RulesService) List(opt *RulesListOptions) (v *string, resp *http.Response, err error) {
+func (s *RulesService) List(ctx context.Context, opt *RulesListOptions) (v *string, resp *http.Response, err error) {
 	err = s.ValidateListOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "rules/list", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "rules/list", opt)
 	if err != nil {
 		return
 	}
@@ -652,13 +653,13 @@ func (s *RulesService) List(opt *RulesListOptions) (v *string, resp *http.Respon
 }
 
 // Repositories lists available rule repositories.
-func (s *RulesService) Repositories(opt *RulesRepositoriesOptions) (v *RulesRepositories, resp *http.Response, err error) {
+func (s *RulesService) Repositories(ctx context.Context, opt *RulesRepositoriesOptions) (v *RulesRepositories, resp *http.Response, err error) {
 	err = s.ValidateRepositoriesOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "rules/repositories", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "rules/repositories", opt)
 	if err != nil {
 		return
 	}
@@ -674,7 +675,7 @@ func (s *RulesService) Repositories(opt *RulesRepositoriesOptions) (v *RulesRepo
 }
 
 // Search searches for a collection of relevant rules matching a specified query.
-func (s *RulesService) Search(opt *RulesSearchOptions) (v *RulesSearch, resp *http.Response, err error) {
+func (s *RulesService) Search(ctx context.Context, opt *RulesSearchOptions) (v *RulesSearch, resp *http.Response, err error) {
 	err = s.ValidateSearchOpt(opt)
 	if err != nil {
 		return
@@ -683,7 +684,7 @@ func (s *RulesService) Search(opt *RulesSearchOptions) (v *RulesSearch, resp *ht
 	// Convert to URL-encodable format
 	urlOpt := s.convertSearchOptForURL(opt)
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "rules/search", urlOpt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "rules/search", urlOpt)
 	if err != nil {
 		return
 	}
@@ -699,13 +700,13 @@ func (s *RulesService) Search(opt *RulesSearchOptions) (v *RulesSearch, resp *ht
 }
 
 // Show retrieves detailed information about a specific rule.
-func (s *RulesService) Show(opt *RulesShowOptions) (v *RulesShow, resp *http.Response, err error) {
+func (s *RulesService) Show(ctx context.Context, opt *RulesShowOptions) (v *RulesShow, resp *http.Response, err error) {
 	err = s.ValidateShowOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "rules/show", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "rules/show", opt)
 	if err != nil {
 		return
 	}
@@ -721,13 +722,13 @@ func (s *RulesService) Show(opt *RulesShowOptions) (v *RulesShow, resp *http.Res
 }
 
 // Tags lists all available rule tags.
-func (s *RulesService) Tags(opt *RulesTagsOptions) (v *RulesTags, resp *http.Response, err error) {
+func (s *RulesService) Tags(ctx context.Context, opt *RulesTagsOptions) (v *RulesTags, resp *http.Response, err error) {
 	err = s.ValidateTagsOpt(opt)
 	if err != nil {
 		return
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "rules/tags", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "rules/tags", opt)
 	if err != nil {
 		return
 	}
@@ -744,7 +745,7 @@ func (s *RulesService) Tags(opt *RulesTagsOptions) (v *RulesTags, resp *http.Res
 
 // Update updates an existing rule.
 // Requires the 'Administer Quality Profiles' permission.
-func (s *RulesService) Update(opt *RulesUpdateOptions) (v *RulesUpdate, resp *http.Response, err error) {
+func (s *RulesService) Update(ctx context.Context, opt *RulesUpdateOptions) (v *RulesUpdate, resp *http.Response, err error) {
 	err = s.ValidateUpdateOpt(opt)
 	if err != nil {
 		return nil, nil, err
@@ -753,7 +754,7 @@ func (s *RulesService) Update(opt *RulesUpdateOptions) (v *RulesUpdate, resp *ht
 	// Convert to URL-encodable format
 	urlOpt := s.convertUpdateOptForURL(opt)
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "rules/update", urlOpt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "rules/update", urlOpt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/rules_service_test.go
+++ b/sonar/rules_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -14,7 +15,7 @@ func TestRules_App(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/rules/app", 200, `{"canWrite":true,"languages":{"java":"Java"}}`))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Rules.App()
+	result, resp, err := client.Rules.App(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	require.NotNil(t, result)
@@ -31,7 +32,7 @@ func TestRules_Create(t *testing.T) {
 		MarkdownDescription: "Test description",
 		TemplateKey:         "java:TemplateRule",
 	}
-	result, resp, err := client.Rules.Create(opt)
+	result, resp, err := client.Rules.Create(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	require.NotNil(t, result)
@@ -43,7 +44,7 @@ func TestRules_Delete(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	opt := &RulesDeleteOptions{Key: "java:MyRule"}
-	resp, err := client.Rules.Delete(opt)
+	resp, err := client.Rules.Delete(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }
@@ -53,7 +54,7 @@ func TestRules_Search(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	opt := &RulesSearchOptions{Languages: []string{"java"}}
-	result, resp, err := client.Rules.Search(opt)
+	result, resp, err := client.Rules.Search(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	require.NotNil(t, result)
@@ -99,7 +100,7 @@ func TestRules_Show(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	opt := &RulesShowOptions{Key: "java:S1067"}
-	result, resp, err := client.Rules.Show(opt)
+	result, resp, err := client.Rules.Show(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	require.NotNil(t, result)
@@ -111,7 +112,7 @@ func TestRules_Tags(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	opt := &RulesTagsOptions{PageSize: 100}
-	result, resp, err := client.Rules.Tags(opt)
+	result, resp, err := client.Rules.Tags(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	require.NotNil(t, result)
@@ -123,7 +124,7 @@ func TestRules_Update(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	opt := &RulesUpdateOptions{Key: "java:MyRule", Name: "Updated Rule"}
-	result, resp, err := client.Rules.Update(opt)
+	result, resp, err := client.Rules.Update(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	require.NotNil(t, result)
@@ -140,7 +141,7 @@ func TestRules_UpdateClearTags(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	opt := &RulesUpdateOptions{Key: "java:MyRule", Tags: []string{}}
-	result, resp, err := client.Rules.Update(opt)
+	result, resp, err := client.Rules.Update(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	require.NotNil(t, result)
@@ -154,7 +155,7 @@ func TestRules_Repositories(t *testing.T) {
 	client := newTestClient(t, server.URL)
 
 	opt := &RulesRepositoriesOptions{}
-	result, resp, err := client.Rules.Repositories(opt)
+	result, resp, err := client.Rules.Repositories(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	require.NotNil(t, result)
@@ -170,7 +171,7 @@ func TestRules_List(t *testing.T) {
 			PageSize: 50,
 		},
 	}
-	_, resp, err := client.Rules.List(opt)
+	_, resp, err := client.Rules.List(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 }

--- a/sonar/server_service.go
+++ b/sonar/server_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // ServerService handles communication with the Server related methods of the SonarQube API.
 type ServerService struct {
@@ -9,8 +12,8 @@ type ServerService struct {
 }
 
 // Version returns the SonarQube server version.
-func (s *ServerService) Version() (v *string, resp *http.Response, err error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "server/version", nil)
+func (s *ServerService) Version(ctx context.Context) (v *string, resp *http.Response, err error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "server/version", nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/server_service_test.go
+++ b/sonar/server_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -13,7 +14,7 @@ func TestServer_Version(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	version, resp, err := client.Server.Version()
+	version, resp, err := client.Server.Version(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, version)
@@ -25,7 +26,7 @@ func TestServer_Version_ErrorResponse(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	version, resp, err := client.Server.Version()
+	version, resp, err := client.Server.Version(context.Background(), )
 	require.Error(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)

--- a/sonar/settings_service.go
+++ b/sonar/settings_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -265,8 +266,8 @@ func (s *SettingsService) ValidateValuesOpt(opt *SettingsValuesOptions) error {
 // Requires the 'Administer System' permission.
 //
 // Since: 6.1.
-func (s *SettingsService) CheckSecretKey() (*SettingsCheckSecretKey, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "settings/check_secret_key", nil)
+func (s *SettingsService) CheckSecretKey(ctx context.Context) (*SettingsCheckSecretKey, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "settings/check_secret_key", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -285,13 +286,13 @@ func (s *SettingsService) CheckSecretKey() (*SettingsCheckSecretKey, *http.Respo
 // Requires 'Administer System' permission.
 //
 // Since: 6.1.
-func (s *SettingsService) Encrypt(opt *SettingsEncryptOptions) (*SettingsEncrypt, *http.Response, error) {
+func (s *SettingsService) Encrypt(ctx context.Context, opt *SettingsEncryptOptions) (*SettingsEncrypt, *http.Response, error) {
 	err := s.ValidateEncryptOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "settings/encrypt", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "settings/encrypt", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -310,8 +311,8 @@ func (s *SettingsService) Encrypt(opt *SettingsEncryptOptions) (*SettingsEncrypt
 // Requires the 'Administer System' permission.
 //
 // Since: 6.1.
-func (s *SettingsService) GenerateSecretKey() (*SettingsGenerateSecretKey, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "settings/generate_secret_key", nil)
+func (s *SettingsService) GenerateSecretKey(ctx context.Context) (*SettingsGenerateSecretKey, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "settings/generate_secret_key", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -335,13 +336,13 @@ func (s *SettingsService) GenerateSecretKey() (*SettingsGenerateSecretKey, *http
 //   - 'Administer' rights on the specified component
 //
 // Since: 6.3.
-func (s *SettingsService) ListDefinitions(opt *SettingsListDefinitionsOptions) (*SettingsListDefinitions, *http.Response, error) {
+func (s *SettingsService) ListDefinitions(ctx context.Context, opt *SettingsListDefinitionsOptions) (*SettingsListDefinitions, *http.Response, error) {
 	err := s.ValidateListDefinitionsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "settings/list_definitions", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "settings/list_definitions", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -359,8 +360,8 @@ func (s *SettingsService) ListDefinitions(opt *SettingsListDefinitionsOptions) (
 // LoginMessage returns the formatted login message, set to the 'sonar.login.message' property.
 //
 // Since: 9.8.
-func (s *SettingsService) LoginMessage() (*SettingsLoginMessage, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "settings/login_message", nil)
+func (s *SettingsService) LoginMessage(ctx context.Context) (*SettingsLoginMessage, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "settings/login_message", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -382,13 +383,13 @@ func (s *SettingsService) LoginMessage() (*SettingsLoginMessage, *http.Response,
 //   - 'Administer' rights on the specified component
 //
 // Since: 6.1.
-func (s *SettingsService) Reset(opt *SettingsResetOptions) (*http.Response, error) {
+func (s *SettingsService) Reset(ctx context.Context, opt *SettingsResetOptions) (*http.Response, error) {
 	err := s.ValidateResetOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "settings/reset", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "settings/reset", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +410,7 @@ func (s *SettingsService) Reset(opt *SettingsResetOptions) (*http.Response, erro
 //   - 'Administer' rights on the specified component
 //
 // Since: 6.1.
-func (s *SettingsService) Set(opt *SettingsSetOptions) (*http.Response, error) {
+func (s *SettingsService) Set(ctx context.Context, opt *SettingsSetOptions) (*http.Response, error) {
 	err := s.ValidateSetOpt(opt)
 	if err != nil {
 		return nil, err
@@ -417,7 +418,7 @@ func (s *SettingsService) Set(opt *SettingsSetOptions) (*http.Response, error) {
 
 	// For SettingsSetOption, we need custom encoding due to FieldValues
 	// being a map[string]any that needs to be JSON-encoded
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "settings/set", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "settings/set", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -437,13 +438,13 @@ func (s *SettingsService) Set(opt *SettingsSetOptions) (*http.Response, error) {
 // Secured settings values are not returned by the endpoint.
 //
 // Since: 6.3.
-func (s *SettingsService) Values(opt *SettingsValuesOptions) (*SettingsValues, *http.Response, error) {
+func (s *SettingsService) Values(ctx context.Context, opt *SettingsValuesOptions) (*SettingsValues, *http.Response, error) {
 	err := s.ValidateValuesOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "settings/values", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "settings/values", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/settings_service_test.go
+++ b/sonar/settings_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -23,7 +24,7 @@ func TestSettingsService_CheckSecretKey(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Settings.CheckSecretKey()
+	result, resp, err := client.Settings.CheckSecretKey(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.True(t, result.SecretKeyAvailable)
@@ -42,7 +43,7 @@ func TestSettingsService_Encrypt(t *testing.T) {
 		Value: "my-secret-value",
 	}
 
-	result, resp, err := client.Settings.Encrypt(opt)
+	result, resp, err := client.Settings.Encrypt(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "{aes-gcm}encrypted-secret", result.EncryptedValue)
@@ -54,7 +55,7 @@ func TestSettingsService_Encrypt_ValidationError(t *testing.T) {
 
 	// Test missing Value
 	opt := &SettingsEncryptOptions{}
-	_, _, err := client.Settings.Encrypt(opt)
+	_, _, err := client.Settings.Encrypt(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -67,7 +68,7 @@ func TestSettingsService_GenerateSecretKey(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Settings.GenerateSecretKey()
+	result, resp, err := client.Settings.GenerateSecretKey(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "AaBbCcDdEeFfGgHhIiJjKk==", result.SecretKey)
@@ -96,7 +97,7 @@ func TestSettingsService_ListDefinitions(t *testing.T) {
 		Component: "my-project",
 	}
 
-	result, resp, err := client.Settings.ListDefinitions(opt)
+	result, resp, err := client.Settings.ListDefinitions(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Definitions, 1)
@@ -113,7 +114,7 @@ func TestSettingsService_LoginMessage(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Settings.LoginMessage()
+	result, resp, err := client.Settings.LoginMessage(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "Welcome to SonarQube!", result.Message)
@@ -139,7 +140,7 @@ func TestSettingsService_Reset(t *testing.T) {
 		Keys: []string{"sonar.test.key", "sonar.other.key"},
 	}
 
-	resp, err := client.Settings.Reset(opt)
+	resp, err := client.Settings.Reset(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -150,7 +151,7 @@ func TestSettingsService_Reset_ValidationError(t *testing.T) {
 
 	// Test missing Keys
 	opt := &SettingsResetOptions{}
-	_, err := client.Settings.Reset(opt)
+	_, err := client.Settings.Reset(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -176,7 +177,7 @@ func TestSettingsService_Set(t *testing.T) {
 		Value: "test-value",
 	}
 
-	resp, err := client.Settings.Set(opt)
+	resp, err := client.Settings.Set(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -189,7 +190,7 @@ func TestSettingsService_Set_ValidationError(t *testing.T) {
 	opt := &SettingsSetOptions{
 		Value: "test-value",
 	}
-	_, err := client.Settings.Set(opt)
+	_, err := client.Settings.Set(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test Value too long
@@ -197,14 +198,14 @@ func TestSettingsService_Set_ValidationError(t *testing.T) {
 		Key:   "sonar.test.key",
 		Value: strings.Repeat("a", MaxSettingValueLength+1),
 	}
-	_, err = client.Settings.Set(opt)
+	_, err = client.Settings.Set(context.Background(), opt)
 	assert.Error(t, err)
 
 	// Test missing Value, Values, and FieldValues
 	opt = &SettingsSetOptions{
 		Key: "sonar.test.key",
 	}
-	_, err = client.Settings.Set(opt)
+	_, err = client.Settings.Set(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -232,7 +233,7 @@ func TestSettingsService_Set_WithMultiValues(t *testing.T) {
 		Values: []string{"value1", "value2", "value3"},
 	}
 
-	resp, err := client.Settings.Set(opt)
+	resp, err := client.Settings.Set(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -273,7 +274,7 @@ func TestSettingsService_Set_WithFieldValues(t *testing.T) {
 		},
 	}
 
-	resp, err := client.Settings.Set(opt)
+	resp, err := client.Settings.Set(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -303,7 +304,7 @@ func TestSettingsService_Values(t *testing.T) {
 		Keys: []string{"sonar.test.key", "sonar.multi.key"},
 	}
 
-	result, resp, err := client.Settings.Values(opt)
+	result, resp, err := client.Settings.Values(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Settings, 2)

--- a/sonar/sources_service.go
+++ b/sonar/sources_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -230,13 +231,13 @@ func (s *SourcesService) ValidateShowOpt(opt *SourcesShowOptions) error {
 // Since: 5.0.
 //
 // Deprecated: This web service is deprecated since 5.1. Use api/sources/lines instead.
-func (s *SourcesService) Index(opt *SourcesIndexOptions) (*SourcesIndex, *http.Response, error) {
+func (s *SourcesService) Index(ctx context.Context, opt *SourcesIndexOptions) (*SourcesIndex, *http.Response, error) {
 	err := s.ValidateIndexOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "sources/index", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "sources/index", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -256,13 +257,13 @@ func (s *SourcesService) Index(opt *SourcesIndexOptions) (*SourcesIndex, *http.R
 // Returns source code snippets relevant to the given issue.
 //
 // Since: 7.8.
-func (s *SourcesService) IssueSnippets(opt *SourcesIssueSnippetsOptions) (*SourcesIssueSnippets, *http.Response, error) {
+func (s *SourcesService) IssueSnippets(ctx context.Context, opt *SourcesIssueSnippetsOptions) (*SourcesIssueSnippets, *http.Response, error) {
 	err := s.ValidateIssueSnippetsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "sources/issue_snippets", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "sources/issue_snippets", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -282,13 +283,13 @@ func (s *SourcesService) IssueSnippets(opt *SourcesIssueSnippetsOptions) (*Sourc
 // Returns source code with additional info like SCM data, coverage, and duplications.
 //
 // Since: 5.0.
-func (s *SourcesService) Lines(opt *SourcesLinesOptions) (*SourcesLines, *http.Response, error) {
+func (s *SourcesService) Lines(ctx context.Context, opt *SourcesLinesOptions) (*SourcesLines, *http.Response, error) {
 	err := s.ValidateLinesOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "sources/lines", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "sources/lines", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -308,13 +309,13 @@ func (s *SourcesService) Lines(opt *SourcesLinesOptions) (*SourcesLines, *http.R
 // Requires 'See Source Code' permission on file's project.
 //
 // Since: 5.0.
-func (s *SourcesService) Raw(opt *SourcesRawOptions) (string, *http.Response, error) {
+func (s *SourcesService) Raw(ctx context.Context, opt *SourcesRawOptions) (string, *http.Response, error) {
 	err := s.ValidateRawOpt(opt)
 	if err != nil {
 		return "", nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "sources/raw", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "sources/raw", opt)
 	if err != nil {
 		return "", nil, err
 	}
@@ -334,13 +335,13 @@ func (s *SourcesService) Raw(opt *SourcesRawOptions) (string, *http.Response, er
 // Returns source code modification information.
 //
 // Since: 4.4.
-func (s *SourcesService) Scm(opt *SourcesScmOptions) (*SourcesScm, *http.Response, error) {
+func (s *SourcesService) Scm(ctx context.Context, opt *SourcesScmOptions) (*SourcesScm, *http.Response, error) {
 	err := s.ValidateScmOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "sources/scm", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "sources/scm", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -359,13 +360,13 @@ func (s *SourcesService) Scm(opt *SourcesScmOptions) (*SourcesScm, *http.Respons
 // Requires 'See Source Code' permission on file's project.
 //
 // Since: 4.4.
-func (s *SourcesService) Show(opt *SourcesShowOptions) (*SourcesShow, *http.Response, error) {
+func (s *SourcesService) Show(ctx context.Context, opt *SourcesShowOptions) (*SourcesShow, *http.Response, error) {
 	err := s.ValidateShowOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "sources/show", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "sources/show", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/sources_service_test.go
+++ b/sonar/sources_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -31,7 +32,7 @@ func TestSourcesService_Index(t *testing.T) {
 		To:       10,
 	}
 
-	result, resp, err := client.Sources.Index(opt)
+	result, resp, err := client.Sources.Index(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "package main", result.Sources["1"])
@@ -43,7 +44,7 @@ func TestSourcesService_Index_ValidationError(t *testing.T) {
 
 	// Test missing Resource
 	opt := &SourcesIndexOptions{}
-	_, _, err := client.Sources.Index(opt)
+	_, _, err := client.Sources.Index(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -69,7 +70,7 @@ func TestSourcesService_IssueSnippets(t *testing.T) {
 		IssueKey: "AX1234567890",
 	}
 
-	result, resp, err := client.Sources.IssueSnippets(opt)
+	result, resp, err := client.Sources.IssueSnippets(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	snippet, ok := (*result)["my-project:src/main.go"]
@@ -83,7 +84,7 @@ func TestSourcesService_IssueSnippets_ValidationError(t *testing.T) {
 
 	// Test missing IssueKey
 	opt := &SourcesIssueSnippetsOptions{}
-	_, _, err := client.Sources.IssueSnippets(opt)
+	_, _, err := client.Sources.IssueSnippets(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -112,7 +113,7 @@ func TestSourcesService_Lines(t *testing.T) {
 		To:     100,
 	}
 
-	result, resp, err := client.Sources.Lines(opt)
+	result, resp, err := client.Sources.Lines(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Sources, 1)
@@ -128,7 +129,7 @@ func TestSourcesService_Lines_ValidationError(t *testing.T) {
 	opt := &SourcesLinesOptions{
 		Branch: "main",
 	}
-	_, _, err := client.Sources.Lines(opt)
+	_, _, err := client.Sources.Lines(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -150,7 +151,7 @@ func TestSourcesService_Raw(t *testing.T) {
 		Key: "my-project:src/main.go",
 	}
 
-	result, resp, err := client.Sources.Raw(opt)
+	result, resp, err := client.Sources.Raw(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, expectedContent, result)
@@ -162,7 +163,7 @@ func TestSourcesService_Raw_ValidationError(t *testing.T) {
 
 	// Test missing Key
 	opt := &SourcesRawOptions{}
-	_, _, err := client.Sources.Raw(opt)
+	_, _, err := client.Sources.Raw(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -183,7 +184,7 @@ func TestSourcesService_Scm(t *testing.T) {
 		CommitsByLine: true,
 	}
 
-	result, resp, err := client.Sources.Scm(opt)
+	result, resp, err := client.Sources.Scm(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Scm, 2)
@@ -197,7 +198,7 @@ func TestSourcesService_Scm_ValidationError(t *testing.T) {
 	opt := &SourcesScmOptions{
 		CommitsByLine: true,
 	}
-	_, _, err := client.Sources.Scm(opt)
+	_, _, err := client.Sources.Scm(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -220,7 +221,7 @@ func TestSourcesService_Show(t *testing.T) {
 		To:   10,
 	}
 
-	result, resp, err := client.Sources.Show(opt)
+	result, resp, err := client.Sources.Show(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Sources, 3)
@@ -232,6 +233,6 @@ func TestSourcesService_Show_ValidationError(t *testing.T) {
 
 	// Test missing Key
 	opt := &SourcesShowOptions{}
-	_, _, err := client.Sources.Show(opt)
+	_, _, err := client.Sources.Show(context.Background(), opt)
 	assert.Error(t, err)
 }

--- a/sonar/system_service.go
+++ b/sonar/system_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -589,13 +590,13 @@ type SystemLogsOptions struct {
 // Requires system administration permission.
 //
 // API Docs: https://next.sonarqube.com/sonarqube/web_api/api/system/change_log_level
-func (s *SystemService) ChangeLogLevel(opt *SystemChangeLogLevelOptions) (*http.Response, error) {
+func (s *SystemService) ChangeLogLevel(ctx context.Context, opt *SystemChangeLogLevelOptions) (*http.Response, error) {
 	err := s.ValidateChangeLogLevelOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "system/change_log_level", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "system/change_log_level", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -620,8 +621,8 @@ func (s *SystemService) ChangeLogLevel(opt *SystemChangeLogLevelOptions) (*http.
 // Deprecated: since 10.6. Use the API v2 version /api/v2/system/migrations-status instead.
 //
 // API Docs: https://next.sonarqube.com/sonarqube/web_api/api/system/db_migration_status
-func (s *SystemService) DbMigrationStatus() (*SystemDbMigrationStatus, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "system/db_migration_status", nil)
+func (s *SystemService) DbMigrationStatus(ctx context.Context) (*SystemDbMigrationStatus, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "system/db_migration_status", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -649,8 +650,8 @@ func (s *SystemService) DbMigrationStatus() (*SystemDbMigrationStatus, *http.Res
 // When SonarQube is in safe mode, only authentication with a system passcode is supported.
 //
 // API Docs: https://next.sonarqube.com/sonarqube/web_api/api/system/health
-func (s *SystemService) Health() (*SystemHealth, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "system/health", nil)
+func (s *SystemService) Health(ctx context.Context) (*SystemHealth, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "system/health", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -669,8 +670,8 @@ func (s *SystemService) Health() (*SystemHealth, *http.Response, error) {
 // Requires 'Administer' permissions.
 //
 // API Docs: https://next.sonarqube.com/sonarqube/web_api/api/system/info
-func (s *SystemService) Info() (*SystemInfo, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "system/info", nil)
+func (s *SystemService) Info(ctx context.Context) (*SystemInfo, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "system/info", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -698,8 +699,8 @@ func (s *SystemService) Info() (*SystemInfo, *http.Response, error) {
 //   - Any other HTTP code: this SonarQube node is not alive and should be rescheduled.
 //
 // API Docs: https://next.sonarqube.com/sonarqube/web_api/api/system/liveness
-func (s *SystemService) Liveness() (*SystemLiveness, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "system/liveness", nil)
+func (s *SystemService) Liveness(ctx context.Context) (*SystemLiveness, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "system/liveness", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -722,13 +723,13 @@ func (s *SystemService) Liveness() (*SystemLiveness, *http.Response, error) {
 // Requires system administration permission.
 //
 // API Docs: https://next.sonarqube.com/sonarqube/web_api/api/system/logs
-func (s *SystemService) Logs(opt *SystemLogsOptions) (*string, *http.Response, error) {
+func (s *SystemService) Logs(ctx context.Context, opt *SystemLogsOptions) (*string, *http.Response, error) {
 	err := s.ValidateLogsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "system/logs", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "system/logs", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -755,8 +756,8 @@ func (s *SystemService) Logs(opt *SystemLogsOptions) (*string, *http.Response, e
 //   - MIGRATION_REQUIRED: DB migration is required.
 //
 // API Docs: https://next.sonarqube.com/sonarqube/web_api/api/system/migrate_db
-func (s *SystemService) MigrateDb() (*SystemMigrateDb, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "system/migrate_db", nil)
+func (s *SystemService) MigrateDb(ctx context.Context) (*SystemMigrateDb, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "system/migrate_db", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -775,8 +776,8 @@ func (s *SystemService) MigrateDb() (*SystemMigrateDb, *http.Response, error) {
 // This can be used for health checks.
 //
 // API Docs: https://next.sonarqube.com/sonarqube/web_api/api/system/ping
-func (s *SystemService) Ping() (*string, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "system/ping", nil)
+func (s *SystemService) Ping(ctx context.Context) (*string, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "system/ping", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -797,8 +798,8 @@ func (s *SystemService) Ping() (*string, *http.Response, error) {
 // Does not reload sonar.properties.
 //
 // API Docs: https://next.sonarqube.com/sonarqube/web_api/api/system/restart
-func (s *SystemService) Restart() (*http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "system/restart", nil)
+func (s *SystemService) Restart(ctx context.Context) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "system/restart", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -822,8 +823,8 @@ func (s *SystemService) Restart() (*http.Response, error) {
 //   - DB_MIGRATION_RUNNING: DB migration is running.
 //
 // API Docs: https://next.sonarqube.com/sonarqube/web_api/api/system/status
-func (s *SystemService) Status() (*SystemStatus, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "system/status", nil)
+func (s *SystemService) Status(ctx context.Context) (*SystemStatus, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "system/status", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -843,8 +844,8 @@ func (s *SystemService) Status() (*SystemStatus, *http.Response, error) {
 // Plugin information is retrieved from Update Center.
 //
 // API Docs: https://next.sonarqube.com/sonarqube/web_api/api/system/upgrades
-func (s *SystemService) Upgrades() (*SystemUpgrades, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "system/upgrades", nil)
+func (s *SystemService) Upgrades(ctx context.Context) (*SystemUpgrades, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "system/upgrades", nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/system_service_test.go
+++ b/sonar/system_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -18,7 +19,7 @@ func TestSystem_ChangeLogLevel(t *testing.T) {
 	client := newTestClient(t, server.url())
 
 	opt := &SystemChangeLogLevelOptions{Level: "INFO"}
-	resp, err := client.System.ChangeLogLevel(opt)
+	resp, err := client.System.ChangeLogLevel(context.Background(), opt)
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
@@ -38,7 +39,7 @@ func TestSystem_ChangeLogLevel_ValidationErrors(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := client.System.ChangeLogLevel(tc.opt)
+			_, err := client.System.ChangeLogLevel(context.Background(), tc.opt)
 			assert.Error(t, err, "expected validation error")
 		})
 	}
@@ -50,7 +51,7 @@ func TestSystem_DbMigrationStatus(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.System.DbMigrationStatus()
+	result, resp, err := client.System.DbMigrationStatus(context.Background(), )
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -63,7 +64,7 @@ func TestSystem_Health(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.System.Health()
+	result, resp, err := client.System.Health(context.Background(), )
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -77,7 +78,7 @@ func TestSystem_Health_WithCauses(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, _, err := client.System.Health()
+	result, _, err := client.System.Health(context.Background(), )
 
 	require.NoError(t, err)
 	assert.Equal(t, "YELLOW", result.Health)
@@ -101,7 +102,7 @@ func TestSystem_Info(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.System.Info()
+	result, resp, err := client.System.Info(context.Background(), )
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -114,7 +115,7 @@ func TestSystem_Liveness(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	_, resp, err := client.System.Liveness()
+	_, resp, err := client.System.Liveness(context.Background(), )
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
@@ -128,7 +129,7 @@ func TestSystem_Logs(t *testing.T) {
 	client := newTestClient(t, server.url())
 
 	opt := &SystemLogsOptions{Name: "app"}
-	result, resp, err := client.System.Logs(opt)
+	result, resp, err := client.System.Logs(context.Background(), opt)
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -142,7 +143,7 @@ func TestSystem_Logs_NilOption(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, _, err := client.System.Logs(nil)
+	result, _, err := client.System.Logs(context.Background(), nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -153,7 +154,7 @@ func TestSystem_Logs_ValidationErrors(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	opt := &SystemLogsOptions{Name: "invalid_log"}
-	_, _, err := client.System.Logs(opt)
+	_, _, err := client.System.Logs(context.Background(), opt)
 
 	assert.Error(t, err, "expected validation error for invalid log name")
 }
@@ -164,7 +165,7 @@ func TestSystem_MigrateDb(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.System.MigrateDb()
+	result, resp, err := client.System.MigrateDb(context.Background(), )
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -176,7 +177,7 @@ func TestSystem_Ping(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.System.Ping()
+	result, resp, err := client.System.Ping(context.Background(), )
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -189,7 +190,7 @@ func TestSystem_Restart(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	resp, err := client.System.Restart()
+	resp, err := client.System.Restart(context.Background(), )
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
@@ -201,7 +202,7 @@ func TestSystem_Status(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.System.Status()
+	result, resp, err := client.System.Status(context.Background(), )
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -234,7 +235,7 @@ func TestSystem_Upgrades(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.System.Upgrades()
+	result, resp, err := client.System.Upgrades(context.Background(), )
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -254,7 +255,7 @@ func TestSystem_Upgrades_NoUpgrades(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, _, err := client.System.Upgrades()
+	result, _, err := client.System.Upgrades(context.Background(), )
 
 	require.NoError(t, err)
 	assert.Empty(t, result.Upgrades)

--- a/sonar/system_v2_service.go
+++ b/sonar/system_v2_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -61,8 +62,8 @@ type SystemPasscodeOptionV2 struct {
 
 // GetMigrationsStatus returns the detailed status of ongoing database migrations.
 // If no migration is ongoing or needed, it still returns appropriate information.
-func (s *SystemServiceV2) GetMigrationsStatus() (*SystemDbMigrationsStatusV2, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "system/migrations-status", nil, nil)
+func (s *SystemServiceV2) GetMigrationsStatus(ctx context.Context) (*SystemDbMigrationsStatusV2, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "system/migrations-status", nil, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -80,8 +81,8 @@ func (s *SystemServiceV2) GetMigrationsStatus() (*SystemDbMigrationsStatusV2, *h
 // CheckLiveness provides liveness of SonarQube, meant to be used as a liveness
 // probe on Kubernetes. Returns a 204 status when alive.
 // Requires 'Administer System' permission or authentication with passcode.
-func (s *SystemServiceV2) CheckLiveness(opt *SystemPasscodeOptionV2) (*http.Response, error) {
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "system/liveness", nil, nil)
+func (s *SystemServiceV2) CheckLiveness(ctx context.Context, opt *SystemPasscodeOptionV2) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "system/liveness", nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -100,8 +101,8 @@ func (s *SystemServiceV2) CheckLiveness(opt *SystemPasscodeOptionV2) (*http.Resp
 
 // GetHealth returns the health status of the SonarQube instance.
 // Requires 'Administer System' permission or authentication with passcode.
-func (s *SystemServiceV2) GetHealth(opt *SystemPasscodeOptionV2) (*SystemHealthV2, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "system/health", nil, nil)
+func (s *SystemServiceV2) GetHealth(ctx context.Context, opt *SystemPasscodeOptionV2) (*SystemHealthV2, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "system/health", nil, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/sonar/system_v2_service_test.go
+++ b/sonar/system_v2_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -24,7 +25,7 @@ func TestSystemV2_GetMigrationsStatus(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/system/migrations-status", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.System.GetMigrationsStatus()
+	result, resp, err := client.V2.System.GetMigrationsStatus(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "MIGRATION_RUNNING", result.Status)
@@ -40,7 +41,7 @@ func TestSystemV2_CheckLiveness(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodGet, "/v2/system/liveness", http.StatusNoContent))
 	client := newTestClient(t, server.url())
 
-	resp, err := client.V2.System.CheckLiveness(nil)
+	resp, err := client.V2.System.CheckLiveness(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -54,7 +55,7 @@ func TestSystemV2_CheckLiveness_WithPasscode(t *testing.T) {
 	})
 	client := newTestClient(t, server.url())
 
-	resp, err := client.V2.System.CheckLiveness(&SystemPasscodeOptionV2{Passcode: "my-passcode"})
+	resp, err := client.V2.System.CheckLiveness(context.Background(), &SystemPasscodeOptionV2{Passcode: "my-passcode"})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -71,7 +72,7 @@ func TestSystemV2_GetHealth(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/system/health", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.System.GetHealth(nil)
+	result, resp, err := client.V2.System.GetHealth(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "GREEN", result.Status)
@@ -93,7 +94,7 @@ func TestSystemV2_GetHealth_WithPasscode(t *testing.T) {
 	})
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.System.GetHealth(&SystemPasscodeOptionV2{Passcode: "secret-passcode"})
+	result, resp, err := client.V2.System.GetHealth(context.Background(), &SystemPasscodeOptionV2{Passcode: "secret-passcode"})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "YELLOW", result.Status)

--- a/sonar/user_groups_service.go
+++ b/sonar/user_groups_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -310,13 +311,13 @@ func (s *UserGroupsService) ValidateUsersOpt(opt *UserGroupsUsersOptions) error 
 // Deprecated: Since 10.4. Use POST /api/v2/authorizations/group-memberships instead.
 //
 // Since: 5.2.
-func (s *UserGroupsService) AddUser(opt *UserGroupsAddUserOptions) (*http.Response, error) {
+func (s *UserGroupsService) AddUser(ctx context.Context, opt *UserGroupsAddUserOptions) (*http.Response, error) {
 	err := s.ValidateAddUserOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "user_groups/add_user", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "user_groups/add_user", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -335,13 +336,13 @@ func (s *UserGroupsService) AddUser(opt *UserGroupsAddUserOptions) (*http.Respon
 // Deprecated: Since 10.4. Use POST /api/v2/authorizations/groups instead.
 //
 // Since: 5.2.
-func (s *UserGroupsService) Create(opt *UserGroupsCreateOptions) (*UserGroupsCreate, *http.Response, error) {
+func (s *UserGroupsService) Create(ctx context.Context, opt *UserGroupsCreateOptions) (*UserGroupsCreate, *http.Response, error) {
 	err := s.ValidateCreateOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "user_groups/create", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "user_groups/create", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -363,13 +364,13 @@ func (s *UserGroupsService) Create(opt *UserGroupsCreateOptions) (*UserGroupsCre
 // Deprecated: Since 10.4. Use DELETE /api/v2/authorizations/groups instead.
 //
 // Since: 5.2.
-func (s *UserGroupsService) Delete(opt *UserGroupsDeleteOptions) (*http.Response, error) {
+func (s *UserGroupsService) Delete(ctx context.Context, opt *UserGroupsDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "user_groups/delete", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "user_groups/delete", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -389,13 +390,13 @@ func (s *UserGroupsService) Delete(opt *UserGroupsDeleteOptions) (*http.Response
 // Deprecated: Since 10.4. Use DELETE /api/v2/authorizations/group-memberships instead.
 //
 // Since: 5.2.
-func (s *UserGroupsService) RemoveUser(opt *UserGroupsRemoveUserOptions) (*http.Response, error) {
+func (s *UserGroupsService) RemoveUser(ctx context.Context, opt *UserGroupsRemoveUserOptions) (*http.Response, error) {
 	err := s.ValidateRemoveUserOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "user_groups/remove_user", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "user_groups/remove_user", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -414,13 +415,13 @@ func (s *UserGroupsService) RemoveUser(opt *UserGroupsRemoveUserOptions) (*http.
 // Deprecated: Since 10.4. Use GET /api/v2/authorizations/groups instead.
 //
 // Since: 5.2.
-func (s *UserGroupsService) Search(opt *UserGroupsSearchOptions) (*UserGroupsSearch, *http.Response, error) {
+func (s *UserGroupsService) Search(ctx context.Context, opt *UserGroupsSearchOptions) (*UserGroupsSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "user_groups/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "user_groups/search", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -441,13 +442,13 @@ func (s *UserGroupsService) Search(opt *UserGroupsSearchOptions) (*UserGroupsSea
 // Deprecated: Since 10.4. Use PATCH /api/v2/authorizations/groups instead.
 //
 // Since: 5.2.
-func (s *UserGroupsService) Update(opt *UserGroupsUpdateOptions) (*http.Response, error) {
+func (s *UserGroupsService) Update(ctx context.Context, opt *UserGroupsUpdateOptions) (*http.Response, error) {
 	err := s.ValidateUpdateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "user_groups/update", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "user_groups/update", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -466,13 +467,13 @@ func (s *UserGroupsService) Update(opt *UserGroupsUpdateOptions) (*http.Response
 // Deprecated: Since 10.4. Use GET /api/v2/authorizations/group-memberships instead.
 //
 // Since: 5.2.
-func (s *UserGroupsService) Users(opt *UserGroupsUsersOptions) (*UserGroupsUsers, *http.Response, error) {
+func (s *UserGroupsService) Users(ctx context.Context, opt *UserGroupsUsersOptions) (*UserGroupsUsers, *http.Response, error) {
 	err := s.ValidateUsersOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "user_groups/users", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "user_groups/users", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/user_groups_service_test.go
+++ b/sonar/user_groups_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -18,7 +19,7 @@ func TestUserGroups_AddUser(t *testing.T) {
 		Login: "g.hopper",
 	}
 
-	resp, err := client.UserGroups.AddUser(opt)
+	resp, err := client.UserGroups.AddUser(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -27,11 +28,11 @@ func TestUserGroups_AddUser_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.UserGroups.AddUser(nil)
+	_, err := client.UserGroups.AddUser(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, err = client.UserGroups.AddUser(&UserGroupsAddUserOptions{
+	_, err = client.UserGroups.AddUser(context.Background(), &UserGroupsAddUserOptions{
 		Login: "user",
 	})
 	assert.Error(t, err)
@@ -56,7 +57,7 @@ func TestUserGroups_Create(t *testing.T) {
 		Description: "Default group",
 	}
 
-	result, resp, err := client.UserGroups.Create(opt)
+	result, resp, err := client.UserGroups.Create(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "sonar-users", result.Group.Name)
@@ -66,23 +67,23 @@ func TestUserGroups_Create_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.UserGroups.Create(nil)
+	_, _, err := client.UserGroups.Create(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, _, err = client.UserGroups.Create(&UserGroupsCreateOptions{
+	_, _, err = client.UserGroups.Create(context.Background(), &UserGroupsCreateOptions{
 		Description: "test",
 	})
 	assert.Error(t, err)
 
 	// Test Name too long
-	_, _, err = client.UserGroups.Create(&UserGroupsCreateOptions{
+	_, _, err = client.UserGroups.Create(context.Background(), &UserGroupsCreateOptions{
 		Name: strings.Repeat("a", MaxGroupNameLength+1),
 	})
 	assert.Error(t, err)
 
 	// Test Description too long
-	_, _, err = client.UserGroups.Create(&UserGroupsCreateOptions{
+	_, _, err = client.UserGroups.Create(context.Background(), &UserGroupsCreateOptions{
 		Name:        "test",
 		Description: strings.Repeat("a", MaxGroupDescriptionLength+1),
 	})
@@ -97,7 +98,7 @@ func TestUserGroups_Delete(t *testing.T) {
 		Name: "sonar-users",
 	}
 
-	resp, err := client.UserGroups.Delete(opt)
+	resp, err := client.UserGroups.Delete(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -106,11 +107,11 @@ func TestUserGroups_Delete_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.UserGroups.Delete(nil)
+	_, err := client.UserGroups.Delete(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, err = client.UserGroups.Delete(&UserGroupsDeleteOptions{})
+	_, err = client.UserGroups.Delete(context.Background(), &UserGroupsDeleteOptions{})
 	assert.Error(t, err)
 }
 
@@ -123,7 +124,7 @@ func TestUserGroups_RemoveUser(t *testing.T) {
 		Login: "g.hopper",
 	}
 
-	resp, err := client.UserGroups.RemoveUser(opt)
+	resp, err := client.UserGroups.RemoveUser(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -154,7 +155,7 @@ func TestUserGroups_Search(t *testing.T) {
 		Fields: []string{"name", "description"},
 	}
 
-	result, resp, err := client.UserGroups.Search(opt)
+	result, resp, err := client.UserGroups.Search(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Groups, 1)
@@ -164,11 +165,11 @@ func TestUserGroups_Search_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.UserGroups.Search(nil)
+	_, _, err := client.UserGroups.Search(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test invalid field
-	_, _, err = client.UserGroups.Search(&UserGroupsSearchOptions{
+	_, _, err = client.UserGroups.Search(context.Background(), &UserGroupsSearchOptions{
 		Fields: []string{"invalid_field"},
 	})
 	assert.Error(t, err)
@@ -184,7 +185,7 @@ func TestUserGroups_Update(t *testing.T) {
 		Description: "Updated description",
 	}
 
-	resp, err := client.UserGroups.Update(opt)
+	resp, err := client.UserGroups.Update(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -193,11 +194,11 @@ func TestUserGroups_Update_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.UserGroups.Update(nil)
+	_, err := client.UserGroups.Update(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing CurrentName
-	_, err = client.UserGroups.Update(&UserGroupsUpdateOptions{
+	_, err = client.UserGroups.Update(context.Background(), &UserGroupsUpdateOptions{
 		Name: "new-group",
 	})
 	assert.Error(t, err)
@@ -228,7 +229,7 @@ func TestUserGroups_Users(t *testing.T) {
 		Selected: SelectionFilterSelected,
 	}
 
-	result, resp, err := client.UserGroups.Users(opt)
+	result, resp, err := client.UserGroups.Users(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Users, 1)
@@ -238,15 +239,15 @@ func TestUserGroups_Users_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.UserGroups.Users(nil)
+	_, _, err := client.UserGroups.Users(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, _, err = client.UserGroups.Users(&UserGroupsUsersOptions{})
+	_, _, err = client.UserGroups.Users(context.Background(), &UserGroupsUsersOptions{})
 	assert.Error(t, err)
 
 	// Test invalid Selected value
-	_, _, err = client.UserGroups.Users(&UserGroupsUsersOptions{
+	_, _, err = client.UserGroups.Users(context.Background(), &UserGroupsUsersOptions{
 		Name:     "test",
 		Selected: "invalid",
 	})

--- a/sonar/user_tokens_service.go
+++ b/sonar/user_tokens_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 const (
 	// TokenTypeUserToken represents a user token that can be used for authentication and project analysis.
@@ -192,13 +195,13 @@ func (s *UserTokensService) ValidateSearchOpt(opt *UserTokensSearchOptions) erro
 //
 // API endpoint: POST /api/user_tokens/generate.
 // Since: 5.3.
-func (s *UserTokensService) Generate(opt *UserTokensGenerateOptions) (*UserTokensGenerate, *http.Response, error) {
+func (s *UserTokensService) Generate(ctx context.Context, opt *UserTokensGenerateOptions) (*UserTokensGenerate, *http.Response, error) {
 	err := s.ValidateGenerateOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "user_tokens/generate", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "user_tokens/generate", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -219,13 +222,13 @@ func (s *UserTokensService) Generate(opt *UserTokensGenerateOptions) (*UserToken
 //
 // API endpoint: POST /api/user_tokens/revoke.
 // Since: 5.3.
-func (s *UserTokensService) Revoke(opt *UserTokensRevokeOptions) (*http.Response, error) {
+func (s *UserTokensService) Revoke(ctx context.Context, opt *UserTokensRevokeOptions) (*http.Response, error) {
 	err := s.ValidateRevokeOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "user_tokens/revoke", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "user_tokens/revoke", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -247,13 +250,13 @@ func (s *UserTokensService) Revoke(opt *UserTokensRevokeOptions) (*http.Response
 //
 // API endpoint: GET /api/user_tokens/search.
 // Since: 5.3.
-func (s *UserTokensService) Search(opt *UserTokensSearchOptions) (*UserTokensSearch, *http.Response, error) {
+func (s *UserTokensService) Search(ctx context.Context, opt *UserTokensSearchOptions) (*UserTokensSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "user_tokens/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "user_tokens/search", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/user_tokens_service_test.go
+++ b/sonar/user_tokens_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -25,7 +26,7 @@ func TestUserTokens_Generate(t *testing.T) {
 		Name: "my-token",
 	}
 
-	result, resp, err := client.UserTokens.Generate(opt)
+	result, resp, err := client.UserTokens.Generate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -53,7 +54,7 @@ func TestUserTokens_Generate_WithType(t *testing.T) {
 		ProjectKey: "my-project",
 	}
 
-	result, resp, err := client.UserTokens.Generate(opt)
+	result, resp, err := client.UserTokens.Generate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "PROJECT_ANALYSIS_TOKEN", result.Type)
@@ -63,22 +64,22 @@ func TestUserTokens_Generate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.UserTokens.Generate(nil)
+	_, _, err := client.UserTokens.Generate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Name should fail validation.
-	_, _, err = client.UserTokens.Generate(&UserTokensGenerateOptions{})
+	_, _, err = client.UserTokens.Generate(context.Background(), &UserTokensGenerateOptions{})
 	assert.Error(t, err)
 
 	// Invalid Type should fail validation.
-	_, _, err = client.UserTokens.Generate(&UserTokensGenerateOptions{
+	_, _, err = client.UserTokens.Generate(context.Background(), &UserTokensGenerateOptions{
 		Name: "my-token",
 		Type: "INVALID_TYPE",
 	})
 	assert.Error(t, err)
 
 	// PROJECT_ANALYSIS_TOKEN without ProjectKey should fail validation.
-	_, _, err = client.UserTokens.Generate(&UserTokensGenerateOptions{
+	_, _, err = client.UserTokens.Generate(context.Background(), &UserTokensGenerateOptions{
 		Name: "my-token",
 		Type: "PROJECT_ANALYSIS_TOKEN",
 	})
@@ -94,7 +95,7 @@ func TestUserTokens_Revoke(t *testing.T) {
 		Name: "my-token",
 	}
 
-	resp, err := client.UserTokens.Revoke(opt)
+	resp, err := client.UserTokens.Revoke(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -103,11 +104,11 @@ func TestUserTokens_Revoke_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.UserTokens.Revoke(nil)
+	_, err := client.UserTokens.Revoke(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Name should fail validation.
-	_, err = client.UserTokens.Revoke(&UserTokensRevokeOptions{})
+	_, err = client.UserTokens.Revoke(context.Background(), &UserTokensRevokeOptions{})
 	assert.Error(t, err)
 }
 
@@ -134,7 +135,7 @@ func TestUserTokens_Search(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.UserTokens.Search(nil)
+	result, resp, err := client.UserTokens.Search(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -155,7 +156,7 @@ func TestUserTokens_Search_WithLogin(t *testing.T) {
 		Login: "testuser",
 	}
 
-	result, _, err := client.UserTokens.Search(opt)
+	result, _, err := client.UserTokens.Search(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, "testuser", result.Login)
 }

--- a/sonar/users_service.go
+++ b/sonar/users_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 const (
 	// MaxLoginLength is the maximum length for a user login.
@@ -737,13 +740,13 @@ func (s *UsersService) ValidateUpdateLoginOpt(opt *UsersUpdateLoginOptions) erro
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: POST /api/users/anonymize.
 // Since: 9.7.
-func (s *UsersService) Anonymize(opt *UsersAnonymizeOptions) (*http.Response, error) {
+func (s *UsersService) Anonymize(ctx context.Context, opt *UsersAnonymizeOptions) (*http.Response, error) {
 	err := s.ValidateAnonymizeOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "users/anonymize", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "users/anonymize", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -763,13 +766,13 @@ func (s *UsersService) Anonymize(opt *UsersAnonymizeOptions) (*http.Response, er
 //
 // API endpoint: POST /api/users/change_password.
 // Since: 5.2.
-func (s *UsersService) ChangePassword(opt *UsersChangePasswordOptions) (*http.Response, error) {
+func (s *UsersService) ChangePassword(ctx context.Context, opt *UsersChangePasswordOptions) (*http.Response, error) {
 	err := s.ValidateChangePasswordOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "users/change_password", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "users/change_password", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -789,13 +792,13 @@ func (s *UsersService) ChangePassword(opt *UsersChangePasswordOptions) (*http.Re
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: POST /api/users/create.
 // Since: 3.7.
-func (s *UsersService) Create(opt *UsersCreateOptions) (*UsersCreate, *http.Response, error) {
+func (s *UsersService) Create(ctx context.Context, opt *UsersCreateOptions) (*UsersCreate, *http.Response, error) {
 	err := s.ValidateCreateOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "users/create", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "users/create", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -814,8 +817,8 @@ func (s *UsersService) Create(opt *UsersCreateOptions) (*UsersCreate, *http.Resp
 //
 // API endpoint: GET /api/users/current.
 // Since: 5.2.
-func (s *UsersService) Current() (*UsersCurrent, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "users/current", nil)
+func (s *UsersService) Current(ctx context.Context) (*UsersCurrent, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "users/current", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -836,13 +839,13 @@ func (s *UsersService) Current() (*UsersCurrent, *http.Response, error) {
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: POST /api/users/deactivate.
 // Since: 3.7.
-func (s *UsersService) Deactivate(opt *UsersDeactivateOptions) (*UsersDeactivate, *http.Response, error) {
+func (s *UsersService) Deactivate(ctx context.Context, opt *UsersDeactivateOptions) (*UsersDeactivate, *http.Response, error) {
 	err := s.ValidateDeactivateOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "users/deactivate", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "users/deactivate", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -862,13 +865,13 @@ func (s *UsersService) Deactivate(opt *UsersDeactivateOptions) (*UsersDeactivate
 //
 // API endpoint: POST /api/users/dismiss_notice.
 // Since: 9.6.
-func (s *UsersService) DismissNotice(opt *UsersDismissNoticeOptions) (*http.Response, error) {
+func (s *UsersService) DismissNotice(ctx context.Context, opt *UsersDismissNoticeOptions) (*http.Response, error) {
 	err := s.ValidateDismissNoticeOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "users/dismiss_notice", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "users/dismiss_notice", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -887,13 +890,13 @@ func (s *UsersService) DismissNotice(opt *UsersDismissNoticeOptions) (*http.Resp
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: GET /api/users/groups.
 // Since: 5.2.
-func (s *UsersService) Groups(opt *UsersGroupsOptions) (*UsersGroups, *http.Response, error) {
+func (s *UsersService) Groups(ctx context.Context, opt *UsersGroupsOptions) (*UsersGroups, *http.Response, error) {
 	err := s.ValidateGroupsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "users/groups", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "users/groups", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -912,8 +915,8 @@ func (s *UsersService) Groups(opt *UsersGroupsOptions) (*UsersGroups, *http.Resp
 //
 // API endpoint: GET /api/users/identity_providers.
 // Since: 5.5.
-func (s *UsersService) IdentityProviders() (*UsersIdentityProviders, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "users/identity_providers", nil)
+func (s *UsersService) IdentityProviders(ctx context.Context) (*UsersIdentityProviders, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "users/identity_providers", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -938,13 +941,13 @@ func (s *UsersService) IdentityProviders() (*UsersIdentityProviders, *http.Respo
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: GET /api/users/search.
 // Since: 3.6.
-func (s *UsersService) Search(opt *UsersSearchOptions) (*UsersSearch, *http.Response, error) {
+func (s *UsersService) Search(ctx context.Context, opt *UsersSearchOptions) (*UsersSearch, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "users/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "users/search", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -964,13 +967,13 @@ func (s *UsersService) Search(opt *UsersSearchOptions) (*UsersSearch, *http.Resp
 //
 // API endpoint: POST /api/users/set_homepage.
 // Since: 7.0.
-func (s *UsersService) SetHomepage(opt *UsersSetHomepageOptions) (*http.Response, error) {
+func (s *UsersService) SetHomepage(ctx context.Context, opt *UsersSetHomepageOptions) (*http.Response, error) {
 	err := s.ValidateSetHomepageOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "users/set_homepage", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "users/set_homepage", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -989,13 +992,13 @@ func (s *UsersService) SetHomepage(opt *UsersSetHomepageOptions) (*http.Response
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: POST /api/users/update.
 // Since: 3.7.
-func (s *UsersService) Update(opt *UsersUpdateOptions) (*UsersUpdate, *http.Response, error) {
+func (s *UsersService) Update(ctx context.Context, opt *UsersUpdateOptions) (*UsersUpdate, *http.Response, error) {
 	err := s.ValidateUpdateOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "users/update", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "users/update", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1019,13 +1022,13 @@ func (s *UsersService) Update(opt *UsersUpdateOptions) (*UsersUpdate, *http.Resp
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: POST /api/users/update_identity_provider.
 // Since: 8.7.
-func (s *UsersService) UpdateIdentityProvider(opt *UsersUpdateIdentityProviderOptions) (*http.Response, error) {
+func (s *UsersService) UpdateIdentityProvider(ctx context.Context, opt *UsersUpdateIdentityProviderOptions) (*http.Response, error) {
 	err := s.ValidateUpdateIdentityProviderOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "users/update_identity_provider", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "users/update_identity_provider", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1045,13 +1048,13 @@ func (s *UsersService) UpdateIdentityProvider(opt *UsersUpdateIdentityProviderOp
 // Deprecated: Since SonarQube 10.4.
 // API endpoint: POST /api/users/update_login.
 // Since: 7.6.
-func (s *UsersService) UpdateLogin(opt *UsersUpdateLoginOptions) (*http.Response, error) {
+func (s *UsersService) UpdateLogin(ctx context.Context, opt *UsersUpdateLoginOptions) (*http.Response, error) {
 	err := s.ValidateUpdateLoginOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "users/update_login", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "users/update_login", opt)
 	if err != nil {
 		return nil, err
 	}

--- a/sonar/users_service_test.go
+++ b/sonar/users_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestUsers_Anonymize(t *testing.T) {
 		Login: "deactivated-user",
 	}
 
-	resp, err := client.Users.Anonymize(opt)
+	resp, err := client.Users.Anonymize(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -25,11 +26,11 @@ func TestUsers_Anonymize_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, err := client.Users.Anonymize(nil)
+	_, err := client.Users.Anonymize(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Login should fail validation.
-	_, err = client.Users.Anonymize(&UsersAnonymizeOptions{})
+	_, err = client.Users.Anonymize(context.Background(), &UsersAnonymizeOptions{})
 	assert.Error(t, err)
 }
 
@@ -42,7 +43,7 @@ func TestUsers_ChangePassword(t *testing.T) {
 		Password: "MyNewPassword123!",
 	}
 
-	resp, err := client.Users.ChangePassword(opt)
+	resp, err := client.Users.ChangePassword(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -74,7 +75,7 @@ func TestUsers_ChangePassword_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.Users.ChangePassword(tt.opt)
+			_, err := client.Users.ChangePassword(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -104,7 +105,7 @@ func TestUsers_Create(t *testing.T) {
 		ScmAccounts: []string{"scm1", "scm2"},
 	}
 
-	result, resp, err := client.Users.Create(opt)
+	result, resp, err := client.Users.Create(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -149,7 +150,7 @@ func TestUsers_Create_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Users.Create(tt.opt)
+			_, _, err := client.Users.Create(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -183,7 +184,7 @@ func TestUsers_Current(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/users/current", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Users.Current()
+	result, resp, err := client.Users.Current(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -213,7 +214,7 @@ func TestUsers_Deactivate(t *testing.T) {
 		Anonymize: false,
 	}
 
-	result, resp, err := client.Users.Deactivate(opt)
+	result, resp, err := client.Users.Deactivate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -240,7 +241,7 @@ func TestUsers_Deactivate_WithAnonymize(t *testing.T) {
 		Anonymize: true,
 	}
 
-	result, resp, err := client.Users.Deactivate(opt)
+	result, resp, err := client.Users.Deactivate(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -250,11 +251,11 @@ func TestUsers_Deactivate_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.Users.Deactivate(nil)
+	_, _, err := client.Users.Deactivate(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Login should fail validation.
-	_, _, err = client.Users.Deactivate(&UsersDeactivateOptions{})
+	_, _, err = client.Users.Deactivate(context.Background(), &UsersDeactivateOptions{})
 	assert.Error(t, err)
 }
 
@@ -266,7 +267,7 @@ func TestUsers_DismissNotice(t *testing.T) {
 		Notice: "educationPrinciples",
 	}
 
-	resp, err := client.Users.DismissNotice(opt)
+	resp, err := client.Users.DismissNotice(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -294,7 +295,7 @@ func TestUsers_DismissNotice_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.Users.DismissNotice(tt.opt)
+			_, err := client.Users.DismissNotice(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -332,7 +333,7 @@ func TestUsers_Groups(t *testing.T) {
 		Login: "myuser",
 	}
 
-	result, resp, err := client.Users.Groups(opt)
+	result, resp, err := client.Users.Groups(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -363,7 +364,7 @@ func TestUsers_Groups_WithPagination(t *testing.T) {
 		},
 	}
 
-	result, resp, err := client.Users.Groups(opt)
+	result, resp, err := client.Users.Groups(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, int64(2), result.Paging.PageIndex)
@@ -388,7 +389,7 @@ func TestUsers_Groups_WithFilter(t *testing.T) {
 		Selected: SelectionFilterSelected,
 	}
 
-	_, resp, err := client.Users.Groups(opt)
+	_, resp, err := client.Users.Groups(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -420,7 +421,7 @@ func TestUsers_Groups_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.Users.Groups(tt.opt)
+			_, _, err := client.Users.Groups(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -449,7 +450,7 @@ func TestUsers_IdentityProviders(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/users/identity_providers", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Users.IdentityProviders()
+	result, resp, err := client.Users.IdentityProviders(context.Background(), )
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -495,7 +496,7 @@ func TestUsers_Search(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/users/search", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Users.Search(nil)
+	result, resp, err := client.Users.Search(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -527,7 +528,7 @@ func TestUsers_Search_WithFilters(t *testing.T) {
 		},
 	}
 
-	_, resp, err := client.Users.Search(opt)
+	_, resp, err := client.Users.Search(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -539,7 +540,7 @@ func TestUsers_Search_ValidationError(t *testing.T) {
 	opt := &UsersSearchOptions{
 		PaginationArgs: PaginationArgs{PageSize: 1000},
 	}
-	_, _, err := client.Users.Search(opt)
+	_, _, err := client.Users.Search(context.Background(), opt)
 	assert.Error(t, err)
 }
 
@@ -552,7 +553,7 @@ func TestUsers_SetHomepage(t *testing.T) {
 		Component: "my-project",
 	}
 
-	resp, err := client.Users.SetHomepage(opt)
+	resp, err := client.Users.SetHomepage(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -580,7 +581,7 @@ func TestUsers_SetHomepage_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.Users.SetHomepage(tt.opt)
+			_, err := client.Users.SetHomepage(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -607,7 +608,7 @@ func TestUsers_Update(t *testing.T) {
 		Email: "updated@example.com",
 	}
 
-	result, resp, err := client.Users.Update(opt)
+	result, resp, err := client.Users.Update(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -618,11 +619,11 @@ func TestUsers_Update_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Nil option should fail validation.
-	_, _, err := client.Users.Update(nil)
+	_, _, err := client.Users.Update(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Missing Login should fail validation.
-	_, _, err = client.Users.Update(&UsersUpdateOptions{})
+	_, _, err = client.Users.Update(context.Background(), &UsersUpdateOptions{})
 	assert.Error(t, err)
 }
 
@@ -636,7 +637,7 @@ func TestUsers_UpdateIdentityProvider(t *testing.T) {
 		NewExternalIdentity: "github-user",
 	}
 
-	resp, err := client.Users.UpdateIdentityProvider(opt)
+	resp, err := client.Users.UpdateIdentityProvider(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -664,7 +665,7 @@ func TestUsers_UpdateIdentityProvider_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.Users.UpdateIdentityProvider(tt.opt)
+			_, err := client.Users.UpdateIdentityProvider(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -679,7 +680,7 @@ func TestUsers_UpdateLogin(t *testing.T) {
 		NewLogin: "newlogin",
 	}
 
-	resp, err := client.Users.UpdateLogin(opt)
+	resp, err := client.Users.UpdateLogin(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -711,7 +712,7 @@ func TestUsers_UpdateLogin_ValidationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.Users.UpdateLogin(tt.opt)
+			_, err := client.Users.UpdateLogin(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}

--- a/sonar/users_v2_service.go
+++ b/sonar/users_v2_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -302,13 +303,13 @@ func validateUsersV2ExternalFields(opt *UsersUpdateOptionsV2) error {
 
 // Search returns a list of users matching the search criteria.
 // By default, only active users are returned.
-func (s *UsersManagementService) Search(opt *UsersSearchOptionV2) (*UsersSearchV2, *http.Response, error) {
+func (s *UsersManagementService) Search(ctx context.Context, opt *UsersSearchOptionV2) (*UsersSearchV2, *http.Response, error) {
 	err := s.ValidateSearchOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "users-management/users", opt, nil)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "users-management/users", opt, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -326,13 +327,13 @@ func (s *UsersManagementService) Search(opt *UsersSearchOptionV2) (*UsersSearchV
 // Create creates a new user. If a deactivated user account exists with the
 // given login, it will be reactivated.
 // Requires Administer System permission.
-func (s *UsersManagementService) Create(opt *UsersCreateOptionsV2) (*UserV2, *http.Response, error) {
+func (s *UsersManagementService) Create(ctx context.Context, opt *UsersCreateOptionsV2) (*UserV2, *http.Response, error) {
 	err := s.ValidateCreateRequest(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodPost, "users-management/users", nil, opt)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPost, "users-management/users", nil, opt)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -348,13 +349,13 @@ func (s *UsersManagementService) Create(opt *UsersCreateOptionsV2) (*UserV2, *ht
 }
 
 // Get retrieves a single user by ID.
-func (s *UsersManagementService) Get(userID string) (*UserV2, *http.Response, error) {
+func (s *UsersManagementService) Get(ctx context.Context, userID string) (*UserV2, *http.Response, error) {
 	err := ValidateRequired(userID, "Id")
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodGet, "users-management/users/"+userID, nil, nil)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "users-management/users/"+userID, nil, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -371,13 +372,13 @@ func (s *UsersManagementService) Get(userID string) (*UserV2, *http.Response, er
 
 // Deactivate deactivates a user.
 // Requires Administer System permission.
-func (s *UsersManagementService) Deactivate(opt *UsersDeactivateOptionsV2) (*http.Response, error) {
+func (s *UsersManagementService) Deactivate(ctx context.Context, opt *UsersDeactivateOptionsV2) (*http.Response, error) {
 	err := s.ValidateDeactivateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodDelete, "users-management/users/"+opt.Id, opt, nil)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodDelete, "users-management/users/"+opt.Id, opt, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -391,13 +392,13 @@ func (s *UsersManagementService) Deactivate(opt *UsersDeactivateOptionsV2) (*htt
 }
 
 // Update updates a user's attributes.
-func (s *UsersManagementService) Update(userID string, opt *UsersUpdateOptionsV2) (*UserV2, *http.Response, error) {
+func (s *UsersManagementService) Update(ctx context.Context, userID string, opt *UsersUpdateOptionsV2) (*UserV2, *http.Response, error) {
 	err := s.ValidateUpdateRequest(userID, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV2APIRequest(http.MethodPatch, "users-management/users/"+userID, nil, opt)
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPatch, "users-management/users/"+userID, nil, opt)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/sonar/users_v2_service_test.go
+++ b/sonar/users_v2_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -24,7 +25,7 @@ func TestUsersV2_Search(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/users-management/users", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.UsersManagement.Search(nil)
+	result, resp, err := client.V2.UsersManagement.Search(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Users, 2)
@@ -42,7 +43,7 @@ func TestUsersV2_Search_WithOptions(t *testing.T) {
 		response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.UsersManagement.Search(&UsersSearchOptionV2{
+	result, resp, err := client.V2.UsersManagement.Search(context.Background(), &UsersSearchOptionV2{
 		PaginationParamsV2: PaginationParamsV2{PageSize: 10},
 		Active:             &active,
 		Query:              "jdoe",
@@ -56,7 +57,7 @@ func TestUsersV2_Search_Validation(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Invalid page size
-	_, _, err := client.V2.UsersManagement.Search(&UsersSearchOptionV2{
+	_, _, err := client.V2.UsersManagement.Search(context.Background(), &UsersSearchOptionV2{
 		PaginationParamsV2: PaginationParamsV2{PageSize: 600},
 	})
 	assert.Error(t, err)
@@ -83,7 +84,7 @@ func TestUsersV2_Create(t *testing.T) {
 		}, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.UsersManagement.Create(&UsersCreateOptionsV2{
+	result, resp, err := client.V2.UsersManagement.Create(context.Background(), &UsersCreateOptionsV2{
 		Login:    "newuser",
 		Name:     "New User",
 		Email:    "new@example.com",
@@ -112,7 +113,7 @@ func TestUsersV2_Create_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.V2.UsersManagement.Create(tt.opt)
+			_, _, err := client.V2.UsersManagement.Create(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -131,7 +132,7 @@ func TestUsersV2_Get(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/users-management/users/user-1", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.UsersManagement.Get("user-1")
+	result, resp, err := client.V2.UsersManagement.Get(context.Background(), "user-1")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "jdoe", result.Login)
@@ -140,7 +141,7 @@ func TestUsersV2_Get(t *testing.T) {
 func TestUsersV2_Get_Validation(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.V2.UsersManagement.Get("")
+	_, _, err := client.V2.UsersManagement.Get(context.Background(), "")
 	assert.Error(t, err)
 }
 
@@ -153,7 +154,7 @@ func TestUsersV2_Deactivate(t *testing.T) {
 		map[string]string{"anonymize": "true"}))
 	client := newTestClient(t, server.url())
 
-	resp, err := client.V2.UsersManagement.Deactivate(&UsersDeactivateOptionsV2{
+	resp, err := client.V2.UsersManagement.Deactivate(context.Background(), &UsersDeactivateOptionsV2{
 		Id:        "user-1",
 		Anonymize: true,
 	})
@@ -174,7 +175,7 @@ func TestUsersV2_Deactivate_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.V2.UsersManagement.Deactivate(tt.opt)
+			_, err := client.V2.UsersManagement.Deactivate(context.Background(), tt.opt)
 			assert.Error(t, err)
 		})
 	}
@@ -198,7 +199,7 @@ func TestUsersV2_Update(t *testing.T) {
 		}, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.UsersManagement.Update("user-1", &UsersUpdateOptionsV2{
+	result, resp, err := client.V2.UsersManagement.Update(context.Background(), "user-1", &UsersUpdateOptionsV2{
 		Name:  "John Updated",
 		Email: "updated@example.com",
 	})
@@ -226,7 +227,7 @@ func TestUsersV2_Update_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := client.V2.UsersManagement.Update(tt.id, tt.opt)
+			_, _, err := client.V2.UsersManagement.Update(context.Background(), tt.id, tt.opt)
 			assert.Error(t, err)
 		})
 	}

--- a/sonar/views_service.go
+++ b/sonar/views_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // ViewsService handles communication with the portfolio related methods of
 // the SonarQube API. This service is only available in Enterprise Edition.
@@ -744,13 +747,13 @@ func (s *ViewsService) ValidateSetTagsModeOpt(opt *ViewsSetTagsModeOptions) erro
 // API endpoint: POST /api/views/add_application.
 // Since: 7.1.
 // Enterprise Edition only.
-func (s *ViewsService) AddApplication(opt *ViewsAddApplicationOptions) (*http.Response, error) {
+func (s *ViewsService) AddApplication(ctx context.Context, opt *ViewsAddApplicationOptions) (*http.Response, error) {
 	err := s.ValidateAddApplicationOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/add_application", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/add_application", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -764,13 +767,13 @@ func (s *ViewsService) AddApplication(opt *ViewsAddApplicationOptions) (*http.Re
 // API endpoint: POST /api/views/add_application_branch.
 // Since: 7.1.
 // Enterprise Edition only.
-func (s *ViewsService) AddApplicationBranch(opt *ViewsAddApplicationBranchOptions) (*http.Response, error) {
+func (s *ViewsService) AddApplicationBranch(ctx context.Context, opt *ViewsAddApplicationBranchOptions) (*http.Response, error) {
 	err := s.ValidateAddApplicationBranchOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/add_application_branch", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/add_application_branch", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -784,13 +787,13 @@ func (s *ViewsService) AddApplicationBranch(opt *ViewsAddApplicationBranchOption
 // API endpoint: POST /api/views/add_portfolio.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) AddPortfolio(opt *ViewsAddPortfolioOptions) (*http.Response, error) {
+func (s *ViewsService) AddPortfolio(ctx context.Context, opt *ViewsAddPortfolioOptions) (*http.Response, error) {
 	err := s.ValidateAddPortfolioOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/add_portfolio", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/add_portfolio", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -804,13 +807,13 @@ func (s *ViewsService) AddPortfolio(opt *ViewsAddPortfolioOptions) (*http.Respon
 // API endpoint: POST /api/views/add_project.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) AddProject(opt *ViewsAddProjectOptions) (*http.Response, error) {
+func (s *ViewsService) AddProject(ctx context.Context, opt *ViewsAddProjectOptions) (*http.Response, error) {
 	err := s.ValidateAddProjectOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/add_project", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/add_project", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -824,13 +827,13 @@ func (s *ViewsService) AddProject(opt *ViewsAddProjectOptions) (*http.Response, 
 // API endpoint: POST /api/views/add_project_branch.
 // Since: 7.1.
 // Enterprise Edition only.
-func (s *ViewsService) AddProjectBranch(opt *ViewsAddProjectBranchOptions) (*http.Response, error) {
+func (s *ViewsService) AddProjectBranch(ctx context.Context, opt *ViewsAddProjectBranchOptions) (*http.Response, error) {
 	err := s.ValidateAddProjectBranchOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/add_project_branch", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/add_project_branch", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -844,13 +847,13 @@ func (s *ViewsService) AddProjectBranch(opt *ViewsAddProjectBranchOptions) (*htt
 // API endpoint: GET /api/views/applications.
 // Since: 7.1.
 // Enterprise Edition only.
-func (s *ViewsService) Applications(opt *ViewsApplicationsOptions) (*ViewsApplications, *http.Response, error) {
+func (s *ViewsService) Applications(ctx context.Context, opt *ViewsApplicationsOptions) (*ViewsApplications, *http.Response, error) {
 	err := s.ValidateApplicationsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/applications", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "views/applications", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -871,13 +874,13 @@ func (s *ViewsService) Applications(opt *ViewsApplicationsOptions) (*ViewsApplic
 // API endpoint: POST /api/views/create.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) Create(opt *ViewsCreateOptions) (*http.Response, error) {
+func (s *ViewsService) Create(ctx context.Context, opt *ViewsCreateOptions) (*http.Response, error) {
 	err := s.ValidateCreateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/create", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/create", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -891,13 +894,13 @@ func (s *ViewsService) Create(opt *ViewsCreateOptions) (*http.Response, error) {
 // API endpoint: POST /api/views/delete.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) Delete(opt *ViewsDeleteOptions) (*http.Response, error) {
+func (s *ViewsService) Delete(ctx context.Context, opt *ViewsDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/delete", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/delete", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -911,8 +914,8 @@ func (s *ViewsService) Delete(opt *ViewsDeleteOptions) (*http.Response, error) {
 // API endpoint: GET /api/views/list.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) List() (*ViewsList, *http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/list", nil)
+func (s *ViewsService) List(ctx context.Context) (*ViewsList, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "views/list", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -933,13 +936,13 @@ func (s *ViewsService) List() (*ViewsList, *http.Response, error) {
 // API endpoint: POST /api/views/move.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) Move(opt *ViewsMoveOptions) (*http.Response, error) {
+func (s *ViewsService) Move(ctx context.Context, opt *ViewsMoveOptions) (*http.Response, error) {
 	err := s.ValidateMoveOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/move", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/move", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -953,13 +956,13 @@ func (s *ViewsService) Move(opt *ViewsMoveOptions) (*http.Response, error) {
 // API endpoint: GET /api/views/move_options.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) MoveOptions(opt *ViewsMoveOptionsOptions) (*ViewsMoveDestinations, *http.Response, error) {
+func (s *ViewsService) MoveOptions(ctx context.Context, opt *ViewsMoveOptionsOptions) (*ViewsMoveDestinations, *http.Response, error) {
 	err := s.ValidateMoveOptionsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/move_options", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "views/move_options", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -980,13 +983,13 @@ func (s *ViewsService) MoveOptions(opt *ViewsMoveOptionsOptions) (*ViewsMoveDest
 // API endpoint: GET /api/views/portfolios.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) SubPortfolios(opt *ViewsSubViewsOptions) (*ViewsSubViews, *http.Response, error) {
+func (s *ViewsService) SubPortfolios(ctx context.Context, opt *ViewsSubViewsOptions) (*ViewsSubViews, *http.Response, error) {
 	err := s.ValidateSubPortfoliosOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/portfolios", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "views/portfolios", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1007,13 +1010,13 @@ func (s *ViewsService) SubPortfolios(opt *ViewsSubViewsOptions) (*ViewsSubViews,
 // API endpoint: GET /api/views/projects.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) Projects(opt *ViewsProjectsOptions) (*ViewsProjects, *http.Response, error) {
+func (s *ViewsService) Projects(ctx context.Context, opt *ViewsProjectsOptions) (*ViewsProjects, *http.Response, error) {
 	err := s.ValidateProjectsOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/projects", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "views/projects", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1034,13 +1037,13 @@ func (s *ViewsService) Projects(opt *ViewsProjectsOptions) (*ViewsProjects, *htt
 // API endpoint: GET /api/views/projects_status.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) ProjectsStatus(opt *ViewsProjectsStatusOptions) (*ViewsProjectsStatus, *http.Response, error) {
+func (s *ViewsService) ProjectsStatus(ctx context.Context, opt *ViewsProjectsStatusOptions) (*ViewsProjectsStatus, *http.Response, error) {
 	err := s.ValidateProjectsStatusOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/projects_status", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "views/projects_status", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1062,8 +1065,8 @@ func (s *ViewsService) ProjectsStatus(opt *ViewsProjectsStatusOptions) (*ViewsPr
 // API endpoint: POST /api/views/refresh.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) Refresh(opt *ViewsRefreshOptions) (*http.Response, error) {
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/refresh", opt)
+func (s *ViewsService) Refresh(ctx context.Context, opt *ViewsRefreshOptions) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/refresh", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1077,13 +1080,13 @@ func (s *ViewsService) Refresh(opt *ViewsRefreshOptions) (*http.Response, error)
 // API endpoint: POST /api/views/remove_application.
 // Since: 7.1.
 // Enterprise Edition only.
-func (s *ViewsService) RemoveApplication(opt *ViewsRemoveApplicationOptions) (*http.Response, error) {
+func (s *ViewsService) RemoveApplication(ctx context.Context, opt *ViewsRemoveApplicationOptions) (*http.Response, error) {
 	err := s.ValidateRemoveApplicationOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/remove_application", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/remove_application", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1097,13 +1100,13 @@ func (s *ViewsService) RemoveApplication(opt *ViewsRemoveApplicationOptions) (*h
 // API endpoint: POST /api/views/remove_application_branch.
 // Since: 7.1.
 // Enterprise Edition only.
-func (s *ViewsService) RemoveApplicationBranch(opt *ViewsRemoveApplicationBranchOptions) (*http.Response, error) {
+func (s *ViewsService) RemoveApplicationBranch(ctx context.Context, opt *ViewsRemoveApplicationBranchOptions) (*http.Response, error) {
 	err := s.ValidateRemoveApplicationBranchOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/remove_application_branch", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/remove_application_branch", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1117,13 +1120,13 @@ func (s *ViewsService) RemoveApplicationBranch(opt *ViewsRemoveApplicationBranch
 // API endpoint: POST /api/views/remove_portfolio.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) RemovePortfolio(opt *ViewsRemovePortfolioOptions) (*http.Response, error) {
+func (s *ViewsService) RemovePortfolio(ctx context.Context, opt *ViewsRemovePortfolioOptions) (*http.Response, error) {
 	err := s.ValidateRemovePortfolioOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/remove_portfolio", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/remove_portfolio", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1137,13 +1140,13 @@ func (s *ViewsService) RemovePortfolio(opt *ViewsRemovePortfolioOptions) (*http.
 // API endpoint: POST /api/views/remove_project.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) RemoveProject(opt *ViewsRemoveProjectOptions) (*http.Response, error) {
+func (s *ViewsService) RemoveProject(ctx context.Context, opt *ViewsRemoveProjectOptions) (*http.Response, error) {
 	err := s.ValidateRemoveProjectOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/remove_project", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/remove_project", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1157,13 +1160,13 @@ func (s *ViewsService) RemoveProject(opt *ViewsRemoveProjectOptions) (*http.Resp
 // API endpoint: POST /api/views/remove_project_branch.
 // Since: 7.1.
 // Enterprise Edition only.
-func (s *ViewsService) RemoveProjectBranch(opt *ViewsRemoveProjectBranchOptions) (*http.Response, error) {
+func (s *ViewsService) RemoveProjectBranch(ctx context.Context, opt *ViewsRemoveProjectBranchOptions) (*http.Response, error) {
 	err := s.ValidateRemoveProjectBranchOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/remove_project_branch", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/remove_project_branch", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1177,7 +1180,7 @@ func (s *ViewsService) RemoveProjectBranch(opt *ViewsRemoveProjectBranchOptions)
 // API endpoint: GET /api/views/search.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) Search(opt *ViewsSearchOptions) (*ViewsSearch, *http.Response, error) {
+func (s *ViewsService) Search(ctx context.Context, opt *ViewsSearchOptions) (*ViewsSearch, *http.Response, error) {
 	if opt != nil {
 		err := opt.Validate()
 		if err != nil {
@@ -1185,7 +1188,7 @@ func (s *ViewsService) Search(opt *ViewsSearchOptions) (*ViewsSearch, *http.Resp
 		}
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/search", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "views/search", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1206,13 +1209,13 @@ func (s *ViewsService) Search(opt *ViewsSearchOptions) (*ViewsSearch, *http.Resp
 // API endpoint: POST /api/views/set_manual_mode.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) SetManualMode(opt *ViewsSetManualModeOptions) (*http.Response, error) {
+func (s *ViewsService) SetManualMode(ctx context.Context, opt *ViewsSetManualModeOptions) (*http.Response, error) {
 	err := s.ValidateSetManualModeOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/set_manual_mode", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/set_manual_mode", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1226,13 +1229,13 @@ func (s *ViewsService) SetManualMode(opt *ViewsSetManualModeOptions) (*http.Resp
 // API endpoint: POST /api/views/set_none_mode.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) SetNoneMode(opt *ViewsSetNoneModeOptions) (*http.Response, error) {
+func (s *ViewsService) SetNoneMode(ctx context.Context, opt *ViewsSetNoneModeOptions) (*http.Response, error) {
 	err := s.ValidateSetNoneModeOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/set_none_mode", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/set_none_mode", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1246,13 +1249,13 @@ func (s *ViewsService) SetNoneMode(opt *ViewsSetNoneModeOptions) (*http.Response
 // API endpoint: POST /api/views/set_regexp_mode.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) SetRegexpMode(opt *ViewsSetRegexpModeOptions) (*http.Response, error) {
+func (s *ViewsService) SetRegexpMode(ctx context.Context, opt *ViewsSetRegexpModeOptions) (*http.Response, error) {
 	err := s.ValidateSetRegexpModeOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/set_regexp_mode", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/set_regexp_mode", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1266,13 +1269,13 @@ func (s *ViewsService) SetRegexpMode(opt *ViewsSetRegexpModeOptions) (*http.Resp
 // API endpoint: POST /api/views/set_remaining_projects_mode.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) SetRemainingProjectsMode(opt *ViewsSetRemainingProjectsModeOptions) (*http.Response, error) {
+func (s *ViewsService) SetRemainingProjectsMode(ctx context.Context, opt *ViewsSetRemainingProjectsModeOptions) (*http.Response, error) {
 	err := s.ValidateSetRemainingProjectsModeOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/set_remaining_projects_mode", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/set_remaining_projects_mode", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1286,13 +1289,13 @@ func (s *ViewsService) SetRemainingProjectsMode(opt *ViewsSetRemainingProjectsMo
 // API endpoint: POST /api/views/set_tags_mode.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) SetTagsMode(opt *ViewsSetTagsModeOptions) (*http.Response, error) {
+func (s *ViewsService) SetTagsMode(ctx context.Context, opt *ViewsSetTagsModeOptions) (*http.Response, error) {
 	err := s.ValidateSetTagsModeOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/set_tags_mode", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/set_tags_mode", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -1306,13 +1309,13 @@ func (s *ViewsService) SetTagsMode(opt *ViewsSetTagsModeOptions) (*http.Response
 // API endpoint: GET /api/views/show.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) Show(opt *ViewsShowOptions) (*ViewsShow, *http.Response, error) {
+func (s *ViewsService) Show(ctx context.Context, opt *ViewsShowOptions) (*ViewsShow, *http.Response, error) {
 	err := s.ValidateShowOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "views/show", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "views/show", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1333,13 +1336,13 @@ func (s *ViewsService) Show(opt *ViewsShowOptions) (*ViewsShow, *http.Response, 
 // API endpoint: POST /api/views/update.
 // Since: 6.6.
 // Enterprise Edition only.
-func (s *ViewsService) Update(opt *ViewsUpdateOptions) (*http.Response, error) {
+func (s *ViewsService) Update(ctx context.Context, opt *ViewsUpdateOptions) (*http.Response, error) {
 	err := s.ValidateUpdateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "views/update", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "views/update", opt)
 	if err != nil {
 		return nil, err
 	}

--- a/sonar/views_service_test.go
+++ b/sonar/views_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestViewsService_AddApplication(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/add_application", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.AddApplication(&ViewsAddApplicationOptions{
+	resp, err := client.Views.AddApplication(context.Background(), &ViewsAddApplicationOptions{
 		Portfolio:   "my-portfolio",
 		Application: "my-application",
 	})
@@ -27,15 +28,15 @@ func TestViewsService_AddApplication(t *testing.T) {
 func TestViewsService_AddApplication_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.AddApplication(nil)
+	resp, err := client.Views.AddApplication(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.AddApplication(&ViewsAddApplicationOptions{Application: "my-app"})
+	resp, err = client.Views.AddApplication(context.Background(), &ViewsAddApplicationOptions{Application: "my-app"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.AddApplication(&ViewsAddApplicationOptions{Portfolio: "my-portfolio"})
+	resp, err = client.Views.AddApplication(context.Background(), &ViewsAddApplicationOptions{Portfolio: "my-portfolio"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -44,7 +45,7 @@ func TestViewsService_RemoveApplication(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/remove_application", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.RemoveApplication(&ViewsRemoveApplicationOptions{
+	resp, err := client.Views.RemoveApplication(context.Background(), &ViewsRemoveApplicationOptions{
 		Portfolio:   "my-portfolio",
 		Application: "my-application",
 	})
@@ -55,15 +56,15 @@ func TestViewsService_RemoveApplication(t *testing.T) {
 func TestViewsService_RemoveApplication_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.RemoveApplication(nil)
+	resp, err := client.Views.RemoveApplication(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.RemoveApplication(&ViewsRemoveApplicationOptions{Application: "my-app"})
+	resp, err = client.Views.RemoveApplication(context.Background(), &ViewsRemoveApplicationOptions{Application: "my-app"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.RemoveApplication(&ViewsRemoveApplicationOptions{Portfolio: "my-portfolio"})
+	resp, err = client.Views.RemoveApplication(context.Background(), &ViewsRemoveApplicationOptions{Portfolio: "my-portfolio"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -76,7 +77,7 @@ func TestViewsService_AddApplicationBranch(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/add_application_branch", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.AddApplicationBranch(&ViewsAddApplicationBranchOptions{
+	resp, err := client.Views.AddApplicationBranch(context.Background(), &ViewsAddApplicationBranchOptions{
 		Application: "my-app",
 		Branch:      "main",
 		Key:         "my-portfolio",
@@ -88,19 +89,19 @@ func TestViewsService_AddApplicationBranch(t *testing.T) {
 func TestViewsService_AddApplicationBranch_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.AddApplicationBranch(nil)
+	resp, err := client.Views.AddApplicationBranch(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.AddApplicationBranch(&ViewsAddApplicationBranchOptions{Branch: "main", Key: "pf"})
+	resp, err = client.Views.AddApplicationBranch(context.Background(), &ViewsAddApplicationBranchOptions{Branch: "main", Key: "pf"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.AddApplicationBranch(&ViewsAddApplicationBranchOptions{Application: "app", Key: "pf"})
+	resp, err = client.Views.AddApplicationBranch(context.Background(), &ViewsAddApplicationBranchOptions{Application: "app", Key: "pf"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.AddApplicationBranch(&ViewsAddApplicationBranchOptions{Application: "app", Branch: "main"})
+	resp, err = client.Views.AddApplicationBranch(context.Background(), &ViewsAddApplicationBranchOptions{Application: "app", Branch: "main"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -109,7 +110,7 @@ func TestViewsService_RemoveApplicationBranch(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/remove_application_branch", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.RemoveApplicationBranch(&ViewsRemoveApplicationBranchOptions{
+	resp, err := client.Views.RemoveApplicationBranch(context.Background(), &ViewsRemoveApplicationBranchOptions{
 		Application: "my-app",
 		Branch:      "main",
 		Key:         "my-portfolio",
@@ -121,7 +122,7 @@ func TestViewsService_RemoveApplicationBranch(t *testing.T) {
 func TestViewsService_RemoveApplicationBranch_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.RemoveApplicationBranch(nil)
+	resp, err := client.Views.RemoveApplicationBranch(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -134,7 +135,7 @@ func TestViewsService_AddPortfolio(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/add_portfolio", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.AddPortfolio(&ViewsAddPortfolioOptions{
+	resp, err := client.Views.AddPortfolio(context.Background(), &ViewsAddPortfolioOptions{
 		Portfolio: "parent-portfolio",
 		Reference: "ref-portfolio",
 	})
@@ -145,15 +146,15 @@ func TestViewsService_AddPortfolio(t *testing.T) {
 func TestViewsService_AddPortfolio_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.AddPortfolio(nil)
+	resp, err := client.Views.AddPortfolio(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.AddPortfolio(&ViewsAddPortfolioOptions{Reference: "ref"})
+	resp, err = client.Views.AddPortfolio(context.Background(), &ViewsAddPortfolioOptions{Reference: "ref"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.AddPortfolio(&ViewsAddPortfolioOptions{Portfolio: "parent"})
+	resp, err = client.Views.AddPortfolio(context.Background(), &ViewsAddPortfolioOptions{Portfolio: "parent"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -162,7 +163,7 @@ func TestViewsService_RemovePortfolio(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/remove_portfolio", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.RemovePortfolio(&ViewsRemovePortfolioOptions{
+	resp, err := client.Views.RemovePortfolio(context.Background(), &ViewsRemovePortfolioOptions{
 		Portfolio: "parent-portfolio",
 		Reference: "sub-portfolio",
 	})
@@ -173,15 +174,15 @@ func TestViewsService_RemovePortfolio(t *testing.T) {
 func TestViewsService_RemovePortfolio_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.RemovePortfolio(nil)
+	resp, err := client.Views.RemovePortfolio(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.RemovePortfolio(&ViewsRemovePortfolioOptions{Reference: "sub"})
+	resp, err = client.Views.RemovePortfolio(context.Background(), &ViewsRemovePortfolioOptions{Reference: "sub"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.RemovePortfolio(&ViewsRemovePortfolioOptions{Portfolio: "parent"})
+	resp, err = client.Views.RemovePortfolio(context.Background(), &ViewsRemovePortfolioOptions{Portfolio: "parent"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -194,7 +195,7 @@ func TestViewsService_AddProject(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/add_project", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.AddProject(&ViewsAddProjectOptions{
+	resp, err := client.Views.AddProject(context.Background(), &ViewsAddProjectOptions{
 		Key:     "my-portfolio",
 		Project: "my-project",
 	})
@@ -205,15 +206,15 @@ func TestViewsService_AddProject(t *testing.T) {
 func TestViewsService_AddProject_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.AddProject(nil)
+	resp, err := client.Views.AddProject(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.AddProject(&ViewsAddProjectOptions{Project: "my-project"})
+	resp, err = client.Views.AddProject(context.Background(), &ViewsAddProjectOptions{Project: "my-project"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.AddProject(&ViewsAddProjectOptions{Key: "my-portfolio"})
+	resp, err = client.Views.AddProject(context.Background(), &ViewsAddProjectOptions{Key: "my-portfolio"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -222,7 +223,7 @@ func TestViewsService_RemoveProject(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/remove_project", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.RemoveProject(&ViewsRemoveProjectOptions{
+	resp, err := client.Views.RemoveProject(context.Background(), &ViewsRemoveProjectOptions{
 		Key:     "my-portfolio",
 		Project: "my-project",
 	})
@@ -233,15 +234,15 @@ func TestViewsService_RemoveProject(t *testing.T) {
 func TestViewsService_RemoveProject_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.RemoveProject(nil)
+	resp, err := client.Views.RemoveProject(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.RemoveProject(&ViewsRemoveProjectOptions{Project: "my-project"})
+	resp, err = client.Views.RemoveProject(context.Background(), &ViewsRemoveProjectOptions{Project: "my-project"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.RemoveProject(&ViewsRemoveProjectOptions{Key: "my-portfolio"})
+	resp, err = client.Views.RemoveProject(context.Background(), &ViewsRemoveProjectOptions{Key: "my-portfolio"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -254,7 +255,7 @@ func TestViewsService_AddProjectBranch(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/add_project_branch", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.AddProjectBranch(&ViewsAddProjectBranchOptions{
+	resp, err := client.Views.AddProjectBranch(context.Background(), &ViewsAddProjectBranchOptions{
 		Branch:  "main",
 		Key:     "my-portfolio",
 		Project: "my-project",
@@ -266,11 +267,11 @@ func TestViewsService_AddProjectBranch(t *testing.T) {
 func TestViewsService_AddProjectBranch_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.AddProjectBranch(nil)
+	resp, err := client.Views.AddProjectBranch(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.AddProjectBranch(&ViewsAddProjectBranchOptions{Key: "pf", Project: "proj"})
+	resp, err = client.Views.AddProjectBranch(context.Background(), &ViewsAddProjectBranchOptions{Key: "pf", Project: "proj"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -279,7 +280,7 @@ func TestViewsService_RemoveProjectBranch(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/remove_project_branch", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.RemoveProjectBranch(&ViewsRemoveProjectBranchOptions{
+	resp, err := client.Views.RemoveProjectBranch(context.Background(), &ViewsRemoveProjectBranchOptions{
 		Branch:  "main",
 		Key:     "my-portfolio",
 		Project: "my-project",
@@ -291,7 +292,7 @@ func TestViewsService_RemoveProjectBranch(t *testing.T) {
 func TestViewsService_RemoveProjectBranch_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.RemoveProjectBranch(nil)
+	resp, err := client.Views.RemoveProjectBranch(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -309,7 +310,7 @@ func TestViewsService_Applications(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/applications", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Views.Applications(&ViewsApplicationsOptions{
+	result, resp, err := client.Views.Applications(context.Background(), &ViewsApplicationsOptions{
 		Portfolio: "my-portfolio",
 	})
 	require.NoError(t, err)
@@ -322,10 +323,10 @@ func TestViewsService_Applications(t *testing.T) {
 func TestViewsService_Applications_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.Views.Applications(nil)
+	_, _, err := client.Views.Applications(context.Background(), nil)
 	assert.Error(t, err)
 
-	_, _, err = client.Views.Applications(&ViewsApplicationsOptions{})
+	_, _, err = client.Views.Applications(context.Background(), &ViewsApplicationsOptions{})
 	assert.Error(t, err)
 }
 
@@ -338,7 +339,7 @@ func TestViewsService_SubPortfolios(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/portfolios", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Views.SubPortfolios(&ViewsSubViewsOptions{
+	result, resp, err := client.Views.SubPortfolios(context.Background(), &ViewsSubViewsOptions{
 		Portfolio: "my-portfolio",
 	})
 	require.NoError(t, err)
@@ -350,10 +351,10 @@ func TestViewsService_SubPortfolios(t *testing.T) {
 func TestViewsService_SubPortfolios_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.Views.SubPortfolios(nil)
+	_, _, err := client.Views.SubPortfolios(context.Background(), nil)
 	assert.Error(t, err)
 
-	_, _, err = client.Views.SubPortfolios(&ViewsSubViewsOptions{})
+	_, _, err = client.Views.SubPortfolios(context.Background(), &ViewsSubViewsOptions{})
 	assert.Error(t, err)
 }
 
@@ -365,7 +366,7 @@ func TestViewsService_Create(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/create", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.Create(&ViewsCreateOptions{
+	resp, err := client.Views.Create(context.Background(), &ViewsCreateOptions{
 		Name: "My Portfolio",
 		Key:  "my-portfolio",
 	})
@@ -377,7 +378,7 @@ func TestViewsService_Create_WithParent(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/create", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.Create(&ViewsCreateOptions{
+	resp, err := client.Views.Create(context.Background(), &ViewsCreateOptions{
 		Name:   "Sub Portfolio",
 		Parent: "parent-portfolio",
 	})
@@ -389,7 +390,7 @@ func TestViewsService_Create_WithVisibility(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/create", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.Create(&ViewsCreateOptions{
+	resp, err := client.Views.Create(context.Background(), &ViewsCreateOptions{
 		Name:        "My Portfolio",
 		Description: "A test portfolio",
 		Visibility:  "private",
@@ -401,15 +402,15 @@ func TestViewsService_Create_WithVisibility(t *testing.T) {
 func TestViewsService_Create_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.Create(nil)
+	resp, err := client.Views.Create(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.Create(&ViewsCreateOptions{})
+	resp, err = client.Views.Create(context.Background(), &ViewsCreateOptions{})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.Create(&ViewsCreateOptions{Name: "My Portfolio", Visibility: "invalid"})
+	resp, err = client.Views.Create(context.Background(), &ViewsCreateOptions{Name: "My Portfolio", Visibility: "invalid"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -422,7 +423,7 @@ func TestViewsService_Delete(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/delete", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.Delete(&ViewsDeleteOptions{
+	resp, err := client.Views.Delete(context.Background(), &ViewsDeleteOptions{
 		Key: "my-portfolio",
 	})
 	require.NoError(t, err)
@@ -432,11 +433,11 @@ func TestViewsService_Delete(t *testing.T) {
 func TestViewsService_Delete_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.Delete(nil)
+	resp, err := client.Views.Delete(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.Delete(&ViewsDeleteOptions{})
+	resp, err = client.Views.Delete(context.Background(), &ViewsDeleteOptions{})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -455,7 +456,7 @@ func TestViewsService_List(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/list", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Views.List()
+	result, resp, err := client.Views.List(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -469,7 +470,7 @@ func TestViewsService_List_Empty(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/list", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Views.List()
+	result, resp, err := client.Views.List(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -484,7 +485,7 @@ func TestViewsService_Move(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/move", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.Move(&ViewsMoveOptions{
+	resp, err := client.Views.Move(context.Background(), &ViewsMoveOptions{
 		Key:         "my-portfolio",
 		Destination: "destination-portfolio",
 	})
@@ -495,15 +496,15 @@ func TestViewsService_Move(t *testing.T) {
 func TestViewsService_Move_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.Move(nil)
+	resp, err := client.Views.Move(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.Move(&ViewsMoveOptions{Destination: "dest"})
+	resp, err = client.Views.Move(context.Background(), &ViewsMoveOptions{Destination: "dest"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.Move(&ViewsMoveOptions{Key: "my-portfolio"})
+	resp, err = client.Views.Move(context.Background(), &ViewsMoveOptions{Key: "my-portfolio"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -522,7 +523,7 @@ func TestViewsService_MoveOptions(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/move_options", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Views.MoveOptions(&ViewsMoveOptionsOptions{
+	result, resp, err := client.Views.MoveOptions(context.Background(), &ViewsMoveOptionsOptions{
 		Key: "my-portfolio",
 	})
 	require.NoError(t, err)
@@ -535,10 +536,10 @@ func TestViewsService_MoveOptions(t *testing.T) {
 func TestViewsService_MoveOptions_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.Views.MoveOptions(nil)
+	_, _, err := client.Views.MoveOptions(context.Background(), nil)
 	assert.Error(t, err)
 
-	_, _, err = client.Views.MoveOptions(&ViewsMoveOptionsOptions{})
+	_, _, err = client.Views.MoveOptions(context.Background(), &ViewsMoveOptionsOptions{})
 	assert.Error(t, err)
 }
 
@@ -557,7 +558,7 @@ func TestViewsService_Projects(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/projects", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Views.Projects(&ViewsProjectsOptions{
+	result, resp, err := client.Views.Projects(context.Background(), &ViewsProjectsOptions{
 		Key:      "my-portfolio",
 		Selected: "all",
 	})
@@ -571,13 +572,13 @@ func TestViewsService_Projects(t *testing.T) {
 func TestViewsService_Projects_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.Views.Projects(nil)
+	_, _, err := client.Views.Projects(context.Background(), nil)
 	assert.Error(t, err)
 
-	_, _, err = client.Views.Projects(&ViewsProjectsOptions{})
+	_, _, err = client.Views.Projects(context.Background(), &ViewsProjectsOptions{})
 	assert.Error(t, err)
 
-	_, _, err = client.Views.Projects(&ViewsProjectsOptions{Key: "pf", Selected: "invalid"})
+	_, _, err = client.Views.Projects(context.Background(), &ViewsProjectsOptions{Key: "pf", Selected: "invalid"})
 	assert.Error(t, err)
 }
 
@@ -591,7 +592,7 @@ func TestViewsService_ProjectsStatus(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/projects_status", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Views.ProjectsStatus(&ViewsProjectsStatusOptions{
+	result, resp, err := client.Views.ProjectsStatus(context.Background(), &ViewsProjectsStatusOptions{
 		Portfolio: "my-portfolio",
 	})
 	require.NoError(t, err)
@@ -604,10 +605,10 @@ func TestViewsService_ProjectsStatus(t *testing.T) {
 func TestViewsService_ProjectsStatus_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.Views.ProjectsStatus(nil)
+	_, _, err := client.Views.ProjectsStatus(context.Background(), nil)
 	assert.Error(t, err)
 
-	_, _, err = client.Views.ProjectsStatus(&ViewsProjectsStatusOptions{})
+	_, _, err = client.Views.ProjectsStatus(context.Background(), &ViewsProjectsStatusOptions{})
 	assert.Error(t, err)
 }
 
@@ -619,7 +620,7 @@ func TestViewsService_Refresh(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/refresh", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.Refresh(nil)
+	resp, err := client.Views.Refresh(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -628,7 +629,7 @@ func TestViewsService_Refresh_WithKey(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/refresh", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.Refresh(&ViewsRefreshOptions{Key: "my-portfolio"})
+	resp, err := client.Views.Refresh(context.Background(), &ViewsRefreshOptions{Key: "my-portfolio"})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -647,7 +648,7 @@ func TestViewsService_Search(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/search", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Views.Search(&ViewsSearchOptions{Q: "Portfolio"})
+	result, resp, err := client.Views.Search(context.Background(), &ViewsSearchOptions{Q: "Portfolio"})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -660,7 +661,7 @@ func TestViewsService_Search_Nil(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/search", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Views.Search(nil)
+	result, resp, err := client.Views.Search(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -669,7 +670,7 @@ func TestViewsService_Search_Nil(t *testing.T) {
 func TestViewsService_Search_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.Views.Search(&ViewsSearchOptions{PaginationArgs: PaginationArgs{Page: -1}})
+	_, _, err := client.Views.Search(context.Background(), &ViewsSearchOptions{PaginationArgs: PaginationArgs{Page: -1}})
 	assert.Error(t, err)
 }
 
@@ -681,7 +682,7 @@ func TestViewsService_SetManualMode(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/set_manual_mode", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.SetManualMode(&ViewsSetManualModeOptions{Portfolio: "my-portfolio"})
+	resp, err := client.Views.SetManualMode(context.Background(), &ViewsSetManualModeOptions{Portfolio: "my-portfolio"})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -689,11 +690,11 @@ func TestViewsService_SetManualMode(t *testing.T) {
 func TestViewsService_SetManualMode_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.SetManualMode(nil)
+	resp, err := client.Views.SetManualMode(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.SetManualMode(&ViewsSetManualModeOptions{})
+	resp, err = client.Views.SetManualMode(context.Background(), &ViewsSetManualModeOptions{})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -702,7 +703,7 @@ func TestViewsService_SetNoneMode(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/set_none_mode", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.SetNoneMode(&ViewsSetNoneModeOptions{Portfolio: "my-portfolio"})
+	resp, err := client.Views.SetNoneMode(context.Background(), &ViewsSetNoneModeOptions{Portfolio: "my-portfolio"})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -710,7 +711,7 @@ func TestViewsService_SetNoneMode(t *testing.T) {
 func TestViewsService_SetNoneMode_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.SetNoneMode(nil)
+	resp, err := client.Views.SetNoneMode(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -719,7 +720,7 @@ func TestViewsService_SetRegexpMode(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/set_regexp_mode", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.SetRegexpMode(&ViewsSetRegexpModeOptions{
+	resp, err := client.Views.SetRegexpMode(context.Background(), &ViewsSetRegexpModeOptions{
 		Portfolio: "my-portfolio",
 		Regexp:    ".*my-project.*",
 	})
@@ -730,15 +731,15 @@ func TestViewsService_SetRegexpMode(t *testing.T) {
 func TestViewsService_SetRegexpMode_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.SetRegexpMode(nil)
+	resp, err := client.Views.SetRegexpMode(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.SetRegexpMode(&ViewsSetRegexpModeOptions{Portfolio: "pf"})
+	resp, err = client.Views.SetRegexpMode(context.Background(), &ViewsSetRegexpModeOptions{Portfolio: "pf"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.SetRegexpMode(&ViewsSetRegexpModeOptions{Regexp: ".*"})
+	resp, err = client.Views.SetRegexpMode(context.Background(), &ViewsSetRegexpModeOptions{Regexp: ".*"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -747,7 +748,7 @@ func TestViewsService_SetRemainingProjectsMode(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/set_remaining_projects_mode", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.SetRemainingProjectsMode(&ViewsSetRemainingProjectsModeOptions{
+	resp, err := client.Views.SetRemainingProjectsMode(context.Background(), &ViewsSetRemainingProjectsModeOptions{
 		Portfolio: "my-portfolio",
 	})
 	require.NoError(t, err)
@@ -757,7 +758,7 @@ func TestViewsService_SetRemainingProjectsMode(t *testing.T) {
 func TestViewsService_SetRemainingProjectsMode_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.SetRemainingProjectsMode(nil)
+	resp, err := client.Views.SetRemainingProjectsMode(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -766,7 +767,7 @@ func TestViewsService_SetTagsMode(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/set_tags_mode", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.SetTagsMode(&ViewsSetTagsModeOptions{
+	resp, err := client.Views.SetTagsMode(context.Background(), &ViewsSetTagsModeOptions{
 		Portfolio: "my-portfolio",
 		Tags:      "java,security",
 	})
@@ -777,11 +778,11 @@ func TestViewsService_SetTagsMode(t *testing.T) {
 func TestViewsService_SetTagsMode_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.SetTagsMode(nil)
+	resp, err := client.Views.SetTagsMode(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.SetTagsMode(&ViewsSetTagsModeOptions{Portfolio: "pf"})
+	resp, err = client.Views.SetTagsMode(context.Background(), &ViewsSetTagsModeOptions{Portfolio: "pf"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -805,7 +806,7 @@ func TestViewsService_Show(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/show", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Views.Show(&ViewsShowOptions{Key: "pf-1"})
+	result, resp, err := client.Views.Show(context.Background(), &ViewsShowOptions{Key: "pf-1"})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -817,10 +818,10 @@ func TestViewsService_Show(t *testing.T) {
 func TestViewsService_Show_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	_, _, err := client.Views.Show(nil)
+	_, _, err := client.Views.Show(context.Background(), nil)
 	assert.Error(t, err)
 
-	_, _, err = client.Views.Show(&ViewsShowOptions{})
+	_, _, err = client.Views.Show(context.Background(), &ViewsShowOptions{})
 	assert.Error(t, err)
 }
 
@@ -832,7 +833,7 @@ func TestViewsService_Update(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/views/update", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Views.Update(&ViewsUpdateOptions{
+	resp, err := client.Views.Update(context.Background(), &ViewsUpdateOptions{
 		Key:  "my-portfolio",
 		Name: "My Renamed Portfolio",
 	})
@@ -843,15 +844,15 @@ func TestViewsService_Update(t *testing.T) {
 func TestViewsService_Update_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Views.Update(nil)
+	resp, err := client.Views.Update(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.Update(&ViewsUpdateOptions{Name: "New Name"})
+	resp, err = client.Views.Update(context.Background(), &ViewsUpdateOptions{Name: "New Name"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Views.Update(&ViewsUpdateOptions{Key: "my-portfolio"})
+	resp, err = client.Views.Update(context.Background(), &ViewsUpdateOptions{Key: "my-portfolio"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }

--- a/sonar/webhooks_service.go
+++ b/sonar/webhooks_service.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -325,13 +326,13 @@ func (s *WebhooksService) ValidateUpdateOpt(opt *WebhooksUpdateOptions) error {
 // Requires 'Administer' permission on the specified project, or global 'Administer' permission.
 //
 // Since: 7.1.
-func (s *WebhooksService) Create(opt *WebhooksCreateOptions) (*WebhooksCreate, *http.Response, error) {
+func (s *WebhooksService) Create(ctx context.Context, opt *WebhooksCreateOptions) (*WebhooksCreate, *http.Response, error) {
 	err := s.ValidateCreateOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "webhooks/create", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "webhooks/create", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -350,13 +351,13 @@ func (s *WebhooksService) Create(opt *WebhooksCreateOptions) (*WebhooksCreate, *
 // Requires 'Administer' permission on the specified project, or global 'Administer' permission.
 //
 // Since: 7.1.
-func (s *WebhooksService) Delete(opt *WebhooksDeleteOptions) (*http.Response, error) {
+func (s *WebhooksService) Delete(ctx context.Context, opt *WebhooksDeleteOptions) (*http.Response, error) {
 	err := s.ValidateDeleteOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "webhooks/delete", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "webhooks/delete", opt)
 	if err != nil {
 		return nil, err
 	}
@@ -374,13 +375,13 @@ func (s *WebhooksService) Delete(opt *WebhooksDeleteOptions) (*http.Response, er
 // Note that additional information is returned by api/webhooks/delivery.
 //
 // Since: 6.2.
-func (s *WebhooksService) Deliveries(opt *WebhooksDeliveriesOptions) (*WebhooksDeliveries, *http.Response, error) {
+func (s *WebhooksService) Deliveries(ctx context.Context, opt *WebhooksDeliveriesOptions) (*WebhooksDeliveries, *http.Response, error) {
 	err := s.ValidateDeliveriesOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "webhooks/deliveries", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "webhooks/deliveries", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -399,13 +400,13 @@ func (s *WebhooksService) Deliveries(opt *WebhooksDeliveriesOptions) (*WebhooksD
 // Requires 'Administer System' permission.
 //
 // Since: 6.2.
-func (s *WebhooksService) Delivery(opt *WebhooksDeliveryOptions) (*WebhooksDelivery, *http.Response, error) {
+func (s *WebhooksService) Delivery(ctx context.Context, opt *WebhooksDeliveryOptions) (*WebhooksDelivery, *http.Response, error) {
 	err := s.ValidateDeliveryOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "webhooks/delivery", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "webhooks/delivery", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -425,13 +426,13 @@ func (s *WebhooksService) Delivery(opt *WebhooksDeliveryOptions) (*WebhooksDeliv
 // Requires 'Administer' permission on the specified project, or global 'Administer' permission.
 //
 // Since: 7.1.
-func (s *WebhooksService) List(opt *WebhooksListOptions) (*WebhooksList, *http.Response, error) {
+func (s *WebhooksService) List(ctx context.Context, opt *WebhooksListOptions) (*WebhooksList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "webhooks/list", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "webhooks/list", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -450,13 +451,13 @@ func (s *WebhooksService) List(opt *WebhooksListOptions) (*WebhooksList, *http.R
 // Requires 'Administer' permission on the specified project, or global 'Administer' permission.
 //
 // Since: 7.1.
-func (s *WebhooksService) Update(opt *WebhooksUpdateOptions) (*http.Response, error) {
+func (s *WebhooksService) Update(ctx context.Context, opt *WebhooksUpdateOptions) (*http.Response, error) {
 	err := s.ValidateUpdateOpt(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodPost, "webhooks/update", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "webhooks/update", opt)
 	if err != nil {
 		return nil, err
 	}

--- a/sonar/webhooks_service_test.go
+++ b/sonar/webhooks_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -28,7 +29,7 @@ func TestWebhooks_Create(t *testing.T) {
 		Secret: "my-secret-at-least-16",
 	}
 
-	result, resp, err := client.Webhooks.Create(opt)
+	result, resp, err := client.Webhooks.Create(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "uuid-webhook-1", result.Webhook.Key)
@@ -38,37 +39,37 @@ func TestWebhooks_Create_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Webhooks.Create(nil)
+	_, _, err := client.Webhooks.Create(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, _, err = client.Webhooks.Create(&WebhooksCreateOptions{
+	_, _, err = client.Webhooks.Create(context.Background(), &WebhooksCreateOptions{
 		URL: "https://example.com",
 	})
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, _, err = client.Webhooks.Create(&WebhooksCreateOptions{
+	_, _, err = client.Webhooks.Create(context.Background(), &WebhooksCreateOptions{
 		Name: "My Webhook",
 	})
 	assert.Error(t, err)
 
 	// Test Name too long
-	_, _, err = client.Webhooks.Create(&WebhooksCreateOptions{
+	_, _, err = client.Webhooks.Create(context.Background(), &WebhooksCreateOptions{
 		Name: strings.Repeat("a", MaxWebhookNameLength+1),
 		URL:  "https://example.com",
 	})
 	assert.Error(t, err)
 
 	// Test URL too long
-	_, _, err = client.Webhooks.Create(&WebhooksCreateOptions{
+	_, _, err = client.Webhooks.Create(context.Background(), &WebhooksCreateOptions{
 		Name: "My Webhook",
 		URL:  strings.Repeat("a", MaxWebhookURLLength+1),
 	})
 	assert.Error(t, err)
 
 	// Test Secret too short
-	_, _, err = client.Webhooks.Create(&WebhooksCreateOptions{
+	_, _, err = client.Webhooks.Create(context.Background(), &WebhooksCreateOptions{
 		Name:   "My Webhook",
 		URL:    "https://example.com",
 		Secret: "short",
@@ -84,7 +85,7 @@ func TestWebhooks_Delete(t *testing.T) {
 		Webhook: "my-webhook-key",
 	}
 
-	resp, err := client.Webhooks.Delete(opt)
+	resp, err := client.Webhooks.Delete(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -93,11 +94,11 @@ func TestWebhooks_Delete_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Webhooks.Delete(nil)
+	_, err := client.Webhooks.Delete(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Webhook
-	_, err = client.Webhooks.Delete(&WebhooksDeleteOptions{})
+	_, err = client.Webhooks.Delete(context.Background(), &WebhooksDeleteOptions{})
 	assert.Error(t, err)
 }
 
@@ -126,7 +127,7 @@ func TestWebhooks_Deliveries(t *testing.T) {
 		Webhook: "webhook-key",
 	}
 
-	result, resp, err := client.Webhooks.Deliveries(opt)
+	result, resp, err := client.Webhooks.Deliveries(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Deliveries, 1)
@@ -136,7 +137,7 @@ func TestWebhooks_Deliveries_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Webhooks.Deliveries(nil)
+	_, _, err := client.Webhooks.Deliveries(context.Background(), nil)
 	assert.Error(t, err)
 }
 
@@ -159,7 +160,7 @@ func TestWebhooks_Delivery(t *testing.T) {
 		DeliveryID: "delivery-1",
 	}
 
-	result, resp, err := client.Webhooks.Delivery(opt)
+	result, resp, err := client.Webhooks.Delivery(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotEmpty(t, result.Delivery.Payload)
@@ -169,11 +170,11 @@ func TestWebhooks_Delivery_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Webhooks.Delivery(nil)
+	_, _, err := client.Webhooks.Delivery(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing DeliveryID
-	_, _, err = client.Webhooks.Delivery(&WebhooksDeliveryOptions{})
+	_, _, err = client.Webhooks.Delivery(context.Background(), &WebhooksDeliveryOptions{})
 	assert.Error(t, err)
 }
 
@@ -194,7 +195,7 @@ func TestWebhooks_List(t *testing.T) {
 
 	opt := &WebhooksListOptions{}
 
-	result, resp, err := client.Webhooks.List(opt)
+	result, resp, err := client.Webhooks.List(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.Webhooks, 1)
@@ -204,7 +205,7 @@ func TestWebhooks_List_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, _, err := client.Webhooks.List(nil)
+	_, _, err := client.Webhooks.List(context.Background(), nil)
 	assert.Error(t, err)
 }
 
@@ -218,7 +219,7 @@ func TestWebhooks_Update(t *testing.T) {
 		URL:     "https://example.com/updated",
 	}
 
-	resp, err := client.Webhooks.Update(opt)
+	resp, err := client.Webhooks.Update(context.Background(), opt)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -227,25 +228,25 @@ func TestWebhooks_Update_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	// Test nil option
-	_, err := client.Webhooks.Update(nil)
+	_, err := client.Webhooks.Update(context.Background(), nil)
 	assert.Error(t, err)
 
 	// Test missing Name
-	_, err = client.Webhooks.Update(&WebhooksUpdateOptions{
+	_, err = client.Webhooks.Update(context.Background(), &WebhooksUpdateOptions{
 		URL:     "https://example.com",
 		Webhook: "webhook-1",
 	})
 	assert.Error(t, err)
 
 	// Test missing URL
-	_, err = client.Webhooks.Update(&WebhooksUpdateOptions{
+	_, err = client.Webhooks.Update(context.Background(), &WebhooksUpdateOptions{
 		Name:    "My Webhook",
 		Webhook: "webhook-1",
 	})
 	assert.Error(t, err)
 
 	// Test missing Webhook
-	_, err = client.Webhooks.Update(&WebhooksUpdateOptions{
+	_, err = client.Webhooks.Update(context.Background(), &WebhooksUpdateOptions{
 		Name: "My Webhook",
 		URL:  "https://example.com",
 	})

--- a/sonar/webservices_service.go
+++ b/sonar/webservices_service.go
@@ -1,6 +1,9 @@
 package sonar
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // WebservicesService handles communication with the webservices related methods
 // of the SonarQube API.
@@ -158,13 +161,13 @@ func (s *WebservicesService) ValidateResponseExampleOpt(opt *WebservicesResponse
 //
 // API endpoint: GET /api/webservices/list.
 // Since: 4.2.
-func (s *WebservicesService) List(opt *WebservicesListOptions) (*WebservicesList, *http.Response, error) {
+func (s *WebservicesService) List(ctx context.Context, opt *WebservicesListOptions) (*WebservicesList, *http.Response, error) {
 	err := s.ValidateListOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "webservices/list", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "webservices/list", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -184,13 +187,13 @@ func (s *WebservicesService) List(opt *WebservicesListOptions) (*WebservicesList
 //
 // API endpoint: GET /api/webservices/response_example.
 // Since: 4.4.
-func (s *WebservicesService) ResponseExample(opt *WebservicesResponseExampleOptions) (*string, *http.Response, error) {
+func (s *WebservicesService) ResponseExample(ctx context.Context, opt *WebservicesResponseExampleOptions) (*string, *http.Response, error) {
 	err := s.ValidateResponseExampleOpt(opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewSonarQubeV1APIRequest(http.MethodGet, "webservices/response_example", opt)
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "webservices/response_example", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sonar/webservices_service_test.go
+++ b/sonar/webservices_service_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -42,7 +43,7 @@ func TestWebservicesService_List(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Webservices.List(nil)
+		result, resp, err := client.Webservices.List(context.Background(), nil)
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -59,7 +60,7 @@ func TestWebservicesService_List(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Webservices.List(&WebservicesListOptions{
+		_, _, err := client.Webservices.List(context.Background(), &WebservicesListOptions{
 			IncludeInternals: true,
 		})
 
@@ -71,7 +72,7 @@ func TestWebservicesService_List(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		_, _, err := client.Webservices.List(&WebservicesListOptions{})
+		_, _, err := client.Webservices.List(context.Background(), &WebservicesListOptions{})
 
 		require.NoError(t, err)
 	})
@@ -90,7 +91,7 @@ func TestWebservicesService_ResponseExample(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Webservices.ResponseExample(&WebservicesResponseExampleOptions{
+		result, resp, err := client.Webservices.ResponseExample(context.Background(), &WebservicesResponseExampleOptions{
 			Action:     "search",
 			Controller: "api/issues",
 		})
@@ -103,7 +104,7 @@ func TestWebservicesService_ResponseExample(t *testing.T) {
 	t.Run("nil option fails validation", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.Webservices.ResponseExample(nil)
+		_, _, err := client.Webservices.ResponseExample(context.Background(), nil)
 
 		assert.Error(t, err)
 	})
@@ -111,7 +112,7 @@ func TestWebservicesService_ResponseExample(t *testing.T) {
 	t.Run("missing action fails validation", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.Webservices.ResponseExample(&WebservicesResponseExampleOptions{
+		_, _, err := client.Webservices.ResponseExample(context.Background(), &WebservicesResponseExampleOptions{
 			Controller: "api/issues",
 		})
 
@@ -121,7 +122,7 @@ func TestWebservicesService_ResponseExample(t *testing.T) {
 	t.Run("missing controller fails validation", func(t *testing.T) {
 		client := newLocalhostClient(t)
 
-		_, _, err := client.Webservices.ResponseExample(&WebservicesResponseExampleOptions{
+		_, _, err := client.Webservices.ResponseExample(context.Background(), &WebservicesResponseExampleOptions{
 			Action: "search",
 		})
 


### PR DESCRIPTION
### Description of your changes

Every exported service method that makes an HTTP call now accepts context.Context as its first parameter. The context is threaded through to http.NewRequestWithContext, replacing the previously hardcoded context.Background().

This enables callers to:
- Cancel in-flight requests (critical for Kubernetes controllers)
- Set per-call timeouts independent of the HTTP client configuration
- Propagate distributed trace spans (OpenTelemetry, etc.)

The reflection-driven CLI (internal/cli/invoke.go) automatically injects context.Background() for all method invocations, so CLI
behaviour is unchanged.

Also updated NewSonarQubeAPIRequest, NewSonarQubeV1APIRequest, NewSonarQubeV2APIRequest all now accept ctx as first parameter

Closes #198 

BREAKING CHANGE: Every service method now requires context.Context as its first argument. Add context.Background() to all call sites for identical behaviour.

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [ ] Added unit tests to cover the code changes.
- [ ] Added end-to-end tests if necessary.
