### PR TITLE
feat(enterprise): support audit_logs endpoints

### DIFF
--- a/integration_testing/audit_logs_test.go
+++ b/integration_testing/audit_logs_test.go
@@ -1,0 +1,75 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Audit Logs Service", Ordered, func() {
+	var (
+		client  *sonar.Client
+		cleanup *helpers.CleanupManager
+	)
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+		cleanup = helpers.NewCleanupManager(client)
+	})
+
+	AfterAll(func() {
+		cleanup.Cleanup()
+	})
+
+	Describe("Download", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.AuditLogs.Download(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+
+			It("should fail without required From", func() {
+				result, resp, err := client.AuditLogs.Download(context.Background(), &sonar.AuditLogsDownloadOptions{
+					To: "2024-12-31T23:59:59+00:00",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+
+			It("should fail without required To", func() {
+				result, resp, err := client.AuditLogs.Download(context.Background(), &sonar.AuditLogsDownloadOptions{
+					From: "2024-01-01T00:00:00+00:00",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should download or return an enterprise-only error", func() {
+				result, resp, err := client.AuditLogs.Download(context.Background(), &sonar.AuditLogsDownloadOptions{
+					From: "2024-01-01T00:00:00+00:00",
+					To:   "2024-12-31T23:59:59+00:00",
+				})
+				if err != nil {
+					// Enterprise-only endpoints return 4xx on Community Edition.
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+})

--- a/sonar/audit_logs_service.go
+++ b/sonar/audit_logs_service.go
@@ -1,0 +1,74 @@
+package sonar
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+)
+
+// AuditLogsService handles communication with the audit logs related methods of
+// the SonarQube API. This service is only available in Enterprise Edition.
+type AuditLogsService struct {
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// AuditLogsDownloadOptions contains parameters for the Download method.
+type AuditLogsDownloadOptions struct {
+	// From is the start datetime in ISO 8601 format. This field is required.
+	From string `url:"from"`
+	// To is the end datetime in ISO 8601 format. This field is required.
+	To string `url:"to"`
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateDownloadOpt validates the options for the Download method.
+func (s *AuditLogsService) ValidateDownloadOpt(opt *AuditLogsDownloadOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.From, "From")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.To, "To")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// Download downloads the audit logs for the given time range as raw JSON bytes.
+// Requires 'Administer System' permission.
+//
+// API endpoint: GET /api/audit_logs/download.
+// Since: 9.1.
+// Enterprise Edition only.
+func (s *AuditLogsService) Download(ctx context.Context, opt *AuditLogsDownloadOptions) ([]byte, *http.Response, error) {
+	err := s.ValidateDownloadOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "audit_logs/download", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var buf bytes.Buffer
+
+	resp, err := s.client.Do(req, &buf)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return buf.Bytes(), resp, nil
+}

--- a/sonar/audit_logs_service_test.go
+++ b/sonar/audit_logs_service_test.go
@@ -1,0 +1,48 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditLogsService_Download(t *testing.T) {
+	data := []byte(`{"events":[{"category":"USER_AUTHENTICATION","action":"LOGIN"}]}`)
+	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/audit_logs/download", http.StatusOK, "application/json", data))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.AuditLogs.Download(context.Background(), &AuditLogsDownloadOptions{
+		From: "2024-01-01T00:00:00+00:00",
+		To:   "2024-12-31T23:59:59+00:00",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, result)
+}
+
+func TestAuditLogsService_Download_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.AuditLogs.Download(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Nil(t, result)
+
+	result, resp, err = client.AuditLogs.Download(context.Background(), &AuditLogsDownloadOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Nil(t, result)
+
+	result, resp, err = client.AuditLogs.Download(context.Background(), &AuditLogsDownloadOptions{From: "2024-01-01T00:00:00+00:00"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Nil(t, result)
+
+	result, resp, err = client.AuditLogs.Download(context.Background(), &AuditLogsDownloadOptions{To: "2024-12-31T23:59:59+00:00"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Nil(t, result)
+}

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -33,6 +33,7 @@ type Client struct {
 	middlewares     []Middleware
 	userAgent       string
 
+	AuditLogs          *AuditLogsService
 	AlmIntegrations    *AlmIntegrationsService
 	AlmSettings        *AlmSettingsService
 	AnalysisCache      *AnalysisCacheService
@@ -393,6 +394,7 @@ func (c *Client) BaseURL() *url.URL {
 //
 //nolint:funlen // necessary to initialize all services
 func initServices(client *Client) {
+	client.AuditLogs = &AuditLogsService{client: client}
 	client.AlmIntegrations = &AlmIntegrationsService{client: client}
 	client.AlmSettings = &AlmSettingsService{client: client}
 	client.AnalysisCache = &AnalysisCacheService{client: client}


### PR DESCRIPTION
## Summary
- Implement `AuditLogsService` with `Download` method for the `api/audit_logs/download` endpoint
- Add unit tests with full validation coverage
- Add integration tests with enterprise-only graceful handling

## Test plan
- [ ] `make lint target=sdk` passes
- [ ] `make test target=sdk` passes
- [ ] Integration tests gracefully handle non-enterprise instances

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)