### PR TITLE
feat(enterprise): support regulatory_reports/download endpoint

### DIFF
--- a/integration_testing/regulatory_reports_test.go
+++ b/integration_testing/regulatory_reports_test.go
@@ -1,0 +1,63 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Regulatory Reports Service", Ordered, func() {
+	var (
+		client  *sonar.Client
+		cleanup *helpers.CleanupManager
+	)
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+		cleanup = helpers.NewCleanupManager(client)
+	})
+
+	AfterAll(func() {
+		cleanup.Cleanup()
+	})
+
+	Describe("Download", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.RegulatoryReports.Download(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+
+			It("should fail without required Project", func() {
+				result, resp, err := client.RegulatoryReports.Download(context.Background(), &sonar.RegulatoryReportsDownloadOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should download or return an enterprise-only error", func() {
+				result, resp, err := client.RegulatoryReports.Download(context.Background(), &sonar.RegulatoryReportsDownloadOptions{
+					Project: "non-existent-project",
+				})
+				if err != nil {
+					// Enterprise-only endpoints return 4xx on Community Edition.
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+})

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -72,6 +72,7 @@ type Client struct {
 	Push               *PushService
 	Qualitygates       *QualitygatesService
 	Qualityprofiles    *QualityprofilesService
+	RegulatoryReports  *RegulatoryReportsService
 	Rules              *RulesService
 	Server             *ServerService
 	Settings           *SettingsService
@@ -432,6 +433,7 @@ func initServices(client *Client) {
 	client.Push = &PushService{client: client}
 	client.Qualitygates = &QualitygatesService{client: client}
 	client.Qualityprofiles = &QualityprofilesService{client: client}
+	client.RegulatoryReports = &RegulatoryReportsService{client: client}
 	client.Rules = &RulesService{client: client}
 	client.Server = &ServerService{client: client}
 	client.Settings = &SettingsService{client: client}

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -66,14 +66,12 @@ type Client struct {
 	ProjectBadges      *ProjectBadgesService
 	ProjectBranches    *ProjectBranchesService
 	ProjectDump        *ProjectDumpService
-	ProjectLinks        *ProjectLinksService
-	ProjectPullRequests *ProjectPullRequestsService
-	ProjectTags         *ProjectTagsService
+	ProjectLinks       *ProjectLinksService
+	ProjectTags        *ProjectTagsService
 	Projects           *ProjectsService
 	Push               *PushService
 	Qualitygates       *QualitygatesService
 	Qualityprofiles    *QualityprofilesService
-	RegulatoryReports  *RegulatoryReportsService
 	Rules              *RulesService
 	Server             *ServerService
 	Settings           *SettingsService
@@ -434,7 +432,6 @@ func initServices(client *Client) {
 	client.Push = &PushService{client: client}
 	client.Qualitygates = &QualitygatesService{client: client}
 	client.Qualityprofiles = &QualityprofilesService{client: client}
-	client.RegulatoryReports = &RegulatoryReportsService{client: client}
 	client.Rules = &RulesService{client: client}
 	client.Server = &ServerService{client: client}
 	client.Settings = &SettingsService{client: client}

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -66,12 +66,14 @@ type Client struct {
 	ProjectBadges      *ProjectBadgesService
 	ProjectBranches    *ProjectBranchesService
 	ProjectDump        *ProjectDumpService
-	ProjectLinks       *ProjectLinksService
-	ProjectTags        *ProjectTagsService
+	ProjectLinks        *ProjectLinksService
+	ProjectPullRequests *ProjectPullRequestsService
+	ProjectTags         *ProjectTagsService
 	Projects           *ProjectsService
 	Push               *PushService
 	Qualitygates       *QualitygatesService
 	Qualityprofiles    *QualityprofilesService
+	RegulatoryReports  *RegulatoryReportsService
 	Rules              *RulesService
 	Server             *ServerService
 	Settings           *SettingsService
@@ -432,6 +434,7 @@ func initServices(client *Client) {
 	client.Push = &PushService{client: client}
 	client.Qualitygates = &QualitygatesService{client: client}
 	client.Qualityprofiles = &QualityprofilesService{client: client}
+	client.RegulatoryReports = &RegulatoryReportsService{client: client}
 	client.Rules = &RulesService{client: client}
 	client.Server = &ServerService{client: client}
 	client.Settings = &SettingsService{client: client}

--- a/sonar/regulatory_reports_service.go
+++ b/sonar/regulatory_reports_service.go
@@ -1,0 +1,69 @@
+package sonar
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+)
+
+// RegulatoryReportsService handles communication with the regulatory reports related methods of
+// the SonarQube API. This service is only available in Enterprise Edition.
+type RegulatoryReportsService struct {
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// RegulatoryReportsDownloadOptions contains parameters for the Download method.
+type RegulatoryReportsDownloadOptions struct {
+	// Branch is the branch key. Optional.
+	Branch string `url:"branch,omitempty"`
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateDownloadOpt validates the options for the Download method.
+func (s *RegulatoryReportsService) ValidateDownloadOpt(opt *RegulatoryReportsDownloadOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Project, "Project")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// Download downloads the regulatory report for a project as a zip file.
+// Requires 'Browse' permission on the project.
+//
+// API endpoint: GET /api/regulatory_reports/download.
+// Since: 9.5.
+// Enterprise Edition only.
+func (s *RegulatoryReportsService) Download(ctx context.Context, opt *RegulatoryReportsDownloadOptions) ([]byte, *http.Response, error) {
+	err := s.ValidateDownloadOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "regulatory_reports/download", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var buf bytes.Buffer
+
+	resp, err := s.client.Do(req, &buf)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return buf.Bytes(), resp, nil
+}

--- a/sonar/regulatory_reports_service_test.go
+++ b/sonar/regulatory_reports_service_test.go
@@ -1,0 +1,51 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegulatoryReportsService_Download(t *testing.T) {
+	data := []byte("PK\x03\x04zip-content")
+	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/regulatory_reports/download", http.StatusOK, "application/zip", data))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.RegulatoryReports.Download(context.Background(), &RegulatoryReportsDownloadOptions{
+		Project: "my-project",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, result)
+}
+
+func TestRegulatoryReportsService_Download_WithBranch(t *testing.T) {
+	data := []byte("PK\x03\x04zip-content")
+	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/regulatory_reports/download", http.StatusOK, "application/zip", data))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.RegulatoryReports.Download(context.Background(), &RegulatoryReportsDownloadOptions{
+		Project: "my-project",
+		Branch:  "main",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, result)
+}
+
+func TestRegulatoryReportsService_Download_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.RegulatoryReports.Download(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Nil(t, result)
+
+	result, resp, err = client.RegulatoryReports.Download(context.Background(), &RegulatoryReportsDownloadOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Nil(t, result)
+}


### PR DESCRIPTION
## Summary
- Implement `RegulatoryReportsService` with `Download` method for the `api/regulatory_reports/download` endpoint
- Returns raw zip bytes for the regulatory report
- Add unit tests including optional `Branch` parameter coverage
- Add integration tests with enterprise-only graceful handling

## Test plan
- [ ] `make lint target=sdk` passes
- [ ] `make test target=sdk` passes
- [ ] Integration tests gracefully handle non-enterprise instances

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)