### PR TITLE
feat: add typed HTTP errors with sentinel helpers

### DIFF
--- a/sonar/client_util.go
+++ b/sonar/client_util.go
@@ -3,6 +3,7 @@ package sonar
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -72,9 +73,10 @@ func Do(httpClient *http.Client, req *http.Request, dest any) (*http.Response, e
 //
 //nolint:govet // fieldalignment: keeping logical field grouping for readability
 type ResponseError struct {
-	Body     []byte
-	Response *http.Response
-	Message  string
+	Body       []byte
+	Response   *http.Response
+	Message    string
+	StatusCode int
 }
 
 // Error returns the error message.
@@ -83,6 +85,36 @@ func (e *ResponseError) Error() string {
 	urlStr := fmt.Sprintf("%s://%s%s", e.Response.Request.URL.Scheme, e.Response.Request.URL.Host, path)
 
 	return fmt.Sprintf("%s %s: %d %s", e.Response.Request.Method, urlStr, e.Response.StatusCode, e.Message)
+}
+
+// IsNotFound reports whether err represents a 404 Not Found response.
+func IsNotFound(err error) bool { return httpStatusIs(err, http.StatusNotFound) }
+
+// IsUnauthorized reports whether err represents a 401 Unauthorized response.
+func IsUnauthorized(err error) bool { return httpStatusIs(err, http.StatusUnauthorized) }
+
+// IsForbidden reports whether err represents a 403 Forbidden response.
+func IsForbidden(err error) bool { return httpStatusIs(err, http.StatusForbidden) }
+
+// IsConflict reports whether err represents a 409 Conflict response.
+func IsConflict(err error) bool { return httpStatusIs(err, http.StatusConflict) }
+
+// IsRateLimited reports whether err represents a 429 Too Many Requests response.
+func IsRateLimited(err error) bool { return httpStatusIs(err, http.StatusTooManyRequests) }
+
+// IsServerError reports whether err represents a 5xx server-side error response.
+func IsServerError(err error) bool {
+	var re *ResponseError
+
+	return errors.As(err, &re) && re.StatusCode >= http.StatusInternalServerError && re.StatusCode < 600
+}
+
+// httpStatusIs reports whether err is a *ResponseError with the given status code.
+// It traverses the error chain via errors.As.
+func httpStatusIs(err error, statusCode int) bool {
+	var re *ResponseError
+
+	return errors.As(err, &re) && re.StatusCode == statusCode
 }
 
 // CheckResponse checks the API response for errors.
@@ -95,7 +127,8 @@ func CheckResponse(resp *http.Response) error {
 	}
 
 	errorResponse := &ResponseError{
-		Response: resp,
+		Response:   resp,
+		StatusCode: resp.StatusCode,
 	}
 
 	data, err := io.ReadAll(resp.Body)

--- a/sonar/client_util.go
+++ b/sonar/client_util.go
@@ -81,10 +81,14 @@ type ResponseError struct {
 
 // Error returns the error message.
 func (e *ResponseError) Error() string {
-	path, _ := url.QueryUnescape(e.Response.Request.URL.Path)
+	if e.Response == nil || e.Response.Request == nil {
+		return fmt.Sprintf("%d %s", e.StatusCode, e.Message)
+	}
+
+	path, _ := url.PathUnescape(e.Response.Request.URL.Path)
 	urlStr := fmt.Sprintf("%s://%s%s", e.Response.Request.URL.Scheme, e.Response.Request.URL.Host, path)
 
-	return fmt.Sprintf("%s %s: %d %s", e.Response.Request.Method, urlStr, e.Response.StatusCode, e.Message)
+	return fmt.Sprintf("%s %s: %d %s", e.Response.Request.Method, urlStr, e.StatusCode, e.Message)
 }
 
 // IsNotFound reports whether err represents a 404 Not Found response.

--- a/sonar/client_util_test.go
+++ b/sonar/client_util_test.go
@@ -206,6 +206,51 @@ func makeAPIError(statusCode int) *ResponseError {
 	}
 }
 
+func TestResponseError_Error_NilResponse(t *testing.T) {
+	// Must not panic when Response or Request is nil.
+	re := &ResponseError{StatusCode: http.StatusNotFound, Message: "not found"}
+	assert.Equal(t, "404 not found", re.Error())
+}
+
+func TestResponseError_Error_NilRequest(t *testing.T) {
+	//nolint:exhaustruct // only fields needed for test populated
+	re := &ResponseError{
+		Response:   &http.Response{StatusCode: http.StatusInternalServerError},
+		StatusCode: http.StatusInternalServerError,
+		Message:    "internal error",
+	}
+	assert.Equal(t, "500 internal error", re.Error())
+}
+
+func TestResponseError_Error_UsesStatusCodeField(t *testing.T) {
+	// StatusCode field is canonical; Response.StatusCode is not used in Error().
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+
+	//nolint:exhaustruct // only fields needed for test populated
+	re := &ResponseError{
+		Response:   &http.Response{StatusCode: 999, Request: req},
+		StatusCode: http.StatusNotFound,
+		Message:    "not found",
+	}
+
+	assert.Contains(t, re.Error(), "404")
+	assert.NotContains(t, re.Error(), "999")
+}
+
+func TestResponseError_Error_PathUnescape(t *testing.T) {
+	// Encoded path segments must be unescaped correctly in the error string.
+	req := httptest.NewRequest(http.MethodGet, "/api/my%20resource", nil)
+
+	//nolint:exhaustruct // only fields needed for test populated
+	re := &ResponseError{
+		Response:   &http.Response{StatusCode: http.StatusNotFound, Request: req},
+		StatusCode: http.StatusNotFound,
+		Message:    "not found",
+	}
+
+	assert.Contains(t, re.Error(), "/api/my resource")
+}
+
 func TestJsonStructToQueryValues(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/sonar/client_util_test.go
+++ b/sonar/client_util_test.go
@@ -128,6 +128,84 @@ func TestNewRequest_BasicAuth(t *testing.T) {
 	assert.Equal(t, "pass", password)
 }
 
+func TestCheckResponse_PopulatesStatusCode(t *testing.T) {
+	for _, code := range []int{http.StatusNotFound, http.StatusUnauthorized, http.StatusForbidden, http.StatusConflict, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		t.Run(fmt.Sprintf("%d", code), func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: code,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+				Request:    httptest.NewRequest(http.MethodGet, "/api/test", nil),
+			}
+
+			err := CheckResponse(resp)
+			require.Error(t, err)
+
+			var re *ResponseError
+			require.ErrorAs(t, err, &re)
+			assert.Equal(t, code, re.StatusCode)
+		})
+	}
+}
+
+func TestIsNotFound(t *testing.T) {
+	assert.True(t, IsNotFound(makeAPIError(http.StatusNotFound)))
+	assert.False(t, IsNotFound(makeAPIError(http.StatusUnauthorized)))
+	assert.False(t, IsNotFound(nil))
+	assert.False(t, IsNotFound(fmt.Errorf("plain error")))
+}
+
+func TestIsUnauthorized(t *testing.T) {
+	assert.True(t, IsUnauthorized(makeAPIError(http.StatusUnauthorized)))
+	assert.False(t, IsUnauthorized(makeAPIError(http.StatusNotFound)))
+}
+
+func TestIsForbidden(t *testing.T) {
+	assert.True(t, IsForbidden(makeAPIError(http.StatusForbidden)))
+	assert.False(t, IsForbidden(makeAPIError(http.StatusUnauthorized)))
+}
+
+func TestIsConflict(t *testing.T) {
+	assert.True(t, IsConflict(makeAPIError(http.StatusConflict)))
+	assert.False(t, IsConflict(makeAPIError(http.StatusNotFound)))
+}
+
+func TestIsRateLimited(t *testing.T) {
+	assert.True(t, IsRateLimited(makeAPIError(http.StatusTooManyRequests)))
+	assert.False(t, IsRateLimited(makeAPIError(http.StatusForbidden)))
+}
+
+func TestIsServerError(t *testing.T) {
+	assert.True(t, IsServerError(makeAPIError(http.StatusInternalServerError)))
+	assert.True(t, IsServerError(makeAPIError(http.StatusBadGateway)))
+	assert.True(t, IsServerError(makeAPIError(599)))
+	assert.False(t, IsServerError(makeAPIError(http.StatusNotFound)))
+	assert.False(t, IsServerError(makeAPIError(http.StatusTooManyRequests)))
+}
+
+func TestSentinels_WorkThroughWrappingChain(t *testing.T) {
+	inner := makeAPIError(http.StatusNotFound)
+	wrapped := fmt.Errorf("operation failed: %w", inner)
+
+	assert.True(t, IsNotFound(wrapped))
+	assert.False(t, IsUnauthorized(wrapped))
+}
+
+// makeAPIError creates a *ResponseError with the given status code for testing.
+func makeAPIError(statusCode int) *ResponseError {
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+
+	//nolint:exhaustruct // only fields needed for test populated
+	return &ResponseError{
+		Response: &http.Response{
+			StatusCode: statusCode,
+			Request:    req,
+		},
+		StatusCode: statusCode,
+		Message:    fmt.Sprintf("status %d", statusCode),
+	}
+}
+
 func TestJsonStructToQueryValues(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
### Description of your changes

This PR implements client helpers to determine the error type quickly.

- Add StatusCode int field to ResponseError, populated in CheckResponse
- Add IsNotFound, IsUnauthorized, IsForbidden, IsConflict, IsRateLimited, IsServerError sentinel helpers backed by errors.As traversal
- IsServerError matches the full 5xx range (500–599)
- All helpers work through fmt.Errorf("%w", ...) wrapping chains
- Raw *http.Response remains accessible on ResponseError as before

Closes #206 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [ ] Added end-to-end tests if necessary.
