### PR TITLE
feat(enterprise): support architecture V2 endpoints

### DIFF
--- a/integration_testing/architecture_v2_test.go
+++ b/integration_testing/architecture_v2_test.go
@@ -1,0 +1,64 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Architecture V2 Service", Ordered, func() {
+	var client *sonar.Client
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+	})
+
+	// =========================================================================
+	// FileGraph
+	// =========================================================================
+	Describe("FileGraph", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.V2.Architecture.FileGraph(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required project key", func() {
+				result, resp, err := client.V2.Architecture.FileGraph(context.Background(), &sonar.ArchitectureFileGraphOptions{
+					BranchKey: "main",
+					Source:    "src/main.go",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("ProjectKey"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should return file graph or an enterprise-only error", func() {
+				result, resp, err := client.V2.Architecture.FileGraph(context.Background(), &sonar.ArchitectureFileGraphOptions{
+					ProjectKey: "nonexistent-project",
+					BranchKey:  "main",
+					Source:     "src/main.go",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+})

--- a/sonar/architecture_v2_service.go
+++ b/sonar/architecture_v2_service.go
@@ -1,0 +1,111 @@
+package sonar
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// ArchitectureService handles communication with the architecture V2 API endpoints.
+// This service is only available in Enterprise Edition.
+type ArchitectureService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Response Types
+// -----------------------------------------------------------------------------
+
+// ArchitectureFileGraph represents the file dependency graph for a project branch.
+type ArchitectureFileGraph struct {
+	// Nodes is the list of file nodes in the dependency graph.
+	Nodes []ArchitectureFileNode `json:"nodes,omitempty"`
+	// Edges is the list of dependency edges between files.
+	Edges []ArchitectureFileEdge `json:"edges,omitempty"`
+}
+
+// ArchitectureFileNode represents a file node in the architecture graph.
+type ArchitectureFileNode struct {
+	// Id is the unique identifier of the file node.
+	Id string `json:"id,omitempty"`
+	// Name is the display name of the file.
+	Name string `json:"name,omitempty"`
+	// Path is the file path within the project.
+	Path string `json:"path,omitempty"`
+}
+
+// ArchitectureFileEdge represents a dependency edge between two file nodes.
+type ArchitectureFileEdge struct {
+	// Source is the id of the source file node.
+	Source string `json:"source,omitempty"`
+	// Target is the id of the target file node.
+	Target string `json:"target,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// ArchitectureFileGraphOptions contains parameters for the FileGraph method.
+type ArchitectureFileGraphOptions struct {
+	// ProjectKey is the project key. This field is required.
+	ProjectKey string `json:"projectKey"`
+	// BranchKey is the branch key. This field is required.
+	BranchKey string `json:"branchKey"`
+	// Source is the source file path to start the graph from. This field is required.
+	Source string `json:"source"`
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateFileGraphOpt validates the options for the FileGraph method.
+func (s *ArchitectureService) ValidateFileGraphOpt(opt *ArchitectureFileGraphOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.ProjectKey, "ProjectKey")
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequired(opt.BranchKey, "BranchKey")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Source, "Source")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// FileGraph returns the file dependency graph for a project branch starting from a source file.
+// Requires 'Browse' permission on the project.
+//
+// API endpoint: GET /api/v2/architecture/file-graph.
+// Enterprise Edition only.
+func (s *ArchitectureService) FileGraph(ctx context.Context, opt *ArchitectureFileGraphOptions) (*ArchitectureFileGraph, *http.Response, error) {
+	err := s.ValidateFileGraphOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "architecture/file-graph", opt, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	result := new(ArchitectureFileGraph)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}

--- a/sonar/architecture_v2_service_test.go
+++ b/sonar/architecture_v2_service_test.go
@@ -1,0 +1,72 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// FileGraph
+// -----------------------------------------------------------------------------
+
+func TestArchitectureService_FileGraph(t *testing.T) {
+	response := ArchitectureFileGraph{
+		Nodes: []ArchitectureFileNode{
+			{Id: "1", Name: "main.go", Path: "src/main.go"},
+			{Id: "2", Name: "utils.go", Path: "src/utils.go"},
+		},
+		Edges: []ArchitectureFileEdge{
+			{Source: "1", Target: "2"},
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/architecture/file-graph", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.V2.Architecture.FileGraph(context.Background(), &ArchitectureFileGraphOptions{
+		ProjectKey: "my-project",
+		BranchKey:  "main",
+		Source:     "src/main.go",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Nodes, 2)
+	assert.Len(t, result.Edges, 1)
+}
+
+func TestArchitectureService_FileGraph_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.V2.Architecture.FileGraph(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.V2.Architecture.FileGraph(context.Background(), &ArchitectureFileGraphOptions{
+		BranchKey: "main",
+		Source:    "src/main.go",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.V2.Architecture.FileGraph(context.Background(), &ArchitectureFileGraphOptions{
+		ProjectKey: "my-project",
+		Source:     "src/main.go",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.V2.Architecture.FileGraph(context.Background(), &ArchitectureFileGraphOptions{
+		ProjectKey: "my-project",
+		BranchKey:  "main",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}


### PR DESCRIPTION
## Summary
- Implement `SonarQube architecture V2 API` with FileGraph method under `client.V2.Architecture`
- Add unit tests with full validation coverage
- Add integration tests with graceful enterprise-only error handling

## Test plan
- [ ] `make lint target=sdk` passes
- [ ] `make test target=sdk` passes

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)