### PR TITLE
feat: add search / list all methods

### DIFF
--- a/integration_testing/hotspots_test.go
+++ b/integration_testing/hotspots_test.go
@@ -490,4 +490,68 @@ var _ = Describe("Hotspots Service", Ordered, func() {
 			})
 		})
 	})
+
+	// =========================================================================
+	// ListAll
+	// =========================================================================
+	Describe("ListAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all hotspots as a flat slice", func() {
+				result, resp, err := client.Hotspots.ListAll(context.Background(), &sonar.HotspotsListOptions{
+					Project: projectKey,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Hotspots.ListAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+
+			It("should fail without required project", func() {
+				result, resp, err := client.Hotspots.ListAll(context.Background(), &sonar.HotspotsListOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// SearchAll
+	// =========================================================================
+	Describe("SearchAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all hotspots as a flat slice", func() {
+				result, resp, err := client.Hotspots.SearchAll(context.Background(), &sonar.HotspotsSearchOptions{
+					Project: projectKey,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Hotspots.SearchAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+
+			It("should fail without project or hotspots parameter", func() {
+				result, resp, err := client.Hotspots.SearchAll(context.Background(), &sonar.HotspotsSearchOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
 })

--- a/integration_testing/issues_test.go
+++ b/integration_testing/issues_test.go
@@ -884,4 +884,53 @@ var _ = Describe("Issues Service", Ordered, func() {
 			})
 		})
 	})
+
+	// =========================================================================
+	// ListAll
+	// =========================================================================
+	Describe("ListAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all issues as a flat slice", func() {
+				result, resp, err := client.Issues.ListAll(context.Background(), &sonar.IssuesListOptions{
+					Project: projectKey,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				// Result may be empty on a fresh project; just verify it's a valid slice
+				_ = result
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Issues.ListAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// SearchAll
+	// =========================================================================
+	Describe("SearchAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all issues for a project as a flat slice", func() {
+				result, resp, err := client.Issues.SearchAll(context.Background(), &sonar.IssuesSearchOptions{
+					Projects: []string{projectKey},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+
+			It("should accept nil options", func() {
+				result, resp, err := client.Issues.SearchAll(context.Background(), nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+		})
+	})
 })

--- a/integration_testing/issues_test.go
+++ b/integration_testing/issues_test.go
@@ -894,9 +894,12 @@ var _ = Describe("Issues Service", Ordered, func() {
 				result, resp, err := client.Issues.ListAll(context.Background(), &sonar.IssuesListOptions{
 					Project: projectKey,
 				})
+				// 503 while indexing is in progress on a fresh instance
+				if resp != nil && resp.StatusCode == http.StatusServiceUnavailable {
+					Skip("Issue indexing is in progress")
+				}
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp).NotTo(BeNil())
-				// Result may be empty on a fresh project; just verify it's a valid slice
 				_ = result
 			})
 		})
@@ -920,6 +923,10 @@ var _ = Describe("Issues Service", Ordered, func() {
 				result, resp, err := client.Issues.SearchAll(context.Background(), &sonar.IssuesSearchOptions{
 					Projects: []string{projectKey},
 				})
+				// 503 while indexing is in progress on a fresh instance
+				if resp != nil && resp.StatusCode == http.StatusServiceUnavailable {
+					Skip("Issue indexing is in progress")
+				}
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp).NotTo(BeNil())
 				_ = result
@@ -927,6 +934,10 @@ var _ = Describe("Issues Service", Ordered, func() {
 
 			It("should accept nil options", func() {
 				result, resp, err := client.Issues.SearchAll(context.Background(), nil)
+				// 503 while indexing is in progress on a fresh instance
+				if resp != nil && resp.StatusCode == http.StatusServiceUnavailable {
+					Skip("Issue indexing is in progress")
+				}
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp).NotTo(BeNil())
 				_ = result

--- a/integration_testing/metrics_test.go
+++ b/integration_testing/metrics_test.go
@@ -138,4 +138,38 @@ var _ = Describe("Metrics Service", Ordered, func() {
 			})
 		})
 	})
+
+	// =========================================================================
+	// SearchAll
+	// =========================================================================
+	Describe("SearchAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all metrics as a flat slice with nil options", func() {
+				result, resp, err := client.Metrics.SearchAll(context.Background(), nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(result).NotTo(BeEmpty())
+			})
+
+			It("should return all metrics as a flat slice with empty options", func() {
+				result, resp, err := client.Metrics.SearchAll(context.Background(), &sonar.MetricsSearchOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(result).NotTo(BeEmpty())
+			})
+
+			It("should include common built-in metrics", func() {
+				result, _, err := client.Metrics.SearchAll(context.Background(), nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				keys := make(map[string]bool, len(result))
+				for _, m := range result {
+					keys[m.Key] = true
+				}
+
+				Expect(keys["bugs"]).To(BeTrue())
+				Expect(keys["coverage"]).To(BeTrue())
+			})
+		})
+	})
 })

--- a/integration_testing/permissions_test.go
+++ b/integration_testing/permissions_test.go
@@ -1919,4 +1919,124 @@ var _ = Describe("Permissions Service", Ordered, func() {
 			})
 		})
 	})
+
+	// =========================================================================
+	// GroupsAll
+	// =========================================================================
+	Describe("GroupsAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all groups as a flat slice with nil options", func() {
+				result, resp, err := client.Permissions.GroupsAll(context.Background(), nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+
+			It("should return all groups as a flat slice with empty options", func() {
+				result, resp, err := client.Permissions.GroupsAll(context.Background(), &sonar.PermissionsGroupsOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+		})
+	})
+
+	// =========================================================================
+	// TemplateGroupsAll
+	// =========================================================================
+	Describe("TemplateGroupsAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all groups for a template as a flat slice", func() {
+				templateName := helpers.UniqueResourceName("tmpl-grpall")
+
+				_, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
+					Name: templateName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				cleanup.RegisterCleanup("template", templateName, func() error {
+					_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
+						TemplateName: templateName,
+					})
+					return err
+				})
+
+				result, resp, err := client.Permissions.TemplateGroupsAll(context.Background(), &sonar.PermissionsTemplateGroupsOptions{
+					TemplateName: templateName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Permissions.TemplateGroupsAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// TemplateUsersAll
+	// =========================================================================
+	Describe("TemplateUsersAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all users for a template as a flat slice", func() {
+				templateName := helpers.UniqueResourceName("tmpl-usrall")
+
+				_, _, err := client.Permissions.CreateTemplate(context.Background(), &sonar.PermissionsCreateTemplateOptions{
+					Name: templateName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				cleanup.RegisterCleanup("template", templateName, func() error {
+					_, err := client.Permissions.DeleteTemplate(context.Background(), &sonar.PermissionsDeleteTemplateOptions{
+						TemplateName: templateName,
+					})
+					return err
+				})
+
+				result, resp, err := client.Permissions.TemplateUsersAll(context.Background(), &sonar.PermissionsTemplateUsersOptions{
+					TemplateName: templateName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Permissions.TemplateUsersAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// UsersAll
+	// =========================================================================
+	Describe("UsersAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all users with permissions as a flat slice with nil options", func() {
+				result, resp, err := client.Permissions.UsersAll(context.Background(), nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+
+			It("should return all users with permissions as a flat slice with empty options", func() {
+				result, resp, err := client.Permissions.UsersAll(context.Background(), &sonar.PermissionsUsersOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+		})
+	})
 })

--- a/integration_testing/projects_test.go
+++ b/integration_testing/projects_test.go
@@ -897,4 +897,74 @@ var _ = Describe("Projects Service", Ordered, func() {
 			}
 		})
 	})
+
+	// =========================================================================
+	// SearchAll
+	// =========================================================================
+	Describe("SearchAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all projects as a flat slice", func() {
+				projectKey := helpers.UniqueResourceName("proj-searchall")
+
+				_, _, err := client.Projects.Create(context.Background(), &sonar.ProjectsCreateOptions{
+					Name:    "SearchAll Test",
+					Project: projectKey,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				cleanup.RegisterCleanup("project", projectKey, func() error {
+					_, err := client.Projects.Delete(context.Background(), &sonar.ProjectsDeleteOptions{
+						Project: projectKey,
+					})
+					return err
+				})
+
+				result, resp, err := client.Projects.SearchAll(context.Background(), &sonar.ProjectsSearchOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+
+				found := false
+				for _, c := range result {
+					if c.Key == projectKey {
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue())
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Projects.SearchAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// SearchMyProjectsAll
+	// =========================================================================
+	Describe("SearchMyProjectsAll", func() {
+		Context("Functional Tests", func() {
+			It("should return projects as a flat slice", func() {
+				result, resp, err := client.Projects.SearchMyProjectsAll(context.Background(), &sonar.ProjectsSearchMyProjectsOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				// result may be empty on a fresh install; just verify it's a valid slice
+				_ = result
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Projects.SearchMyProjectsAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
 })

--- a/integration_testing/qualitygates_test.go
+++ b/integration_testing/qualitygates_test.go
@@ -1392,4 +1392,131 @@ var _ = Describe("Qualitygates Service", Ordered, func() {
 			}
 		})
 	})
+
+	// =========================================================================
+	// SearchAll
+	// =========================================================================
+	Describe("SearchAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all projects as a flat slice", func() {
+				gateName := helpers.UniqueResourceName("qg-searchall")
+
+				_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
+					Name: gateName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				cleanup.RegisterCleanup("qualitygate", gateName, func() error {
+					_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
+						Name: gateName,
+					})
+					return err
+				})
+
+				result, resp, err := client.Qualitygates.SearchAll(context.Background(), &sonar.QualitygatesSearchOptions{
+					GateName: gateName,
+					Selected: sonar.SelectionFilterAll,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Qualitygates.SearchAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+
+			It("should fail with missing gate name", func() {
+				result, resp, err := client.Qualitygates.SearchAll(context.Background(), &sonar.QualitygatesSearchOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// SearchGroupsAll
+	// =========================================================================
+	Describe("SearchGroupsAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all groups as a flat slice", func() {
+				gateName := helpers.UniqueResourceName("qg-sgrpall")
+
+				_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
+					Name: gateName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				cleanup.RegisterCleanup("qualitygate", gateName, func() error {
+					_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
+						Name: gateName,
+					})
+					return err
+				})
+
+				result, resp, err := client.Qualitygates.SearchGroupsAll(context.Background(), &sonar.QualitygatesSearchGroupsOptions{
+					GateName: gateName,
+					Selected: sonar.SelectionFilterAll,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Qualitygates.SearchGroupsAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// SearchUsersAll
+	// =========================================================================
+	Describe("SearchUsersAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all users as a flat slice", func() {
+				gateName := helpers.UniqueResourceName("qg-susrall")
+
+				_, _, err := client.Qualitygates.Create(context.Background(), &sonar.QualitygatesCreateOptions{
+					Name: gateName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				cleanup.RegisterCleanup("qualitygate", gateName, func() error {
+					_, err := client.Qualitygates.Delete(context.Background(), &sonar.QualitygatesDeleteOptions{
+						Name: gateName,
+					})
+					return err
+				})
+
+				result, resp, err := client.Qualitygates.SearchUsersAll(context.Background(), &sonar.QualitygatesSearchUsersOptions{
+					GateName: gateName,
+					Selected: sonar.SelectionFilterAll,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Qualitygates.SearchUsersAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
 })

--- a/integration_testing/qualityprofiles_test.go
+++ b/integration_testing/qualityprofiles_test.go
@@ -1730,4 +1730,174 @@ var _ = Describe("Qualityprofiles Service", Ordered, func() {
 			Expect(*backupResult).NotTo(BeEmpty())
 		})
 	})
+
+	// =========================================================================
+	// ChangelogAll
+	// =========================================================================
+	Describe("ChangelogAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all changelog events as a flat slice", func() {
+				profileName := helpers.UniqueResourceName("qp-chlogall")
+
+				_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
+					Name:     profileName,
+					Language: "java",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
+					_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
+						QualityProfile: profileName,
+						Language:       "java",
+					})
+					return err
+				})
+
+				result, resp, err := client.Qualityprofiles.ChangelogAll(context.Background(), &sonar.QualityprofilesChangelogOptions{
+					QualityProfile: profileName,
+					Language:       "java",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Qualityprofiles.ChangelogAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// ProjectsAll
+	// =========================================================================
+	Describe("ProjectsAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all projects as a flat slice", func() {
+				profileName := helpers.UniqueResourceName("qp-projall")
+
+				createResult, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
+					Name:     profileName,
+					Language: "java",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(createResult).NotTo(BeNil())
+
+				cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
+					_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
+						QualityProfile: profileName,
+						Language:       "java",
+					})
+					return err
+				})
+
+				result, resp, err := client.Qualityprofiles.ProjectsAll(context.Background(), &sonar.QualityprofilesProjectsOptions{
+					Key: createResult.Profile.Key,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Qualityprofiles.ProjectsAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// SearchGroupsAll
+	// =========================================================================
+	Describe("SearchGroupsAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all groups as a flat slice", func() {
+				profileName := helpers.UniqueResourceName("qp-sgrpall")
+
+				_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
+					Name:     profileName,
+					Language: "java",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
+					_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
+						QualityProfile: profileName,
+						Language:       "java",
+					})
+					return err
+				})
+
+				result, resp, err := client.Qualityprofiles.SearchGroupsAll(context.Background(), &sonar.QualityprofilesSearchGroupsOptions{
+					Language:       "java",
+					QualityProfile: profileName,
+					Selected:       sonar.SelectionFilterAll,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Qualityprofiles.SearchGroupsAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// SearchUsersAll
+	// =========================================================================
+	Describe("SearchUsersAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all users as a flat slice", func() {
+				profileName := helpers.UniqueResourceName("qp-susrall")
+
+				_, _, err := client.Qualityprofiles.Create(context.Background(), &sonar.QualityprofilesCreateOptions{
+					Name:     profileName,
+					Language: "java",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				cleanup.RegisterCleanup("qualityprofile", profileName, func() error {
+					_, err := client.Qualityprofiles.Delete(context.Background(), &sonar.QualityprofilesDeleteOptions{
+						QualityProfile: profileName,
+						Language:       "java",
+					})
+					return err
+				})
+
+				result, resp, err := client.Qualityprofiles.SearchUsersAll(context.Background(), &sonar.QualityprofilesSearchUsersOptions{
+					Language:       "java",
+					QualityProfile: profileName,
+					Selected:       sonar.SelectionFilterAll,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				_ = result
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Qualityprofiles.SearchUsersAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
 })

--- a/integration_testing/rules_test.go
+++ b/integration_testing/rules_test.go
@@ -854,4 +854,36 @@ var _ = Describe("Rules Service", Ordered, func() {
 			Expect(result).NotTo(BeNil())
 		})
 	})
+
+	// =========================================================================
+	// SearchAll
+	// =========================================================================
+	Describe("SearchAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all rules as a flat slice with nil options", func() {
+				result, resp, err := client.Rules.SearchAll(context.Background(), nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(result).NotTo(BeEmpty())
+			})
+
+			It("should return all rules as a flat slice with empty options", func() {
+				result, resp, err := client.Rules.SearchAll(context.Background(), &sonar.RulesSearchOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(result).NotTo(BeEmpty())
+			})
+
+			It("should filter by language", func() {
+				result, resp, err := client.Rules.SearchAll(context.Background(), &sonar.RulesSearchOptions{
+					Languages: []string{"java"},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				for _, r := range result {
+					Expect(r.Lang).To(Equal("java"))
+				}
+			})
+		})
+	})
 })

--- a/integration_testing/user_groups_test.go
+++ b/integration_testing/user_groups_test.go
@@ -1008,4 +1008,72 @@ var _ = Describe("UserGroups Service", Ordered, func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+
+	// =========================================================================
+	// SearchAll
+	// =========================================================================
+	Describe("SearchAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all groups as a flat slice", func() {
+				//nolint:staticcheck // Using deprecated API until v2 API is implemented
+				result, resp, err := client.UserGroups.SearchAll(context.Background(), &sonar.UserGroupsSearchOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(result).NotTo(BeEmpty())
+			})
+
+			It("should include the built-in sonar-users group", func() {
+				//nolint:staticcheck // Using deprecated API until v2 API is implemented
+				result, _, err := client.UserGroups.SearchAll(context.Background(), &sonar.UserGroupsSearchOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				found := false
+				for _, g := range result {
+					if g.Name == "sonar-users" {
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue())
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				//nolint:staticcheck // Using deprecated API until v2 API is implemented
+				result, resp, err := client.UserGroups.SearchAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// UsersAll
+	// =========================================================================
+	Describe("UsersAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all users in a group as a flat slice", func() {
+				//nolint:staticcheck // Using deprecated API until v2 API is implemented
+				result, resp, err := client.UserGroups.UsersAll(context.Background(), &sonar.UserGroupsUsersOptions{
+					Name: "sonar-users",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				// sonar-users always contains at least the admin user
+				Expect(result).NotTo(BeEmpty())
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				//nolint:staticcheck // Using deprecated API until v2 API is implemented
+				result, resp, err := client.UserGroups.UsersAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
 })

--- a/integration_testing/users_test.go
+++ b/integration_testing/users_test.go
@@ -982,4 +982,61 @@ var _ = Describe("Users Service", Ordered, func() {
 			Expect(deactivateResult.User.Active).To(BeFalse())
 		})
 	})
+
+	// =========================================================================
+	// SearchAll
+	// =========================================================================
+	Describe("SearchAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all users as a flat slice with nil options", func() {
+				//nolint:staticcheck // Using deprecated API until v2 API is implemented
+				result, resp, err := client.Users.SearchAll(context.Background(), nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(result).NotTo(BeEmpty())
+			})
+
+			It("should include the admin user", func() {
+				//nolint:staticcheck // Using deprecated API until v2 API is implemented
+				result, _, err := client.Users.SearchAll(context.Background(), nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				found := false
+				for _, u := range result {
+					if u.Login == "admin" {
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue())
+			})
+		})
+	})
+
+	// =========================================================================
+	// GroupsAll
+	// =========================================================================
+	Describe("GroupsAll", func() {
+		Context("Functional Tests", func() {
+			It("should return all groups for a user as a flat slice", func() {
+				//nolint:staticcheck // Using deprecated API until v2 API is implemented
+				result, resp, err := client.Users.GroupsAll(context.Background(), &sonar.UsersGroupsOptions{
+					Login: "admin",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(result).NotTo(BeEmpty())
+			})
+		})
+
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				//nolint:staticcheck // Using deprecated API until v2 API is implemented
+				result, resp, err := client.Users.GroupsAll(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
 })

--- a/sonar/hotspots_service.go
+++ b/sonar/hotspots_service.go
@@ -967,3 +967,41 @@ func (s *HotspotsService) Show(ctx context.Context, opt *HotspotsShowOptions) (*
 
 	return result, resp, nil
 }
+
+// ListAll fetches all pages from List and returns a flat slice of hotspots.
+func (s *HotspotsService) ListAll(ctx context.Context, opt *HotspotsListOptions) ([]HotspotSummary, *http.Response, error) {
+	err := s.ValidateListOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]HotspotSummary, int64, *http.Response, error) {
+		r, resp, err := s.List(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Hotspots, r.Paging.Total, resp, nil
+	})
+}
+
+// SearchAll fetches all pages from Search and returns a flat slice of hotspots.
+func (s *HotspotsService) SearchAll(ctx context.Context, opt *HotspotsSearchOptions) ([]HotspotSummary, *http.Response, error) {
+	err := s.ValidateSearchOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]HotspotSummary, int64, *http.Response, error) {
+		r, resp, err := s.Search(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Hotspots, r.Paging.Total, resp, nil
+	})
+}

--- a/sonar/hotspots_service_test.go
+++ b/sonar/hotspots_service_test.go
@@ -952,3 +952,59 @@ func TestHotspots_ValidateListOpt(t *testing.T) {
 		})
 	}
 }
+
+func TestHotspotsService_ListAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"hotspots":[{"key":"h1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"hotspots":[{"key":"h2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &HotspotsListOptions{Project: "myproject"}
+		result, _, err := client.Hotspots.ListAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Hotspots.ListAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestHotspotsService_SearchAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"hotspots":[{"key":"h1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"hotspots":[{"key":"h2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &HotspotsSearchOptions{Project: "myproject"}
+		result, _, err := client.Hotspots.SearchAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Hotspots.SearchAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}

--- a/sonar/issues_service.go
+++ b/sonar/issues_service.go
@@ -1704,3 +1704,44 @@ func (s *IssuesService) ValidateTagsOpt(opt *IssuesTagsOptions) error {
 
 	return nil
 }
+
+// ListAll fetches all pages from List and returns a flat slice of issues.
+func (s *IssuesService) ListAll(ctx context.Context, opt *IssuesListOptions) ([]Issue, *http.Response, error) {
+	err := s.ValidateListOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]Issue, int64, *http.Response, error) {
+		r, resp, err := s.List(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Issues, r.Paging.Total, resp, nil
+	})
+}
+
+// SearchAll fetches all pages from Search and returns a flat slice of issues.
+func (s *IssuesService) SearchAll(ctx context.Context, opt *IssuesSearchOptions) ([]Issue, *http.Response, error) {
+	err := s.ValidateSearchOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var opts IssuesSearchOptions
+	if opt != nil {
+		opts = *opt
+	}
+
+	return allPages(ctx, &opts.Page, &opts.PageSize, func(ctx context.Context) ([]Issue, int64, *http.Response, error) {
+		r, resp, err := s.Search(ctx, &opts)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Issues, r.Paging.Total, resp, nil
+	})
+}

--- a/sonar/issues_service_test.go
+++ b/sonar/issues_service_test.go
@@ -1137,3 +1137,53 @@ func TestIssues_ValidateTagsOpt(t *testing.T) {
 		})
 	}
 }
+
+func TestIssuesService_ListAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"issues":[{"key":"i1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"issues":[{"key":"i2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &IssuesListOptions{Project: "myproject"}
+		result, _, err := client.Issues.ListAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Issues.ListAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestIssuesService_SearchAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"issues":[{"key":"i1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"issues":[{"key":"i2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &IssuesSearchOptions{}
+		result, _, err := client.Issues.SearchAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+}

--- a/sonar/metrics_service.go
+++ b/sonar/metrics_service.go
@@ -128,3 +128,25 @@ func (s *MetricsService) Types(ctx context.Context) (*MetricsTypes, *http.Respon
 
 	return result, resp, nil
 }
+
+// SearchAll fetches all pages from Search and returns a flat slice of metrics.
+func (s *MetricsService) SearchAll(ctx context.Context, opt *MetricsSearchOptions) ([]Metric, *http.Response, error) {
+	err := s.ValidateSearchOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var opts MetricsSearchOptions
+	if opt != nil {
+		opts = *opt
+	}
+
+	return allPages(ctx, &opts.Page, &opts.PageSize, func(ctx context.Context) ([]Metric, int64, *http.Response, error) {
+		r, resp, err := s.Search(ctx, &opts)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Metrics, r.Paging.Total, resp, nil
+	})
+}

--- a/sonar/metrics_service_test.go
+++ b/sonar/metrics_service_test.go
@@ -113,3 +113,25 @@ func TestMetrics_ValidateSearchOpt(t *testing.T) {
 		})
 	}
 }
+
+func TestMetricsService_SearchAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"metrics":[{"key":"coverage"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"metrics":[{"key":"bugs"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &MetricsSearchOptions{}
+		result, _, err := client.Metrics.SearchAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+}

--- a/sonar/pagination.go
+++ b/sonar/pagination.go
@@ -1,0 +1,58 @@
+package sonar
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// allPages fetches every page from a V1 paginated endpoint, accumulating items
+// into a single slice. page and pageSize are pointers into the caller's options
+// struct so the helper can advance pagination without an extra allocation.
+//
+// fetch wraps the single-page call and extracts (items, total, response, err).
+// If the context is cancelled between pages, allPages returns the items
+// collected so far together with the context error.
+func allPages[T any](
+	ctx context.Context,
+	page *int64,
+	pageSize *int64,
+	fetch func(context.Context) ([]T, int64, *http.Response, error),
+) ([]T, *http.Response, error) {
+	*page = 1
+
+	if *pageSize == 0 {
+		*pageSize = MaxPageSize
+	}
+
+	var all []T
+
+	var resp *http.Response
+
+	for {
+		ctxErr := ctx.Err()
+		if ctxErr != nil {
+			return all, resp, fmt.Errorf("%w", ctxErr)
+		}
+
+		items, total, r, err := fetch(ctx)
+		resp = r
+
+		if err != nil {
+			ctxErr = ctx.Err()
+			if ctxErr != nil {
+				return all, resp, fmt.Errorf("%w", ctxErr)
+			}
+
+			return nil, resp, err
+		}
+
+		all = append(all, items...)
+
+		if int64(len(all)) >= total {
+			return all, resp, nil
+		}
+
+		*page++
+	}
+}

--- a/sonar/pagination_test.go
+++ b/sonar/pagination_test.go
@@ -1,0 +1,112 @@
+package sonar
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildMetricItems returns a JSON array string with n metric objects.
+func buildMetricItems(start, count int) string {
+	parts := make([]string, count)
+	for i := range parts {
+		parts[i] = fmt.Sprintf(`{"key":"m%d"}`, start+i)
+	}
+
+	return "[" + strings.Join(parts, ",") + "]"
+}
+
+// TestAllPages_QueryParameters verifies that allPages sends the correct query
+// parameters: ps defaults to MaxPageSize (500) when not set, and p advances by
+// one for each subsequent request.
+func TestAllPages_QueryParameters(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		queries []url.Values
+	)
+
+	const total = 501 // forces two pages at pageSize=500
+
+	callCount := 0
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		queries = append(queries, r.URL.Query())
+		callCount++
+		local := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if local == 1 {
+			// First page: 500 items, 1 more remains.
+			items := buildMetricItems(1, 500)
+			fmt.Fprintf(w, `{"paging":{"pageIndex":1,"pageSize":500,"total":%d},"metrics":%s}`, total, items)
+		} else {
+			// Second page: final 1 item.
+			fmt.Fprintf(w, `{"paging":{"pageIndex":2,"pageSize":500,"total":%d},"metrics":[{"key":"m501"}]}`, total)
+		}
+	})
+
+	client := newTestClient(t, server.URL)
+
+	// No page size specified — allPages must default to MaxPageSize (500).
+	result, _, err := client.Metrics.SearchAll(context.Background(), &MetricsSearchOptions{})
+	require.NoError(t, err)
+	assert.Len(t, result, total)
+	require.Len(t, queries, 2)
+
+	// First request: must use MaxPageSize and start at page 1.
+	assert.Equal(t, "500", queries[0].Get("ps"), "first request must use maximum page size")
+	assert.Equal(t, "1", queries[0].Get("p"), "first request must start at page 1")
+
+	// Second request: page size unchanged, page number advances.
+	assert.Equal(t, "500", queries[1].Get("ps"), "second request must keep the same page size")
+	assert.Equal(t, "2", queries[1].Get("p"), "second request must advance to page 2")
+}
+
+// TestAllPages_ContextCancellation verifies that when the context is cancelled
+// between pages, allPages returns the partial results collected so far together
+// with a wrapped context.Canceled error, without making another HTTP request.
+//
+// The fetch function is mocked directly so we avoid any race between the HTTP
+// transport and context propagation.
+func TestAllPages_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	callCount := 0
+	page := int64(0)
+	pageSize := int64(0) // will be defaulted to MaxPageSize by allPages
+
+	fakeResp := &http.Response{StatusCode: http.StatusOK}
+
+	fetch := func(_ context.Context) ([]string, int64, *http.Response, error) {
+		callCount++
+		// After delivering the first page, cancel so the next iteration sees a
+		// cancelled context before issuing another request.
+		cancel()
+
+		return []string{"item1"}, 3, fakeResp, nil // total=3 requires more pages
+	}
+
+	result, resp, err := allPages(ctx, &page, &pageSize, fetch)
+
+	// Partial results from the completed page must be present.
+	require.Len(t, result, 1)
+	assert.Equal(t, "item1", result[0])
+
+	// The error must wrap context.Canceled.
+	assert.ErrorIs(t, err, context.Canceled)
+
+	// The response from the last successful fetch must be returned.
+	assert.Equal(t, fakeResp, resp)
+
+	// No second fetch must have been made.
+	assert.Equal(t, 1, callCount, "must not issue a second request after cancellation")
+}

--- a/sonar/permissions_service.go
+++ b/sonar/permissions_service.go
@@ -1671,3 +1671,105 @@ func (s *PermissionsService) Users(ctx context.Context, opt *PermissionsUsersOpt
 
 	return result, resp, nil
 }
+
+// permissionsMaxPageSize is the maximum page size accepted by permissions API endpoints.
+// The permissions API enforces a lower limit than the global MaxPageSize of 500.
+const permissionsMaxPageSize int64 = 100
+
+// GroupsAll fetches all pages from Groups and returns a flat slice of groups.
+func (s *PermissionsService) GroupsAll(ctx context.Context, opt *PermissionsGroupsOptions) ([]PermissionGroup, *http.Response, error) {
+	err := s.ValidateGroupsOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var opts PermissionsGroupsOptions
+	if opt != nil {
+		opts = *opt
+	}
+
+	if opts.PageSize == 0 || opts.PageSize > permissionsMaxPageSize {
+		opts.PageSize = permissionsMaxPageSize
+	}
+
+	return allPages(ctx, &opts.Page, &opts.PageSize, func(ctx context.Context) ([]PermissionGroup, int64, *http.Response, error) {
+		r, resp, err := s.Groups(ctx, &opts)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Groups, r.Paging.Total, resp, nil
+	})
+}
+
+// TemplateGroupsAll fetches all pages from TemplateGroups and returns a flat slice of groups.
+func (s *PermissionsService) TemplateGroupsAll(ctx context.Context, opt *PermissionsTemplateGroupsOptions) ([]PermissionsTemplateGroup, *http.Response, error) {
+	err := s.ValidateTemplateGroupsOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	opts := *opt
+
+	if opts.PageSize == 0 || opts.PageSize > permissionsMaxPageSize {
+		opts.PageSize = permissionsMaxPageSize
+	}
+
+	return allPages(ctx, &opts.Page, &opts.PageSize, func(ctx context.Context) ([]PermissionsTemplateGroup, int64, *http.Response, error) {
+		r, resp, err := s.TemplateGroups(ctx, &opts)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Groups, r.Paging.Total, resp, nil
+	})
+}
+
+// TemplateUsersAll fetches all pages from TemplateUsers and returns a flat slice of users.
+func (s *PermissionsService) TemplateUsersAll(ctx context.Context, opt *PermissionsTemplateUsersOptions) ([]PermissionsTemplateUser, *http.Response, error) {
+	err := s.ValidateTemplateUsersOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	opts := *opt
+
+	if opts.PageSize == 0 || opts.PageSize > permissionsMaxPageSize {
+		opts.PageSize = permissionsMaxPageSize
+	}
+
+	return allPages(ctx, &opts.Page, &opts.PageSize, func(ctx context.Context) ([]PermissionsTemplateUser, int64, *http.Response, error) {
+		r, resp, err := s.TemplateUsers(ctx, &opts)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Users, r.Paging.Total, resp, nil
+	})
+}
+
+// UsersAll fetches all pages from Users and returns a flat slice of users.
+func (s *PermissionsService) UsersAll(ctx context.Context, opt *PermissionsUsersOptions) ([]PermissionUser, *http.Response, error) {
+	err := s.ValidateUsersOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var opts PermissionsUsersOptions
+	if opt != nil {
+		opts = *opt
+	}
+
+	if opts.PageSize == 0 || opts.PageSize > permissionsMaxPageSize {
+		opts.PageSize = permissionsMaxPageSize
+	}
+
+	return allPages(ctx, &opts.Page, &opts.PageSize, func(ctx context.Context) ([]PermissionUser, int64, *http.Response, error) {
+		r, resp, err := s.Users(ctx, &opts)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Users, r.Paging.Total, resp, nil
+	})
+}

--- a/sonar/permissions_service_test.go
+++ b/sonar/permissions_service_test.go
@@ -1087,3 +1087,104 @@ func TestPermissions_isValidPermission(t *testing.T) {
 		})
 	}
 }
+
+func TestPermissionsService_GroupsAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"groups":[{"name":"g1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"groups":[{"name":"g2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &PermissionsGroupsOptions{}
+		result, _, err := client.Permissions.GroupsAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+}
+
+func TestPermissionsService_TemplateGroupsAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"groups":[{"name":"g1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"groups":[{"name":"g2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &PermissionsTemplateGroupsOptions{TemplateID: "tmpl1"}
+		result, _, err := client.Permissions.TemplateGroupsAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Permissions.TemplateGroupsAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestPermissionsService_TemplateUsersAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"users":[{"login":"u1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"users":[{"login":"u2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &PermissionsTemplateUsersOptions{TemplateID: "tmpl1"}
+		result, _, err := client.Permissions.TemplateUsersAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Permissions.TemplateUsersAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestPermissionsService_UsersAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"users":[{"login":"u1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"users":[{"login":"u2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &PermissionsUsersOptions{}
+		result, _, err := client.Permissions.UsersAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+}

--- a/sonar/projects_service.go
+++ b/sonar/projects_service.go
@@ -639,3 +639,41 @@ func (s *ProjectsService) UpdateVisibility(ctx context.Context, opt *ProjectsUpd
 
 	return resp, nil
 }
+
+// SearchAll fetches all pages from Search and returns a flat slice of components.
+func (s *ProjectsService) SearchAll(ctx context.Context, opt *ProjectsSearchOptions) ([]ProjectSearchComponent, *http.Response, error) {
+	err := s.ValidateSearchOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]ProjectSearchComponent, int64, *http.Response, error) {
+		r, resp, err := s.Search(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Components, r.Paging.Total, resp, nil
+	})
+}
+
+// SearchMyProjectsAll fetches all pages from SearchMyProjects and returns a flat slice of projects.
+func (s *ProjectsService) SearchMyProjectsAll(ctx context.Context, opt *ProjectsSearchMyProjectsOptions) ([]MyProject, *http.Response, error) {
+	err := s.ValidateSearchMyProjectsOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]MyProject, int64, *http.Response, error) {
+		r, resp, err := s.SearchMyProjects(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Projects, r.Paging.Total, resp, nil
+	})
+}

--- a/sonar/projects_service_test.go
+++ b/sonar/projects_service_test.go
@@ -349,3 +349,59 @@ func TestProjectsService_UpdateVisibility_ValidationError(t *testing.T) {
 	_, err = client.Projects.UpdateVisibility(context.Background(), opt)
 	assert.Error(t, err)
 }
+
+func TestProjectsService_SearchAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"components":[{"key":"project1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"components":[{"key":"project2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &ProjectsSearchOptions{}
+		result, _, err := client.Projects.SearchAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Projects.SearchAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestProjectsService_SearchMyProjectsAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"projects":[{"key":"p1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"projects":[{"key":"p2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &ProjectsSearchMyProjectsOptions{}
+		result, _, err := client.Projects.SearchMyProjectsAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Projects.SearchMyProjectsAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}

--- a/sonar/qualitygates_service.go
+++ b/sonar/qualitygates_service.go
@@ -1411,3 +1411,60 @@ func (s *QualitygatesService) ValidateUpdateConditionOpt(opt *QualitygatesUpdate
 
 	return nil
 }
+
+// SearchAll fetches all pages from Search and returns a flat slice of projects.
+func (s *QualitygatesService) SearchAll(ctx context.Context, opt *QualitygatesSearchOptions) ([]QualityGateProject, *http.Response, error) {
+	err := s.ValidateSearchOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]QualityGateProject, int64, *http.Response, error) {
+		r, resp, err := s.Search(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Results, r.Paging.Total, resp, nil
+	})
+}
+
+// SearchGroupsAll fetches all pages from SearchGroups and returns a flat slice of groups.
+func (s *QualitygatesService) SearchGroupsAll(ctx context.Context, opt *QualitygatesSearchGroupsOptions) ([]QualityGateGroup, *http.Response, error) {
+	err := s.ValidateSearchGroupsOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]QualityGateGroup, int64, *http.Response, error) {
+		r, resp, err := s.SearchGroups(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Groups, r.Paging.Total, resp, nil
+	})
+}
+
+// SearchUsersAll fetches all pages from SearchUsers and returns a flat slice of users.
+func (s *QualitygatesService) SearchUsersAll(ctx context.Context, opt *QualitygatesSearchUsersOptions) ([]QualityGateUser, *http.Response, error) {
+	err := s.ValidateSearchUsersOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]QualityGateUser, int64, *http.Response, error) {
+		r, resp, err := s.SearchUsers(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Users, r.Paging.Total, resp, nil
+	})
+}

--- a/sonar/qualitygates_service_test.go
+++ b/sonar/qualitygates_service_test.go
@@ -672,3 +672,87 @@ func TestValidation_EdgeCases(t *testing.T) {
 	})
 	assert.Error(t, err)
 }
+
+func TestQualitygatesService_SearchAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"results":[{"key":"p1","name":"Project 1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"results":[{"key":"p2","name":"Project 2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &QualitygatesSearchOptions{GateName: "Default"}
+		result, _, err := client.Qualitygates.SearchAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Qualitygates.SearchAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestQualitygatesService_SearchGroupsAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"groups":[{"name":"g1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"groups":[{"name":"g2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &QualitygatesSearchGroupsOptions{GateName: "Default"}
+		result, _, err := client.Qualitygates.SearchGroupsAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Qualitygates.SearchGroupsAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestQualitygatesService_SearchUsersAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"users":[{"login":"u1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"users":[{"login":"u2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &QualitygatesSearchUsersOptions{GateName: "Default"}
+		result, _, err := client.Qualitygates.SearchUsersAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Qualitygates.SearchUsersAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}

--- a/sonar/qualityprofiles_service.go
+++ b/sonar/qualityprofiles_service.go
@@ -2369,6 +2369,82 @@ func (s *QualityprofilesService) ValidateShowOpt(opt *QualityprofilesShowOptions
 	return nil
 }
 
+// ChangelogAll fetches all pages from Changelog and returns a flat slice of events.
+func (s *QualityprofilesService) ChangelogAll(ctx context.Context, opt *QualityprofilesChangelogOptions) ([]ChangelogEvent, *http.Response, error) {
+	err := s.ValidateChangelogOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]ChangelogEvent, int64, *http.Response, error) {
+		r, resp, err := s.Changelog(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Events, r.Paging.Total, resp, nil
+	})
+}
+
+// ProjectsAll fetches all pages from Projects and returns a flat slice of projects.
+func (s *QualityprofilesService) ProjectsAll(ctx context.Context, opt *QualityprofilesProjectsOptions) ([]QualityprofilesProfileProject, *http.Response, error) {
+	err := s.ValidateProjectsOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]QualityprofilesProfileProject, int64, *http.Response, error) {
+		r, resp, err := s.Projects(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Results, r.Paging.Total, resp, nil
+	})
+}
+
+// SearchGroupsAll fetches all pages from SearchGroups and returns a flat slice of groups.
+func (s *QualityprofilesService) SearchGroupsAll(ctx context.Context, opt *QualityprofilesSearchGroupsOptions) ([]QualityprofilesProfileGroup, *http.Response, error) {
+	err := s.ValidateSearchGroupsOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]QualityprofilesProfileGroup, int64, *http.Response, error) {
+		r, resp, err := s.SearchGroups(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Groups, r.Paging.Total, resp, nil
+	})
+}
+
+// SearchUsersAll fetches all pages from SearchUsers and returns a flat slice of users.
+func (s *QualityprofilesService) SearchUsersAll(ctx context.Context, opt *QualityprofilesSearchUsersOptions) ([]QualityprofilesProfileUser, *http.Response, error) {
+	err := s.ValidateSearchUsersOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]QualityprofilesProfileUser, int64, *http.Response, error) {
+		r, resp, err := s.SearchUsers(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Users, r.Paging.Total, resp, nil
+	})
+}
+
 // -----------------------------------------------------------------------------
 // Conversion Functions
 // -----------------------------------------------------------------------------

--- a/sonar/qualityprofiles_service_test.go
+++ b/sonar/qualityprofiles_service_test.go
@@ -1238,3 +1238,115 @@ func TestQualityprofiles_ConvertActivateRuleOptForURL(t *testing.T) {
 	assert.Contains(t, urlOpt.Params, "max=10")
 	assert.Contains(t, urlOpt.Params, "threshold=5")
 }
+
+func TestQualityprofilesService_ChangelogAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"events":[{"action":"ACTIVATED"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"events":[{"action":"DEACTIVATED"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &QualityprofilesChangelogOptions{Language: "java", QualityProfile: "Sonar way"}
+		result, _, err := client.Qualityprofiles.ChangelogAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Qualityprofiles.ChangelogAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestQualityprofilesService_ProjectsAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"results":[{"key":"p1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"results":[{"key":"p2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &QualityprofilesProjectsOptions{Key: "myprofile"}
+		result, _, err := client.Qualityprofiles.ProjectsAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Qualityprofiles.ProjectsAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestQualityprofilesService_SearchGroupsAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"groups":[{"name":"g1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"groups":[{"name":"g2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &QualityprofilesSearchGroupsOptions{Language: "java", QualityProfile: "Sonar way"}
+		result, _, err := client.Qualityprofiles.SearchGroupsAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Qualityprofiles.SearchGroupsAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestQualityprofilesService_SearchUsersAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"users":[{"login":"u1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"users":[{"login":"u2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &QualityprofilesSearchUsersOptions{Language: "java", QualityProfile: "Sonar way"}
+		result, _, err := client.Qualityprofiles.SearchUsersAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Qualityprofiles.SearchUsersAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}

--- a/sonar/rules_service.go
+++ b/sonar/rules_service.go
@@ -1106,6 +1106,28 @@ func (s *RulesService) ValidateUpdateOpt(opt *RulesUpdateOptions) error {
 	return nil
 }
 
+// SearchAll fetches all pages from Search and returns a flat slice of rules.
+func (s *RulesService) SearchAll(ctx context.Context, opt *RulesSearchOptions) ([]RulesDetails, *http.Response, error) {
+	err := s.ValidateSearchOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var opts RulesSearchOptions
+	if opt != nil {
+		opts = *opt
+	}
+
+	return allPages(ctx, &opts.Page, &opts.PageSize, func(ctx context.Context) ([]RulesDetails, int64, *http.Response, error) {
+		r, resp, err := s.Search(ctx, &opts)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Rules, r.Paging.Total, resp, nil
+	})
+}
+
 // convertCreateOptForURL converts RulesCreateOptions to a URL-encodable format.
 func (s *RulesService) convertCreateOptForURL(opt *RulesCreateOptions) *rulesCreateURLOptions {
 	//nolint:exhaustruct // Only populate fields that have values

--- a/sonar/rules_service_test.go
+++ b/sonar/rules_service_test.go
@@ -848,3 +848,31 @@ func TestEmptySlicesAndMaps(t *testing.T) {
 	assert.Empty(t, urlOpt.Severities)
 	assert.Empty(t, urlOpt.Tags)
 }
+
+func TestRulesService_SearchAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"rules":[{"key":"rule1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"rules":[{"key":"rule2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &RulesSearchOptions{}
+		result, _, err := client.Rules.SearchAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Rules.SearchAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}

--- a/sonar/user_groups_service.go
+++ b/sonar/user_groups_service.go
@@ -487,3 +487,41 @@ func (s *UserGroupsService) Users(ctx context.Context, opt *UserGroupsUsersOptio
 
 	return result, resp, nil
 }
+
+// SearchAll fetches all pages from Search and returns a flat slice of groups.
+func (s *UserGroupsService) SearchAll(ctx context.Context, opt *UserGroupsSearchOptions) ([]UserGroupsDetail, *http.Response, error) {
+	err := s.ValidateSearchOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]UserGroupsDetail, int64, *http.Response, error) {
+		r, resp, err := s.Search(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Groups, r.Paging.Total, resp, nil
+	})
+}
+
+// UsersAll fetches all pages from Users and returns a flat slice of users.
+func (s *UserGroupsService) UsersAll(ctx context.Context, opt *UserGroupsUsersOptions) ([]UserGroupsUser, *http.Response, error) {
+	err := s.ValidateUsersOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]UserGroupsUser, int64, *http.Response, error) {
+		r, resp, err := s.Users(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Users, r.Paging.Total, resp, nil
+	})
+}

--- a/sonar/user_groups_service_test.go
+++ b/sonar/user_groups_service_test.go
@@ -253,3 +253,59 @@ func TestUserGroups_Users_ValidationError(t *testing.T) {
 	})
 	assert.Error(t, err)
 }
+
+func TestUserGroupsService_SearchAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"groups":[{"name":"g1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"groups":[{"name":"g2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &UserGroupsSearchOptions{}
+		result, _, err := client.UserGroups.SearchAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.UserGroups.SearchAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestUserGroupsService_UsersAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"users":[{"login":"u1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"users":[{"login":"u2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &UserGroupsUsersOptions{Name: "mygroup"}
+		result, _, err := client.UserGroups.UsersAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.UserGroups.UsersAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}

--- a/sonar/users_service.go
+++ b/sonar/users_service.go
@@ -1066,3 +1066,44 @@ func (s *UsersService) UpdateLogin(ctx context.Context, opt *UsersUpdateLoginOpt
 
 	return resp, nil
 }
+
+// SearchAll fetches all pages from Search and returns a flat slice of users.
+func (s *UsersService) SearchAll(ctx context.Context, opt *UsersSearchOptions) ([]UsersSearchResult, *http.Response, error) {
+	err := s.ValidateSearchOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var opts UsersSearchOptions
+	if opt != nil {
+		opts = *opt
+	}
+
+	return allPages(ctx, &opts.Page, &opts.PageSize, func(ctx context.Context) ([]UsersSearchResult, int64, *http.Response, error) {
+		r, resp, err := s.Search(ctx, &opts)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Users, r.Paging.Total, resp, nil
+	})
+}
+
+// GroupsAll fetches all pages from Groups and returns a flat slice of user groups.
+func (s *UsersService) GroupsAll(ctx context.Context, opt *UsersGroupsOptions) ([]UsersGroup, *http.Response, error) {
+	err := s.ValidateGroupsOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]UsersGroup, int64, *http.Response, error) {
+		r, resp, err := s.Groups(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Groups, r.Paging.Total, resp, nil
+	})
+}

--- a/sonar/users_service_test.go
+++ b/sonar/users_service_test.go
@@ -717,3 +717,53 @@ func TestUsers_UpdateLogin_ValidationError(t *testing.T) {
 		})
 	}
 }
+
+func TestUsersService_SearchAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"users":[{"login":"user1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"users":[{"login":"user2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &UsersSearchOptions{}
+		result, _, err := client.Users.SearchAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+}
+
+func TestUsersService_GroupsAll(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		callCount := 0
+		server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":1,"pageSize":500,"total":2},"groups":[{"name":"g1"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"paging":{"pageIndex":2,"pageSize":500,"total":2},"groups":[{"name":"g2"}]}`))
+			}
+		})
+
+		client := newTestClient(t, server.URL)
+		opt := &UsersGroupsOptions{Login: "user1"}
+		result, _, err := client.Users.GroupsAll(context.Background(), opt)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("nil option", func(t *testing.T) {
+		client := newLocalhostClient(t)
+		_, _, err := client.Users.GroupsAll(context.Background(), nil)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
### Description of your changes

This PR adds the support of Search / List all functions that automatically iterate over pagination to retrieve all results from paginated queries.

Closes #205 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
