### PR TITLE
feat(enterprise): support project_pull_requests endpoints

### DIFF
--- a/integration_testing/project_pull_requests_test.go
+++ b/integration_testing/project_pull_requests_test.go
@@ -1,0 +1,105 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Project Pull Requests Service", Ordered, func() {
+	var client *sonar.Client
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+	})
+
+	// =========================================================================
+	// Delete
+	// =========================================================================
+	Describe("Delete", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.ProjectPullRequests.Delete(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required project", func() {
+				resp, err := client.ProjectPullRequests.Delete(context.Background(), &sonar.ProjectPullRequestsDeleteOptions{
+					PullRequest: "123",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Project"))
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required pull request", func() {
+				resp, err := client.ProjectPullRequests.Delete(context.Background(), &sonar.ProjectPullRequestsDeleteOptions{
+					Project: "my-project",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("PullRequest"))
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should succeed or return an expected error", func() {
+				resp, err := client.ProjectPullRequests.Delete(context.Background(), &sonar.ProjectPullRequestsDeleteOptions{
+					Project:     "nonexistent-project",
+					PullRequest: "nonexistent-pr",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// List
+	// =========================================================================
+	Describe("List", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.ProjectPullRequests.List(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required project", func() {
+				result, resp, err := client.ProjectPullRequests.List(context.Background(), &sonar.ProjectPullRequestsListOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Project"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should succeed or return an expected error", func() {
+				result, resp, err := client.ProjectPullRequests.List(context.Background(), &sonar.ProjectPullRequestsListOptions{
+					Project: "nonexistent-project",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+})

--- a/sonar/alm_settings_service_test.go
+++ b/sonar/alm_settings_service_test.go
@@ -591,7 +591,7 @@ func TestAlmSettings_ListDefinitions(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/alm_settings/list_definitions", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.AlmSettings.ListDefinitions(context.Background(), )
+	result, resp, err := client.AlmSettings.ListDefinitions(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/analysis_cache_service_test.go
+++ b/sonar/analysis_cache_service_test.go
@@ -1,8 +1,8 @@
 package sonar
 
 import (
-	"context"
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"

--- a/sonar/analysis_reports_service_test.go
+++ b/sonar/analysis_reports_service_test.go
@@ -25,7 +25,7 @@ func TestAnalysisReports_QueueStatus(t *testing.T) {
 			server := newTestServer(t, handler)
 			client := newTestClient(t, server.url())
 
-			result, resp, err := client.AnalysisReports.QueueStatus(context.Background(), )
+			result, resp, err := client.AnalysisReports.QueueStatus(context.Background())
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			require.NotNil(t, result)

--- a/sonar/analysis_v2_service_test.go
+++ b/sonar/analysis_v2_service_test.go
@@ -1,8 +1,8 @@
 package sonar
 
 import (
-	"context"
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"testing"
@@ -19,7 +19,7 @@ func TestAnalysisV2_GetVersion(t *testing.T) {
 	server := newTestServer(t, mockTextHandler(t, http.MethodGet, "/v2/analysis/version", http.StatusOK, "10.5.0.12345"))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Analysis.GetVersion(context.Background(), )
+	result, resp, err := client.V2.Analysis.GetVersion(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "10.5.0.12345", *result)
@@ -168,7 +168,7 @@ func TestAnalysisV2_GetScannerEngineMetadata(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/analysis/engine", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Analysis.GetScannerEngineMetadata(context.Background(), )
+	result, resp, err := client.V2.Analysis.GetScannerEngineMetadata(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "scanner-engine.jar", result.Filename)

--- a/sonar/authentication_service_test.go
+++ b/sonar/authentication_service_test.go
@@ -49,7 +49,7 @@ func TestAuthentication_Logout(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	resp, err := client.Authentication.Logout(context.Background(), )
+	resp, err := client.Authentication.Logout(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -70,7 +70,7 @@ func TestAuthentication_Validate(t *testing.T) {
 			server := newTestServer(t, handler)
 			client := newTestClient(t, server.url())
 
-			result, resp, err := client.Authentication.Validate(context.Background(), )
+			result, resp, err := client.Authentication.Validate(context.Background())
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			require.NotNil(t, result)

--- a/sonar/batch_service_test.go
+++ b/sonar/batch_service_test.go
@@ -51,7 +51,7 @@ func TestBatchService_GetIndex(t *testing.T) {
 		server := newTestServer(t, handler)
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Batch.GetIndex(context.Background(), )
+		result, resp, err := client.Batch.GetIndex(context.Background())
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/sonar/ce_service_test.go
+++ b/sonar/ce_service_test.go
@@ -289,7 +289,7 @@ func TestCe_CancelAll(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Ce.CancelAll(context.Background(), )
+	resp, err := client.Ce.CancelAll(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -411,7 +411,7 @@ func TestCe_IndexationStatus(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Ce.IndexationStatus(context.Background(), )
+	result, resp, err := client.Ce.IndexationStatus(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -428,7 +428,7 @@ func TestCe_Info(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Ce.Info(context.Background(), )
+	result, resp, err := client.Ce.Info(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -440,7 +440,7 @@ func TestCe_Pause(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Ce.Pause(context.Background(), )
+	resp, err := client.Ce.Pause(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -450,7 +450,7 @@ func TestCe_Resume(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Ce.Resume(context.Background(), )
+	resp, err := client.Ce.Resume(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -604,7 +604,7 @@ func TestCe_TaskTypes(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Ce.TaskTypes(context.Background(), )
+	result, resp, err := client.Ce.TaskTypes(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -622,7 +622,7 @@ func TestCe_WorkerCount(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Ce.WorkerCount(context.Background(), )
+	result, resp, err := client.Ce.WorkerCount(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -33,56 +33,57 @@ type Client struct {
 	middlewares     []Middleware
 	userAgent       string
 
-	AuditLogs          *AuditLogsService
-	AlmIntegrations    *AlmIntegrationsService
-	AlmSettings        *AlmSettingsService
-	AnalysisCache      *AnalysisCacheService
-	AnalysisReports    *AnalysisReportsService
-	Authentication     *AuthenticationService
-	Batch              *BatchService
-	Ce                 *CeService
-	Components         *ComponentsService
-	Developers         *DevelopersService
-	DismissMessage     *DismissMessageService
-	Duplications       *DuplicationsService
-	Emails             *EmailsService
-	Favorites          *FavoritesService
-	Features           *FeaturesService
-	GithubProvisioning *GithubProvisioningService
-	Hotspots           *HotspotsService
-	Issues             *IssuesService
-	L10N               *L10NService
-	Editions           *EditionsService
-	Languages          *LanguagesService
-	Measures           *MeasuresService
-	Views              *ViewsService
-	Metrics            *MetricsService
-	Monitoring         *MonitoringService
-	Navigation         *NavigationService
-	NewCodePeriods     *NewCodePeriodsService
-	Notifications      *NotificationsService
-	Permissions        *PermissionsService
-	Plugins            *PluginsService
-	ProjectAnalyses    *ProjectAnalysesService
-	ProjectBadges      *ProjectBadgesService
-	ProjectBranches    *ProjectBranchesService
-	ProjectDump        *ProjectDumpService
-	ProjectLinks       *ProjectLinksService
-	ProjectTags        *ProjectTagsService
-	Projects           *ProjectsService
-	Push               *PushService
-	Qualitygates       *QualitygatesService
-	Qualityprofiles    *QualityprofilesService
-	Rules              *RulesService
-	Server             *ServerService
-	Settings           *SettingsService
-	Sources            *SourcesService
-	System             *SystemService
-	UserGroups         *UserGroupsService
-	UserTokens         *UserTokensService
-	Users              *UsersService
-	Webhooks           *WebhooksService
-	Webservices        *WebservicesService
+	AuditLogs           *AuditLogsService
+	AlmIntegrations     *AlmIntegrationsService
+	AlmSettings         *AlmSettingsService
+	AnalysisCache       *AnalysisCacheService
+	AnalysisReports     *AnalysisReportsService
+	Authentication      *AuthenticationService
+	Batch               *BatchService
+	Ce                  *CeService
+	Components          *ComponentsService
+	Developers          *DevelopersService
+	DismissMessage      *DismissMessageService
+	Duplications        *DuplicationsService
+	Emails              *EmailsService
+	Favorites           *FavoritesService
+	Features            *FeaturesService
+	GithubProvisioning  *GithubProvisioningService
+	Hotspots            *HotspotsService
+	Issues              *IssuesService
+	L10N                *L10NService
+	Editions            *EditionsService
+	Languages           *LanguagesService
+	Measures            *MeasuresService
+	Views               *ViewsService
+	Metrics             *MetricsService
+	Monitoring          *MonitoringService
+	Navigation          *NavigationService
+	NewCodePeriods      *NewCodePeriodsService
+	Notifications       *NotificationsService
+	Permissions         *PermissionsService
+	Plugins             *PluginsService
+	ProjectAnalyses     *ProjectAnalysesService
+	ProjectBadges       *ProjectBadgesService
+	ProjectBranches     *ProjectBranchesService
+	ProjectDump         *ProjectDumpService
+	ProjectLinks        *ProjectLinksService
+	ProjectPullRequests *ProjectPullRequestsService
+	ProjectTags         *ProjectTagsService
+	Projects            *ProjectsService
+	Push                *PushService
+	Qualitygates        *QualitygatesService
+	Qualityprofiles     *QualityprofilesService
+	Rules               *RulesService
+	Server              *ServerService
+	Settings            *SettingsService
+	Sources             *SourcesService
+	System              *SystemService
+	UserGroups          *UserGroupsService
+	UserTokens          *UserTokensService
+	Users               *UsersService
+	Webhooks            *WebhooksService
+	Webservices         *WebservicesService
 
 	// V2 contains all V2 API services.
 	V2 *ServicesV2
@@ -429,6 +430,7 @@ func initServices(client *Client) {
 	client.ProjectBranches = &ProjectBranchesService{client: client}
 	client.ProjectDump = &ProjectDumpService{client: client}
 	client.ProjectLinks = &ProjectLinksService{client: client}
+	client.ProjectPullRequests = &ProjectPullRequestsService{client: client}
 	client.ProjectTags = &ProjectTagsService{client: client}
 	client.Projects = &ProjectsService{client: client}
 	client.Push = &PushService{client: client}

--- a/sonar/dop_translation_v2_service_test.go
+++ b/sonar/dop_translation_v2_service_test.go
@@ -120,7 +120,7 @@ func TestDopTranslationV2_GetDopSettings(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/dop-translation/dop-settings", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.DopTranslation.GetDopSettings(context.Background(), )
+	result, resp, err := client.V2.DopTranslation.GetDopSettings(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Len(t, result.DopSettings, 2)

--- a/sonar/features_service_test.go
+++ b/sonar/features_service_test.go
@@ -14,7 +14,7 @@ func TestFeatures_List(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.Features.List(context.Background(), )
+	result, resp, err := client.Features.List(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -28,7 +28,7 @@ func TestFeatures_List_Empty(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.Features.List(context.Background(), )
+	result, resp, err := client.Features.List(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/github_provisioning_service_test.go
+++ b/sonar/github_provisioning_service_test.go
@@ -27,7 +27,7 @@ func TestGithubProvisioning_Check(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.GithubProvisioning.Check(context.Background(), )
+	result, resp, err := client.GithubProvisioning.Check(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -49,7 +49,7 @@ func TestGithubProvisioning_Check_WithError(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.GithubProvisioning.Check(context.Background(), )
+	result, resp, err := client.GithubProvisioning.Check(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "failed", result.Application.AutoProvisioning.Status)
@@ -61,7 +61,7 @@ func TestGithubProvisioning_Check_EmptyResponse(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.GithubProvisioning.Check(context.Background(), )
+	result, resp, err := client.GithubProvisioning.Check(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/marketplace_v2_service_test.go
+++ b/sonar/marketplace_v2_service_test.go
@@ -21,7 +21,7 @@ func TestMarketplaceV2_BillAzureAccount(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodPost, "/v2/marketplace/azure/billing", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.Marketplace.BillAzureAccount(context.Background(), )
+	result, resp, err := client.V2.Marketplace.BillAzureAccount(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.True(t, result.Success)

--- a/sonar/metrics_service_test.go
+++ b/sonar/metrics_service_test.go
@@ -81,7 +81,7 @@ func TestMetrics_Types(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.Metrics.Types(context.Background(), )
+	result, resp, err := client.Metrics.Types(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/monitoring_service_test.go
+++ b/sonar/monitoring_service_test.go
@@ -18,7 +18,7 @@ sonarqube_health 1`
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.Monitoring.Metrics(context.Background(), )
+	result, resp, err := client.Monitoring.Metrics(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/navigation_service_test.go
+++ b/sonar/navigation_service_test.go
@@ -91,7 +91,7 @@ func TestNavigationService_Global(t *testing.T) {
 		server := newTestServer(t, mockHandler(t, http.MethodGet, "/navigation/global", http.StatusOK, response))
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Navigation.Global(context.Background(), )
+		result, resp, err := client.Navigation.Global(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, "10.5.0", result.Version)
@@ -109,7 +109,7 @@ func TestNavigationService_Marketplace(t *testing.T) {
 		server := newTestServer(t, mockHandler(t, http.MethodGet, "/navigation/marketplace", http.StatusOK, response))
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Navigation.Marketplace(context.Background(), )
+		result, resp, err := client.Navigation.Marketplace(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, int64(1000000), result.Ncloc)
@@ -128,7 +128,7 @@ func TestNavigationService_Settings(t *testing.T) {
 		server := newTestServer(t, mockHandler(t, http.MethodGet, "/navigation/settings", http.StatusOK, response))
 		client := newTestClient(t, server.URL)
 
-		result, resp, err := client.Navigation.Settings(context.Background(), )
+		result, resp, err := client.Navigation.Settings(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.True(t, result.ShowUpdateCenter)

--- a/sonar/plugins_service_test.go
+++ b/sonar/plugins_service_test.go
@@ -37,7 +37,7 @@ func TestPluginsService_Available(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/plugins/available", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Plugins.Available(context.Background(), )
+	result, resp, err := client.Plugins.Available(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -50,7 +50,7 @@ func TestPluginsService_CancelAll(t *testing.T) {
 	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/plugins/cancel_all", http.StatusNoContent))
 	client := newTestClient(t, server.URL)
 
-	resp, err := client.Plugins.CancelAll(context.Background(), )
+	resp, err := client.Plugins.CancelAll(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
@@ -213,7 +213,7 @@ func TestPluginsService_Pending(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/plugins/pending", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Plugins.Pending(context.Background(), )
+	result, resp, err := client.Plugins.Pending(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -312,7 +312,7 @@ func TestPluginsService_Updates(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/plugins/updates", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Plugins.Updates(context.Background(), )
+	result, resp, err := client.Plugins.Updates(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/project_pull_requests_service.go
+++ b/sonar/project_pull_requests_service.go
@@ -118,7 +118,7 @@ func (s *ProjectPullRequestsService) Delete(ctx context.Context, opt *ProjectPul
 }
 
 // List lists the pull request analyses of a project.
-// Requires Browse permission on the project.
+// Requires Browse or Execute Analysis permission on the project.
 //
 // API endpoint: GET /api/project_pull_requests/list.
 // Since: 7.1.

--- a/sonar/project_pull_requests_service.go
+++ b/sonar/project_pull_requests_service.go
@@ -29,18 +29,23 @@ type ProjectPullRequest struct {
 	// URL is the URL of the pull request in the source code manager.
 	URL string `json:"url,omitempty"`
 	// Status contains the quality gate status and issue counts for the pull request.
-	Status struct {
-		// QualityGateStatus is the quality gate status (e.g. "OK", "ERROR").
-		QualityGateStatus string `json:"qualityGateStatus,omitempty"`
-		// Bugs is the number of bugs found.
-		Bugs int `json:"bugs,omitempty"`
-		// Vulnerabilities is the number of vulnerabilities found.
-		Vulnerabilities int `json:"vulnerabilities,omitempty"`
-		// CodeSmells is the number of code smells found.
-		CodeSmells int `json:"codeSmells,omitempty"`
-	} `json:"status,omitzero"`
+	Status ProjectPullRequestStatus `json:"status,omitzero"`
 	// IsOrphan indicates whether the pull request is orphaned (target branch no longer exists).
 	IsOrphan bool `json:"isOrphan,omitempty"`
+	// AnalysisDate is the date and time when the pull request was last analyzed, in ISO 8601 format.
+	AnalysisDate string `json:"analysisDate,omitempty"`
+}
+
+// ProjectPullRequestStatus represents the status of a pull request analysis, including quality gate status and issue counts.
+type ProjectPullRequestStatus struct {
+	// QualityGateStatus is the quality gate status (e.g. "OK", "ERROR").
+	QualityGateStatus string `json:"qualityGateStatus,omitempty"`
+	// Bugs is the number of bugs found.
+	Bugs int `json:"bugs,omitempty"`
+	// Vulnerabilities is the number of vulnerabilities found.
+	Vulnerabilities int `json:"vulnerabilities,omitempty"`
+	// CodeSmells is the number of code smells found.
+	CodeSmells int `json:"codeSmells,omitempty"`
 }
 
 // ProjectPullRequestsList represents the response from the list endpoint.

--- a/sonar/project_pull_requests_service.go
+++ b/sonar/project_pull_requests_service.go
@@ -17,6 +17,8 @@ type ProjectPullRequestsService struct {
 // -----------------------------------------------------------------------------
 
 // ProjectPullRequest represents a pull request analysis in SonarQube.
+//
+//nolint:govet // Field alignment is less important than logical grouping
 type ProjectPullRequest struct {
 	// Key is the pull request key/identifier.
 	Key string `json:"key,omitempty"`

--- a/sonar/project_pull_requests_service.go
+++ b/sonar/project_pull_requests_service.go
@@ -1,0 +1,144 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+)
+
+// ProjectPullRequestsService handles communication with the project pull requests
+// related methods of the SonarQube API.
+type ProjectPullRequestsService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Response Types
+// -----------------------------------------------------------------------------
+
+// ProjectPullRequest represents a pull request analysis in SonarQube.
+type ProjectPullRequest struct {
+	// Key is the pull request key/identifier.
+	Key string `json:"key,omitempty"`
+	// Title is the pull request title.
+	Title string `json:"title,omitempty"`
+	// Branch is the source branch of the pull request.
+	Branch string `json:"branch,omitempty"`
+	// Base is the target branch of the pull request.
+	Base string `json:"base,omitempty"`
+	// URL is the URL of the pull request in the source code manager.
+	URL string `json:"url,omitempty"`
+	// Status contains the quality gate status and issue counts for the pull request.
+	Status struct {
+		// QualityGateStatus is the quality gate status (e.g. "OK", "ERROR").
+		QualityGateStatus string `json:"qualityGateStatus,omitempty"`
+		// Bugs is the number of bugs found.
+		Bugs int `json:"bugs,omitempty"`
+		// Vulnerabilities is the number of vulnerabilities found.
+		Vulnerabilities int `json:"vulnerabilities,omitempty"`
+		// CodeSmells is the number of code smells found.
+		CodeSmells int `json:"codeSmells,omitempty"`
+	} `json:"status,omitzero"`
+	// IsOrphan indicates whether the pull request is orphaned (target branch no longer exists).
+	IsOrphan bool `json:"isOrphan,omitempty"`
+}
+
+// ProjectPullRequestsList represents the response from the list endpoint.
+type ProjectPullRequestsList struct {
+	// PullRequests is the list of pull requests for the project.
+	PullRequests []ProjectPullRequest `json:"pullRequests,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// ProjectPullRequestsDeleteOptions contains parameters for the Delete method.
+type ProjectPullRequestsDeleteOptions struct {
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+	// PullRequest is the pull request key. This field is required.
+	PullRequest string `url:"pullRequest"`
+}
+
+// ProjectPullRequestsListOptions contains parameters for the List method.
+type ProjectPullRequestsListOptions struct {
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateDeleteOpt validates the options for the Delete method.
+func (s *ProjectPullRequestsService) ValidateDeleteOpt(opt *ProjectPullRequestsDeleteOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Project, "Project")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.PullRequest, "PullRequest")
+}
+
+// ValidateListOpt validates the options for the List method.
+func (s *ProjectPullRequestsService) ValidateListOpt(opt *ProjectPullRequestsListOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Project, "Project")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// Delete deletes a pull request analysis.
+// Requires Administer permission on the project.
+//
+// API endpoint: POST /api/project_pull_requests/delete.
+// Since: 7.1.
+func (s *ProjectPullRequestsService) Delete(ctx context.Context, opt *ProjectPullRequestsDeleteOptions) (*http.Response, error) {
+	err := s.ValidateDeleteOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "project_pull_requests/delete", opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// List lists the pull request analyses of a project.
+// Requires Browse permission on the project.
+//
+// API endpoint: GET /api/project_pull_requests/list.
+// Since: 7.1.
+func (s *ProjectPullRequestsService) List(ctx context.Context, opt *ProjectPullRequestsListOptions) (*ProjectPullRequestsList, *http.Response, error) {
+	err := s.ValidateListOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "project_pull_requests/list", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(ProjectPullRequestsList)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}

--- a/sonar/project_pull_requests_service_test.go
+++ b/sonar/project_pull_requests_service_test.go
@@ -1,0 +1,87 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// Delete
+// -----------------------------------------------------------------------------
+
+func TestProjectPullRequestsService_Delete(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/project_pull_requests/delete", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.ProjectPullRequests.Delete(context.Background(), &ProjectPullRequestsDeleteOptions{
+		Project:     "my-project",
+		PullRequest: "123",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestProjectPullRequestsService_Delete_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.ProjectPullRequests.Delete(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.ProjectPullRequests.Delete(context.Background(), &ProjectPullRequestsDeleteOptions{PullRequest: "123"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.ProjectPullRequests.Delete(context.Background(), &ProjectPullRequestsDeleteOptions{Project: "my-project"})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// List
+// -----------------------------------------------------------------------------
+
+func TestProjectPullRequestsService_List(t *testing.T) {
+	response := ProjectPullRequestsList{
+		PullRequests: []ProjectPullRequest{
+			{
+				Key:      "123",
+				Title:    "My Pull Request",
+				Branch:   "feature/my-feature",
+				Base:     "main",
+				IsOrphan: false,
+				URL:      "https://github.com/org/repo/pull/123",
+			},
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/project_pull_requests/list", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.ProjectPullRequests.List(context.Background(), &ProjectPullRequestsListOptions{
+		Project: "my-project",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotNil(t, result)
+	assert.Len(t, result.PullRequests, 1)
+	assert.Equal(t, "123", result.PullRequests[0].Key)
+	assert.Equal(t, "My Pull Request", result.PullRequests[0].Title)
+}
+
+func TestProjectPullRequestsService_List_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.ProjectPullRequests.List(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.ProjectPullRequests.List(context.Background(), &ProjectPullRequestsListOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}

--- a/sonar/qualitygates_service_test.go
+++ b/sonar/qualitygates_service_test.go
@@ -199,7 +199,7 @@ func TestQualityGates_List(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualitygates/list", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Qualitygates.List(context.Background(), )
+	result, resp, err := client.Qualitygates.List(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/qualityprofiles_service_test.go
+++ b/sonar/qualityprofiles_service_test.go
@@ -703,7 +703,7 @@ func TestQualityprofiles_Exporters(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualityprofiles/exporters", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Qualityprofiles.Exporters(context.Background(), )
+	result, resp, err := client.Qualityprofiles.Exporters(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -721,7 +721,7 @@ func TestQualityprofiles_Importers(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/qualityprofiles/importers", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Qualityprofiles.Importers(context.Background(), )
+	result, resp, err := client.Qualityprofiles.Importers(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/rules_service_test.go
+++ b/sonar/rules_service_test.go
@@ -15,7 +15,7 @@ func TestRules_App(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/rules/app", 200, `{"canWrite":true,"languages":{"java":"Java"}}`))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Rules.App(context.Background(), )
+	result, resp, err := client.Rules.App(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	require.NotNil(t, result)

--- a/sonar/server_service_test.go
+++ b/sonar/server_service_test.go
@@ -14,7 +14,7 @@ func TestServer_Version(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	version, resp, err := client.Server.Version(context.Background(), )
+	version, resp, err := client.Server.Version(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, version)
@@ -26,7 +26,7 @@ func TestServer_Version_ErrorResponse(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	version, resp, err := client.Server.Version(context.Background(), )
+	version, resp, err := client.Server.Version(context.Background())
 	require.Error(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)

--- a/sonar/settings_service_test.go
+++ b/sonar/settings_service_test.go
@@ -24,7 +24,7 @@ func TestSettingsService_CheckSecretKey(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Settings.CheckSecretKey(context.Background(), )
+	result, resp, err := client.Settings.CheckSecretKey(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.True(t, result.SecretKeyAvailable)
@@ -68,7 +68,7 @@ func TestSettingsService_GenerateSecretKey(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Settings.GenerateSecretKey(context.Background(), )
+	result, resp, err := client.Settings.GenerateSecretKey(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "AaBbCcDdEeFfGgHhIiJjKk==", result.SecretKey)
@@ -114,7 +114,7 @@ func TestSettingsService_LoginMessage(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Settings.LoginMessage(context.Background(), )
+	result, resp, err := client.Settings.LoginMessage(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "Welcome to SonarQube!", result.Message)

--- a/sonar/system_service_test.go
+++ b/sonar/system_service_test.go
@@ -51,7 +51,7 @@ func TestSystem_DbMigrationStatus(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.System.DbMigrationStatus(context.Background(), )
+	result, resp, err := client.System.DbMigrationStatus(context.Background())
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -64,7 +64,7 @@ func TestSystem_Health(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.System.Health(context.Background(), )
+	result, resp, err := client.System.Health(context.Background())
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -78,7 +78,7 @@ func TestSystem_Health_WithCauses(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, _, err := client.System.Health(context.Background(), )
+	result, _, err := client.System.Health(context.Background())
 
 	require.NoError(t, err)
 	assert.Equal(t, "YELLOW", result.Health)
@@ -102,7 +102,7 @@ func TestSystem_Info(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.System.Info(context.Background(), )
+	result, resp, err := client.System.Info(context.Background())
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -115,7 +115,7 @@ func TestSystem_Liveness(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	_, resp, err := client.System.Liveness(context.Background(), )
+	_, resp, err := client.System.Liveness(context.Background())
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
@@ -165,7 +165,7 @@ func TestSystem_MigrateDb(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.System.MigrateDb(context.Background(), )
+	result, resp, err := client.System.MigrateDb(context.Background())
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -177,7 +177,7 @@ func TestSystem_Ping(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.System.Ping(context.Background(), )
+	result, resp, err := client.System.Ping(context.Background())
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -190,7 +190,7 @@ func TestSystem_Restart(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	resp, err := client.System.Restart(context.Background(), )
+	resp, err := client.System.Restart(context.Background())
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
@@ -202,7 +202,7 @@ func TestSystem_Status(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.System.Status(context.Background(), )
+	result, resp, err := client.System.Status(context.Background())
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -235,7 +235,7 @@ func TestSystem_Upgrades(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.System.Upgrades(context.Background(), )
+	result, resp, err := client.System.Upgrades(context.Background())
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -255,7 +255,7 @@ func TestSystem_Upgrades_NoUpgrades(t *testing.T) {
 	server := newTestServer(t, handler)
 	client := newTestClient(t, server.url())
 
-	result, _, err := client.System.Upgrades(context.Background(), )
+	result, _, err := client.System.Upgrades(context.Background())
 
 	require.NoError(t, err)
 	assert.Empty(t, result.Upgrades)

--- a/sonar/system_v2_service_test.go
+++ b/sonar/system_v2_service_test.go
@@ -25,7 +25,7 @@ func TestSystemV2_GetMigrationsStatus(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/system/migrations-status", http.StatusOK, response))
 	client := newTestClient(t, server.url())
 
-	result, resp, err := client.V2.System.GetMigrationsStatus(context.Background(), )
+	result, resp, err := client.V2.System.GetMigrationsStatus(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "MIGRATION_RUNNING", result.Status)

--- a/sonar/transport_test.go
+++ b/sonar/transport_test.go
@@ -35,7 +35,7 @@ func TestWithTransportConfig_SetsCustomTransport(t *testing.T) {
 }
 
 func TestWithTransportConfig_IgnoredWhenHTTPClientProvided(t *testing.T) {
-	customTransport := &http.Transport{MaxIdleConns: 99} //nolint:exhaustruct
+	customTransport := &http.Transport{MaxIdleConns: 99}     //nolint:exhaustruct
 	customClient := &http.Client{Transport: customTransport} //nolint:exhaustruct
 
 	cfg := TransportConfig{

--- a/sonar/users_service_test.go
+++ b/sonar/users_service_test.go
@@ -184,7 +184,7 @@ func TestUsers_Current(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/users/current", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Users.Current(context.Background(), )
+	result, resp, err := client.Users.Current(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)
@@ -450,7 +450,7 @@ func TestUsers_IdentityProviders(t *testing.T) {
 	server := newTestServer(t, mockHandler(t, http.MethodGet, "/users/identity_providers", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
-	result, resp, err := client.Users.IdentityProviders(context.Background(), )
+	result, resp, err := client.Users.IdentityProviders(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NotNil(t, result)


### PR DESCRIPTION
### Description of your changes

This PR adds the new "ProjectPullRequests" Service to interact with the enterprise project pull requests endpoints.

Packaged with full mock api response unit tests

e2e tests are dummies for now.

Closes #212

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
