### PR TITLE
feat: use Retry-After header on 429 responses

### DIFF
--- a/sonar/retry.go
+++ b/sonar/retry.go
@@ -97,10 +97,11 @@ func (r *retryRoundTripper) retryLoop(req *http.Request, hasBody bool) (*http.Re
 
 // retryDelay returns the duration to wait before the next attempt.
 // For 429 responses with a valid Retry-After header, that value takes precedence
-// over the computed exponential backoff.
+// over the computed exponential backoff. A Retry-After of zero is honoured as an
+// explicit instruction to retry immediately rather than falling back to backoff.
 func (r *retryRoundTripper) retryDelay(resp *http.Response, attempt int) time.Duration {
 	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
-		if d := parseRetryAfterHeader(resp.Header.Get("Retry-After")); d > 0 {
+		if d, ok := parseRetryAfterHeader(resp.Header.Get("Retry-After")); ok {
 			return d
 		}
 	}
@@ -193,34 +194,36 @@ func sleepContext(ctx context.Context, delay time.Duration) bool {
 	}
 }
 
-// parseRetryAfterHeader parses a Retry-After header value and returns the wait
-// duration. It supports both the delay-seconds form ("30") and the HTTP-date
-// form ("Wed, 21 Oct 2025 07:28:00 GMT"). Returns 0 for absent, malformed, or
-// past-dated values.
-func parseRetryAfterHeader(header string) time.Duration {
+// parseRetryAfterHeader parses a Retry-After header value. It supports both the
+// delay-seconds form ("30") and the HTTP-date form ("Wed, 21 Oct 2025 07:28:00 GMT").
+//
+// Returns (duration, true) when the header is present and parseable. A value of
+// zero is valid and means "retry immediately" (e.g. Retry-After: 0 or a past
+// HTTP-date). Returns (0, false) when the header is absent, malformed, or carries
+// a negative integer.
+func parseRetryAfterHeader(header string) (time.Duration, bool) {
 	if header == "" {
-		return 0
+		return 0, false
 	}
 
-	// delay-seconds form.
+	// delay-seconds form: non-negative integer.
 	secs, secsErr := strconv.Atoi(header)
 	if secsErr == nil {
-		if secs > 0 {
-			return time.Duration(secs) * time.Second
+		if secs >= 0 {
+			return time.Duration(secs) * time.Second, true
 		}
 
-		return 0
+		return 0, false
 	}
 
-	// HTTP-date form.
+	// HTTP-date form. A past-dated value is treated as an instruction to retry
+	// immediately (zero delay) rather than falling back to backoff.
 	t, dateErr := http.ParseTime(header)
 	if dateErr == nil {
-		if d := time.Until(t); d > 0 {
-			return d
-		}
+		return max(time.Until(t), 0), true
 	}
 
-	return 0
+	return 0, false
 }
 
 // drainAndClose discards resp's body and closes it so the connection can be reused.

--- a/sonar/retry.go
+++ b/sonar/retry.go
@@ -86,12 +86,26 @@ func (r *retryRoundTripper) retryLoop(req *http.Request, hasBody bool) (*http.Re
 			return result, resultErr
 		}
 
-		if !sleepContext(req.Context(), r.computeDelay(attempt)) {
+		// resp headers are still accessible after evaluate drains the body.
+		if !sleepContext(req.Context(), r.retryDelay(resp, attempt)) {
 			return nil, req.Context().Err() //nolint:wrapcheck // context error is the direct cause
 		}
 	}
 
 	return nil, fmt.Errorf("retry: exhausted %d attempts", r.opts.MaxAttempts)
+}
+
+// retryDelay returns the duration to wait before the next attempt.
+// For 429 responses with a valid Retry-After header, that value takes precedence
+// over the computed exponential backoff.
+func (r *retryRoundTripper) retryDelay(resp *http.Response, attempt int) time.Duration {
+	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+		if d := parseRetryAfterHeader(resp.Header.Get("Retry-After")); d > 0 {
+			return d
+		}
+	}
+
+	return r.computeDelay(attempt)
 }
 
 // doAttempt clones the request (replaying the body when present) and executes it.
@@ -177,6 +191,36 @@ func sleepContext(ctx context.Context, delay time.Duration) bool {
 	case <-timer.C:
 		return true
 	}
+}
+
+// parseRetryAfterHeader parses a Retry-After header value and returns the wait
+// duration. It supports both the delay-seconds form ("30") and the HTTP-date
+// form ("Wed, 21 Oct 2025 07:28:00 GMT"). Returns 0 for absent, malformed, or
+// past-dated values.
+func parseRetryAfterHeader(header string) time.Duration {
+	if header == "" {
+		return 0
+	}
+
+	// delay-seconds form.
+	secs, secsErr := strconv.Atoi(header)
+	if secsErr == nil {
+		if secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+
+		return 0
+	}
+
+	// HTTP-date form.
+	t, dateErr := http.ParseTime(header)
+	if dateErr == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+
+	return 0
 }
 
 // drainAndClose discards resp's body and closes it so the connection can be reused.

--- a/sonar/retry_test.go
+++ b/sonar/retry_test.go
@@ -255,6 +255,208 @@ func TestSleepContext_ZeroDelayReturnsTrue(t *testing.T) {
 	assert.True(t, result)
 }
 
+// =============================================
+// Retry-After tests (#201)
+// =============================================
+
+func TestRetryRoundTripper_RetryAfterSeconds(t *testing.T) {
+	transport := &countingTransport{
+		responses: []*http.Response{
+			makeResponseWithHeader(http.StatusTooManyRequests, "Retry-After", "0"),
+			makeResponse(http.StatusOK),
+		},
+	}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{
+			MaxAttempts:          3,
+			InitialDelay:         time.Millisecond,
+			MaxDelay:             5 * time.Millisecond,
+			RetryableStatusCodes: []int{429},
+		},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", http.NoBody)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, transport.calls)
+}
+
+func TestRetryRoundTripper_RetryAfterDate_Future(t *testing.T) {
+	futureDate := time.Now().Add(50 * time.Millisecond).UTC().Format(http.TimeFormat)
+	transport := &countingTransport{
+		responses: []*http.Response{
+			makeResponseWithHeader(http.StatusTooManyRequests, "Retry-After", futureDate),
+			makeResponse(http.StatusOK),
+		},
+	}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{
+			MaxAttempts:          3,
+			InitialDelay:         time.Millisecond,
+			MaxDelay:             5 * time.Millisecond,
+			RetryableStatusCodes: []int{429},
+		},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", http.NoBody)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, transport.calls)
+}
+
+func TestRetryRoundTripper_RetryAfterAbsent_FallsBackToBackoff(t *testing.T) {
+	transport := &countingTransport{
+		responses: []*http.Response{
+			makeResponse(http.StatusTooManyRequests),
+			makeResponse(http.StatusOK),
+		},
+	}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{
+			MaxAttempts:          3,
+			InitialDelay:         time.Millisecond,
+			MaxDelay:             5 * time.Millisecond,
+			RetryableStatusCodes: []int{429},
+		},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", http.NoBody)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, transport.calls)
+}
+
+func TestRetryRoundTripper_RetryDisabled_429ReturnedAsIs(t *testing.T) {
+	transport := &countingTransport{
+		responses: []*http.Response{
+			makeResponseWithHeader(http.StatusTooManyRequests, "Retry-After", "10"),
+		},
+	}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{MaxAttempts: 1, RetryableStatusCodes: []int{429}},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", http.NoBody)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, 1, transport.calls)
+}
+
+func TestRetryDelay_UsesRetryAfterOnRateLimitResponse(t *testing.T) {
+	rt := &retryRoundTripper{
+		base: http.DefaultTransport,
+		opts: RetryOptions{InitialDelay: time.Second, MaxDelay: time.Minute},
+	}
+
+	resp := makeResponseWithHeader(http.StatusTooManyRequests, "Retry-After", "5")
+	delay := rt.retryDelay(resp, 0)
+
+	assert.Equal(t, 5*time.Second, delay)
+}
+
+func TestRetryDelay_IgnoresRetryAfterOnNon429(t *testing.T) {
+	rt := &retryRoundTripper{
+		base: http.DefaultTransport,
+		opts: RetryOptions{InitialDelay: 10 * time.Millisecond, MaxDelay: time.Second},
+	}
+
+	resp := makeResponseWithHeader(http.StatusServiceUnavailable, "Retry-After", "5")
+	delay := rt.retryDelay(resp, 0)
+
+	// Should use exponential backoff, not the Retry-After value (5s).
+	assert.Less(t, delay, 5*time.Second)
+}
+
+func TestParseRetryAfterHeader_Seconds(t *testing.T) {
+	tests := []struct {
+		header   string
+		expected time.Duration
+	}{
+		{"10", 10 * time.Second},
+		{"0", 0},
+		{"-1", 0},
+		{"3600", 3600 * time.Second},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.header, func(t *testing.T) {
+			assert.Equal(t, tc.expected, parseRetryAfterHeader(tc.header))
+		})
+	}
+}
+
+func TestParseRetryAfterHeader_HTTPDate(t *testing.T) {
+	future := time.Now().Add(time.Minute).UTC()
+	header := future.Format(http.TimeFormat)
+
+	delay := parseRetryAfterHeader(header)
+	assert.Greater(t, delay, time.Duration(0))
+	assert.LessOrEqual(t, delay, time.Minute)
+}
+
+func TestParseRetryAfterHeader_PastDate(t *testing.T) {
+	past := time.Now().Add(-time.Minute).UTC()
+	header := past.Format(http.TimeFormat)
+
+	assert.Equal(t, time.Duration(0), parseRetryAfterHeader(header))
+}
+
+func TestParseRetryAfterHeader_Empty(t *testing.T) {
+	assert.Equal(t, time.Duration(0), parseRetryAfterHeader(""))
+}
+
+func TestParseRetryAfterHeader_Invalid(t *testing.T) {
+	assert.Equal(t, time.Duration(0), parseRetryAfterHeader("not-a-date-or-number"))
+}
+
+// makeResponseWithHeader creates a test response with a single header set.
+func makeResponseWithHeader(statusCode int, key, value string) *http.Response {
+	resp := makeResponse(statusCode)
+	resp.Header.Set(key, value)
+
+	return resp
+}
+
+func TestWithRetry_429ContextCancellationDuringWait(t *testing.T) {
+	// The Retry-After header requests a 60s wait; the context times out in 100ms.
+	// This verifies that sleepContext honours context cancellation and does not block.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	transport := &countingTransport{
+		responses: []*http.Response{
+			makeResponseWithHeader(http.StatusTooManyRequests, "Retry-After", "60"),
+		},
+	}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{
+			MaxAttempts:          3,
+			InitialDelay:         time.Millisecond,
+			MaxDelay:             5 * time.Millisecond,
+			RetryableStatusCodes: []int{429},
+		},
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", http.NoBody)
+
+	start := time.Now()
+	_, err := rt.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	// Must finish well under 60s (the Retry-After value).
+	assert.Less(t, elapsed, time.Second)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
 func TestSleepContext_TimerReleasedOnContextCancel(t *testing.T) {
 	// Cancelling the context while sleeping must unblock immediately and not leak
 	// the timer (time.NewTimer + Stop rather than time.After).

--- a/sonar/retry_test.go
+++ b/sonar/retry_test.go
@@ -283,29 +283,21 @@ func TestRetryRoundTripper_RetryAfterSeconds(t *testing.T) {
 	assert.Equal(t, 2, transport.calls)
 }
 
-func TestRetryRoundTripper_RetryAfterDate_Future(t *testing.T) {
-	futureDate := time.Now().Add(50 * time.Millisecond).UTC().Format(http.TimeFormat)
-	transport := &countingTransport{
-		responses: []*http.Response{
-			makeResponseWithHeader(http.StatusTooManyRequests, "Retry-After", futureDate),
-			makeResponse(http.StatusOK),
-		},
-	}
+func TestRetryDelay_UsesRetryAfterHTTPDateOnRateLimitResponse(t *testing.T) {
+	// Test retryDelay directly to avoid waiting for the actual delay.
+	// Use 30s in the future — well beyond http.TimeFormat's 1-second precision so
+	// the formatted date is always still in the future when time.Until is called.
 	rt := &retryRoundTripper{
-		base: transport,
-		opts: RetryOptions{
-			MaxAttempts:          3,
-			InitialDelay:         time.Millisecond,
-			MaxDelay:             5 * time.Millisecond,
-			RetryableStatusCodes: []int{429},
-		},
+		base: http.DefaultTransport,
+		opts: RetryOptions{InitialDelay: time.Second, MaxDelay: time.Minute},
 	}
 
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", http.NoBody)
-	resp, err := rt.RoundTrip(req)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, 2, transport.calls)
+	future := time.Now().Add(30 * time.Second).UTC()
+	resp := makeResponseWithHeader(http.StatusTooManyRequests, "Retry-After", future.Format(http.TimeFormat))
+
+	delay := rt.retryDelay(resp, 0)
+	assert.Greater(t, delay, 25*time.Second)
+	assert.LessOrEqual(t, delay, 31*time.Second)
 }
 
 func TestRetryRoundTripper_RetryAfterAbsent_FallsBackToBackoff(t *testing.T) {
@@ -362,6 +354,19 @@ func TestRetryDelay_UsesRetryAfterOnRateLimitResponse(t *testing.T) {
 	assert.Equal(t, 5*time.Second, delay)
 }
 
+func TestRetryDelay_ZeroRetryAfterOverridesBackoff(t *testing.T) {
+	rt := &retryRoundTripper{
+		base: http.DefaultTransport,
+		opts: RetryOptions{InitialDelay: 10 * time.Second, MaxDelay: time.Minute},
+	}
+
+	// Retry-After: 0 must result in immediate retry, not fall back to the backoff.
+	resp := makeResponseWithHeader(http.StatusTooManyRequests, "Retry-After", "0")
+	delay := rt.retryDelay(resp, 0)
+
+	assert.Equal(t, time.Duration(0), delay)
+}
+
 func TestRetryDelay_IgnoresRetryAfterOnNon429(t *testing.T) {
 	rt := &retryRoundTripper{
 		base: http.DefaultTransport,
@@ -377,44 +382,55 @@ func TestRetryDelay_IgnoresRetryAfterOnNon429(t *testing.T) {
 
 func TestParseRetryAfterHeader_Seconds(t *testing.T) {
 	tests := []struct {
-		header   string
-		expected time.Duration
+		header      string
+		expected    time.Duration
+		expectValid bool
 	}{
-		{"10", 10 * time.Second},
-		{"0", 0},
-		{"-1", 0},
-		{"3600", 3600 * time.Second},
+		{"10", 10 * time.Second, true},
+		{"0", 0, true},   // zero is a valid instruction to retry immediately
+		{"-1", 0, false}, // negative integers are invalid
+		{"3600", 3600 * time.Second, true},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.header, func(t *testing.T) {
-			assert.Equal(t, tc.expected, parseRetryAfterHeader(tc.header))
+			d, ok := parseRetryAfterHeader(tc.header)
+			assert.Equal(t, tc.expected, d)
+			assert.Equal(t, tc.expectValid, ok)
 		})
 	}
 }
 
 func TestParseRetryAfterHeader_HTTPDate(t *testing.T) {
-	future := time.Now().Add(time.Minute).UTC()
+	// Use 30s in the future to survive http.TimeFormat's 1-second precision.
+	future := time.Now().Add(30 * time.Second).UTC()
 	header := future.Format(http.TimeFormat)
 
-	delay := parseRetryAfterHeader(header)
-	assert.Greater(t, delay, time.Duration(0))
-	assert.LessOrEqual(t, delay, time.Minute)
+	d, ok := parseRetryAfterHeader(header)
+	assert.True(t, ok)
+	assert.Greater(t, d, 25*time.Second)
+	assert.LessOrEqual(t, d, 31*time.Second)
 }
 
 func TestParseRetryAfterHeader_PastDate(t *testing.T) {
+	// A past HTTP-date is valid: the server's intended wait has already elapsed,
+	// so the result is zero delay (retry immediately) rather than falling back to backoff.
 	past := time.Now().Add(-time.Minute).UTC()
 	header := past.Format(http.TimeFormat)
 
-	assert.Equal(t, time.Duration(0), parseRetryAfterHeader(header))
+	d, ok := parseRetryAfterHeader(header)
+	assert.True(t, ok)
+	assert.Equal(t, time.Duration(0), d)
 }
 
 func TestParseRetryAfterHeader_Empty(t *testing.T) {
-	assert.Equal(t, time.Duration(0), parseRetryAfterHeader(""))
+	_, ok := parseRetryAfterHeader("")
+	assert.False(t, ok)
 }
 
 func TestParseRetryAfterHeader_Invalid(t *testing.T) {
-	assert.Equal(t, time.Duration(0), parseRetryAfterHeader("not-a-date-or-number"))
+	_, ok := parseRetryAfterHeader("not-a-date-or-number")
+	assert.False(t, ok)
 }
 
 // makeResponseWithHeader creates a test response with a single header set.


### PR DESCRIPTION
### Description of your changes

This PR adds the automatic parsing of 429 / retry after headers in order to avoid false errors passed to the user.

When a 429 Too Many Requests response carries a Retry-After header, use that duration as the inter-attempt delay instead of the computed exponential backoff. Both delay-seconds (integer) and HTTP-date formats are supported.

- parseRetryAfterHeader handles both RFC 7231 forms (seconds and HTTP-date)
- retryDelay extracts the Retry-After override for 429 responses
- Waiting is interrupted immediately if the context is cancelled/expired
- Falls back to exponential backoff when Retry-After is absent or invalid
- If retry is disabled (MaxAttempts <= 1), 429 is returned as-is

Closes #201 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [ ] Added end-to-end tests if necessary.
