### PR TITLE
feat(enterprise): support architecture V2 endpoints

### DIFF
--- a/integration_testing/architecture_v2_test.go
+++ b/integration_testing/architecture_v2_test.go
@@ -1,0 +1,69 @@
+package integration_testing_test
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Architecture V2 Service", Ordered, func() {
+	var client *sonar.Client
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+	})
+
+	// =========================================================================
+	// FileGraph
+	// =========================================================================
+	Describe("FileGraph", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.V2.Architecture.FileGraph(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required project key", func() {
+				result, resp, err := client.V2.Architecture.FileGraph(context.Background(), &sonar.ArchitectureFileGraphOptions{
+					BranchKey: "main",
+					Source:    "java",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("ProjectKey"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should return file graph or an enterprise-only error", func() {
+				result, resp, err := client.V2.Architecture.FileGraph(context.Background(), &sonar.ArchitectureFileGraphOptions{
+					ProjectKey: "nonexistent-project",
+					BranchKey:  "main",
+					Source:     "java",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+					// Enterprise-only / not-found gate: accept the expected error codes only,
+					// so unrelated failures (network errors, 5xx, decoding issues) are not
+					// silently swallowed by this test.
+					Expect(resp.StatusCode).To(BeElementOf(http.StatusNotFound, http.StatusForbidden, http.StatusPaymentRequired))
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+})

--- a/sonar/architecture_v2_service.go
+++ b/sonar/architecture_v2_service.go
@@ -1,0 +1,106 @@
+package sonar
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// ArchitectureService handles communication with the architecture V2 API endpoints.
+// This service is only available in Enterprise Edition. The underlying endpoint is
+// marked internal by SonarQube (x-sonar-internal) and its request/response contract
+// may change without notice between SonarQube versions.
+type ArchitectureService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// ArchitectureFileGraphOptions contains parameters for the FileGraph method.
+type ArchitectureFileGraphOptions struct {
+	// ProjectKey is the project key. This field is required.
+	ProjectKey string `json:"projectKey"`
+	// BranchKey is the branch key. This field is required.
+	BranchKey string `json:"branchKey"`
+	// Source is the language/analyzer that produced this graph, e.g. "java", "python", "js".
+	// This field is required.
+	Source string `json:"source"`
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateFileGraphOpt validates the options for the FileGraph method.
+func (s *ArchitectureService) ValidateFileGraphOpt(opt *ArchitectureFileGraphOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.ProjectKey, "ProjectKey")
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequired(opt.BranchKey, "BranchKey")
+	if err != nil {
+		return err
+	}
+
+	return ValidateRequired(opt.Source, "Source")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// architectureFileGraphResponse is a defined string type (rather than a bare
+// string) used solely to decode the FileGraph response body. client.Do treats
+// a destination of type *string as an opaque text/plain payload and forces an
+// "Accept: text/plain" request header for it. Unlike other opaque *string
+// endpoints in this SDK (e.g. AnalysisService.GetVersion), the API spec
+// declares this endpoint's 200 response as "application/json" with a string
+// schema, not "text/plain" — and live verification against a SonarQube
+// 2025.2 Enterprise instance confirmed that V2 endpoints strictly enforce
+// their declared content type: requesting "Accept: text/plain" against a
+// JSON-only V2 endpoint returns 406 Not Acceptable rather than the payload.
+// Using a distinct named type keeps client.Do on its default JSON-decode
+// path (default "Accept: application/json"), which both matches the
+// endpoint's contract and correctly unescapes the JSON string payload.
+type architectureFileGraphResponse string
+
+// FileGraph returns the file dependency graph for a project branch, for the given
+// source language. Requires 'Browse' permission on the project.
+//
+// The SonarQube API documents this endpoint's response as an opaque JSON string; its
+// exact payload format (e.g. serialized graph nodes/edges, DOT graph text) is not
+// published, so the decoded string is returned as-is for callers to parse as needed.
+//
+// API endpoint: GET /api/v2/architecture/file-graph.
+// Enterprise Edition only. Marked internal by SonarQube and subject to change
+// without notice.
+func (s *ArchitectureService) FileGraph(ctx context.Context, opt *ArchitectureFileGraphOptions) (*string, *http.Response, error) {
+	err := s.ValidateFileGraphOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "architecture/file-graph", opt, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	var result architectureFileGraphResponse
+
+	resp, err := s.client.Do(req, &result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	strResult := string(result)
+
+	return &strResult, resp, nil
+}

--- a/sonar/architecture_v2_service_test.go
+++ b/sonar/architecture_v2_service_test.go
@@ -1,0 +1,84 @@
+package sonar
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// FileGraph
+// -----------------------------------------------------------------------------
+
+func TestArchitectureService_FileGraph(t *testing.T) {
+	// The raw payload intentionally contains characters (quotes, newlines) that
+	// only round-trip correctly if the response is treated as a JSON-encoded
+	// string and unescaped, rather than copied as opaque raw bytes.
+	rawPayload := "{\"nodes\":[{\"id\":\"1\"}],\"edges\":[]}\nwith a \"quote\""
+
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "unexpected HTTP method")
+		assert.Equal(t, "/v2/architecture/file-graph", r.URL.Path, "unexpected URL path")
+		// The API spec declares this endpoint's 200 response as
+		// "application/json" only (unlike genuinely text/plain endpoints such
+		// as AnalysisService.GetVersion). Live verification against a real
+		// SonarQube 2025.2 Enterprise instance showed that V2 endpoints
+		// strictly enforce their declared content type via Spring content
+		// negotiation: sending "Accept: text/plain" against a JSON-only V2
+		// endpoint returns 406 Not Acceptable instead of the payload. This
+		// assertion locks in that the client must request application/json.
+		assert.Equal(t, "application/json", r.Header.Get("Accept"), "FileGraph must not request text/plain")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(rawPayload))
+	})
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.V2.Architecture.FileGraph(context.Background(), &ArchitectureFileGraphOptions{
+		ProjectKey: "my-project",
+		BranchKey:  "main",
+		Source:     "java",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result)
+	assert.Equal(t, rawPayload, *result)
+}
+
+func TestArchitectureService_FileGraph_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.V2.Architecture.FileGraph(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.V2.Architecture.FileGraph(context.Background(), &ArchitectureFileGraphOptions{
+		BranchKey: "main",
+		Source:    "java",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.V2.Architecture.FileGraph(context.Background(), &ArchitectureFileGraphOptions{
+		ProjectKey: "my-project",
+		Source:     "java",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.V2.Architecture.FileGraph(context.Background(), &ArchitectureFileGraphOptions{
+		ProjectKey: "my-project",
+		BranchKey:  "main",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -118,6 +118,8 @@ type Client struct {
 type ServicesV2 struct {
 	// Analysis provides methods for the Analysis V2 API.
 	Analysis *AnalysisService
+	// Architecture provides methods for the Architecture V2 API.
+	Architecture *ArchitectureService
 	// Authorizations provides methods for the Authorizations V2 API.
 	Authorizations *AuthorizationsService
 	// CleanCodePolicy provides methods for the Clean Code Policy V2 API.
@@ -541,6 +543,7 @@ func initServices(client *Client) {
 func initServicesV2(client *Client) {
 	client.V2 = &ServicesV2{
 		Analysis:        &AnalysisService{client: client},
+		Architecture:    &ArchitectureService{client: client},
 		Authorizations:  &AuthorizationsService{client: client},
 		CleanCodePolicy: &CleanCodePolicyService{client: client},
 		DopTranslation:  &DopTranslationService{client: client},


### PR DESCRIPTION
### Description of your changes

This PR adds the new "ArchitectureV2" Service to interact with the enterprise Architecture (v2) endpoints.

Packaged with full mock api response unit tests

e2e tests are dummies for now.

Closes #218 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
