### PR TITLE
feat(enterprise): support SAML endpoints

### DIFF
--- a/integration_testing/saml_test.go
+++ b/integration_testing/saml_test.go
@@ -1,0 +1,75 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("SAML Service", Ordered, func() {
+	var client *sonar.Client
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+	})
+
+	// =========================================================================
+	// Validation
+	// =========================================================================
+	Describe("Validation", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Saml.Validation(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required SAMLResponse", func() {
+				result, resp, err := client.Saml.Validation(context.Background(), &sonar.SamlValidationOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("SAMLResponse"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should validate or return an expected error", func() {
+				result, resp, err := client.Saml.Validation(context.Background(), &sonar.SamlValidationOptions{
+					SAMLResponse: "invalid-saml-response",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// ValidationInit
+	// =========================================================================
+	Describe("ValidationInit", func() {
+		Context("Functional Tests", func() {
+			It("should initiate validation or return an expected error", func() {
+				resp, err := client.Saml.ValidationInit(context.Background())
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+				}
+			})
+		})
+	})
+})

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -73,6 +73,7 @@ type Client struct {
 	Qualitygates       *QualitygatesService
 	Qualityprofiles    *QualityprofilesService
 	Rules              *RulesService
+	Saml               *SamlService
 	Server             *ServerService
 	Settings           *SettingsService
 	Sources            *SourcesService
@@ -433,6 +434,7 @@ func initServices(client *Client) {
 	client.Qualitygates = &QualitygatesService{client: client}
 	client.Qualityprofiles = &QualityprofilesService{client: client}
 	client.Rules = &RulesService{client: client}
+	client.Saml = &SamlService{client: client}
 	client.Server = &ServerService{client: client}
 	client.Settings = &SettingsService{client: client}
 	client.Sources = &SourcesService{client: client}

--- a/sonar/saml_service.go
+++ b/sonar/saml_service.go
@@ -1,0 +1,83 @@
+package sonar
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+)
+
+// SamlService handles communication with the SAML related methods of
+// the SonarQube API. This service is internal.
+type SamlService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// SamlValidationOptions contains parameters for the Validation method.
+type SamlValidationOptions struct {
+	// SAMLResponse is the SAML response to validate. This field is required.
+	SAMLResponse string `url:"SAMLResponse"`
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateValidationOpt validates the options for the Validation method.
+func (s *SamlService) ValidateValidationOpt(opt *SamlValidationOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.SAMLResponse, "SAMLResponse")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// Validation validates a SAML response and returns the resulting HTML page.
+// Requires authentication.
+//
+// API endpoint: POST saml/validation.
+// Since: 9.7.
+// Internal endpoint.
+func (s *SamlService) Validation(ctx context.Context, opt *SamlValidationOptions) ([]byte, *http.Response, error) {
+	err := s.ValidateValidationOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "saml/validation", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var buf bytes.Buffer
+
+	resp, err := s.client.Do(req, &buf)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return buf.Bytes(), resp, nil
+}
+
+// ValidationInit initiates the SAML validation flow.
+// Requires authentication.
+//
+// API endpoint: GET saml/validation_init.
+// Since: 9.7.
+// Internal endpoint.
+func (s *SamlService) ValidationInit(ctx context.Context) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "saml/validation_init", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/sonar/saml_service_test.go
+++ b/sonar/saml_service_test.go
@@ -1,0 +1,54 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// Validation
+// -----------------------------------------------------------------------------
+
+func TestSamlService_Validation(t *testing.T) {
+	data := []byte(`<html><body>SAML Validation Result</body></html>`)
+	server := newTestServer(t, mockBinaryHandler(t, http.MethodPost, "/saml/validation", http.StatusOK, "text/html", data))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Saml.Validation(context.Background(), &SamlValidationOptions{
+		SAMLResponse: "base64encodedsamlresponse",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, result)
+}
+
+func TestSamlService_Validation_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.Saml.Validation(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.Saml.Validation(context.Background(), &SamlValidationOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// ValidationInit
+// -----------------------------------------------------------------------------
+
+func TestSamlService_ValidationInit(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodGet, "/saml/validation_init", http.StatusOK))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Saml.ValidationInit(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}


### PR DESCRIPTION
## Summary
- Implement `SonarQube saml API` with Validation and ValidationInit methods
- Add unit tests with full validation coverage
- Add integration tests with graceful error handling

## Test plan
- [ ] `make lint target=sdk` passes
- [ ] `make test target=sdk` passes

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)