### PR TITLE
feat(enterprise): support security_reports endpoints

### DIFF
--- a/integration_testing/security_reports_test.go
+++ b/integration_testing/security_reports_test.go
@@ -1,0 +1,119 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Security Reports Service", Ordered, func() {
+	var client *sonar.Client
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+	})
+
+	// =========================================================================
+	// Download
+	// =========================================================================
+	Describe("Download", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.SecurityReports.Download(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required project", func() {
+				result, resp, err := client.SecurityReports.Download(context.Background(), &sonar.SecurityReportsDownloadOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Project"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should succeed or return an enterprise-only error", func() {
+				result, resp, err := client.SecurityReports.Download(context.Background(), &sonar.SecurityReportsDownloadOptions{
+					Project: "nonexistent-project",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Show
+	// =========================================================================
+	Describe("Show", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.SecurityReports.Show(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required project", func() {
+				result, resp, err := client.SecurityReports.Show(context.Background(), &sonar.SecurityReportsShowOptions{
+					Standard: "owaspTop10",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Project"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required standard", func() {
+				result, resp, err := client.SecurityReports.Show(context.Background(), &sonar.SecurityReportsShowOptions{
+					Project: "my-project",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Standard"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail with invalid standard", func() {
+				result, resp, err := client.SecurityReports.Show(context.Background(), &sonar.SecurityReportsShowOptions{
+					Project:  "my-project",
+					Standard: "invalid-standard",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should succeed or return an enterprise-only error", func() {
+				result, resp, err := client.SecurityReports.Show(context.Background(), &sonar.SecurityReportsShowOptions{
+					Project:  "nonexistent-project",
+					Standard: "owaspTop10",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+})

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -73,6 +73,7 @@ type Client struct {
 	Qualitygates       *QualitygatesService
 	Qualityprofiles    *QualityprofilesService
 	Rules              *RulesService
+	SecurityReports    *SecurityReportsService
 	Server             *ServerService
 	Settings           *SettingsService
 	Sources            *SourcesService
@@ -433,6 +434,7 @@ func initServices(client *Client) {
 	client.Qualitygates = &QualitygatesService{client: client}
 	client.Qualityprofiles = &QualityprofilesService{client: client}
 	client.Rules = &RulesService{client: client}
+	client.SecurityReports = &SecurityReportsService{client: client}
 	client.Server = &ServerService{client: client}
 	client.Settings = &SettingsService{client: client}
 	client.Sources = &SourcesService{client: client}

--- a/sonar/security_reports_service.go
+++ b/sonar/security_reports_service.go
@@ -1,0 +1,167 @@
+package sonar
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+)
+
+// SecurityReportsService handles communication with the security reports related
+// methods of the SonarQube API. This service is internal and enterprise-only.
+type SecurityReportsService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Response Types
+// -----------------------------------------------------------------------------
+
+// SecurityReportsShow represents the response from the show endpoint.
+type SecurityReportsShow struct {
+	// Categories is the list of security report categories.
+	Categories []SecurityReportCategory `json:"categories,omitempty"`
+}
+
+// SecurityReportCategory represents a category in a security report.
+type SecurityReportCategory struct {
+	// Category is the category name.
+	Category string `json:"category,omitempty"`
+	// Vulnerabilities is the number of vulnerabilities in this category.
+	Vulnerabilities int `json:"vulnerabilities,omitempty"`
+	// ActiveRules is the number of active rules for this category.
+	ActiveRules int `json:"activeRules,omitempty"`
+	// ToReviewSecurityHotspots is the number of security hotspots to review.
+	ToReviewSecurityHotspots int `json:"toReviewSecurityHotspots,omitempty"`
+	// ReviewedSecurityHotspots is the number of reviewed security hotspots.
+	ReviewedSecurityHotspots int `json:"reviewedSecurityHotspots,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// SecurityReportsDownloadOptions contains parameters for the Download method.
+type SecurityReportsDownloadOptions struct {
+	// Branch filters the results by branch. Optional.
+	Branch string `url:"branch,omitempty"`
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+}
+
+// SecurityReportsShowOptions contains parameters for the Show method.
+type SecurityReportsShowOptions struct {
+	// Branch filters the results by branch. Optional.
+	Branch string `url:"branch,omitempty"`
+	// IncludeDistribution includes distribution information when set. Optional.
+	IncludeDistribution string `url:"includeDistribution,omitempty"`
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+	// Standard is the security standard to report on. This field is required.
+	Standard string `url:"standard"`
+}
+
+// -----------------------------------------------------------------------------
+// Allowed Value Sets
+// -----------------------------------------------------------------------------
+
+//nolint:gochecknoglobals // constant set of allowed values
+var allowedSecurityStandards = map[string]struct{}{
+	"owaspTop10":      {},
+	"sansTop25":       {},
+	"cwe":             {},
+	"owaspTop10-2021": {},
+	"pciDss-3.2":      {},
+	"pciDss-4.0":      {},
+	"owaspAsvs-4.0":   {},
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateDownloadOpt validates the options for the Download method.
+func (s *SecurityReportsService) ValidateDownloadOpt(opt *SecurityReportsDownloadOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Project, "Project")
+}
+
+// ValidateShowOpt validates the options for the Show method.
+func (s *SecurityReportsService) ValidateShowOpt(opt *SecurityReportsShowOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Project, "Project")
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequired(opt.Standard, "Standard")
+	if err != nil {
+		return err
+	}
+
+	return IsValueAuthorized(opt.Standard, allowedSecurityStandards, "Standard")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// Download downloads a security report as a PDF document.
+// Requires Browse permission on the project.
+//
+// API endpoint: GET /api/security_reports/download.
+// Since: 8.8.
+// Internal endpoint.
+func (s *SecurityReportsService) Download(ctx context.Context, opt *SecurityReportsDownloadOptions) ([]byte, *http.Response, error) {
+	err := s.ValidateDownloadOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "security_reports/download", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var buf bytes.Buffer
+
+	resp, err := s.client.Do(req, &buf)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return buf.Bytes(), resp, nil
+}
+
+// Show returns the security report for a project.
+// Requires Browse permission on the project.
+//
+// API endpoint: GET /api/security_reports/show.
+// Since: 7.3.
+// Internal endpoint.
+func (s *SecurityReportsService) Show(ctx context.Context, opt *SecurityReportsShowOptions) (*SecurityReportsShow, *http.Response, error) {
+	err := s.ValidateShowOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "security_reports/show", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(SecurityReportsShow)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}

--- a/sonar/security_reports_service_test.go
+++ b/sonar/security_reports_service_test.go
@@ -1,0 +1,95 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// Download
+// -----------------------------------------------------------------------------
+
+func TestSecurityReportsService_Download(t *testing.T) {
+	data := []byte(`%PDF test content`)
+	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/security_reports/download", http.StatusOK, "application/pdf", data))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.SecurityReports.Download(context.Background(), &SecurityReportsDownloadOptions{
+		Project: "my-project",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, result)
+}
+
+func TestSecurityReportsService_Download_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.SecurityReports.Download(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.SecurityReports.Download(context.Background(), &SecurityReportsDownloadOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// Show
+// -----------------------------------------------------------------------------
+
+func TestSecurityReportsService_Show(t *testing.T) {
+	response := SecurityReportsShow{
+		Categories: []SecurityReportCategory{
+			{
+				Category:                 "A1",
+				Vulnerabilities:          5,
+				ActiveRules:              10,
+				ToReviewSecurityHotspots: 3,
+				ReviewedSecurityHotspots: 2,
+			},
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/security_reports/show", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.SecurityReports.Show(context.Background(), &SecurityReportsShowOptions{
+		Project:  "my-project",
+		Standard: "owaspTop10",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Categories, 1)
+	assert.Equal(t, "A1", result.Categories[0].Category)
+}
+
+func TestSecurityReportsService_Show_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.SecurityReports.Show(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.SecurityReports.Show(context.Background(), &SecurityReportsShowOptions{Standard: "owaspTop10"})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.SecurityReports.Show(context.Background(), &SecurityReportsShowOptions{Project: "my-project"})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.SecurityReports.Show(context.Background(), &SecurityReportsShowOptions{Project: "my-project", Standard: "invalid-standard"})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}


### PR DESCRIPTION
## Summary
- Implement `SecurityReports` SDK service with `Download` and `Show` methods
- Add binary PDF download support using bytes.Buffer pattern
- Add unit tests with validation and functional coverage
- Add integration tests with graceful enterprise-only error handling

## Test plan
- [x] `make lint target=sdk` passes
- [x] `make test target=sdk` passes
- [x] Integration tests handle non-enterprise instances gracefully

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)