### PR TITLE
feat(enterprise): support applications endpoints

### DIFF
--- a/integration_testing/applications_test.go
+++ b/integration_testing/applications_test.go
@@ -34,15 +34,17 @@ var _ = Describe("Applications Service", Ordered, func() {
 	Describe("Create", func() {
 		Context("Parameter Validation", func() {
 			It("should fail with nil options", func() {
-				resp, err := client.Applications.Create(context.Background(), nil)
+				result, resp, err := client.Applications.Create(context.Background(), nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(result).To(BeNil())
 				Expect(resp).To(BeNil())
 			})
 
 			It("should fail without required name", func() {
-				resp, err := client.Applications.Create(context.Background(), &sonar.ApplicationsCreateOptions{})
+				result, resp, err := client.Applications.Create(context.Background(), &sonar.ApplicationsCreateOptions{})
 				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
 				Expect(resp).To(BeNil())
 			})
 		})
@@ -50,7 +52,7 @@ var _ = Describe("Applications Service", Ordered, func() {
 		Context("Functional Tests", func() {
 			It("should create application or return an enterprise-only error", func() {
 				appKey := helpers.UniqueResourceName("application")
-				resp, err := client.Applications.Create(context.Background(), &sonar.ApplicationsCreateOptions{
+				result, resp, err := client.Applications.Create(context.Background(), &sonar.ApplicationsCreateOptions{
 					Name: appKey,
 					Key:  appKey,
 				})
@@ -58,6 +60,7 @@ var _ = Describe("Applications Service", Ordered, func() {
 					Expect(resp).NotTo(BeNil())
 				} else {
 					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
 					cleanup.RegisterCleanup("application", appKey, func() error {
 						_, cleanupErr := client.Applications.Delete(context.Background(), &sonar.ApplicationsDeleteOptions{
 							Application: appKey,

--- a/integration_testing/applications_test.go
+++ b/integration_testing/applications_test.go
@@ -1,0 +1,187 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Applications Service", Ordered, func() {
+	var (
+		client  *sonar.Client
+		cleanup *helpers.CleanupManager
+	)
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+		cleanup = helpers.NewCleanupManager(client)
+	})
+
+	AfterAll(func() {
+		cleanup.Cleanup()
+	})
+
+	// =========================================================================
+	// Create
+	// =========================================================================
+	Describe("Create", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Applications.Create(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required name", func() {
+				resp, err := client.Applications.Create(context.Background(), &sonar.ApplicationsCreateOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should create application or return an enterprise-only error", func() {
+				appKey := helpers.UniqueResourceName("application")
+				resp, err := client.Applications.Create(context.Background(), &sonar.ApplicationsCreateOptions{
+					Name: appKey,
+					Key:  appKey,
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					cleanup.RegisterCleanup("application", appKey, func() error {
+						_, cleanupErr := client.Applications.Delete(context.Background(), &sonar.ApplicationsDeleteOptions{
+							Application: appKey,
+						})
+						return cleanupErr
+					})
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Delete
+	// =========================================================================
+	Describe("Delete", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Applications.Delete(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should fail for nonexistent application", func() {
+				resp, err := client.Applications.Delete(context.Background(), &sonar.ApplicationsDeleteOptions{
+					Application: "nonexistent-application-xyz",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Show
+	// =========================================================================
+	Describe("Show", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Applications.Show(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should return application or an enterprise-only error", func() {
+				result, resp, err := client.Applications.Show(context.Background(), &sonar.ApplicationsShowOptions{
+					Application: "nonexistent-application-xyz",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// AddProject / RemoveProject
+	// =========================================================================
+	Describe("AddProject", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Applications.AddProject(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+			})
+		})
+	})
+
+	Describe("RemoveProject", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Applications.RemoveProject(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// SetTags
+	// =========================================================================
+	Describe("SetTags", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.Applications.SetTags(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+			})
+		})
+	})
+
+	// =========================================================================
+	// SearchProjects
+	// =========================================================================
+	Describe("SearchProjects", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.Applications.SearchProjects(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should return projects or an enterprise-only error", func() {
+				result, resp, err := client.Applications.SearchProjects(context.Background(), &sonar.ApplicationsSearchProjectsOptions{
+					Application: "nonexistent-application-xyz",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+})

--- a/sonar/applications_service.go
+++ b/sonar/applications_service.go
@@ -1,0 +1,621 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+)
+
+// ApplicationsService handles communication with the application related methods
+// of the SonarQube API. This service is only available in Enterprise Edition.
+type ApplicationsService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Response Types
+// -----------------------------------------------------------------------------
+
+// Application represents a SonarQube application.
+type Application struct {
+	// Key is the application key.
+	Key string `json:"key,omitempty"`
+	// Name is the application name.
+	Name string `json:"name,omitempty"`
+	// Description is the application description.
+	Description string `json:"description,omitempty"`
+	// Visibility is the application visibility (public or private).
+	Visibility string `json:"visibility,omitempty"`
+}
+
+// ApplicationDetails represents detailed information about an application.
+type ApplicationDetails struct {
+	// Key is the application key.
+	Key string `json:"key,omitempty"`
+	// Name is the application name.
+	Name string `json:"name,omitempty"`
+	// Description is the application description.
+	Description string `json:"description,omitempty"`
+	// Visibility is the application visibility.
+	Visibility string `json:"visibility,omitempty"`
+	// Tags is the list of tags assigned to the application.
+	Tags []string `json:"tags,omitempty"`
+}
+
+// ApplicationBranch represents a branch of an application.
+type ApplicationBranch struct {
+	// Name is the branch name.
+	Name string `json:"name,omitempty"`
+	// IsMain indicates whether this is the main branch.
+	IsMain bool `json:"isMain,omitempty"`
+}
+
+// ApplicationProject represents a project within an application.
+type ApplicationProject struct {
+	// Key is the project key.
+	Key string `json:"key,omitempty"`
+	// Name is the project name.
+	Name string `json:"name,omitempty"`
+	// Selected indicates whether the project is selected in the application.
+	Selected bool `json:"selected,omitempty"`
+}
+
+// ApplicationsShow represents the response from the show endpoint.
+type ApplicationsShow struct {
+	// Application contains the application details.
+	Application ApplicationDetails `json:"application,omitzero"`
+}
+
+// ApplicationsSearchProjects represents the response from the search_projects endpoint.
+type ApplicationsSearchProjects struct {
+	// Projects is the list of projects in the application.
+	Projects []ApplicationProject `json:"projects,omitempty"`
+	// Paging contains pagination information.
+	Paging Paging `json:"paging,omitzero"`
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// ApplicationsCreateOptions contains parameters for the Create method.
+type ApplicationsCreateOptions struct {
+	// Description is the application description. Optional.
+	Description string `url:"description,omitempty"`
+	// Key is the application key. Optional, will be generated from name if not provided.
+	Key string `url:"key,omitempty"`
+	// Name is the application name. This field is required.
+	Name string `url:"name"`
+	// Visibility is the application visibility (public or private). Optional.
+	Visibility string `url:"visibility,omitempty"`
+}
+
+// ApplicationsDeleteOptions contains parameters for the Delete method.
+type ApplicationsDeleteOptions struct {
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+}
+
+// ApplicationsShowOptions contains parameters for the Show method.
+type ApplicationsShowOptions struct {
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+	// Branch is the branch name. Optional.
+	Branch string `url:"branch,omitempty"`
+}
+
+// ApplicationsUpdateOptions contains parameters for the Update method.
+type ApplicationsUpdateOptions struct {
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+	// Description is the new description for the application. Optional.
+	Description string `url:"description,omitempty"`
+	// Name is the new name for the application. This field is required.
+	Name string `url:"name"`
+}
+
+// ApplicationsAddProjectOptions contains parameters for the AddProject method.
+type ApplicationsAddProjectOptions struct {
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+}
+
+// ApplicationsRemoveProjectOptions contains parameters for the RemoveProject method.
+type ApplicationsRemoveProjectOptions struct {
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+}
+
+// ApplicationsCreateBranchOptions contains parameters for the CreateBranch method.
+type ApplicationsCreateBranchOptions struct {
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+	// Branch is the branch name. This field is required.
+	Branch string `url:"branch"`
+	// Project is the list of project keys (can be specified multiple times). This field is required.
+	Project []string `url:"project"`
+	// ProjectBranch is the list of project branch names (can be specified multiple times). This field is required.
+	ProjectBranch []string `url:"projectBranch"`
+}
+
+// ApplicationsDeleteBranchOptions contains parameters for the DeleteBranch method.
+type ApplicationsDeleteBranchOptions struct {
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+	// Branch is the branch name. This field is required.
+	Branch string `url:"branch"`
+}
+
+// ApplicationsUpdateBranchOptions contains parameters for the UpdateBranch method.
+type ApplicationsUpdateBranchOptions struct {
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+	// Branch is the current branch name. This field is required.
+	Branch string `url:"branch"`
+	// Name is the new branch name. This field is required.
+	Name string `url:"name"`
+	// Project is the list of project keys. This field is required.
+	Project []string `url:"project"`
+	// ProjectBranch is the list of project branch names. This field is required.
+	ProjectBranch []string `url:"projectBranch"`
+}
+
+// ApplicationsSetTagsOptions contains parameters for the SetTags method.
+type ApplicationsSetTagsOptions struct {
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+	// Tags is a comma-separated list of tags. This field is required.
+	Tags string `url:"tags"`
+}
+
+// ApplicationsSearchProjectsOptions contains parameters for the SearchProjects method.
+//
+//nolint:govet // fieldalignment: keeping logical field grouping for readability
+type ApplicationsSearchProjectsOptions struct {
+	PaginationArgs
+
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+	// Q limits search to project names containing this string. Optional.
+	Q string `url:"q,omitempty"`
+	// Selected filters by selection state (selected, deselected, all). Optional.
+	Selected string `url:"selected,omitempty"`
+}
+
+// ApplicationsRefreshOptions contains parameters for the Refresh method.
+type ApplicationsRefreshOptions struct {
+	// Key is the application key. If not specified, all applications are refreshed. Optional.
+	Key string `url:"key,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// Allowed Value Sets
+// -----------------------------------------------------------------------------
+
+//nolint:gochecknoglobals // constant set of allowed values
+var allowedApplicationVisibilities = map[string]struct{}{
+	"private": {},
+	"public":  {},
+}
+
+//nolint:gochecknoglobals // constant set of allowed values
+var allowedApplicationProjectSelections = map[string]struct{}{
+	SelectionFilterAll:        {},
+	SelectionFilterSelected:   {},
+	SelectionFilterDeselected: {},
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateCreateOpt validates the options for the Create method.
+func (s *ApplicationsService) ValidateCreateOpt(opt *ApplicationsCreateOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Name, "Name")
+	if err != nil {
+		return err
+	}
+
+	return IsValueAuthorized(opt.Visibility, allowedApplicationVisibilities, "Visibility")
+}
+
+// ValidateDeleteOpt validates the options for the Delete method.
+func (s *ApplicationsService) ValidateDeleteOpt(opt *ApplicationsDeleteOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Application, "Application")
+}
+
+// ValidateShowOpt validates the options for the Show method.
+func (s *ApplicationsService) ValidateShowOpt(opt *ApplicationsShowOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Application, "Application")
+}
+
+// ValidateUpdateOpt validates the options for the Update method.
+func (s *ApplicationsService) ValidateUpdateOpt(opt *ApplicationsUpdateOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Application, "Application")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Name, "Name")
+}
+
+// ValidateAddProjectOpt validates the options for the AddProject method.
+func (s *ApplicationsService) ValidateAddProjectOpt(opt *ApplicationsAddProjectOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Application, "Application")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Project, "Project")
+}
+
+// ValidateRemoveProjectOpt validates the options for the RemoveProject method.
+func (s *ApplicationsService) ValidateRemoveProjectOpt(opt *ApplicationsRemoveProjectOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Application, "Application")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Project, "Project")
+}
+
+// ValidateCreateBranchOpt validates the options for the CreateBranch method.
+func (s *ApplicationsService) ValidateCreateBranchOpt(opt *ApplicationsCreateBranchOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Application, "Application")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Branch, "Branch")
+}
+
+// ValidateDeleteBranchOpt validates the options for the DeleteBranch method.
+func (s *ApplicationsService) ValidateDeleteBranchOpt(opt *ApplicationsDeleteBranchOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Application, "Application")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Branch, "Branch")
+}
+
+// ValidateUpdateBranchOpt validates the options for the UpdateBranch method.
+func (s *ApplicationsService) ValidateUpdateBranchOpt(opt *ApplicationsUpdateBranchOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Application, "Application")
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequired(opt.Branch, "Branch")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Name, "Name")
+}
+
+// ValidateSetTagsOpt validates the options for the SetTags method.
+func (s *ApplicationsService) ValidateSetTagsOpt(opt *ApplicationsSetTagsOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Application, "Application")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Tags, "Tags")
+}
+
+// ValidateSearchProjectsOpt validates the options for the SearchProjects method.
+func (s *ApplicationsService) ValidateSearchProjectsOpt(opt *ApplicationsSearchProjectsOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Application, "Application")
+	if err != nil {
+		return err
+	}
+
+	err = opt.Validate()
+	if err != nil {
+		return err
+	}
+
+	return IsValueAuthorized(opt.Selected, allowedApplicationProjectSelections, "Selected")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// Create creates a new application.
+// Requires 'Administer System' or 'Create Applications' permission.
+//
+// API endpoint: POST /api/applications/create.
+// Since: 7.3.
+// Enterprise Edition only.
+func (s *ApplicationsService) Create(ctx context.Context, opt *ApplicationsCreateOptions) (*http.Response, error) {
+	err := s.ValidateCreateOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "applications/create", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Delete deletes an application definition.
+// Requires 'Administrator' permission on the application.
+//
+// API endpoint: POST /api/applications/delete.
+// Since: 7.3.
+// Enterprise Edition only.
+func (s *ApplicationsService) Delete(ctx context.Context, opt *ApplicationsDeleteOptions) (*http.Response, error) {
+	err := s.ValidateDeleteOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "applications/delete", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Show returns an application and its associated projects.
+// Requires 'Browse' permission on the application and on its child projects.
+//
+// API endpoint: GET /api/applications/show.
+// Since: 7.3.
+// Enterprise Edition only.
+func (s *ApplicationsService) Show(ctx context.Context, opt *ApplicationsShowOptions) (*ApplicationsShow, *http.Response, error) {
+	err := s.ValidateShowOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "applications/show", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(ApplicationsShow)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// Update updates an application.
+// Requires 'Administrator' permission on the application.
+//
+// API endpoint: POST /api/applications/update.
+// Since: 7.3.
+// Enterprise Edition only.
+func (s *ApplicationsService) Update(ctx context.Context, opt *ApplicationsUpdateOptions) (*http.Response, error) {
+	err := s.ValidateUpdateOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "applications/update", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// AddProject adds a project to an application.
+// Requires 'Administrator' permission on the application.
+//
+// API endpoint: POST /api/applications/add_project.
+// Since: 7.3.
+// Enterprise Edition only.
+func (s *ApplicationsService) AddProject(ctx context.Context, opt *ApplicationsAddProjectOptions) (*http.Response, error) {
+	err := s.ValidateAddProjectOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "applications/add_project", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// RemoveProject removes a project from an application.
+// Requires 'Administrator' permission on the application.
+//
+// API endpoint: POST /api/applications/remove_project.
+// Since: 7.3.
+// Enterprise Edition only.
+func (s *ApplicationsService) RemoveProject(ctx context.Context, opt *ApplicationsRemoveProjectOptions) (*http.Response, error) {
+	err := s.ValidateRemoveProjectOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "applications/remove_project", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// CreateBranch creates a new branch on an application.
+// Requires 'Administrator' permission on the application.
+//
+// API endpoint: POST /api/applications/create_branch.
+// Since: 7.3.
+// Enterprise Edition only.
+func (s *ApplicationsService) CreateBranch(ctx context.Context, opt *ApplicationsCreateBranchOptions) (*http.Response, error) {
+	err := s.ValidateCreateBranchOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "applications/create_branch", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// DeleteBranch deletes a branch on an application.
+// Requires 'Administrator' permission on the application.
+//
+// API endpoint: POST /api/applications/delete_branch.
+// Since: 7.3.
+// Enterprise Edition only.
+func (s *ApplicationsService) DeleteBranch(ctx context.Context, opt *ApplicationsDeleteBranchOptions) (*http.Response, error) {
+	err := s.ValidateDeleteBranchOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "applications/delete_branch", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// UpdateBranch updates a branch on an application.
+// Requires 'Administrator' permission on the application.
+//
+// API endpoint: POST /api/applications/update_branch.
+// Since: 7.3.
+// Enterprise Edition only.
+func (s *ApplicationsService) UpdateBranch(ctx context.Context, opt *ApplicationsUpdateBranchOptions) (*http.Response, error) {
+	err := s.ValidateUpdateBranchOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "applications/update_branch", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// SetTags sets tags on an application.
+// Requires 'Administer' permission on the application.
+//
+// API endpoint: POST /api/applications/set_tags.
+// Since: 8.3.
+// Enterprise Edition only.
+func (s *ApplicationsService) SetTags(ctx context.Context, opt *ApplicationsSetTagsOptions) (*http.Response, error) {
+	err := s.ValidateSetTagsOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "applications/set_tags", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// SearchProjects lists projects manually selected in an application.
+// Requires 'Administrator' permission on the application.
+//
+// API endpoint: GET /api/applications/search_projects.
+// Since: 7.3.
+// Enterprise Edition only.
+func (s *ApplicationsService) SearchProjects(ctx context.Context, opt *ApplicationsSearchProjectsOptions) (*ApplicationsSearchProjects, *http.Response, error) {
+	err := s.ValidateSearchProjectsOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "applications/search_projects", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(ApplicationsSearchProjects)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// Refresh triggers a recomputation of an application's measures.
+// Requires 'Administer System' or 'Administer' rights on the application.
+//
+// API endpoint: POST /api/applications/refresh.
+// Since: 8.6.
+// Enterprise Edition only.
+func (s *ApplicationsService) Refresh(ctx context.Context, opt *ApplicationsRefreshOptions) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "applications/refresh", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/sonar/applications_service.go
+++ b/sonar/applications_service.go
@@ -26,6 +26,22 @@ type Application struct {
 	Description string `json:"description,omitempty"`
 	// Visibility is the application visibility (public or private).
 	Visibility string `json:"visibility,omitempty"`
+	// Projects is the list of projects in the application.
+	Projects []string `json:"projects,omitempty"`
+}
+
+// ApplicationsCreate represents the response from the create endpoint.
+type ApplicationsCreate struct {
+	// Application contains the created application.
+	Application Application `json:"application,omitzero"`
+}
+
+// ApplicationBranch represents a branch of an application.
+type ApplicationBranch struct {
+	// Name is the branch name.
+	Name string `json:"name,omitempty"`
+	// IsMain indicates whether this is the main branch.
+	IsMain bool `json:"isMain,omitempty"`
 }
 
 // ApplicationDetails represents detailed information about an application.
@@ -40,14 +56,8 @@ type ApplicationDetails struct {
 	Visibility string `json:"visibility,omitempty"`
 	// Tags is the list of tags assigned to the application.
 	Tags []string `json:"tags,omitempty"`
-}
-
-// ApplicationBranch represents a branch of an application.
-type ApplicationBranch struct {
-	// Name is the branch name.
-	Name string `json:"name,omitempty"`
-	// IsMain indicates whether this is the main branch.
-	IsMain bool `json:"isMain,omitempty"`
+	// Branches is the list of branches of the application.
+	Branches []ApplicationBranch `json:"branches,omitempty"`
 }
 
 // ApplicationProject represents a project within an application.
@@ -298,7 +308,20 @@ func (s *ApplicationsService) ValidateCreateBranchOpt(opt *ApplicationsCreateBra
 		return err
 	}
 
-	return ValidateRequired(opt.Branch, "Branch")
+	err = ValidateRequired(opt.Branch, "Branch")
+	if err != nil {
+		return err
+	}
+
+	if len(opt.Project) == 0 {
+		return NewValidationError("Project", "at least one project is required", ErrMissingRequired)
+	}
+
+	if len(opt.ProjectBranch) == 0 {
+		return NewValidationError("ProjectBranch", "at least one project branch is required", ErrMissingRequired)
+	}
+
+	return nil
 }
 
 // ValidateDeleteBranchOpt validates the options for the DeleteBranch method.
@@ -331,7 +354,20 @@ func (s *ApplicationsService) ValidateUpdateBranchOpt(opt *ApplicationsUpdateBra
 		return err
 	}
 
-	return ValidateRequired(opt.Name, "Name")
+	err = ValidateRequired(opt.Name, "Name")
+	if err != nil {
+		return err
+	}
+
+	if len(opt.Project) == 0 {
+		return NewValidationError("Project", "at least one project is required", ErrMissingRequired)
+	}
+
+	if len(opt.ProjectBranch) == 0 {
+		return NewValidationError("ProjectBranch", "at least one project branch is required", ErrMissingRequired)
+	}
+
+	return nil
 }
 
 // ValidateSetTagsOpt validates the options for the SetTags method.
@@ -377,18 +413,25 @@ func (s *ApplicationsService) ValidateSearchProjectsOpt(opt *ApplicationsSearchP
 // API endpoint: POST /api/applications/create.
 // Since: 7.3.
 // Enterprise Edition only.
-func (s *ApplicationsService) Create(ctx context.Context, opt *ApplicationsCreateOptions) (*http.Response, error) {
+func (s *ApplicationsService) Create(ctx context.Context, opt *ApplicationsCreateOptions) (*ApplicationsCreate, *http.Response, error) {
 	err := s.ValidateCreateOpt(opt)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "applications/create", opt)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return s.client.Do(req, nil)
+	result := new(ApplicationsCreate)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
 }
 
 // Delete deletes an application definition.
@@ -603,6 +646,28 @@ func (s *ApplicationsService) SearchProjects(ctx context.Context, opt *Applicati
 	}
 
 	return result, resp, nil
+}
+
+// SearchAllProjects fetches all pages from SearchProjects and returns a flat slice of projects.
+// Requires 'Administrator' permission on the application.
+//
+// Enterprise Edition only.
+func (s *ApplicationsService) SearchAllProjects(ctx context.Context, opt *ApplicationsSearchProjectsOptions) ([]ApplicationProject, *http.Response, error) {
+	err := s.ValidateSearchProjectsOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o := *opt
+
+	return allPages(ctx, &o.Page, &o.PageSize, func(ctx context.Context) ([]ApplicationProject, int64, *http.Response, error) {
+		r, resp, err := s.SearchProjects(ctx, &o)
+		if err != nil {
+			return nil, 0, resp, err
+		}
+
+		return r.Projects, r.Paging.Total, resp, nil
+	})
 }
 
 // Refresh triggers a recomputation of an application's measures.

--- a/sonar/applications_service.go
+++ b/sonar/applications_service.go
@@ -45,6 +45,8 @@ type ApplicationBranch struct {
 }
 
 // ApplicationDetails represents detailed information about an application.
+//
+//nolint:govet // fieldalignment: logical field grouping takes priority over optimal packing
 type ApplicationDetails struct {
 	// Key is the application key.
 	Key string `json:"key,omitempty"`
@@ -54,18 +56,30 @@ type ApplicationDetails struct {
 	Description string `json:"description,omitempty"`
 	// Visibility is the application visibility.
 	Visibility string `json:"visibility,omitempty"`
+	// Branch is the name of the branch currently being viewed.
+	Branch string `json:"branch,omitempty"`
+	// IsMain indicates whether the currently viewed branch is the main branch.
+	IsMain bool `json:"isMain,omitempty"`
 	// Tags is the list of tags assigned to the application.
 	Tags []string `json:"tags,omitempty"`
+	// Projects is the list of projects configured in the application.
+	Projects []ApplicationProject `json:"projects,omitempty"`
 	// Branches is the list of branches of the application.
 	Branches []ApplicationBranch `json:"branches,omitempty"`
 }
 
-// ApplicationProject represents a project within an application.
+// ApplicationProject represents a project configured within an application.
 type ApplicationProject struct {
 	// Key is the project key.
 	Key string `json:"key,omitempty"`
 	// Name is the project name.
 	Name string `json:"name,omitempty"`
+	// Branch is the project branch used in this application branch.
+	Branch string `json:"branch,omitempty"`
+	// IsMain indicates whether the project branch is the main branch.
+	IsMain bool `json:"isMain,omitempty"`
+	// Enabled indicates whether the project is enabled in the application.
+	Enabled bool `json:"enabled,omitempty"`
 	// Selected indicates whether the project is selected in the application.
 	Selected bool `json:"selected,omitempty"`
 }
@@ -74,6 +88,22 @@ type ApplicationProject struct {
 type ApplicationsShow struct {
 	// Application contains the application details.
 	Application ApplicationDetails `json:"application,omitzero"`
+}
+
+// ApplicationLeakPeriod represents the new code period start date for a project within an application.
+type ApplicationLeakPeriod struct {
+	// Project is the project key.
+	Project string `json:"project,omitempty"`
+	// ProjectName is the project name.
+	ProjectName string `json:"projectName,omitempty"`
+	// Date is the start date of the new code period.
+	Date string `json:"date,omitempty"`
+}
+
+// ApplicationsShowLeak represents the response from the show_leak endpoint.
+type ApplicationsShowLeak struct {
+	// Leaks is the list of new code period dates per project in the application.
+	Leaks []ApplicationLeakPeriod `json:"leaks,omitempty"`
 }
 
 // ApplicationsSearchProjects represents the response from the search_projects endpoint.
@@ -108,6 +138,14 @@ type ApplicationsDeleteOptions struct {
 
 // ApplicationsShowOptions contains parameters for the Show method.
 type ApplicationsShowOptions struct {
+	// Application is the application key. This field is required.
+	Application string `url:"application"`
+	// Branch is the branch name. Optional.
+	Branch string `url:"branch,omitempty"`
+}
+
+// ApplicationsShowLeakOptions contains parameters for the ShowLeak method.
+type ApplicationsShowLeakOptions struct {
 	// Application is the application key. This field is required.
 	Application string `url:"application"`
 	// Branch is the branch name. Optional.
@@ -178,8 +216,8 @@ type ApplicationsUpdateBranchOptions struct {
 type ApplicationsSetTagsOptions struct {
 	// Application is the application key. This field is required.
 	Application string `url:"application"`
-	// Tags is a comma-separated list of tags. This field is required.
-	Tags string `url:"tags"`
+	// Tags is the list of tags to set on the application. This field is required.
+	Tags []string `url:"tags,comma"`
 }
 
 // ApplicationsSearchProjectsOptions contains parameters for the SearchProjects method.
@@ -190,8 +228,8 @@ type ApplicationsSearchProjectsOptions struct {
 
 	// Application is the application key. This field is required.
 	Application string `url:"application"`
-	// Q limits search to project names containing this string. Optional.
-	Q string `url:"q,omitempty"`
+	// Query limits search to project names containing this string. Optional.
+	Query string `url:"q,omitempty"`
 	// Selected filters by selection state (selected, deselected, all). Optional.
 	Selected string `url:"selected,omitempty"`
 }
@@ -248,6 +286,15 @@ func (s *ApplicationsService) ValidateDeleteOpt(opt *ApplicationsDeleteOptions) 
 
 // ValidateShowOpt validates the options for the Show method.
 func (s *ApplicationsService) ValidateShowOpt(opt *ApplicationsShowOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Application, "Application")
+}
+
+// ValidateShowLeakOpt validates the options for the ShowLeak method.
+func (s *ApplicationsService) ValidateShowLeakOpt(opt *ApplicationsShowLeakOptions) error {
 	if opt == nil {
 		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
 	}
@@ -381,7 +428,11 @@ func (s *ApplicationsService) ValidateSetTagsOpt(opt *ApplicationsSetTagsOptions
 		return err
 	}
 
-	return ValidateRequired(opt.Tags, "Tags")
+	if len(opt.Tags) == 0 {
+		return NewValidationError("Tags", "is required", ErrMissingRequired)
+	}
+
+	return nil
 }
 
 // ValidateSearchProjectsOpt validates the options for the SearchProjects method.
@@ -472,6 +523,33 @@ func (s *ApplicationsService) Show(ctx context.Context, opt *ApplicationsShowOpt
 	}
 
 	result := new(ApplicationsShow)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// ShowLeak returns an application and its associated projects with new code period metrics.
+// Requires 'Browse' permission on the application and on its child projects.
+//
+// API endpoint: GET /api/applications/show_leak.
+// Since: 7.3.
+// Enterprise Edition only.
+func (s *ApplicationsService) ShowLeak(ctx context.Context, opt *ApplicationsShowLeakOptions) (*ApplicationsShowLeak, *http.Response, error) {
+	err := s.ValidateShowLeakOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "applications/show_leak", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(ApplicationsShowLeak)
 
 	resp, err := s.client.Do(req, result)
 	if err != nil {

--- a/sonar/applications_service_test.go
+++ b/sonar/applications_service_test.go
@@ -350,10 +350,19 @@ func TestApplicationsService_UpdateBranch_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 
-	resp, err = client.Applications.UpdateBranch(context.Background(), &ApplicationsUpdateBranchOptions{
-		Application: "app",
-		Branch:      "branch",
-	})
+	resp, err = client.Applications.UpdateBranch(context.Background(), &ApplicationsUpdateBranchOptions{Application: "app", Branch: "branch"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.UpdateBranch(context.Background(), &ApplicationsUpdateBranchOptions{Application: "app", Branch: "branch", Name: "name"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.UpdateBranch(context.Background(), &ApplicationsUpdateBranchOptions{Application: "app", Branch: "branch", Name: "name", Project: []string{"p1"}})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.UpdateBranch(context.Background(), &ApplicationsUpdateBranchOptions{Application: "app", Branch: "branch", Name: "name", Project: []string{"p1", "p2"}, ProjectBranch: []string{"main"}})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 

--- a/sonar/applications_service_test.go
+++ b/sonar/applications_service_test.go
@@ -14,33 +14,43 @@ import (
 // -----------------------------------------------------------------------------
 
 func TestApplicationsService_Create(t *testing.T) {
-	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/applications/create", http.StatusNoContent))
+	response := ApplicationsCreate{
+		Application: Application{
+			Key:  "my-application",
+			Name: "My Application",
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodPost, "/applications/create", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Applications.Create(context.Background(), &ApplicationsCreateOptions{
+	result, resp, err := client.Applications.Create(context.Background(), &ApplicationsCreateOptions{
 		Name: "My Application",
 		Key:  "my-application",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "my-application", result.Application.Key)
 }
 
 func TestApplicationsService_Create_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
-	resp, err := client.Applications.Create(context.Background(), nil)
+	result, resp, err := client.Applications.Create(context.Background(), nil)
 	assert.Error(t, err)
+	assert.Nil(t, result)
 	assert.Nil(t, resp)
 
-	resp, err = client.Applications.Create(context.Background(), &ApplicationsCreateOptions{})
+	result, resp, err = client.Applications.Create(context.Background(), &ApplicationsCreateOptions{})
 	assert.Error(t, err)
+	assert.Nil(t, result)
 	assert.Nil(t, resp)
 
-	resp, err = client.Applications.Create(context.Background(), &ApplicationsCreateOptions{
+	result, resp, err = client.Applications.Create(context.Background(), &ApplicationsCreateOptions{
 		Name:       "My App",
 		Visibility: "invalid",
 	})
 	assert.Error(t, err)
+	assert.Nil(t, result)
 	assert.Nil(t, resp)
 }
 
@@ -174,6 +184,22 @@ func TestApplicationsService_RemoveProject(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
+func TestApplicationsService_RemoveProject_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Applications.RemoveProject(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.RemoveProject(context.Background(), &ApplicationsRemoveProjectOptions{Project: "proj"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.RemoveProject(context.Background(), &ApplicationsRemoveProjectOptions{Application: "app"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
 // -----------------------------------------------------------------------------
 // CreateBranch / DeleteBranch / UpdateBranch
 // -----------------------------------------------------------------------------
@@ -202,6 +228,21 @@ func TestApplicationsService_CreateBranch_ValidationError(t *testing.T) {
 	resp, err = client.Applications.CreateBranch(context.Background(), &ApplicationsCreateBranchOptions{Branch: "b"})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
+
+	resp, err = client.Applications.CreateBranch(context.Background(), &ApplicationsCreateBranchOptions{
+		Application: "app",
+		Branch:      "b",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.CreateBranch(context.Background(), &ApplicationsCreateBranchOptions{
+		Application: "app",
+		Branch:      "b",
+		Project:     []string{"proj1"},
+	})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
 }
 
 func TestApplicationsService_DeleteBranch(t *testing.T) {
@@ -214,6 +255,22 @@ func TestApplicationsService_DeleteBranch(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestApplicationsService_DeleteBranch_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Applications.DeleteBranch(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.DeleteBranch(context.Background(), &ApplicationsDeleteBranchOptions{Branch: "b"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.DeleteBranch(context.Background(), &ApplicationsDeleteBranchOptions{Application: "app"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
 }
 
 func TestApplicationsService_UpdateBranch(t *testing.T) {
@@ -241,6 +298,23 @@ func TestApplicationsService_UpdateBranch_ValidationError(t *testing.T) {
 	resp, err = client.Applications.UpdateBranch(context.Background(), &ApplicationsUpdateBranchOptions{
 		Application: "app",
 		Branch:      "branch",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.UpdateBranch(context.Background(), &ApplicationsUpdateBranchOptions{
+		Application: "app",
+		Branch:      "branch",
+		Name:        "new-name",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.UpdateBranch(context.Background(), &ApplicationsUpdateBranchOptions{
+		Application: "app",
+		Branch:      "branch",
+		Name:        "new-name",
+		Project:     []string{"proj1"},
 	})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
@@ -311,6 +385,29 @@ func TestApplicationsService_SearchProjects_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// SearchAllProjects
+// -----------------------------------------------------------------------------
+
+func TestApplicationsService_SearchAllProjects(t *testing.T) {
+	response := ApplicationsSearchProjects{
+		Projects: []ApplicationProject{
+			{Key: "proj1", Name: "Project 1", Selected: true},
+			{Key: "proj2", Name: "Project 2", Selected: false},
+		},
+		Paging: Paging{Total: 2, PageIndex: 1, PageSize: 100},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/applications/search_projects", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	results, resp, err := client.Applications.SearchAllProjects(context.Background(), &ApplicationsSearchProjectsOptions{
+		Application: "my-application",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, results, 2)
 }
 
 // -----------------------------------------------------------------------------

--- a/sonar/applications_service_test.go
+++ b/sonar/applications_service_test.go
@@ -1,0 +1,327 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// Create
+// -----------------------------------------------------------------------------
+
+func TestApplicationsService_Create(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/applications/create", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Applications.Create(context.Background(), &ApplicationsCreateOptions{
+		Name: "My Application",
+		Key:  "my-application",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestApplicationsService_Create_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Applications.Create(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.Create(context.Background(), &ApplicationsCreateOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.Create(context.Background(), &ApplicationsCreateOptions{
+		Name:       "My App",
+		Visibility: "invalid",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// Delete
+// -----------------------------------------------------------------------------
+
+func TestApplicationsService_Delete(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/applications/delete", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Applications.Delete(context.Background(), &ApplicationsDeleteOptions{
+		Application: "my-application",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestApplicationsService_Delete_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Applications.Delete(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.Delete(context.Background(), &ApplicationsDeleteOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// Show
+// -----------------------------------------------------------------------------
+
+func TestApplicationsService_Show(t *testing.T) {
+	response := ApplicationsShow{
+		Application: ApplicationDetails{
+			Key:  "my-application",
+			Name: "My Application",
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/applications/show", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Applications.Show(context.Background(), &ApplicationsShowOptions{
+		Application: "my-application",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "my-application", result.Application.Key)
+}
+
+func TestApplicationsService_Show_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.Applications.Show(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// Update
+// -----------------------------------------------------------------------------
+
+func TestApplicationsService_Update(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/applications/update", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Applications.Update(context.Background(), &ApplicationsUpdateOptions{
+		Application: "my-application",
+		Name:        "Updated Application",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestApplicationsService_Update_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Applications.Update(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.Update(context.Background(), &ApplicationsUpdateOptions{Name: "name"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.Update(context.Background(), &ApplicationsUpdateOptions{Application: "app"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// AddProject / RemoveProject
+// -----------------------------------------------------------------------------
+
+func TestApplicationsService_AddProject(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/applications/add_project", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Applications.AddProject(context.Background(), &ApplicationsAddProjectOptions{
+		Application: "my-application",
+		Project:     "my-project",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestApplicationsService_AddProject_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Applications.AddProject(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.AddProject(context.Background(), &ApplicationsAddProjectOptions{Project: "proj"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestApplicationsService_RemoveProject(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/applications/remove_project", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Applications.RemoveProject(context.Background(), &ApplicationsRemoveProjectOptions{
+		Application: "my-application",
+		Project:     "my-project",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+// -----------------------------------------------------------------------------
+// CreateBranch / DeleteBranch / UpdateBranch
+// -----------------------------------------------------------------------------
+
+func TestApplicationsService_CreateBranch(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/applications/create_branch", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Applications.CreateBranch(context.Background(), &ApplicationsCreateBranchOptions{
+		Application:   "my-application",
+		Branch:        "feature-branch",
+		Project:       []string{"proj1"},
+		ProjectBranch: []string{"main"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestApplicationsService_CreateBranch_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Applications.CreateBranch(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.CreateBranch(context.Background(), &ApplicationsCreateBranchOptions{Branch: "b"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestApplicationsService_DeleteBranch(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/applications/delete_branch", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Applications.DeleteBranch(context.Background(), &ApplicationsDeleteBranchOptions{
+		Application: "my-application",
+		Branch:      "feature-branch",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestApplicationsService_UpdateBranch(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/applications/update_branch", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Applications.UpdateBranch(context.Background(), &ApplicationsUpdateBranchOptions{
+		Application:   "my-application",
+		Branch:        "feature-branch",
+		Name:          "new-branch-name",
+		Project:       []string{"proj1"},
+		ProjectBranch: []string{"main"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestApplicationsService_UpdateBranch_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Applications.UpdateBranch(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.UpdateBranch(context.Background(), &ApplicationsUpdateBranchOptions{
+		Application: "app",
+		Branch:      "branch",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// SetTags
+// -----------------------------------------------------------------------------
+
+func TestApplicationsService_SetTags(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/applications/set_tags", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Applications.SetTags(context.Background(), &ApplicationsSetTagsOptions{
+		Application: "my-application",
+		Tags:        "tag1,tag2",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestApplicationsService_SetTags_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.Applications.SetTags(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.Applications.SetTags(context.Background(), &ApplicationsSetTagsOptions{Application: "app"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// SearchProjects
+// -----------------------------------------------------------------------------
+
+func TestApplicationsService_SearchProjects(t *testing.T) {
+	response := ApplicationsSearchProjects{
+		Projects: []ApplicationProject{
+			{Key: "proj1", Name: "Project 1", Selected: true},
+		},
+		Paging: Paging{Total: 1, PageIndex: 1, PageSize: 10},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/applications/search_projects", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Applications.SearchProjects(context.Background(), &ApplicationsSearchProjectsOptions{
+		Application: "my-application",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, result.Projects, 1)
+}
+
+func TestApplicationsService_SearchProjects_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.Applications.SearchProjects(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.Applications.SearchProjects(context.Background(), &ApplicationsSearchProjectsOptions{
+		Application: "app",
+		Selected:    "invalid",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// Refresh
+// -----------------------------------------------------------------------------
+
+func TestApplicationsService_Refresh(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/applications/refresh", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.Applications.Refresh(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}

--- a/sonar/applications_service_test.go
+++ b/sonar/applications_service_test.go
@@ -88,25 +88,80 @@ func TestApplicationsService_Delete_ValidationError(t *testing.T) {
 func TestApplicationsService_Show(t *testing.T) {
 	response := ApplicationsShow{
 		Application: ApplicationDetails{
-			Key:  "my-application",
-			Name: "My Application",
+			Key:        "MY_APP",
+			Name:       "My Application",
+			Branch:     "main",
+			IsMain:     true,
+			Visibility: "private",
+			Tags:       []string{"react", "spring"},
+			Projects: []ApplicationProject{
+				{Key: "project:one", Name: "Project One", Branch: "main", IsMain: true, Enabled: true, Selected: true},
+				{Key: "project:two", Name: "Project Two", Branch: "main", IsMain: true, Enabled: true, Selected: true},
+			},
+			Branches: []ApplicationBranch{
+				{Name: "main", IsMain: true},
+				{Name: "branch-2.0", IsMain: false},
+			},
 		},
 	}
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/applications/show", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
 	result, resp, err := client.Applications.Show(context.Background(), &ApplicationsShowOptions{
-		Application: "my-application",
+		Application: "MY_APP",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "my-application", result.Application.Key)
+	assert.Equal(t, "MY_APP", result.Application.Key)
+	assert.True(t, result.Application.IsMain)
+	assert.Equal(t, "main", result.Application.Branch)
+	assert.Len(t, result.Application.Projects, 2)
+	assert.True(t, result.Application.Projects[0].Enabled)
+	assert.Len(t, result.Application.Branches, 2)
+	assert.Len(t, result.Application.Tags, 2)
 }
 
 func TestApplicationsService_Show_ValidationError(t *testing.T) {
 	client := newLocalhostClient(t)
 
 	result, resp, err := client.Applications.Show(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// ShowLeak
+// -----------------------------------------------------------------------------
+
+func TestApplicationsService_ShowLeak(t *testing.T) {
+	response := ApplicationsShowLeak{
+		Leaks: []ApplicationLeakPeriod{
+			{Project: "my_project", ProjectName: "My Project", Date: "2017-01-01T11:39:03+0100"},
+			{Project: "another_project", ProjectName: "Another Project", Date: "2017-02-01T11:39:03+0100"},
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/applications/show_leak", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Applications.ShowLeak(context.Background(), &ApplicationsShowLeakOptions{
+		Application: "my-application",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, result.Leaks, 2)
+	assert.Equal(t, "my_project", result.Leaks[0].Project)
+}
+
+func TestApplicationsService_ShowLeak_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.Applications.ShowLeak(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.Applications.ShowLeak(context.Background(), &ApplicationsShowLeakOptions{})
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Nil(t, resp)
@@ -330,7 +385,7 @@ func TestApplicationsService_SetTags(t *testing.T) {
 
 	resp, err := client.Applications.SetTags(context.Background(), &ApplicationsSetTagsOptions{
 		Application: "my-application",
-		Tags:        "tag1,tag2",
+		Tags:        []string{"tag1", "tag2"},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -33,6 +33,7 @@ type Client struct {
 	middlewares     []Middleware
 	userAgent       string
 
+	Applications        *ApplicationsService
 	AuditLogs           *AuditLogsService
 	AlmIntegrations     *AlmIntegrationsService
 	AlmSettings         *AlmSettingsService
@@ -396,6 +397,7 @@ func (c *Client) BaseURL() *url.URL {
 //
 //nolint:funlen // necessary to initialize all services
 func initServices(client *Client) {
+	client.Applications = &ApplicationsService{client: client}
 	client.AuditLogs = &AuditLogsService{client: client}
 	client.AlmIntegrations = &AlmIntegrationsService{client: client}
 	client.AlmSettings = &AlmSettingsService{client: client}

--- a/sonar/permissions_service.go
+++ b/sonar/permissions_service.go
@@ -373,9 +373,9 @@ type PermissionsBulkApplyTemplateOptions struct {
 	AnalyzedBefore string `url:"analyzedBefore,omitempty"`
 	// OnProvisionedOnly filters to only provisioned projects.
 	OnProvisionedOnly bool `url:"onProvisionedOnly,omitempty"`
-	// Projects is a comma-separated list of project keys.
+	// Projects is the list of project keys to restrict the operation to.
 	// Maximum 1000 values allowed.
-	Projects []string `url:"projects,omitempty"`
+	Projects []string `url:"projects,omitempty,comma"`
 	// Query limits search to project names containing the string or project keys matching exactly.
 	Query string `url:"q,omitempty"`
 	// Qualifiers filters by component qualifiers. Default is TRK (projects).

--- a/sonar/views_service.go
+++ b/sonar/views_service.go
@@ -170,8 +170,8 @@ type ViewsDeleteOptions struct {
 type ViewsSearchOptions struct {
 	PaginationArgs
 
-	// Q limits search to portfolios whose name or key contains this value.
-	Q string `url:"q,omitempty"`
+	// Query limits search to portfolios whose name or key contains this value.
+	Query string `url:"q,omitempty"`
 	// Qualifiers filters by component qualifier (VW for portfolio, SVW for sub-portfolio).
 	Qualifiers string `url:"qualifiers,omitempty"`
 	// OnlyFavorites if true restricts results to favorite portfolios only.
@@ -377,8 +377,8 @@ type ViewsSetTagsModeOptions struct {
 	Branch string `url:"branch,omitempty"`
 	// Portfolio is the portfolio key. This field is required.
 	Portfolio string `url:"portfolio"`
-	// Tags is a comma-separated list of project tags. This field is required.
-	Tags string `url:"tags"`
+	// Tags is the list of project tags to match. This field is required.
+	Tags []string `url:"tags,comma"`
 }
 
 // -----------------------------------------------------------------------------
@@ -734,7 +734,11 @@ func (s *ViewsService) ValidateSetTagsModeOpt(opt *ViewsSetTagsModeOptions) erro
 		return err
 	}
 
-	return ValidateRequired(opt.Tags, "Tags")
+	if len(opt.Tags) == 0 {
+		return NewValidationError("Tags", "is required", ErrMissingRequired)
+	}
+
+	return nil
 }
 
 // -----------------------------------------------------------------------------

--- a/sonar/views_service_test.go
+++ b/sonar/views_service_test.go
@@ -648,7 +648,7 @@ func TestViewsService_Search(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/views/search", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Views.Search(context.Background(), &ViewsSearchOptions{Q: "Portfolio"})
+	result, resp, err := client.Views.Search(context.Background(), &ViewsSearchOptions{Query: "Portfolio"})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -769,7 +769,7 @@ func TestViewsService_SetTagsMode(t *testing.T) {
 
 	resp, err := client.Views.SetTagsMode(context.Background(), &ViewsSetTagsModeOptions{
 		Portfolio: "my-portfolio",
-		Tags:      "java,security",
+		Tags:      []string{"java", "security"},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)


### PR DESCRIPTION
### Description of your changes

This PR adds the new "Applications" Service to interact with the enterprise applications endpoints.

e2e tests are dummies for now.

Closes #209 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
