### PR TITLE
feat: add WithMiddleware option for HTTP transport chain

### DIFF
--- a/sonar/client.go
+++ b/sonar/client.go
@@ -219,17 +219,9 @@ func setDefaults(client *Client) error {
 		}
 	}
 
-	if client.retryOptions != nil {
-		baseTransport := client.httpClient.Transport
-		if baseTransport == nil {
-			baseTransport = http.DefaultTransport
-		}
-
-		clone := *client.httpClient
-		clone.Transport = &retryRoundTripper{base: baseTransport, opts: *client.retryOptions}
-		client.httpClient = &clone
-	}
-
+	// Middleware is applied first so that retry sits outermost. Each retry attempt
+	// therefore passes through the full middleware chain, letting middleware observe
+	// every individual attempt rather than just the first one.
 	if len(client.middlewares) > 0 {
 		baseTransport := client.httpClient.Transport
 		if baseTransport == nil {
@@ -239,6 +231,17 @@ func setDefaults(client *Client) error {
 		transport := applyMiddlewares(baseTransport, client.middlewares)
 		clone := *client.httpClient
 		clone.Transport = transport
+		client.httpClient = &clone
+	}
+
+	if client.retryOptions != nil {
+		baseTransport := client.httpClient.Transport
+		if baseTransport == nil {
+			baseTransport = http.DefaultTransport
+		}
+
+		clone := *client.httpClient
+		clone.Transport = &retryRoundTripper{base: baseTransport, opts: *client.retryOptions}
 		client.httpClient = &clone
 	}
 
@@ -302,8 +305,14 @@ func WithTransportConfig(cfg TransportConfig) ClientOptionFunc {
 // rest of the chain. When WithHTTPClient is also used, middleware wraps that
 // client's transport.
 func WithMiddleware(middlewares ...Middleware) ClientOptionFunc {
-	return func(c *Client) error {
-		c.middlewares = append(c.middlewares, middlewares...)
+	return func(client *Client) error {
+		for i, mw := range middlewares {
+			if mw == nil {
+				return fmt.Errorf("WithMiddleware: middleware at index %d is nil", i)
+			}
+		}
+
+		client.middlewares = append(client.middlewares, middlewares...)
 
 		return nil
 	}

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -30,6 +30,7 @@ type Client struct {
 	httpClient      *http.Client
 	retryOptions    *RetryOptions
 	transportConfig *TransportConfig
+	middlewares     []Middleware
 	userAgent       string
 
 	AlmIntegrations    *AlmIntegrationsService
@@ -229,6 +230,18 @@ func setDefaults(client *Client) error {
 		client.httpClient = &clone
 	}
 
+	if len(client.middlewares) > 0 {
+		baseTransport := client.httpClient.Transport
+		if baseTransport == nil {
+			baseTransport = http.DefaultTransport
+		}
+
+		transport := applyMiddlewares(baseTransport, client.middlewares)
+		clone := *client.httpClient
+		clone.Transport = transport
+		client.httpClient = &clone
+	}
+
 	if client.userAgent == "" {
 		client.userAgent = defaultUserAgent
 	}
@@ -279,6 +292,18 @@ func WithHTTPClient(httpClient *http.Client) ClientOptionFunc {
 func WithTransportConfig(cfg TransportConfig) ClientOptionFunc {
 	return func(c *Client) error {
 		c.transportConfig = &cfg
+
+		return nil
+	}
+}
+
+// WithMiddleware is a ClientOptionFunc that appends HTTP transport middleware to
+// the client. Middleware is applied outermost-first: middlewares[0] wraps the
+// rest of the chain. When WithHTTPClient is also used, middleware wraps that
+// client's transport.
+func WithMiddleware(middlewares ...Middleware) ClientOptionFunc {
+	return func(c *Client) error {
+		c.middlewares = append(c.middlewares, middlewares...)
 
 		return nil
 	}

--- a/sonar/middleware.go
+++ b/sonar/middleware.go
@@ -1,0 +1,21 @@
+package sonar
+
+import (
+	"net/http"
+	"slices"
+)
+
+// Middleware is a function that wraps an http.RoundTripper.
+// Use WithMiddleware to attach middleware to the client transport chain.
+type Middleware func(http.RoundTripper) http.RoundTripper
+
+// applyMiddlewares wraps base with each middleware in reverse order so that
+// middlewares[0] is the outermost (first to handle a request).
+func applyMiddlewares(base http.RoundTripper, middlewares []Middleware) http.RoundTripper {
+	transport := base
+	for _, mw := range slices.Backward(middlewares) {
+		transport = mw(transport)
+	}
+
+	return transport
+}

--- a/sonar/middleware_test.go
+++ b/sonar/middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -115,4 +116,58 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+// TestWithMiddleware_ObservesEveryRetryAttempt verifies that middleware sits inside
+// the retry transport so it is invoked once per attempt, not once per logical call.
+func TestWithMiddleware_ObservesEveryRetryAttempt(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	ts := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		if callCount < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middlewareCalls := 0
+	countingMW := func(next http.RoundTripper) http.RoundTripper {
+		return roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			middlewareCalls++
+			return next.RoundTrip(req)
+		})
+	}
+
+	client, err := NewClient(nil,
+		WithBaseURL(ts.url()),
+		WithMiddleware(countingMW),
+		WithRetry(RetryOptions{
+			MaxAttempts:          4,
+			InitialDelay:         time.Millisecond,
+			MaxDelay:             5 * time.Millisecond,
+			RetryableStatusCodes: []int{503},
+		}),
+	)
+	require.NoError(t, err)
+
+	req, err := client.NewSonarQubeV1APIRequest(context.Background(), http.MethodGet, "ping", nil)
+	require.NoError(t, err)
+
+	_, _ = client.Do(req, nil)
+
+	// 3 server calls → middleware must have been invoked 3 times (once per attempt).
+	assert.Equal(t, 3, middlewareCalls, "middleware should be called once per retry attempt")
+}
+
+// TestWithMiddleware_NilMiddlewareReturnsError verifies that a nil middleware value
+// is rejected at construction time rather than causing a panic later.
+func TestWithMiddleware_NilMiddlewareReturnsError(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewClient(nil, WithMiddleware(nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil")
 }

--- a/sonar/middleware_test.go
+++ b/sonar/middleware_test.go
@@ -1,0 +1,118 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingTransport is an http.RoundTripper that records whether it was called.
+//
+//nolint:exhaustruct // next is set explicitly; called is intentionally zero-value false
+type recordingTransport struct {
+	next   http.RoundTripper
+	called bool
+}
+
+func (r *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.called = true
+
+	return r.next.RoundTrip(req)
+}
+
+// TestWithMiddleware_WrapsTransport verifies that middleware is invoked on each request.
+func TestWithMiddleware_WrapsTransport(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, mockHandler(t, http.MethodGet, "/authentication/validate", http.StatusOK, nil))
+
+	recorder := &recordingTransport{}
+
+	mw := func(next http.RoundTripper) http.RoundTripper {
+		recorder.next = next
+
+		return recorder
+	}
+
+	client, err := NewClient(nil, WithBaseURL(ts.url()), WithMiddleware(mw))
+	require.NoError(t, err)
+
+	_, _, _ = client.Authentication.Validate(context.Background())
+
+	assert.True(t, recorder.called, "middleware RoundTripper should have been called")
+}
+
+// TestWithMiddleware_OutermostFirst verifies that the first middleware provided is
+// the outermost wrapper (first to execute on a request).
+func TestWithMiddleware_OutermostFirst(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, mockHandler(t, http.MethodGet, "/authentication/validate", http.StatusOK, nil))
+
+	var callOrder []int
+
+	makeOrderedMiddleware := func(id int) Middleware {
+		return func(next http.RoundTripper) http.RoundTripper {
+			return roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				callOrder = append(callOrder, id)
+
+				return next.RoundTrip(req)
+			})
+		}
+	}
+
+	client, err := NewClient(nil, WithBaseURL(ts.url()), WithMiddleware(makeOrderedMiddleware(1), makeOrderedMiddleware(2)))
+	require.NoError(t, err)
+
+	_, _, _ = client.Authentication.Validate(context.Background())
+
+	assert.Equal(t, []int{1, 2}, callOrder, "middleware should execute outermost (index 0) first")
+}
+
+// TestWithMiddleware_WithHTTPClient verifies that middleware wraps the transport of
+// a custom http.Client provided via WithHTTPClient.
+func TestWithMiddleware_WithHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, mockHandler(t, http.MethodGet, "/authentication/validate", http.StatusOK, nil))
+
+	innerRecorder := &recordingTransport{next: http.DefaultTransport}
+	customClient := &http.Client{Transport: innerRecorder}
+
+	outerRecorder := &recordingTransport{}
+
+	mw := func(next http.RoundTripper) http.RoundTripper {
+		outerRecorder.next = next
+
+		return outerRecorder
+	}
+
+	client, err := NewClient(nil, WithBaseURL(ts.url()), WithHTTPClient(customClient), WithMiddleware(mw))
+	require.NoError(t, err)
+
+	_, _, _ = client.Authentication.Validate(context.Background())
+
+	assert.True(t, outerRecorder.called, "outer middleware should have been called")
+	assert.True(t, innerRecorder.called, "inner custom transport should have been called through middleware chain")
+}
+
+// TestWithMiddleware_NoMiddleware_DefaultUnchanged verifies that when no middleware is
+// provided the client uses http.DefaultClient without wrapping it.
+func TestWithMiddleware_NoMiddleware_DefaultUnchanged(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(nil)
+	require.NoError(t, err)
+
+	assert.Same(t, http.DefaultClient, client.httpClient, "httpClient should be http.DefaultClient when no middleware is provided")
+}
+
+// roundTripFunc is a convenience type that implements http.RoundTripper via a function.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}


### PR DESCRIPTION
### Description of your changes

This PR introduces the Middleware type and WithMiddleware ClientOptionFunc so callers can inject logging, tracing, or custom-header logic without replacing the entire HTTP client. Middleware is applied outermost-first and wraps the transport of any custom client provided via WithHTTPClient.

Closes #204 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [ ] Added end-to-end tests if necessary.
