### PR TITLE
feat(enterprise): support scim_management endpoints

### DIFF
--- a/integration_testing/scim_management_test.go
+++ b/integration_testing/scim_management_test.go
@@ -1,0 +1,71 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("SCIM Management Service", Ordered, func() {
+	var client *sonar.Client
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+	})
+
+	// =========================================================================
+	// Disable
+	// =========================================================================
+	Describe("Disable", func() {
+		Context("Functional Tests", func() {
+			It("should succeed or return an enterprise-only error", func() {
+				resp, err := client.ScimManagement.Disable(context.Background())
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Enable
+	// =========================================================================
+	Describe("Enable", func() {
+		Context("Functional Tests", func() {
+			It("should succeed or return an enterprise-only error", func() {
+				resp, err := client.ScimManagement.Enable(context.Background())
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Status
+	// =========================================================================
+	Describe("Status", func() {
+		Context("Functional Tests", func() {
+			It("should succeed or return an enterprise-only error", func() {
+				result, resp, err := client.ScimManagement.Status(context.Background())
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+})

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -98,6 +98,7 @@ type Client struct {
 	RegulatoryReports   *RegulatoryReportsService
 	Rules               *RulesService
 	Saml                *SamlService
+	ScimManagement      *ScimManagementService
 	Server              *ServerService
 	Settings            *SettingsService
 	Sources             *SourcesService
@@ -521,6 +522,7 @@ func initServices(client *Client) {
 	client.RegulatoryReports = &RegulatoryReportsService{client: client}
 	client.Rules = &RulesService{client: client}
 	client.Saml = &SamlService{client: client}
+	client.ScimManagement = &ScimManagementService{client: client}
 	client.Server = &ServerService{client: client}
 	client.Settings = &SettingsService{client: client}
 	client.Sources = &SourcesService{client: client}

--- a/sonar/scim_management_service.go
+++ b/sonar/scim_management_service.go
@@ -1,0 +1,79 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+)
+
+// ScimManagementService handles communication with the SCIM management related
+// methods of the SonarQube API. This service is only available in Enterprise Edition.
+type ScimManagementService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Response Types
+// -----------------------------------------------------------------------------
+
+// ScimManagementStatus represents the SCIM provisioning status.
+type ScimManagementStatus struct {
+	// Enabled indicates whether SCIM provisioning is enabled.
+	Enabled bool `json:"enabled"`
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// Disable disables SCIM provisioning.
+// Requires 'Administer System' permission.
+//
+// API endpoint: POST /api/scim_management/disable.
+// Since: 10.0.
+// Internal endpoint.
+func (s *ScimManagementService) Disable(ctx context.Context) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "scim_management/disable", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Enable enables SCIM provisioning.
+// Requires 'Administer System' permission.
+//
+// API endpoint: POST /api/scim_management/enable.
+// Since: 10.0.
+// Internal endpoint.
+func (s *ScimManagementService) Enable(ctx context.Context) (*http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodPost, "scim_management/enable", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// Status returns the SCIM provisioning status.
+// Requires 'Administer System' permission.
+//
+// API endpoint: GET /api/scim_management/status.
+// Since: 10.0.
+// Internal endpoint.
+func (s *ScimManagementService) Status(ctx context.Context) (*ScimManagementStatus, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "scim_management/status", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(ScimManagementStatus)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}

--- a/sonar/scim_management_service_test.go
+++ b/sonar/scim_management_service_test.go
@@ -1,0 +1,54 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// Disable
+// -----------------------------------------------------------------------------
+
+func TestScimManagementService_Disable(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/scim_management/disable", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.ScimManagement.Disable(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+// -----------------------------------------------------------------------------
+// Enable
+// -----------------------------------------------------------------------------
+
+func TestScimManagementService_Enable(t *testing.T) {
+	server := newTestServer(t, mockEmptyHandler(t, http.MethodPost, "/scim_management/enable", http.StatusNoContent))
+	client := newTestClient(t, server.URL)
+
+	resp, err := client.ScimManagement.Enable(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+// -----------------------------------------------------------------------------
+// Status
+// -----------------------------------------------------------------------------
+
+func TestScimManagementService_Status(t *testing.T) {
+	response := ScimManagementStatus{
+		Enabled: true,
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/scim_management/status", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.ScimManagement.Status(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotNil(t, result)
+	assert.True(t, result.Enabled)
+}


### PR DESCRIPTION
### Description of your changes

This PR adds the new "SCIMManagement" Service to interact with the enterprise SCIM management endpoints.

Packaged with full mock api response unit tests

e2e tests are dummies for now.

Closes #215 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
