### PR TITLE
feat: add WithTransportConfig option for custom HTTP transport

### DIFF
--- a/sonar/client.go
+++ b/sonar/client.go
@@ -22,14 +22,15 @@ import (
 //
 //nolint:govet // fieldalignment: keeping logical field grouping for readability
 type Client struct {
-	baseURL      *url.URL
-	username     string
-	password     string
-	token        string
-	authType     authType
-	httpClient   *http.Client
-	retryOptions *RetryOptions
-	userAgent    string
+	baseURL         *url.URL
+	username        string
+	password        string
+	token           string
+	authType        authType
+	httpClient      *http.Client
+	retryOptions    *RetryOptions
+	transportConfig *TransportConfig
+	userAgent       string
 
 	AlmIntegrations    *AlmIntegrationsService
 	AlmSettings        *AlmSettingsService
@@ -209,7 +210,12 @@ func setDefaults(client *Client) error {
 	}
 
 	if client.httpClient == nil {
-		client.httpClient = http.DefaultClient
+		if client.transportConfig != nil {
+			//nolint:exhaustruct // Timeout, Jar, CheckRedirect intentionally left at zero values
+			client.httpClient = &http.Client{Transport: buildTransport(*client.transportConfig)}
+		} else {
+			client.httpClient = http.DefaultClient
+		}
 	}
 
 	if client.retryOptions != nil {
@@ -263,6 +269,16 @@ func WithBaseURL(urlStr string) ClientOptionFunc {
 func WithHTTPClient(httpClient *http.Client) ClientOptionFunc {
 	return func(c *Client) error {
 		c.httpClient = httpClient
+
+		return nil
+	}
+}
+
+// WithTransportConfig is a ClientOptionFunc that configures the SDK-managed HTTP
+// transport. It is ignored when WithHTTPClient is also used.
+func WithTransportConfig(cfg TransportConfig) ClientOptionFunc {
+	return func(c *Client) error {
+		c.transportConfig = &cfg
 
 		return nil
 	}

--- a/sonar/transport.go
+++ b/sonar/transport.go
@@ -1,0 +1,29 @@
+package sonar
+
+import (
+	"crypto/tls"
+	"net/http"
+	"time"
+)
+
+// TransportConfig holds configuration for the SDK-managed HTTP transport.
+// It is ignored when WithHTTPClient is also used.
+type TransportConfig struct {
+	TLSClientConfig     *tls.Config
+	MaxIdleConns        int
+	IdleConnTimeout     time.Duration
+	TLSHandshakeTimeout time.Duration
+	DisableCompression  bool
+}
+
+// buildTransport creates an *http.Transport from cfg.
+func buildTransport(cfg TransportConfig) *http.Transport {
+	//nolint:exhaustruct // only configure the fields the caller specified
+	return &http.Transport{
+		MaxIdleConns:        cfg.MaxIdleConns,
+		IdleConnTimeout:     cfg.IdleConnTimeout,
+		TLSHandshakeTimeout: cfg.TLSHandshakeTimeout,
+		TLSClientConfig:     cfg.TLSClientConfig,
+		DisableCompression:  cfg.DisableCompression,
+	}
+}

--- a/sonar/transport_test.go
+++ b/sonar/transport_test.go
@@ -1,0 +1,86 @@
+package sonar
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithTransportConfig_SetsCustomTransport(t *testing.T) {
+	cfg := TransportConfig{
+		MaxIdleConns:        42,
+		IdleConnTimeout:     30 * time.Second,
+		TLSHandshakeTimeout: 10 * time.Second,
+		DisableCompression:  true,
+	}
+
+	client, err := NewClient(nil, WithTransportConfig(cfg))
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	assert.NotSame(t, http.DefaultClient, client.httpClient, "expected a dedicated http.Client, not the default")
+	require.NotNil(t, client.httpClient.Transport, "expected a non-nil transport")
+
+	transport, ok := client.httpClient.Transport.(*http.Transport)
+	require.True(t, ok, "expected transport to be *http.Transport")
+
+	assert.Equal(t, 42, transport.MaxIdleConns)
+	assert.Equal(t, 30*time.Second, transport.IdleConnTimeout)
+	assert.Equal(t, 10*time.Second, transport.TLSHandshakeTimeout)
+	assert.True(t, transport.DisableCompression)
+}
+
+func TestWithTransportConfig_IgnoredWhenHTTPClientProvided(t *testing.T) {
+	customTransport := &http.Transport{MaxIdleConns: 99} //nolint:exhaustruct
+	customClient := &http.Client{Transport: customTransport} //nolint:exhaustruct
+
+	cfg := TransportConfig{
+		MaxIdleConns: 1,
+	}
+
+	client, err := NewClient(nil, WithHTTPClient(customClient), WithTransportConfig(cfg))
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	assert.Same(t, customClient, client.httpClient, "expected the provided http.Client to be used")
+
+	transport, ok := client.httpClient.Transport.(*http.Transport)
+	require.True(t, ok, "expected transport to be *http.Transport")
+	assert.Equal(t, 99, transport.MaxIdleConns, "expected the custom client's transport to be preserved")
+}
+
+func TestWithTransportConfig_DefaultUnchanged(t *testing.T) {
+	client, err := NewClient(nil)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	assert.Same(t, http.DefaultClient, client.httpClient, "expected http.DefaultClient when no options are provided")
+}
+
+func TestWithTransportConfig_TLSConfig(t *testing.T) {
+	tlsCfg := &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // intentional for testing
+		MinVersion:         tls.VersionTLS12,
+	}
+
+	cfg := TransportConfig{
+		TLSClientConfig: tlsCfg,
+	}
+
+	client, err := NewClient(nil, WithTransportConfig(cfg))
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	require.NotNil(t, client.httpClient.Transport, "expected a non-nil transport")
+
+	transport, ok := client.httpClient.Transport.(*http.Transport)
+	require.True(t, ok, "expected transport to be *http.Transport")
+
+	require.NotNil(t, transport.TLSClientConfig, "expected TLSClientConfig to be set")
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify) //nolint:gosec
+	assert.Equal(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion)
+}


### PR DESCRIPTION
### Description of your changes

This PR allows to configure the Transport config when creating the client.

Expose HTTP transport configuration at client construction time via a new WithTransportConfig option, supporting custom TLS settings and connection pool tuning. WithHTTPClient takes precedence and causes WithTransportConfig to be ignored. Default behaviour is unchanged.

Closes #203 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [ ] Added unit tests to cover the code changes.
- [ ] Added end-to-end tests if necessary.
