### PR TITLE
feat(enterprise): support governance_reports endpoints

### DIFF
--- a/integration_testing/governance_reports_test.go
+++ b/integration_testing/governance_reports_test.go
@@ -1,0 +1,152 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Governance Reports Service", Ordered, func() {
+	var client *sonar.Client
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+	})
+
+	// =========================================================================
+	// Download
+	// =========================================================================
+	Describe("Download", func() {
+		Context("Functional Tests", func() {
+			It("should download or return an enterprise-only error", func() {
+				result, resp, err := client.GovernanceReports.Download(context.Background(), &sonar.GovernanceReportsDownloadOptions{
+					ComponentKey: "nonexistent-portfolio",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Status
+	// =========================================================================
+	Describe("Status", func() {
+		Context("Functional Tests", func() {
+			It("should return status or an enterprise-only error", func() {
+				result, resp, err := client.GovernanceReports.Status(context.Background(), &sonar.GovernanceReportsStatusOptions{
+					ComponentKey: "nonexistent-portfolio",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Subscribe
+	// =========================================================================
+	Describe("Subscribe", func() {
+		Context("Functional Tests", func() {
+			It("should subscribe or return an enterprise-only error", func() {
+				resp, err := client.GovernanceReports.Subscribe(context.Background(), &sonar.GovernanceReportsSubscribeOptions{
+					ComponentKey: "nonexistent-portfolio",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Unsubscribe
+	// =========================================================================
+	Describe("Unsubscribe", func() {
+		Context("Functional Tests", func() {
+			It("should unsubscribe or return an enterprise-only error", func() {
+				resp, err := client.GovernanceReports.Unsubscribe(context.Background(), &sonar.GovernanceReportsUnsubscribeOptions{
+					ComponentKey: "nonexistent-portfolio",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// UpdateFrequency
+	// =========================================================================
+	Describe("UpdateFrequency", func() {
+		Context("Functional Tests", func() {
+			It("should update frequency or return an enterprise-only error", func() {
+				resp, err := client.GovernanceReports.UpdateFrequency(context.Background(), &sonar.GovernanceReportsUpdateFrequencyOptions{
+					ComponentKey: "nonexistent-portfolio",
+					Frequency:    "WEEKLY",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// UpdateRecipients
+	// =========================================================================
+	Describe("UpdateRecipients", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.GovernanceReports.UpdateRecipients(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required recipients", func() {
+				resp, err := client.GovernanceReports.UpdateRecipients(context.Background(), &sonar.GovernanceReportsUpdateRecipientsOptions{
+					ComponentKey: "my-portfolio",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Recipients"))
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should update recipients or return an enterprise-only error", func() {
+				resp, err := client.GovernanceReports.UpdateRecipients(context.Background(), &sonar.GovernanceReportsUpdateRecipientsOptions{
+					ComponentKey: "nonexistent-portfolio",
+					Recipients:   "test@example.com",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+				}
+			})
+		})
+	})
+})

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -70,6 +70,7 @@ type Client struct {
 	Favorites           *FavoritesService
 	Features            *FeaturesService
 	GithubProvisioning  *GithubProvisioningService
+	GovernanceReports   *GovernanceReportsService
 	Hotspots            *HotspotsService
 	Issues              *IssuesService
 	L10N                *L10NService
@@ -497,6 +498,7 @@ func initServices(client *Client) {
 	client.Favorites = &FavoritesService{client: client}
 	client.Features = &FeaturesService{client: client}
 	client.GithubProvisioning = &GithubProvisioningService{client: client}
+	client.GovernanceReports = &GovernanceReportsService{client: client}
 	client.Hotspots = &HotspotsService{client: client}
 	client.Issues = &IssuesService{client: client}
 	client.L10N = &L10NService{client: client}

--- a/sonar/governance_reports_service.go
+++ b/sonar/governance_reports_service.go
@@ -1,0 +1,244 @@
+package sonar
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+)
+
+// GovernanceReportsService handles communication with the governance reports
+// related methods of the SonarQube API.
+// This service is only available in Enterprise Edition.
+type GovernanceReportsService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Response Types
+// -----------------------------------------------------------------------------
+
+// GovernanceReportsStatus represents the metadata of a governance report.
+//
+// Verified against a live SonarQube 2025.2 Enterprise Edition instance:
+// componentKey/hasFile do not exist on the real response; the actual shape
+// is canDownload/canSubscribe/canAdmin/globalFrequency/subscribed, plus
+// componentRecipients/globalRecipients when recipients have been configured.
+//
+//nolint:govet // fieldalignment: keeping fields grouped in the order the API returns them
+type GovernanceReportsStatus struct {
+	// ComponentRecipients is the list of recipient emails configured on the
+	// component itself. Only present when component-level recipients exist.
+	ComponentRecipients []string `json:"componentRecipients,omitempty"`
+	// GlobalRecipients is the list of recipient emails configured at the
+	// global level. Only present when global recipients exist.
+	GlobalRecipients []string `json:"globalRecipients,omitempty"`
+	// GlobalFrequency is the report frequency configured at the global level
+	// (e.g. "monthly").
+	GlobalFrequency string `json:"globalFrequency,omitempty"`
+	// CanDownload indicates whether the current user can download the report.
+	CanDownload bool `json:"canDownload"`
+	// CanSubscribe indicates whether the current user can subscribe to the report.
+	CanSubscribe bool `json:"canSubscribe"`
+	// CanAdmin indicates whether the current user can administer the report
+	// (update its frequency and recipients).
+	CanAdmin bool `json:"canAdmin"`
+	// Subscribed indicates whether the current user is subscribed to reports.
+	Subscribed bool `json:"subscribed"`
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// GovernanceReportsDownloadOptions contains parameters for the Download method.
+type GovernanceReportsDownloadOptions struct {
+	// BranchKey is the branch key. Optional.
+	BranchKey string `url:"branchKey,omitempty"`
+	// ComponentID is the component id. Optional.
+	ComponentID string `url:"componentId,omitempty"`
+	// ComponentKey is the component key. Optional.
+	ComponentKey string `url:"componentKey,omitempty"`
+}
+
+// GovernanceReportsStatusOptions contains parameters for the Status method.
+type GovernanceReportsStatusOptions struct {
+	// BranchKey is the branch key. Optional.
+	BranchKey string `url:"branchKey,omitempty"`
+	// ComponentID is the component id. Optional.
+	ComponentID string `url:"componentId,omitempty"`
+	// ComponentKey is the component key. Optional.
+	ComponentKey string `url:"componentKey,omitempty"`
+}
+
+// GovernanceReportsSubscribeOptions contains parameters for the Subscribe method.
+type GovernanceReportsSubscribeOptions struct {
+	// BranchKey is the branch key. Optional.
+	BranchKey string `url:"branchKey,omitempty"`
+	// ComponentID is the component id. Optional.
+	ComponentID string `url:"componentId,omitempty"`
+	// ComponentKey is the component key. Optional.
+	ComponentKey string `url:"componentKey,omitempty"`
+}
+
+// GovernanceReportsUnsubscribeOptions contains parameters for the Unsubscribe method.
+type GovernanceReportsUnsubscribeOptions struct {
+	// BranchKey is the branch key. Optional.
+	BranchKey string `url:"branchKey,omitempty"`
+	// ComponentID is the component id. Optional.
+	ComponentID string `url:"componentId,omitempty"`
+	// ComponentKey is the component key. Optional.
+	ComponentKey string `url:"componentKey,omitempty"`
+}
+
+// GovernanceReportsUpdateFrequencyOptions contains parameters for the UpdateFrequency method.
+type GovernanceReportsUpdateFrequencyOptions struct {
+	// BranchKey is the branch key. Optional.
+	BranchKey string `url:"branchKey,omitempty"`
+	// ComponentID is the component id. Optional.
+	ComponentID string `url:"componentId,omitempty"`
+	// ComponentKey is the component key. Optional.
+	ComponentKey string `url:"componentKey,omitempty"`
+	// Frequency is the report frequency. Optional. Valid values: DAILY, WEEKLY, MONTHLY.
+	Frequency string `url:"frequency,omitempty"`
+}
+
+// GovernanceReportsUpdateRecipientsOptions contains parameters for the UpdateRecipients method.
+type GovernanceReportsUpdateRecipientsOptions struct {
+	// BranchKey is the branch key. Optional.
+	BranchKey string `url:"branchKey,omitempty"`
+	// ComponentID is the component id. Optional.
+	ComponentID string `url:"componentId,omitempty"`
+	// ComponentKey is the component key. Optional.
+	ComponentKey string `url:"componentKey,omitempty"`
+	// Recipients is the list of recipient emails. This field is required.
+	Recipients string `url:"recipients"`
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateUpdateRecipientsOpt validates the options for the UpdateRecipients method.
+func (s *GovernanceReportsService) ValidateUpdateRecipientsOpt(opt *GovernanceReportsUpdateRecipientsOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Recipients, "Recipients")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// Download downloads the PDF report of a portfolio, sub-portfolio, project or application.
+// Requires 'Browse' permission on the component.
+//
+// API endpoint: GET /api/governance_reports/download.
+// Since: 1.0.
+// Enterprise Edition only.
+func (s *GovernanceReportsService) Download(ctx context.Context, opt *GovernanceReportsDownloadOptions) ([]byte, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "governance_reports/download", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.Header.Set("Accept", "application/pdf")
+
+	var buf bytes.Buffer
+
+	resp, err := s.client.Do(req, &buf)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return buf.Bytes(), resp, nil
+}
+
+// Status returns PDF report metadata (action rights, report availability etc.).
+// Requires 'Browse' permission on the component.
+//
+// API endpoint: GET /api/governance_reports/status.
+// Since: 1.0.
+// Enterprise Edition only.
+func (s *GovernanceReportsService) Status(ctx context.Context, opt *GovernanceReportsStatusOptions) (*GovernanceReportsStatus, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "governance_reports/status", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(GovernanceReportsStatus)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// Subscribe subscribes the current user to reports for a component.
+// Requires authentication and 'Browse' permission on the component.
+//
+// API endpoint: POST /api/governance_reports/subscribe.
+// Since: 1.0.
+// Enterprise Edition only.
+func (s *GovernanceReportsService) Subscribe(ctx context.Context, opt *GovernanceReportsSubscribeOptions) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "governance_reports/subscribe", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Unsubscribe unsubscribes the current user from reports for a component.
+// Requires authentication and 'Browse' permission on the component.
+//
+// API endpoint: POST /api/governance_reports/unsubscribe.
+// Since: 1.0.
+// Enterprise Edition only.
+func (s *GovernanceReportsService) Unsubscribe(ctx context.Context, opt *GovernanceReportsUnsubscribeOptions) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "governance_reports/unsubscribe", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// UpdateFrequency updates the frequency at which a report is sent for a component.
+// Requires 'Administer' permission.
+//
+// API endpoint: POST /api/governance_reports/update_frequency.
+// Since: 1.0.
+// Enterprise Edition only.
+func (s *GovernanceReportsService) UpdateFrequency(ctx context.Context, opt *GovernanceReportsUpdateFrequencyOptions) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "governance_reports/update_frequency", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// UpdateRecipients updates the list of users who will receive reports for a component.
+// Requires 'Administer' permission.
+//
+// API endpoint: POST /api/governance_reports/update_recipients.
+// Since: 1.0.
+// Enterprise Edition only.
+func (s *GovernanceReportsService) UpdateRecipients(ctx context.Context, opt *GovernanceReportsUpdateRecipientsOptions) (*http.Response, error) {
+	err := s.ValidateUpdateRecipientsOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "governance_reports/update_recipients", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/sonar/governance_reports_service_test.go
+++ b/sonar/governance_reports_service_test.go
@@ -1,0 +1,138 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// Download
+// -----------------------------------------------------------------------------
+
+func TestGovernanceReportsService_Download(t *testing.T) {
+	data := []byte(`%PDF-1.4 report content`)
+	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/governance_reports/download", http.StatusOK, "application/pdf", data))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.GovernanceReports.Download(context.Background(), &GovernanceReportsDownloadOptions{
+		ComponentKey: "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, result)
+}
+
+func TestGovernanceReportsService_Download_NoOptions(t *testing.T) {
+	data := []byte(`%PDF-1.4 report content`)
+	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/governance_reports/download", http.StatusOK, "application/pdf", data))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.GovernanceReports.Download(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, result)
+}
+
+// -----------------------------------------------------------------------------
+// Status
+// -----------------------------------------------------------------------------
+
+func TestGovernanceReportsService_Status(t *testing.T) {
+	response := GovernanceReportsStatus{
+		CanDownload:         true,
+		CanSubscribe:        true,
+		CanAdmin:            true,
+		GlobalFrequency:     "monthly",
+		Subscribed:          false,
+		ComponentRecipients: []string{"test@example.com"},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/governance_reports/status", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.GovernanceReports.Status(context.Background(), &GovernanceReportsStatusOptions{
+		ComponentKey: "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotNil(t, result)
+	assert.True(t, result.CanDownload)
+	assert.True(t, result.CanSubscribe)
+	assert.True(t, result.CanAdmin)
+	assert.Equal(t, "monthly", result.GlobalFrequency)
+	assert.False(t, result.Subscribed)
+	assert.Equal(t, []string{"test@example.com"}, result.ComponentRecipients)
+}
+
+// -----------------------------------------------------------------------------
+// Subscribe / Unsubscribe
+// -----------------------------------------------------------------------------
+
+func TestGovernanceReportsService_Subscribe(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/governance_reports/subscribe", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.GovernanceReports.Subscribe(context.Background(), &GovernanceReportsSubscribeOptions{
+		ComponentKey: "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestGovernanceReportsService_Unsubscribe(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/governance_reports/unsubscribe", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.GovernanceReports.Unsubscribe(context.Background(), &GovernanceReportsUnsubscribeOptions{
+		ComponentKey: "my-portfolio",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+// -----------------------------------------------------------------------------
+// UpdateFrequency
+// -----------------------------------------------------------------------------
+
+func TestGovernanceReportsService_UpdateFrequency(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/governance_reports/update_frequency", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.GovernanceReports.UpdateFrequency(context.Background(), &GovernanceReportsUpdateFrequencyOptions{
+		ComponentKey: "my-portfolio",
+		Frequency:    "WEEKLY",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+// -----------------------------------------------------------------------------
+// UpdateRecipients
+// -----------------------------------------------------------------------------
+
+func TestGovernanceReportsService_UpdateRecipients(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/governance_reports/update_recipients", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.GovernanceReports.UpdateRecipients(context.Background(), &GovernanceReportsUpdateRecipientsOptions{
+		ComponentKey: "my-portfolio",
+		Recipients:   "user@example.com",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestGovernanceReportsService_UpdateRecipients_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.GovernanceReports.UpdateRecipients(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.GovernanceReports.UpdateRecipients(context.Background(), &GovernanceReportsUpdateRecipientsOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}


### PR DESCRIPTION
### Description of your changes

This PR adds the new "GovernanceReports" Service to interact with the enterprise Governance reports endpoints.

Packaged with full mock api response unit tests

e2e tests are dummies for now.

Closes #211 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
