### PR TITLE
feat(enterprise): support fix_suggestions V2 endpoints

### DIFF
--- a/integration_testing/fix_suggestions_v2_test.go
+++ b/integration_testing/fix_suggestions_v2_test.go
@@ -1,0 +1,189 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Fix Suggestions V2 Service", Ordered, func() {
+	var client *sonar.Client
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+	})
+
+	Describe("CreateSuggestion", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.V2.FixSuggestions.CreateSuggestion(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+		})
+		Context("Functional Tests", func() {
+			It("should create suggestion or return an expected error", func() {
+				result, resp, err := client.V2.FixSuggestions.CreateSuggestion(context.Background(), &sonar.FixSuggestionsCreateOptions{
+					IssueId: "nonexistent-issue",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	Describe("GetEnablement", func() {
+		Context("Functional Tests", func() {
+			It("should return enablement or an expected error", func() {
+				result, resp, err := client.V2.FixSuggestions.GetEnablement(context.Background())
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	Describe("SetEnablement", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				resp, err := client.V2.FixSuggestions.SetEnablement(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail with an invalid enablement value", func() {
+				resp, err := client.V2.FixSuggestions.SetEnablement(context.Background(), &sonar.FixSuggestionsSetEnablementOptions{
+					Enablement: "NOT_A_VALID_STATE",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+			})
+		})
+		Context("Functional Tests", func() {
+			It("should set enablement or return an expected error", func() {
+				resp, err := client.V2.FixSuggestions.SetEnablement(context.Background(), &sonar.FixSuggestionsSetEnablementOptions{
+					Enablement: sonar.FixSuggestionsEnablementDisabled,
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+				}
+			})
+		})
+	})
+
+	Describe("AwarenessBannerInteraction", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.V2.FixSuggestions.AwarenessBannerInteraction(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail with an invalid banner type", func() {
+				result, resp, err := client.V2.FixSuggestions.AwarenessBannerInteraction(context.Background(), &sonar.FixSuggestionsAwarenessBannerOptions{
+					BannerType: "NOT_A_VALID_TYPE",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+		})
+		Context("Functional Tests", func() {
+			It("should record the interaction or return an expected error", func() {
+				result, resp, err := client.V2.FixSuggestions.AwarenessBannerInteraction(context.Background(), &sonar.FixSuggestionsAwarenessBannerOptions{
+					BannerType: sonar.FixSuggestionsBannerTypeEnable,
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	Describe("GetIssueAvailability", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.V2.FixSuggestions.GetIssueAvailability(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+		})
+		Context("Functional Tests", func() {
+			It("should return availability or an expected error", func() {
+				result, resp, err := client.V2.FixSuggestions.GetIssueAvailability(context.Background(), &sonar.FixSuggestionsIssueOptions{
+					IssueId: "nonexistent-issue",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	Describe("GetServiceInfo", func() {
+		Context("Functional Tests", func() {
+			It("should return service info or an expected error", func() {
+				result, resp, err := client.V2.FixSuggestions.GetServiceInfo(context.Background())
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	Describe("GetSubscriptionType", func() {
+		Context("Functional Tests", func() {
+			It("should return subscription type or an expected error", func() {
+				result, resp, err := client.V2.FixSuggestions.GetSubscriptionType(context.Background())
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	Describe("GetSupportedLlmProviders", func() {
+		Context("Functional Tests", func() {
+			It("should return providers or an expected error", func() {
+				result, resp, err := client.V2.FixSuggestions.GetSupportedLlmProviders(context.Background())
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+})

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -128,6 +128,8 @@ type ServicesV2 struct {
 	CleanCodePolicy *CleanCodePolicyService
 	// DopTranslation provides methods for the Dop Translation V2 API.
 	DopTranslation *DopTranslationService
+	// FixSuggestions provides methods for the Fix Suggestions V2 API.
+	FixSuggestions *FixSuggestionsService
 	// Marketplace provides methods for the Marketplace V2 API.
 	Marketplace *MarketplaceService
 	// Sca provides methods for the SCA V2 API.
@@ -553,6 +555,7 @@ func initServicesV2(client *Client) {
 		Authorizations:  &AuthorizationsService{client: client},
 		CleanCodePolicy: &CleanCodePolicyService{client: client},
 		DopTranslation:  &DopTranslationService{client: client},
+		FixSuggestions:  &FixSuggestionsService{client: client},
 		Marketplace:     &MarketplaceService{client: client},
 		Sca:             &ScaService{client: client},
 		System:          &SystemServiceV2{client: client},

--- a/sonar/fix_suggestions_v2_service.go
+++ b/sonar/fix_suggestions_v2_service.go
@@ -1,0 +1,418 @@
+package sonar
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const (
+	// FixSuggestionsEnablementEnabledForAllProjects represents the "ENABLED_FOR_ALL_PROJECTS" feature enablement state (enabled for all projects).
+	FixSuggestionsEnablementEnabledForAllProjects = "ENABLED_FOR_ALL_PROJECTS"
+	// FixSuggestionsEnablementDisabled represents the "DISABLED" feature enablement state.
+	FixSuggestionsEnablementDisabled = "DISABLED"
+	// FixSuggestionsEnablementEnabledForSomeProjects represents the "ENABLED_FOR_SOME_PROJECTS" feature enablement state.
+	FixSuggestionsEnablementEnabledForSomeProjects = "ENABLED_FOR_SOME_PROJECTS"
+
+	// FixSuggestionsBannerTypeEnable represents the "ENABLE" awareness banner interaction type.
+	FixSuggestionsBannerTypeEnable = "ENABLE"
+	// FixSuggestionsBannerTypeLearnMore represents the "LEARN_MORE" awareness banner interaction type.
+	FixSuggestionsBannerTypeLearnMore = "LEARN_MORE"
+)
+
+// FixSuggestionsService handles communication with the AI fix suggestions V2 API endpoints.
+// This service is only available in Enterprise Edition with AI features enabled.
+type FixSuggestionsService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+//nolint:gochecknoglobals // these are constant sets of allowed values
+var (
+	// allowedFixSuggestionsEnablements is the set of supported feature enablement states.
+	allowedFixSuggestionsEnablements = map[string]struct{}{
+		FixSuggestionsEnablementEnabledForAllProjects:  {},
+		FixSuggestionsEnablementDisabled:               {},
+		FixSuggestionsEnablementEnabledForSomeProjects: {},
+	}
+
+	// allowedFixSuggestionsBannerTypes is the set of supported awareness banner interaction types.
+	allowedFixSuggestionsBannerTypes = map[string]struct{}{
+		FixSuggestionsBannerTypeEnable:    {},
+		FixSuggestionsBannerTypeLearnMore: {},
+	}
+)
+
+// -----------------------------------------------------------------------------
+// Response Types
+// -----------------------------------------------------------------------------
+
+// FixSuggestionChange represents a code change proposed by an AI fix suggestion.
+//
+//nolint:govet // fieldalignment: keeping logical field grouping for readability
+type FixSuggestionChange struct {
+	// StartLine is the starting line of the code to replace.
+	StartLine int `json:"startLine,omitempty"`
+	// EndLine is the ending line of the code to replace.
+	EndLine int `json:"endLine,omitempty"`
+	// NewCode is the replacement code proposed by the AI.
+	NewCode string `json:"newCode,omitempty"`
+}
+
+// FixSuggestion represents an AI-generated fix suggestion for an issue.
+type FixSuggestion struct {
+	// Id is the unique identifier of the fix suggestion.
+	Id string `json:"id,omitempty"`
+	// IssueId is the identifier of the issue this suggestion addresses.
+	IssueId string `json:"issueId,omitempty"`
+	// Explanation describes the reasoning behind the proposed fix.
+	Explanation string `json:"explanation,omitempty"`
+	// Changes is the list of code changes to apply.
+	Changes []FixSuggestionChange `json:"changes,omitempty"`
+}
+
+// FixSuggestionProvider represents an LLM provider configuration for fix suggestions.
+type FixSuggestionProvider struct {
+	// Key is the provider key.
+	Key string `json:"key,omitempty"`
+	// ModelKey is the model key used.
+	ModelKey string `json:"modelKey,omitempty"`
+	// Endpoint is the provider endpoint URL.
+	Endpoint string `json:"endpoint,omitempty"`
+}
+
+// FixSuggestionsFeatureEnablement represents the AI CodeFix feature enablement state.
+//
+//nolint:govet // fieldalignment: keeping logical field grouping for readability
+type FixSuggestionsFeatureEnablement struct {
+	// Enablement is the enablement state.
+	Enablement string `json:"enablement,omitempty"`
+	// EnabledProjectKeys lists project keys where the feature is enabled.
+	EnabledProjectKeys []string `json:"enabledProjectKeys,omitempty"`
+	// Provider contains the LLM provider configuration.
+	Provider FixSuggestionProvider `json:"provider,omitzero"`
+}
+
+// FixSuggestionsAwarenessBanner represents the response from a banner interaction.
+type FixSuggestionsAwarenessBanner struct {
+	// Id is the interaction identifier.
+	Id string `json:"id,omitempty"`
+}
+
+// FixSuggestionIssueAvailability represents fix suggestion availability for an issue.
+type FixSuggestionIssueAvailability struct {
+	// IssueId is the issue identifier.
+	IssueId string `json:"issueId,omitempty"`
+	// AiSuggestion indicates whether an AI suggestion is available.
+	AiSuggestion string `json:"aiSuggestion,omitempty"`
+}
+
+// FixSuggestionsServiceInfo represents the AI CodeFix service status.
+//
+//nolint:govet // fieldalignment: keeping logical field grouping for readability
+type FixSuggestionsServiceInfo struct {
+	// Status is the current service status.
+	Status string `json:"status,omitempty"`
+	// IsEnabled indicates whether the service is enabled.
+	IsEnabled bool `json:"isEnabled,omitempty"`
+	// SubscriptionType is the subscription type.
+	SubscriptionType string `json:"subscriptionType,omitempty"`
+}
+
+// FixSuggestionsSubscriptionType represents the subscription type response.
+type FixSuggestionsSubscriptionType struct {
+	// SubscriptionType is the subscription type string.
+	SubscriptionType string `json:"subscriptionType,omitempty"`
+}
+
+// FixSuggestionsLlmModel represents a supported LLM model.
+type FixSuggestionsLlmModel struct {
+	// Key is the model key.
+	Key string `json:"key,omitempty"`
+	// Name is the display name.
+	Name string `json:"name,omitempty"`
+	// Recommended indicates whether this is the recommended model.
+	Recommended bool `json:"recommended,omitempty"`
+}
+
+// FixSuggestionsLlmProvider represents a supported LLM provider.
+//
+//nolint:govet // fieldalignment: keeping logical field grouping for readability
+type FixSuggestionsLlmProvider struct {
+	// Key is the provider key.
+	Key string `json:"key,omitempty"`
+	// Name is the display name.
+	Name string `json:"name,omitempty"`
+	// SelfHosted indicates whether this is a self-hosted provider.
+	SelfHosted bool `json:"selfHosted,omitempty"`
+	// Models is the list of models available from this provider.
+	Models []FixSuggestionsLlmModel `json:"models,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// Request Types
+// -----------------------------------------------------------------------------
+
+// FixSuggestionsCreateOptions contains parameters for the CreateSuggestion method.
+type FixSuggestionsCreateOptions struct {
+	// IssueId is the issue identifier to generate a fix for. This field is required.
+	IssueId string `json:"issueId"`
+}
+
+// FixSuggestionsSetEnablementOptions contains parameters for the SetEnablement method.
+type FixSuggestionsSetEnablementOptions struct {
+	// Enablement is the desired feature enablement state. This field is required.
+	// Allowed values: ENABLED_FOR_ALL_PROJECTS, DISABLED, ENABLED_FOR_SOME_PROJECTS.
+	Enablement string `json:"enablement"`
+}
+
+// FixSuggestionsAwarenessBannerOptions contains parameters for the AwarenessBannerInteraction method.
+type FixSuggestionsAwarenessBannerOptions struct {
+	// BannerType is the type of banner interaction that occurred. This field is required.
+	// Allowed values: ENABLE, LEARN_MORE.
+	BannerType string `json:"bannerType"`
+}
+
+// FixSuggestionsIssueOptions contains parameters for the GetIssueAvailability method.
+type FixSuggestionsIssueOptions struct {
+	// IssueId is the issue identifier. This field is required.
+	IssueId string `json:"issueId"`
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateCreateSuggestionOpt validates the options for the CreateSuggestion method.
+func (s *FixSuggestionsService) ValidateCreateSuggestionOpt(opt *FixSuggestionsCreateOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.IssueId, "IssueId")
+}
+
+// ValidateSetEnablementOpt validates the options for the SetEnablement method.
+func (s *FixSuggestionsService) ValidateSetEnablementOpt(opt *FixSuggestionsSetEnablementOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Enablement, "Enablement")
+	if err != nil {
+		return err
+	}
+
+	return IsValueAuthorized(opt.Enablement, allowedFixSuggestionsEnablements, "Enablement")
+}
+
+// ValidateAwarenessBannerOpt validates the options for the AwarenessBannerInteraction method.
+func (s *FixSuggestionsService) ValidateAwarenessBannerOpt(opt *FixSuggestionsAwarenessBannerOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.BannerType, "BannerType")
+	if err != nil {
+		return err
+	}
+
+	return IsValueAuthorized(opt.BannerType, allowedFixSuggestionsBannerTypes, "BannerType")
+}
+
+// ValidateGetIssueAvailabilityOpt validates the options for the GetIssueAvailability method.
+func (s *FixSuggestionsService) ValidateGetIssueAvailabilityOpt(opt *FixSuggestionsIssueOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.IssueId, "IssueId")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// CreateSuggestion generates an AI fix suggestion for the given issue.
+// Requires 'Browse' permission on the project.
+//
+// API endpoint: POST /api/v2/fix-suggestions/ai-suggestions.
+// Enterprise Edition only.
+func (s *FixSuggestionsService) CreateSuggestion(ctx context.Context, opt *FixSuggestionsCreateOptions) (*FixSuggestion, *http.Response, error) {
+	err := s.ValidateCreateSuggestionOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPost, "fix-suggestions/ai-suggestions", nil, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	result := new(FixSuggestion)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// GetEnablement returns the AI CodeFix feature enablement configuration.
+// Requires 'Administer System' permission.
+//
+// API endpoint: GET /api/v2/fix-suggestions/feature-enablements.
+// Enterprise Edition only.
+func (s *FixSuggestionsService) GetEnablement(ctx context.Context) (*FixSuggestionsFeatureEnablement, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "fix-suggestions/feature-enablements", nil, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	result := new(FixSuggestionsFeatureEnablement)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// SetEnablement enables or disables the AI CodeFix feature.
+// Requires 'Administer System' permission.
+//
+// API endpoint: PATCH /api/v2/fix-suggestions/feature-enablements.
+// Enterprise Edition only.
+func (s *FixSuggestionsService) SetEnablement(ctx context.Context, opt *FixSuggestionsSetEnablementOptions) (*http.Response, error) {
+	err := s.ValidateSetEnablementOpt(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPatch, "fix-suggestions/feature-enablements", nil, opt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// AwarenessBannerInteraction records a user interaction with the AI awareness banner.
+// Requires authentication.
+//
+// API endpoint: POST /api/v2/fix-suggestions/feature-enablements/awareness-banner-interactions.
+// Enterprise Edition only.
+func (s *FixSuggestionsService) AwarenessBannerInteraction(ctx context.Context, opt *FixSuggestionsAwarenessBannerOptions) (*FixSuggestionsAwarenessBanner, *http.Response, error) {
+	err := s.ValidateAwarenessBannerOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPost, "fix-suggestions/feature-enablements/awareness-banner-interactions", nil, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	result := new(FixSuggestionsAwarenessBanner)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// GetIssueAvailability checks whether an AI fix suggestion is available for the given issue.
+// Requires 'Browse' permission on the project.
+//
+// API endpoint: GET /api/v2/fix-suggestions/issues/{issueId}.
+// Enterprise Edition only.
+func (s *FixSuggestionsService) GetIssueAvailability(ctx context.Context, opt *FixSuggestionsIssueOptions) (*FixSuggestionIssueAvailability, *http.Response, error) {
+	err := s.ValidateGetIssueAvailabilityOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "fix-suggestions/issues/"+url.PathEscape(opt.IssueId), nil, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	result := new(FixSuggestionIssueAvailability)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// GetServiceInfo returns the AI CodeFix service status and subscription information.
+// Requires 'Administer System' permission.
+//
+// API endpoint: GET /api/v2/fix-suggestions/service-info.
+// Enterprise Edition only.
+func (s *FixSuggestionsService) GetServiceInfo(ctx context.Context) (*FixSuggestionsServiceInfo, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "fix-suggestions/service-info", nil, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	result := new(FixSuggestionsServiceInfo)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// GetSubscriptionType returns the AI CodeFix subscription type.
+// Requires 'Administer System' permission.
+//
+// API endpoint: GET /api/v2/fix-suggestions/service-info/subscription-type.
+// Enterprise Edition only.
+func (s *FixSuggestionsService) GetSubscriptionType(ctx context.Context) (*FixSuggestionsSubscriptionType, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "fix-suggestions/service-info/subscription-type", nil, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	result := new(FixSuggestionsSubscriptionType)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// GetSupportedLlmProviders returns the list of supported LLM providers.
+// Requires 'Administer System' permission.
+//
+// API endpoint: GET /api/v2/fix-suggestions/supported-llm-providers.
+// The endpoint returns a bare JSON array (confirmed against the SonarQube
+// server implementation), not an object wrapping a "providers" field.
+// Enterprise Edition only.
+func (s *FixSuggestionsService) GetSupportedLlmProviders(ctx context.Context) ([]FixSuggestionsLlmProvider, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "fix-suggestions/supported-llm-providers", nil, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	var result []FixSuggestionsLlmProvider
+
+	resp, err := s.client.Do(req, &result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}

--- a/sonar/fix_suggestions_v2_service_test.go
+++ b/sonar/fix_suggestions_v2_service_test.go
@@ -1,0 +1,178 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixSuggestionsService_CreateSuggestion(t *testing.T) {
+	response := FixSuggestion{
+		Id:          "suggestion-1",
+		IssueId:     "issue-123",
+		Explanation: "Fix the null pointer dereference",
+		Changes:     []FixSuggestionChange{{StartLine: 10, EndLine: 12, NewCode: "if obj != nil {"}},
+	}
+	server := newTestServer(t, mockJSONBodyHandler(t, http.MethodPost, "/v2/fix-suggestions/ai-suggestions", http.StatusOK,
+		map[string]any{"issueId": "issue-123"}, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.V2.FixSuggestions.CreateSuggestion(context.Background(), &FixSuggestionsCreateOptions{
+		IssueId: "issue-123",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "suggestion-1", result.Id)
+}
+
+func TestFixSuggestionsService_CreateSuggestion_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.V2.FixSuggestions.CreateSuggestion(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.V2.FixSuggestions.CreateSuggestion(context.Background(), &FixSuggestionsCreateOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}
+
+func TestFixSuggestionsService_GetEnablement(t *testing.T) {
+	response := FixSuggestionsFeatureEnablement{
+		Enablement:         "ENABLED_FOR_ALL_PROJECTS",
+		EnabledProjectKeys: []string{"proj-1"},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/fix-suggestions/feature-enablements", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.V2.FixSuggestions.GetEnablement(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "ENABLED_FOR_ALL_PROJECTS", result.Enablement)
+}
+
+func TestFixSuggestionsService_SetEnablement(t *testing.T) {
+	server := newTestServer(t, mockPatchHandler(t, "/v2/fix-suggestions/feature-enablements", http.StatusNoContent,
+		map[string]any{"enablement": FixSuggestionsEnablementEnabledForAllProjects}, nil))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.V2.FixSuggestions.SetEnablement(context.Background(), &FixSuggestionsSetEnablementOptions{
+		Enablement: FixSuggestionsEnablementEnabledForAllProjects,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestFixSuggestionsService_SetEnablement_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	resp, err := client.V2.FixSuggestions.SetEnablement(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.V2.FixSuggestions.SetEnablement(context.Background(), &FixSuggestionsSetEnablementOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = client.V2.FixSuggestions.SetEnablement(context.Background(), &FixSuggestionsSetEnablementOptions{
+		Enablement: "NOT_A_VALID_STATE",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestFixSuggestionsService_AwarenessBannerInteraction(t *testing.T) {
+	response := FixSuggestionsAwarenessBanner{Id: "interaction-1"}
+	server := newTestServer(t, mockJSONBodyHandler(t, http.MethodPost, "/v2/fix-suggestions/feature-enablements/awareness-banner-interactions",
+		http.StatusOK, map[string]any{"bannerType": FixSuggestionsBannerTypeEnable}, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.V2.FixSuggestions.AwarenessBannerInteraction(context.Background(), &FixSuggestionsAwarenessBannerOptions{
+		BannerType: FixSuggestionsBannerTypeEnable,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "interaction-1", result.Id)
+}
+
+func TestFixSuggestionsService_AwarenessBannerInteraction_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.V2.FixSuggestions.AwarenessBannerInteraction(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.V2.FixSuggestions.AwarenessBannerInteraction(context.Background(), &FixSuggestionsAwarenessBannerOptions{
+		BannerType: "INFO",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}
+
+func TestFixSuggestionsService_GetIssueAvailability(t *testing.T) {
+	response := FixSuggestionIssueAvailability{IssueId: "issue-123", AiSuggestion: "AVAILABLE"}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/fix-suggestions/issues/issue-123", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.V2.FixSuggestions.GetIssueAvailability(context.Background(), &FixSuggestionsIssueOptions{
+		IssueId: "issue-123",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "AVAILABLE", result.AiSuggestion)
+}
+
+func TestFixSuggestionsService_GetIssueAvailability_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.V2.FixSuggestions.GetIssueAvailability(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}
+
+func TestFixSuggestionsService_GetServiceInfo(t *testing.T) {
+	response := FixSuggestionsServiceInfo{Status: "UP", IsEnabled: true, SubscriptionType: "PAID"}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/fix-suggestions/service-info", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.V2.FixSuggestions.GetServiceInfo(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "UP", result.Status)
+	assert.True(t, result.IsEnabled)
+}
+
+func TestFixSuggestionsService_GetSubscriptionType(t *testing.T) {
+	response := FixSuggestionsSubscriptionType{SubscriptionType: "PAID"}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/fix-suggestions/service-info/subscription-type", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.V2.FixSuggestions.GetSubscriptionType(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "PAID", result.SubscriptionType)
+}
+
+func TestFixSuggestionsService_GetSupportedLlmProviders(t *testing.T) {
+	// The real endpoint returns a bare JSON array (verified live against a
+	// SonarQube 2025.2 Enterprise instance's OpenAPI schema and server
+	// bytecode), not an object wrapping a "providers" field.
+	response := []FixSuggestionsLlmProvider{
+		{Key: "openai", Name: "OpenAI", SelfHosted: false},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/fix-suggestions/supported-llm-providers", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.V2.FixSuggestions.GetSupportedLlmProviders(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, result, 1)
+}


### PR DESCRIPTION
### Description of your changes

This PR adds the new "FixSuggestionsV2" Service to interact with the enterprise Fix Suggestions (v2) endpoints.

Packaged with full mock api response unit tests

e2e tests are dummies for now.

Closes #219 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
