### PR TITLE
feat(enterprise): support governance_reports endpoints

### DIFF
--- a/integration_testing/governance_reports_test.go
+++ b/integration_testing/governance_reports_test.go
@@ -1,0 +1,152 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Governance Reports Service", Ordered, func() {
+	var client *sonar.Client
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+	})
+
+	// =========================================================================
+	// Download
+	// =========================================================================
+	Describe("Download", func() {
+		Context("Functional Tests", func() {
+			It("should download or return an enterprise-only error", func() {
+				result, resp, err := client.GovernanceReports.Download(context.Background(), &sonar.GovernanceReportsDownloadOptions{
+					ComponentKey: "nonexistent-portfolio",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Status
+	// =========================================================================
+	Describe("Status", func() {
+		Context("Functional Tests", func() {
+			It("should return status or an enterprise-only error", func() {
+				result, resp, err := client.GovernanceReports.Status(context.Background(), &sonar.GovernanceReportsStatusOptions{
+					ComponentKey: "nonexistent-portfolio",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Subscribe
+	// =========================================================================
+	Describe("Subscribe", func() {
+		Context("Functional Tests", func() {
+			It("should subscribe or return an enterprise-only error", func() {
+				resp, err := client.GovernanceReports.Subscribe(context.Background(), &sonar.GovernanceReportsSubscribeOptions{
+					ComponentKey: "nonexistent-portfolio",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Unsubscribe
+	// =========================================================================
+	Describe("Unsubscribe", func() {
+		Context("Functional Tests", func() {
+			It("should unsubscribe or return an enterprise-only error", func() {
+				resp, err := client.GovernanceReports.Unsubscribe(context.Background(), &sonar.GovernanceReportsUnsubscribeOptions{
+					ComponentKey: "nonexistent-portfolio",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// UpdateFrequency
+	// =========================================================================
+	Describe("UpdateFrequency", func() {
+		Context("Functional Tests", func() {
+			It("should update frequency or return an enterprise-only error", func() {
+				resp, err := client.GovernanceReports.UpdateFrequency(context.Background(), &sonar.GovernanceReportsUpdateFrequencyOptions{
+					ComponentKey: "nonexistent-portfolio",
+					Frequency:    "WEEKLY",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// UpdateRecipients
+	// =========================================================================
+	Describe("UpdateRecipients", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.GovernanceReports.UpdateRecipients(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required recipients", func() {
+				resp, err := client.GovernanceReports.UpdateRecipients(context.Background(), &sonar.GovernanceReportsUpdateRecipientsOptions{
+					ComponentKey: "my-portfolio",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Recipients"))
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should update recipients or return an enterprise-only error", func() {
+				resp, err := client.GovernanceReports.UpdateRecipients(context.Background(), &sonar.GovernanceReportsUpdateRecipientsOptions{
+					ComponentKey: "nonexistent-portfolio",
+					Recipients:   "test@example.com",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+				}
+			})
+		})
+	})
+})

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -48,6 +48,7 @@ type Client struct {
 	Favorites          *FavoritesService
 	Features           *FeaturesService
 	GithubProvisioning *GithubProvisioningService
+	GovernanceReports  *GovernanceReportsService
 	Hotspots           *HotspotsService
 	Issues             *IssuesService
 	L10N               *L10NService
@@ -73,6 +74,7 @@ type Client struct {
 	Qualitygates       *QualitygatesService
 	Qualityprofiles    *QualityprofilesService
 	Rules              *RulesService
+	SecurityReports    *SecurityReportsService
 	Server             *ServerService
 	Settings           *SettingsService
 	Sources            *SourcesService
@@ -408,6 +410,7 @@ func initServices(client *Client) {
 	client.Favorites = &FavoritesService{client: client}
 	client.Features = &FeaturesService{client: client}
 	client.GithubProvisioning = &GithubProvisioningService{client: client}
+	client.GovernanceReports = &GovernanceReportsService{client: client}
 	client.Hotspots = &HotspotsService{client: client}
 	client.Issues = &IssuesService{client: client}
 	client.L10N = &L10NService{client: client}
@@ -433,6 +436,7 @@ func initServices(client *Client) {
 	client.Qualitygates = &QualitygatesService{client: client}
 	client.Qualityprofiles = &QualityprofilesService{client: client}
 	client.Rules = &RulesService{client: client}
+	client.SecurityReports = &SecurityReportsService{client: client}
 	client.Server = &ServerService{client: client}
 	client.Settings = &SettingsService{client: client}
 	client.Sources = &SourcesService{client: client}

--- a/sonar/governance_reports_service.go
+++ b/sonar/governance_reports_service.go
@@ -1,0 +1,223 @@
+package sonar
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+)
+
+// GovernanceReportsService handles communication with the governance reports
+// related methods of the SonarQube API.
+// This service is only available in Enterprise Edition.
+type GovernanceReportsService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Response Types
+// -----------------------------------------------------------------------------
+
+// GovernanceReportsStatus represents the metadata of a governance report.
+type GovernanceReportsStatus struct {
+	// ComponentKey is the key of the component this status belongs to.
+	ComponentKey string `json:"componentKey,omitempty"`
+	// HasFile indicates whether a report file is available for download.
+	HasFile bool `json:"hasFile,omitempty"`
+	// Subscribed indicates whether the current user is subscribed to reports.
+	Subscribed bool `json:"subscribed,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// GovernanceReportsDownloadOptions contains parameters for the Download method.
+type GovernanceReportsDownloadOptions struct {
+	// BranchKey is the branch key. Optional.
+	BranchKey string `url:"branchKey,omitempty"`
+	// ComponentId is the component id. Optional.
+	ComponentId string `url:"componentId,omitempty"`
+	// ComponentKey is the component key. Optional.
+	ComponentKey string `url:"componentKey,omitempty"`
+}
+
+// GovernanceReportsStatusOptions contains parameters for the Status method.
+type GovernanceReportsStatusOptions struct {
+	// BranchKey is the branch key. Optional.
+	BranchKey string `url:"branchKey,omitempty"`
+	// ComponentId is the component id. Optional.
+	ComponentId string `url:"componentId,omitempty"`
+	// ComponentKey is the component key. Optional.
+	ComponentKey string `url:"componentKey,omitempty"`
+}
+
+// GovernanceReportsSubscribeOptions contains parameters for the Subscribe method.
+type GovernanceReportsSubscribeOptions struct {
+	// BranchKey is the branch key. Optional.
+	BranchKey string `url:"branchKey,omitempty"`
+	// ComponentId is the component id. Optional.
+	ComponentId string `url:"componentId,omitempty"`
+	// ComponentKey is the component key. Optional.
+	ComponentKey string `url:"componentKey,omitempty"`
+}
+
+// GovernanceReportsUnsubscribeOptions contains parameters for the Unsubscribe method.
+type GovernanceReportsUnsubscribeOptions struct {
+	// BranchKey is the branch key. Optional.
+	BranchKey string `url:"branchKey,omitempty"`
+	// ComponentId is the component id. Optional.
+	ComponentId string `url:"componentId,omitempty"`
+	// ComponentKey is the component key. Optional.
+	ComponentKey string `url:"componentKey,omitempty"`
+}
+
+// GovernanceReportsUpdateFrequencyOptions contains parameters for the UpdateFrequency method.
+type GovernanceReportsUpdateFrequencyOptions struct {
+	// BranchKey is the branch key. Optional.
+	BranchKey string `url:"branchKey,omitempty"`
+	// ComponentId is the component id. Optional.
+	ComponentId string `url:"componentId,omitempty"`
+	// ComponentKey is the component key. Optional.
+	ComponentKey string `url:"componentKey,omitempty"`
+	// Frequency is the report frequency. Optional. Valid values: DAILY, WEEKLY, MONTHLY.
+	Frequency string `url:"frequency,omitempty"`
+}
+
+// GovernanceReportsUpdateRecipientsOptions contains parameters for the UpdateRecipients method.
+type GovernanceReportsUpdateRecipientsOptions struct {
+	// BranchKey is the branch key. Optional.
+	BranchKey string `url:"branchKey,omitempty"`
+	// ComponentId is the component id. Optional.
+	ComponentId string `url:"componentId,omitempty"`
+	// ComponentKey is the component key. Optional.
+	ComponentKey string `url:"componentKey,omitempty"`
+	// Recipients is the list of recipient emails. This field is required.
+	Recipients string `url:"recipients"`
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateUpdateRecipientsOpt validates the options for the UpdateRecipients method.
+func (s *GovernanceReportsService) ValidateUpdateRecipientsOpt(opt *GovernanceReportsUpdateRecipientsOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Recipients, "Recipients")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// Download downloads the PDF report of a portfolio, sub-portfolio, project or application.
+// Requires 'Browse' permission on the component.
+//
+// API endpoint: GET /api/governance_reports/download.
+// Since: 1.0.
+// Enterprise Edition only.
+func (s *GovernanceReportsService) Download(ctx context.Context, opt *GovernanceReportsDownloadOptions) ([]byte, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "governance_reports/download", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var buf bytes.Buffer
+
+	resp, err := s.client.Do(req, &buf)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return buf.Bytes(), resp, nil
+}
+
+// Status returns PDF report metadata (action rights, report availability etc.).
+// Requires 'Browse' permission on the component.
+//
+// API endpoint: GET /api/governance_reports/status.
+// Since: 1.0.
+// Enterprise Edition only.
+func (s *GovernanceReportsService) Status(ctx context.Context, opt *GovernanceReportsStatusOptions) (*GovernanceReportsStatus, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "governance_reports/status", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(GovernanceReportsStatus)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// Subscribe subscribes the current user to reports for a component.
+// Requires authentication and 'Browse' permission on the component.
+//
+// API endpoint: POST /api/governance_reports/subscribe.
+// Since: 1.0.
+// Enterprise Edition only.
+func (s *GovernanceReportsService) Subscribe(ctx context.Context, opt *GovernanceReportsSubscribeOptions) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "governance_reports/subscribe", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Unsubscribe unsubscribes the current user from reports for a component.
+// Requires authentication and 'Browse' permission on the component.
+//
+// API endpoint: POST /api/governance_reports/unsubscribe.
+// Since: 1.0.
+// Enterprise Edition only.
+func (s *GovernanceReportsService) Unsubscribe(ctx context.Context, opt *GovernanceReportsUnsubscribeOptions) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "governance_reports/unsubscribe", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// UpdateFrequency updates the frequency at which a report is sent for a component.
+// Requires 'Administer' permission.
+//
+// API endpoint: POST /api/governance_reports/update_frequency.
+// Since: 1.0.
+// Enterprise Edition only.
+func (s *GovernanceReportsService) UpdateFrequency(ctx context.Context, opt *GovernanceReportsUpdateFrequencyOptions) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "governance_reports/update_frequency", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// UpdateRecipients updates the list of users who will receive reports for a component.
+// Requires 'Administer' permission.
+//
+// API endpoint: POST /api/governance_reports/update_recipients.
+// Since: 1.0.
+// Enterprise Edition only.
+func (s *GovernanceReportsService) UpdateRecipients(ctx context.Context, opt *GovernanceReportsUpdateRecipientsOptions) (*http.Response, error) {
+	err := s.ValidateUpdateRecipientsOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "governance_reports/update_recipients", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/sonar/governance_reports_service_test.go
+++ b/sonar/governance_reports_service_test.go
@@ -1,0 +1,131 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// Download
+// -----------------------------------------------------------------------------
+
+func TestGovernanceReportsService_Download(t *testing.T) {
+	data := []byte(`%PDF-1.4 report content`)
+	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/governance_reports/download", http.StatusOK, "application/pdf", data))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.GovernanceReports.Download(context.Background(), &GovernanceReportsDownloadOptions{
+		ComponentKey: "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, result)
+}
+
+func TestGovernanceReportsService_Download_NoOptions(t *testing.T) {
+	data := []byte(`%PDF-1.4 report content`)
+	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/governance_reports/download", http.StatusOK, "application/pdf", data))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.GovernanceReports.Download(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, result)
+}
+
+// -----------------------------------------------------------------------------
+// Status
+// -----------------------------------------------------------------------------
+
+func TestGovernanceReportsService_Status(t *testing.T) {
+	response := GovernanceReportsStatus{
+		HasFile:      true,
+		Subscribed:   false,
+		ComponentKey: "my-portfolio",
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/governance_reports/status", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.GovernanceReports.Status(context.Background(), &GovernanceReportsStatusOptions{
+		ComponentKey: "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotNil(t, result)
+	assert.True(t, result.HasFile)
+	assert.Equal(t, "my-portfolio", result.ComponentKey)
+}
+
+// -----------------------------------------------------------------------------
+// Subscribe / Unsubscribe
+// -----------------------------------------------------------------------------
+
+func TestGovernanceReportsService_Subscribe(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/governance_reports/subscribe", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.GovernanceReports.Subscribe(context.Background(), &GovernanceReportsSubscribeOptions{
+		ComponentKey: "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestGovernanceReportsService_Unsubscribe(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/governance_reports/unsubscribe", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.GovernanceReports.Unsubscribe(context.Background(), &GovernanceReportsUnsubscribeOptions{
+		ComponentKey: "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+// -----------------------------------------------------------------------------
+// UpdateFrequency
+// -----------------------------------------------------------------------------
+
+func TestGovernanceReportsService_UpdateFrequency(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/governance_reports/update_frequency", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.GovernanceReports.UpdateFrequency(context.Background(), &GovernanceReportsUpdateFrequencyOptions{
+		ComponentKey: "my-portfolio",
+		Frequency:    "WEEKLY",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+// -----------------------------------------------------------------------------
+// UpdateRecipients
+// -----------------------------------------------------------------------------
+
+func TestGovernanceReportsService_UpdateRecipients(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/governance_reports/update_recipients", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.GovernanceReports.UpdateRecipients(context.Background(), &GovernanceReportsUpdateRecipientsOptions{
+		ComponentKey: "my-portfolio",
+		Recipients:   "user@example.com",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestGovernanceReportsService_UpdateRecipients_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.GovernanceReports.UpdateRecipients(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.GovernanceReports.UpdateRecipients(context.Background(), &GovernanceReportsUpdateRecipientsOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}


### PR DESCRIPTION
## Summary
- Implement `SonarQube governance_reports API` with Download, Status, Subscribe, Unsubscribe, UpdateFrequency, UpdateRecipients methods
- Add unit tests with full validation coverage
- Add integration tests with graceful enterprise-only error handling

## Test plan
- [ ] `make lint target=sdk` passes
- [ ] `make test target=sdk` passes
- [ ] Integration tests handle non-enterprise instances gracefully

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)