### PR TITLE
feat(enterprise): support project_pull_requests endpoints

### DIFF
--- a/integration_testing/project_pull_requests_test.go
+++ b/integration_testing/project_pull_requests_test.go
@@ -1,0 +1,105 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Project Pull Requests Service", Ordered, func() {
+	var client *sonar.Client
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+	})
+
+	// =========================================================================
+	// Delete
+	// =========================================================================
+	Describe("Delete", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.ProjectPullRequests.Delete(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required project", func() {
+				resp, err := client.ProjectPullRequests.Delete(context.Background(), &sonar.ProjectPullRequestsDeleteOptions{
+					PullRequest: "123",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Project"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required pull request", func() {
+				resp, err := client.ProjectPullRequests.Delete(context.Background(), &sonar.ProjectPullRequestsDeleteOptions{
+					Project: "my-project",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("PullRequest"))
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should succeed or return an expected error", func() {
+				resp, err := client.ProjectPullRequests.Delete(context.Background(), &sonar.ProjectPullRequestsDeleteOptions{
+					Project:     "nonexistent-project",
+					PullRequest: "nonexistent-pr",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// List
+	// =========================================================================
+	Describe("List", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.ProjectPullRequests.List(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required project", func() {
+				result, resp, err := client.ProjectPullRequests.List(context.Background(), &sonar.ProjectPullRequestsListOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Project"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should succeed or return an expected error", func() {
+				result, resp, err := client.ProjectPullRequests.List(context.Background(), &sonar.ProjectPullRequestsListOptions{
+					Project: "nonexistent-project",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+})

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -33,55 +33,56 @@ type Client struct {
 	middlewares     []Middleware
 	userAgent       string
 
-	AlmIntegrations    *AlmIntegrationsService
-	AlmSettings        *AlmSettingsService
-	AnalysisCache      *AnalysisCacheService
-	AnalysisReports    *AnalysisReportsService
-	Authentication     *AuthenticationService
-	Batch              *BatchService
-	Ce                 *CeService
-	Components         *ComponentsService
-	Developers         *DevelopersService
-	DismissMessage     *DismissMessageService
-	Duplications       *DuplicationsService
-	Emails             *EmailsService
-	Favorites          *FavoritesService
-	Features           *FeaturesService
-	GithubProvisioning *GithubProvisioningService
-	Hotspots           *HotspotsService
-	Issues             *IssuesService
-	L10N               *L10NService
-	Editions           *EditionsService
-	Languages          *LanguagesService
-	Measures           *MeasuresService
-	Views              *ViewsService
-	Metrics            *MetricsService
-	Monitoring         *MonitoringService
-	Navigation         *NavigationService
-	NewCodePeriods     *NewCodePeriodsService
-	Notifications      *NotificationsService
-	Permissions        *PermissionsService
-	Plugins            *PluginsService
-	ProjectAnalyses    *ProjectAnalysesService
-	ProjectBadges      *ProjectBadgesService
-	ProjectBranches    *ProjectBranchesService
-	ProjectDump        *ProjectDumpService
-	ProjectLinks       *ProjectLinksService
-	ProjectTags        *ProjectTagsService
-	Projects           *ProjectsService
-	Push               *PushService
-	Qualitygates       *QualitygatesService
-	Qualityprofiles    *QualityprofilesService
-	Rules              *RulesService
-	Server             *ServerService
-	Settings           *SettingsService
-	Sources            *SourcesService
-	System             *SystemService
-	UserGroups         *UserGroupsService
-	UserTokens         *UserTokensService
-	Users              *UsersService
-	Webhooks           *WebhooksService
-	Webservices        *WebservicesService
+	AlmIntegrations     *AlmIntegrationsService
+	AlmSettings         *AlmSettingsService
+	AnalysisCache       *AnalysisCacheService
+	AnalysisReports     *AnalysisReportsService
+	Authentication      *AuthenticationService
+	Batch               *BatchService
+	Ce                  *CeService
+	Components          *ComponentsService
+	Developers          *DevelopersService
+	DismissMessage      *DismissMessageService
+	Duplications        *DuplicationsService
+	Emails              *EmailsService
+	Favorites           *FavoritesService
+	Features            *FeaturesService
+	GithubProvisioning  *GithubProvisioningService
+	Hotspots            *HotspotsService
+	Issues              *IssuesService
+	L10N                *L10NService
+	Editions            *EditionsService
+	Languages           *LanguagesService
+	Measures            *MeasuresService
+	Views               *ViewsService
+	Metrics             *MetricsService
+	Monitoring          *MonitoringService
+	Navigation          *NavigationService
+	NewCodePeriods      *NewCodePeriodsService
+	Notifications       *NotificationsService
+	Permissions         *PermissionsService
+	Plugins             *PluginsService
+	ProjectAnalyses     *ProjectAnalysesService
+	ProjectBadges       *ProjectBadgesService
+	ProjectBranches     *ProjectBranchesService
+	ProjectDump         *ProjectDumpService
+	ProjectLinks        *ProjectLinksService
+	ProjectPullRequests *ProjectPullRequestsService
+	ProjectTags         *ProjectTagsService
+	Projects            *ProjectsService
+	Push                *PushService
+	Qualitygates        *QualitygatesService
+	Qualityprofiles     *QualityprofilesService
+	Rules               *RulesService
+	Server              *ServerService
+	Settings            *SettingsService
+	Sources             *SourcesService
+	System              *SystemService
+	UserGroups          *UserGroupsService
+	UserTokens          *UserTokensService
+	Users               *UsersService
+	Webhooks            *WebhooksService
+	Webservices         *WebservicesService
 
 	// V2 contains all V2 API services.
 	V2 *ServicesV2
@@ -427,6 +428,7 @@ func initServices(client *Client) {
 	client.ProjectBranches = &ProjectBranchesService{client: client}
 	client.ProjectDump = &ProjectDumpService{client: client}
 	client.ProjectLinks = &ProjectLinksService{client: client}
+	client.ProjectPullRequests = &ProjectPullRequestsService{client: client}
 	client.ProjectTags = &ProjectTagsService{client: client}
 	client.Projects = &ProjectsService{client: client}
 	client.Push = &PushService{client: client}

--- a/sonar/project_pull_requests_service.go
+++ b/sonar/project_pull_requests_service.go
@@ -1,0 +1,144 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+)
+
+// ProjectPullRequestsService handles communication with the project pull requests
+// related methods of the SonarQube API.
+type ProjectPullRequestsService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Response Types
+// -----------------------------------------------------------------------------
+
+// ProjectPullRequest represents a pull request analysis in SonarQube.
+type ProjectPullRequest struct {
+	// Key is the pull request key/identifier.
+	Key string `json:"key,omitempty"`
+	// Title is the pull request title.
+	Title string `json:"title,omitempty"`
+	// Branch is the source branch of the pull request.
+	Branch string `json:"branch,omitempty"`
+	// Base is the target branch of the pull request.
+	Base string `json:"base,omitempty"`
+	// URL is the URL of the pull request in the source code manager.
+	URL string `json:"url,omitempty"`
+	// Status contains the quality gate status and issue counts for the pull request.
+	Status struct {
+		// QualityGateStatus is the quality gate status (e.g. "OK", "ERROR").
+		QualityGateStatus string `json:"qualityGateStatus,omitempty"`
+		// Bugs is the number of bugs found.
+		Bugs int `json:"bugs,omitempty"`
+		// Vulnerabilities is the number of vulnerabilities found.
+		Vulnerabilities int `json:"vulnerabilities,omitempty"`
+		// CodeSmells is the number of code smells found.
+		CodeSmells int `json:"codeSmells,omitempty"`
+	} `json:"status,omitzero"`
+	// IsOrphan indicates whether the pull request is orphaned (target branch no longer exists).
+	IsOrphan bool `json:"isOrphan,omitempty"`
+}
+
+// ProjectPullRequestsList represents the response from the list endpoint.
+type ProjectPullRequestsList struct {
+	// PullRequests is the list of pull requests for the project.
+	PullRequests []ProjectPullRequest `json:"pullRequests,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// ProjectPullRequestsDeleteOptions contains parameters for the Delete method.
+type ProjectPullRequestsDeleteOptions struct {
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+	// PullRequest is the pull request key. This field is required.
+	PullRequest string `url:"pullRequest"`
+}
+
+// ProjectPullRequestsListOptions contains parameters for the List method.
+type ProjectPullRequestsListOptions struct {
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateDeleteOpt validates the options for the Delete method.
+func (s *ProjectPullRequestsService) ValidateDeleteOpt(opt *ProjectPullRequestsDeleteOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Project, "Project")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.PullRequest, "PullRequest")
+}
+
+// ValidateListOpt validates the options for the List method.
+func (s *ProjectPullRequestsService) ValidateListOpt(opt *ProjectPullRequestsListOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Project, "Project")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// Delete deletes a pull request analysis.
+// Requires Administer permission on the project.
+//
+// API endpoint: POST /api/project_pull_requests/delete.
+// Since: 7.1.
+func (s *ProjectPullRequestsService) Delete(ctx context.Context, opt *ProjectPullRequestsDeleteOptions) (*http.Response, error) {
+	err := s.ValidateDeleteOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_pull_requests/delete", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// List lists the pull request analyses of a project.
+// Requires Browse permission on the project.
+//
+// API endpoint: GET /api/project_pull_requests/list.
+// Since: 7.1.
+func (s *ProjectPullRequestsService) List(ctx context.Context, opt *ProjectPullRequestsListOptions) (*ProjectPullRequestsList, *http.Response, error) {
+	err := s.ValidateListOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "project_pull_requests/list", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(ProjectPullRequestsList)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}

--- a/sonar/project_pull_requests_service_test.go
+++ b/sonar/project_pull_requests_service_test.go
@@ -1,0 +1,87 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// Delete
+// -----------------------------------------------------------------------------
+
+func TestProjectPullRequestsService_Delete(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/project_pull_requests/delete", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.ProjectPullRequests.Delete(context.Background(), &ProjectPullRequestsDeleteOptions{
+		Project:     "my-project",
+		PullRequest: "123",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestProjectPullRequestsService_Delete_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.ProjectPullRequests.Delete(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.ProjectPullRequests.Delete(context.Background(), &ProjectPullRequestsDeleteOptions{PullRequest: "123"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.ProjectPullRequests.Delete(context.Background(), &ProjectPullRequestsDeleteOptions{Project: "my-project"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// List
+// -----------------------------------------------------------------------------
+
+func TestProjectPullRequestsService_List(t *testing.T) {
+	response := ProjectPullRequestsList{
+		PullRequests: []ProjectPullRequest{
+			{
+				Key:      "123",
+				Title:    "My Pull Request",
+				Branch:   "feature/my-feature",
+				Base:     "main",
+				IsOrphan: false,
+				URL:      "https://github.com/org/repo/pull/123",
+			},
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/project_pull_requests/list", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.ProjectPullRequests.List(context.Background(), &ProjectPullRequestsListOptions{
+		Project: "my-project",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotNil(t, result)
+	assert.Len(t, result.PullRequests, 1)
+	assert.Equal(t, "123", result.PullRequests[0].Key)
+	assert.Equal(t, "My Pull Request", result.PullRequests[0].Title)
+}
+
+func TestProjectPullRequestsService_List_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.ProjectPullRequests.List(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.ProjectPullRequests.List(context.Background(), &ProjectPullRequestsListOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}


### PR DESCRIPTION
## Summary
- Implement `ProjectPullRequests` SDK service with `Delete` and `List` methods
- Add unit tests with validation and functional coverage
- Add integration tests with graceful error handling

## Test plan
- [x] `make lint target=sdk` passes
- [x] `make test target=sdk` passes
- [x] Integration tests handle non-enterprise instances gracefully

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)