### PR TITLE
feat: add opt-in retry with exponential backoff and full jitter

### DIFF
--- a/sonar/client.go
+++ b/sonar/client.go
@@ -22,13 +22,14 @@ import (
 //
 //nolint:govet // fieldalignment: keeping logical field grouping for readability
 type Client struct {
-	baseURL    *url.URL
-	username   string
-	password   string
-	token      string
-	authType   authType
-	httpClient *http.Client
-	userAgent  string
+	baseURL      *url.URL
+	username     string
+	password     string
+	token        string
+	authType     authType
+	httpClient   *http.Client
+	retryOptions *RetryOptions
+	userAgent    string
 
 	AlmIntegrations    *AlmIntegrationsService
 	AlmSettings        *AlmSettingsService
@@ -209,6 +210,17 @@ func setDefaults(client *Client) error {
 
 	if client.httpClient == nil {
 		client.httpClient = http.DefaultClient
+	}
+
+	if client.retryOptions != nil {
+		baseTransport := client.httpClient.Transport
+		if baseTransport == nil {
+			baseTransport = http.DefaultTransport
+		}
+
+		clone := *client.httpClient
+		clone.Transport = &retryRoundTripper{base: baseTransport, opts: *client.retryOptions}
+		client.httpClient = &clone
 	}
 
 	if client.userAgent == "" {

--- a/sonar/retry.go
+++ b/sonar/retry.go
@@ -8,6 +8,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"slices"
+	"strconv"
 	"time"
 )
 
@@ -33,7 +34,9 @@ type RetryOptions struct {
 // backoff and full jitter around the HTTP transport. Retry is disabled by default.
 func WithRetry(opts RetryOptions) ClientOptionFunc {
 	return func(c *Client) error {
-		c.retryOptions = &opts
+		copied := opts
+		copied.RetryableStatusCodes = slices.Clone(opts.RetryableStatusCodes)
+		c.retryOptions = &copied
 
 		return nil
 	}
@@ -48,6 +51,9 @@ type retryRoundTripper struct {
 // RoundTrip executes the request, retrying on configured status codes or network
 // errors with exponential backoff and full jitter. Retries stop immediately when
 // the request context is cancelled or its deadline is exceeded.
+//
+// When retries occur, the final response carries an X-Retry-Attempts header with
+// the total number of attempts made.
 //
 //nolint:wrapcheck // pass-through transport: errors from base RoundTripper are intentionally not wrapped
 func (r *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -65,12 +71,18 @@ func (r *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 }
 
 // retryLoop runs up to MaxAttempts, sleeping between retries.
+// On the final response, X-Retry-Attempts is set to the total attempt count
+// when more than one attempt was made.
 func (r *retryRoundTripper) retryLoop(req *http.Request, hasBody bool) (*http.Response, error) {
 	for attempt := range r.opts.MaxAttempts {
 		resp, err := r.doAttempt(req, hasBody)
 		isLast := attempt >= r.opts.MaxAttempts-1
 
 		if done, result, resultErr := r.evaluate(req.Context(), resp, err, isLast); done {
+			if result != nil && attempt > 0 {
+				result.Header.Set("X-Retry-Attempts", strconv.Itoa(attempt+1))
+			}
+
 			return result, resultErr
 		}
 
@@ -100,9 +112,17 @@ func (r *retryRoundTripper) doAttempt(req *http.Request, hasBody bool) (*http.Re
 
 // evaluate decides whether the loop should stop after an attempt.
 // Returns (true, resp, err) to stop, (false, nil, nil) to sleep and continue.
+//
+// When the context is cancelled, the context error is returned rather than the
+// transport error so callers can reliably detect cancellation/timeouts.
 func (r *retryRoundTripper) evaluate(ctx context.Context, resp *http.Response, err error, isLast bool) (bool, *http.Response, error) {
 	if err != nil {
-		if ctx.Err() != nil || isLast {
+		ctxErr := ctx.Err()
+		if ctxErr != nil {
+			return true, nil, ctxErr //nolint:wrapcheck // context error is the direct cause
+		}
+
+		if isLast {
 			return true, nil, err
 		}
 
@@ -137,7 +157,8 @@ func (r *retryRoundTripper) computeDelay(attempt int) time.Duration {
 }
 
 // sleepContext waits for delay, returning false immediately if ctx is already done
-// or becomes done while waiting.
+// or becomes done while waiting. It uses time.NewTimer rather than time.After so
+// the timer is stopped and its resources released as soon as the context fires.
 func sleepContext(ctx context.Context, delay time.Duration) bool {
 	if ctx.Err() != nil {
 		return false
@@ -147,10 +168,13 @@ func sleepContext(ctx context.Context, delay time.Duration) bool {
 		return true
 	}
 
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
 	select {
 	case <-ctx.Done():
 		return false
-	case <-time.After(delay):
+	case <-timer.C:
 		return true
 	}
 }

--- a/sonar/retry.go
+++ b/sonar/retry.go
@@ -1,0 +1,166 @@
+package sonar
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"slices"
+	"time"
+)
+
+const retryBackoffBase = 2
+
+// RetryOptions configures opt-in retry with exponential backoff and full jitter.
+// The zero value disables retrying (default behaviour).
+//
+//nolint:govet // fieldalignment: keeping logical field grouping for readability
+type RetryOptions struct {
+	// MaxAttempts is the total number of attempts including the first.
+	// Values of 0 or 1 disable retries.
+	MaxAttempts int
+	// InitialDelay is the base delay used in the exponential backoff calculation.
+	InitialDelay time.Duration
+	// MaxDelay caps the computed backoff delay.
+	MaxDelay time.Duration
+	// RetryableStatusCodes lists HTTP status codes that should trigger a retry.
+	RetryableStatusCodes []int
+}
+
+// WithRetry is a ClientOptionFunc that enables opt-in retry with exponential
+// backoff and full jitter around the HTTP transport. Retry is disabled by default.
+func WithRetry(opts RetryOptions) ClientOptionFunc {
+	return func(c *Client) error {
+		c.retryOptions = &opts
+
+		return nil
+	}
+}
+
+// retryRoundTripper wraps a base http.RoundTripper with configurable retry logic.
+type retryRoundTripper struct {
+	base http.RoundTripper
+	opts RetryOptions
+}
+
+// RoundTrip executes the request, retrying on configured status codes or network
+// errors with exponential backoff and full jitter. Retries stop immediately when
+// the request context is cancelled or its deadline is exceeded.
+//
+//nolint:wrapcheck // pass-through transport: errors from base RoundTripper are intentionally not wrapped
+func (r *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if r.opts.MaxAttempts <= 1 {
+		return r.base.RoundTrip(req)
+	}
+
+	hasBody := req.Body != nil && req.Body != http.NoBody
+	if hasBody && req.GetBody == nil {
+		// Non-replayable body: cannot retry safely.
+		return r.base.RoundTrip(req)
+	}
+
+	return r.retryLoop(req, hasBody)
+}
+
+// retryLoop runs up to MaxAttempts, sleeping between retries.
+func (r *retryRoundTripper) retryLoop(req *http.Request, hasBody bool) (*http.Response, error) {
+	for attempt := range r.opts.MaxAttempts {
+		resp, err := r.doAttempt(req, hasBody)
+		isLast := attempt >= r.opts.MaxAttempts-1
+
+		if done, result, resultErr := r.evaluate(req.Context(), resp, err, isLast); done {
+			return result, resultErr
+		}
+
+		if !sleepContext(req.Context(), r.computeDelay(attempt)) {
+			return nil, req.Context().Err() //nolint:wrapcheck // context error is the direct cause
+		}
+	}
+
+	return nil, fmt.Errorf("retry: exhausted %d attempts", r.opts.MaxAttempts)
+}
+
+// doAttempt clones the request (replaying the body when present) and executes it.
+func (r *retryRoundTripper) doAttempt(req *http.Request, hasBody bool) (*http.Response, error) {
+	clonedReq := req.Clone(req.Context())
+
+	if hasBody {
+		var err error
+
+		clonedReq.Body, err = req.GetBody()
+		if err != nil {
+			return nil, fmt.Errorf("retry: failed to replay request body: %w", err)
+		}
+	}
+
+	return r.base.RoundTrip(clonedReq) //nolint:wrapcheck
+}
+
+// evaluate decides whether the loop should stop after an attempt.
+// Returns (true, resp, err) to stop, (false, nil, nil) to sleep and continue.
+func (r *retryRoundTripper) evaluate(ctx context.Context, resp *http.Response, err error, isLast bool) (bool, *http.Response, error) {
+	if err != nil {
+		if ctx.Err() != nil || isLast {
+			return true, nil, err
+		}
+
+		return false, nil, nil
+	}
+
+	if !r.isRetryable(resp.StatusCode) || isLast {
+		return true, resp, nil
+	}
+
+	drainAndClose(resp)
+
+	return false, nil, nil
+}
+
+// isRetryable reports whether statusCode is in the configured retry list.
+func (r *retryRoundTripper) isRetryable(statusCode int) bool {
+	return slices.Contains(r.opts.RetryableStatusCodes, statusCode)
+}
+
+// computeDelay returns the backoff duration for the given attempt index using full
+// jitter: a random value in [0, min(InitialDelay * 2^attempt, MaxDelay)).
+func (r *retryRoundTripper) computeDelay(attempt int) time.Duration {
+	maxDelay := float64(r.opts.MaxDelay)
+	base := float64(r.opts.InitialDelay) * math.Pow(retryBackoffBase, float64(attempt))
+
+	if base > maxDelay {
+		base = maxDelay
+	}
+
+	return time.Duration(rand.Float64() * base) //nolint:gosec // math/rand/v2 sufficient for jitter
+}
+
+// sleepContext waits for delay, returning false immediately if ctx is already done
+// or becomes done while waiting.
+func sleepContext(ctx context.Context, delay time.Duration) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+
+	if delay <= 0 {
+		return true
+	}
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(delay):
+		return true
+	}
+}
+
+// drainAndClose discards resp's body and closes it so the connection can be reused.
+func drainAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}

--- a/sonar/retry_test.go
+++ b/sonar/retry_test.go
@@ -3,6 +3,7 @@ package sonar
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -252,4 +253,94 @@ func TestSleepContext_CancelledContextReturnsFalse(t *testing.T) {
 func TestSleepContext_ZeroDelayReturnsTrue(t *testing.T) {
 	result := sleepContext(context.Background(), 0)
 	assert.True(t, result)
+}
+
+func TestSleepContext_TimerReleasedOnContextCancel(t *testing.T) {
+	// Cancelling the context while sleeping must unblock immediately and not leak
+	// the timer (time.NewTimer + Stop rather than time.After).
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	result := sleepContext(ctx, time.Hour)
+	assert.False(t, result)
+	assert.Less(t, time.Since(start), time.Second)
+}
+
+func TestEvaluate_ContextErrorPreferredOverTransportError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	rt := &retryRoundTripper{
+		base: http.DefaultTransport,
+		opts: RetryOptions{MaxAttempts: 3, RetryableStatusCodes: []int{503}},
+	}
+
+	transportErr := fmt.Errorf("connection refused")
+	done, result, err := rt.evaluate(ctx, nil, transportErr, false)
+
+	assert.True(t, done)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestRetryRoundTripper_AttemptsHeaderSetAfterRetry(t *testing.T) {
+	transport := &countingTransport{
+		responses: []*http.Response{
+			makeResponse(http.StatusServiceUnavailable),
+			makeResponse(http.StatusServiceUnavailable),
+			makeResponse(http.StatusOK),
+		},
+	}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{
+			MaxAttempts:          4,
+			InitialDelay:         time.Millisecond,
+			MaxDelay:             5 * time.Millisecond,
+			RetryableStatusCodes: []int{503},
+		},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", http.NoBody)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// 3 total attempts → header value "3".
+	assert.Equal(t, "3", resp.Header.Get("X-Retry-Attempts"))
+}
+
+func TestRetryRoundTripper_AttemptsHeaderAbsentWithNoRetry(t *testing.T) {
+	transport := &countingTransport{responses: []*http.Response{makeResponse(http.StatusOK)}}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{MaxAttempts: 4, RetryableStatusCodes: []int{503}},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", http.NoBody)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Header.Get("X-Retry-Attempts"))
+}
+
+func TestWithRetry_SliceIsolatedFromCaller(t *testing.T) {
+	codes := []int{503}
+	client, err := NewClient(nil, WithRetry(RetryOptions{
+		MaxAttempts:          2,
+		InitialDelay:         time.Millisecond,
+		MaxDelay:             5 * time.Millisecond,
+		RetryableStatusCodes: codes,
+	}))
+	require.NoError(t, err)
+
+	// Mutate the original slice after client creation.
+	codes[0] = 200
+
+	// The client's retry transport should still use 503, not 200.
+	transport := client.httpClient.Transport.(*retryRoundTripper)
+	assert.Equal(t, []int{503}, transport.opts.RetryableStatusCodes)
 }

--- a/sonar/retry_test.go
+++ b/sonar/retry_test.go
@@ -1,0 +1,255 @@
+package sonar
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingTransport records every call and returns pre-configured responses in order.
+type countingTransport struct {
+	responses []*http.Response
+	errors    []error
+	calls     int
+}
+
+func (c *countingTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	i := c.calls
+	c.calls++
+
+	if i < len(c.errors) && c.errors[i] != nil {
+		return nil, c.errors[i]
+	}
+
+	if i < len(c.responses) {
+		return c.responses[i], nil
+	}
+
+	return makeResponse(http.StatusOK), nil
+}
+
+func makeResponse(statusCode int) *http.Response {
+	//nolint:exhaustruct // only status and body matter for tests
+	return &http.Response{
+		StatusCode: statusCode,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
+	}
+}
+
+func TestRetryRoundTripper_SingleAttemptWhenDisabled(t *testing.T) {
+	transport := &countingTransport{responses: []*http.Response{makeResponse(http.StatusServiceUnavailable)}}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{MaxAttempts: 0, RetryableStatusCodes: []int{503}},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", http.NoBody)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, 1, transport.calls)
+}
+
+func TestRetryRoundTripper_RetriesOnRetryableStatus(t *testing.T) {
+	transport := &countingTransport{
+		responses: []*http.Response{
+			makeResponse(http.StatusServiceUnavailable),
+			makeResponse(http.StatusServiceUnavailable),
+			makeResponse(http.StatusOK),
+		},
+	}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{
+			MaxAttempts:          4,
+			InitialDelay:         time.Millisecond,
+			MaxDelay:             5 * time.Millisecond,
+			RetryableStatusCodes: []int{503},
+		},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", http.NoBody)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 3, transport.calls)
+}
+
+func TestRetryRoundTripper_NoRetryOnNonRetryableStatus(t *testing.T) {
+	transport := &countingTransport{responses: []*http.Response{makeResponse(http.StatusBadRequest)}}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{MaxAttempts: 4, RetryableStatusCodes: []int{503}},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", http.NoBody)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, 1, transport.calls)
+}
+
+func TestRetryRoundTripper_ExhaustsAllAttempts(t *testing.T) {
+	transport := &countingTransport{
+		responses: []*http.Response{
+			makeResponse(http.StatusBadGateway),
+			makeResponse(http.StatusBadGateway),
+			makeResponse(http.StatusBadGateway),
+		},
+	}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{
+			MaxAttempts:          3,
+			InitialDelay:         time.Millisecond,
+			MaxDelay:             5 * time.Millisecond,
+			RetryableStatusCodes: []int{502},
+		},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", http.NoBody)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+	assert.Equal(t, 3, transport.calls)
+}
+
+func TestRetryRoundTripper_ContextCancelledStopsRetry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	transport := &countingTransport{}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{
+			MaxAttempts:          4,
+			InitialDelay:         time.Second,
+			MaxDelay:             time.Second,
+			RetryableStatusCodes: []int{503},
+		},
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", http.NoBody)
+	// The base transport will also receive the cancelled context and may return an error.
+	_, _ = rt.RoundTrip(req)
+	// We just verify we don't spin endlessly; the exact error depends on the transport.
+	assert.LessOrEqual(t, transport.calls, 1)
+}
+
+func TestRetryRoundTripper_NonReplayableBodyNotRetried(t *testing.T) {
+	transport := &countingTransport{responses: []*http.Response{makeResponse(http.StatusServiceUnavailable)}}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{MaxAttempts: 4, RetryableStatusCodes: []int{503}},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", io.NopCloser(bytes.NewReader([]byte("body"))))
+	// GetBody is nil because we used io.NopCloser directly, not bytes.NewReader via http.NewRequest.
+	require.Nil(t, req.GetBody)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, 1, transport.calls)
+}
+
+func TestRetryRoundTripper_ReplayableBodyRetried(t *testing.T) {
+	transport := &countingTransport{
+		responses: []*http.Response{
+			makeResponse(http.StatusServiceUnavailable),
+			makeResponse(http.StatusOK),
+		},
+	}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{
+			MaxAttempts:          3,
+			InitialDelay:         time.Millisecond,
+			MaxDelay:             5 * time.Millisecond,
+			RetryableStatusCodes: []int{503},
+		},
+	}
+
+	body := bytes.NewReader([]byte(`{"key":"value"}`))
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", body)
+	// http.NewRequest with bytes.Reader sets GetBody automatically.
+	require.NotNil(t, req.GetBody)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, transport.calls)
+}
+
+func TestWithRetry_ClientIntegration(t *testing.T) {
+	callCount := 0
+	ts := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		if callCount < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	client, err := NewClient(nil,
+		WithBaseURL(ts.url()),
+		WithRetry(RetryOptions{
+			MaxAttempts:          4,
+			InitialDelay:         time.Millisecond,
+			MaxDelay:             5 * time.Millisecond,
+			RetryableStatusCodes: []int{503},
+		}),
+	)
+	require.NoError(t, err)
+
+	req, err := client.NewSonarQubeV1APIRequest(context.Background(), http.MethodGet, "api/system/ping", nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 3, callCount)
+}
+
+func TestComputeDelay_FullJitter(t *testing.T) {
+	rt := &retryRoundTripper{
+		base: http.DefaultTransport,
+		opts: RetryOptions{
+			InitialDelay: 100 * time.Millisecond,
+			MaxDelay:     10 * time.Second,
+		},
+	}
+
+	for attempt := range 5 {
+		delay := rt.computeDelay(attempt)
+		assert.GreaterOrEqual(t, delay, time.Duration(0))
+
+		cap := time.Duration(float64(rt.opts.InitialDelay) * float64(int(1)<<attempt))
+		if cap > rt.opts.MaxDelay {
+			cap = rt.opts.MaxDelay
+		}
+
+		assert.LessOrEqual(t, delay, cap)
+	}
+}
+
+func TestSleepContext_CancelledContextReturnsFalse(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result := sleepContext(ctx, time.Second)
+	assert.False(t, result)
+}
+
+func TestSleepContext_ZeroDelayReturnsTrue(t *testing.T) {
+	result := sleepContext(context.Background(), 0)
+	assert.True(t, result)
+}


### PR DESCRIPTION
### Description of your changes

This PR adds the support of an opt in exponential retry mechanism in the client options:

- Add RetryOptions struct and WithRetry option func
- Implement retryRoundTripper as an http.RoundTripper wrapping the base transport
- Retries respect request context: cancelled/deadline-exceeded context stops immediately
- Full jitter backoff: random delay in [0, min(InitialDelay * 2^attempt, MaxDelay))
- Non-replayable request bodies skip retry logic to avoid data loss
- Retry is disabled by default (zero config = current behaviour)

Has corresponding unit tests coverage.

Closes #202 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
