### PR TITLE
feat(enterprise): support security_reports endpoints

### DIFF
--- a/integration_testing/security_reports_test.go
+++ b/integration_testing/security_reports_test.go
@@ -1,0 +1,119 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Security Reports Service", Ordered, func() {
+	var client *sonar.Client
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+	})
+
+	// =========================================================================
+	// Download
+	// =========================================================================
+	Describe("Download", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.SecurityReports.Download(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required project", func() {
+				result, resp, err := client.SecurityReports.Download(context.Background(), &sonar.SecurityReportsDownloadOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Project"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should succeed or return an enterprise-only error", func() {
+				result, resp, err := client.SecurityReports.Download(context.Background(), &sonar.SecurityReportsDownloadOptions{
+					Project: "nonexistent-project",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+
+	// =========================================================================
+	// Show
+	// =========================================================================
+	Describe("Show", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.SecurityReports.Show(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("required"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required project", func() {
+				result, resp, err := client.SecurityReports.Show(context.Background(), &sonar.SecurityReportsShowOptions{
+					Standard: "owaspTop10",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Project"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail without required standard", func() {
+				result, resp, err := client.SecurityReports.Show(context.Background(), &sonar.SecurityReportsShowOptions{
+					Project: "my-project",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Standard"))
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+
+			It("should fail with invalid standard", func() {
+				result, resp, err := client.SecurityReports.Show(context.Background(), &sonar.SecurityReportsShowOptions{
+					Project:  "my-project",
+					Standard: "invalid-standard",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+				Expect(resp).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should succeed or return an enterprise-only error", func() {
+				result, resp, err := client.SecurityReports.Show(context.Background(), &sonar.SecurityReportsShowOptions{
+					Project:  "nonexistent-project",
+					Standard: "owaspTop10",
+				})
+				if err != nil {
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+})

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -98,6 +98,7 @@ type Client struct {
 	RegulatoryReports   *RegulatoryReportsService
 	Rules               *RulesService
 	Saml                *SamlService
+	SecurityReports     *SecurityReportsService
 	ScimManagement      *ScimManagementService
 	Server              *ServerService
 	Settings            *SettingsService
@@ -524,6 +525,7 @@ func initServices(client *Client) {
 	client.RegulatoryReports = &RegulatoryReportsService{client: client}
 	client.Rules = &RulesService{client: client}
 	client.Saml = &SamlService{client: client}
+	client.SecurityReports = &SecurityReportsService{client: client}
 	client.ScimManagement = &ScimManagementService{client: client}
 	client.Server = &ServerService{client: client}
 	client.Settings = &SettingsService{client: client}

--- a/sonar/security_reports_service.go
+++ b/sonar/security_reports_service.go
@@ -1,0 +1,202 @@
+package sonar
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+)
+
+// SecurityReportsService handles communication with the security reports related
+// methods of the SonarQube API. This service is internal and enterprise-only.
+type SecurityReportsService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Response Types
+// -----------------------------------------------------------------------------
+
+// SecurityReportsShow represents the response from the show endpoint.
+type SecurityReportsShow struct {
+	// Categories is the list of security report categories.
+	Categories []SecurityReportCategory `json:"categories,omitempty"`
+}
+
+// SecurityReportCategory represents a category in a security report.
+type SecurityReportCategory struct {
+	// Category is the category name.
+	Category string `json:"category,omitempty"`
+	// Version is the standard revision this category belongs to (e.g. "2017", "2021"
+	// for owaspTop10, "3.2", "4.0" for pciDss). Empty for standards without revisions.
+	Version string `json:"version,omitempty"`
+	// Distribution is the CWE breakdown for this category. Only populated when
+	// includeDistribution is requested (and non-empty for CWE-oriented standards).
+	Distribution []SecurityReportCWEDistribution `json:"distribution,omitempty"`
+	// Vulnerabilities is the number of vulnerabilities in this category.
+	Vulnerabilities int `json:"vulnerabilities,omitempty"`
+	// SecurityReviewRating is the security review rating (1-5, A-E) for this category.
+	SecurityReviewRating int `json:"securityReviewRating,omitempty"`
+	// ActiveRules is the number of active rules for this category.
+	ActiveRules int `json:"activeRules,omitempty"`
+	// TotalRules is the total number of rules (active or not) for this category.
+	TotalRules int `json:"totalRules,omitempty"`
+	// ToReviewSecurityHotspots is the number of security hotspots to review.
+	ToReviewSecurityHotspots int `json:"toReviewSecurityHotspots,omitempty"`
+	// ReviewedSecurityHotspots is the number of reviewed security hotspots.
+	ReviewedSecurityHotspots int `json:"reviewedSecurityHotspots,omitempty"`
+	// HasMoreRules indicates whether more rules exist beyond TotalRules.
+	HasMoreRules bool `json:"hasMoreRules,omitempty"`
+}
+
+// SecurityReportCWEDistribution represents the per-CWE breakdown within a security
+// report category, returned when includeDistribution is set.
+type SecurityReportCWEDistribution struct {
+	// CWE is the CWE identifier (e.g. "89").
+	CWE string `json:"cwe,omitempty"`
+	// Vulnerabilities is the number of vulnerabilities for this CWE.
+	Vulnerabilities int `json:"vulnerabilities,omitempty"`
+	// VulnerabilityRating is the vulnerability rating (1-5, A-E) for this CWE.
+	VulnerabilityRating int `json:"vulnerabilityRating,omitempty"`
+	// SecurityReviewRating is the security review rating (1-5, A-E) for this CWE.
+	SecurityReviewRating int `json:"securityReviewRating,omitempty"`
+	// ActiveRules is the number of active rules for this CWE.
+	ActiveRules int `json:"activeRules,omitempty"`
+	// TotalRules is the total number of rules (active or not) for this CWE.
+	TotalRules int `json:"totalRules,omitempty"`
+	// ToReviewSecurityHotspots is the number of security hotspots to review.
+	ToReviewSecurityHotspots int `json:"toReviewSecurityHotspots,omitempty"`
+	// ReviewedSecurityHotspots is the number of reviewed security hotspots.
+	ReviewedSecurityHotspots int `json:"reviewedSecurityHotspots,omitempty"`
+	// HasMoreRules indicates whether more rules exist beyond TotalRules.
+	HasMoreRules bool `json:"hasMoreRules,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// SecurityReportsDownloadOptions contains parameters for the Download method.
+type SecurityReportsDownloadOptions struct {
+	// Branch filters the results by branch. Optional.
+	Branch string `url:"branch,omitempty"`
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+}
+
+// SecurityReportsShowOptions contains parameters for the Show method.
+type SecurityReportsShowOptions struct {
+	// Branch filters the results by branch. Optional.
+	Branch string `url:"branch,omitempty"`
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+	// Standard is the security standard to report on. This field is required.
+	Standard string `url:"standard"`
+	// IncludeDistribution includes distribution information when set. Optional.
+	IncludeDistribution bool `url:"includeDistribution,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// Allowed Value Sets
+// -----------------------------------------------------------------------------
+
+//nolint:gochecknoglobals // constant set of allowed values
+var allowedSecurityStandards = map[string]struct{}{
+	"owaspTop10":          {},
+	"sonarsourceSecurity": {},
+	"cweTop25":            {},
+	"pciDss":              {},
+	"owaspAsvs":           {},
+	"stig":                {},
+	"casa":                {},
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateDownloadOpt validates the options for the Download method.
+func (s *SecurityReportsService) ValidateDownloadOpt(opt *SecurityReportsDownloadOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Project, "Project")
+}
+
+// ValidateShowOpt validates the options for the Show method.
+func (s *SecurityReportsService) ValidateShowOpt(opt *SecurityReportsShowOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.Project, "Project")
+	if err != nil {
+		return err
+	}
+
+	err = ValidateRequired(opt.Standard, "Standard")
+	if err != nil {
+		return err
+	}
+
+	return IsValueAuthorized(opt.Standard, allowedSecurityStandards, "Standard")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// Download downloads a security report as a PDF document.
+// Requires Browse permission on the project.
+//
+// API endpoint: GET /api/security_reports/download.
+// Since: 8.8.
+// Internal endpoint.
+func (s *SecurityReportsService) Download(ctx context.Context, opt *SecurityReportsDownloadOptions) ([]byte, *http.Response, error) {
+	err := s.ValidateDownloadOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "security_reports/download", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var buf bytes.Buffer
+
+	resp, err := s.client.Do(req, &buf)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return buf.Bytes(), resp, nil
+}
+
+// Show returns the security report for a project.
+// Requires Browse permission on the project.
+//
+// API endpoint: GET /api/security_reports/show.
+// Since: 7.3.
+// Internal endpoint.
+func (s *SecurityReportsService) Show(ctx context.Context, opt *SecurityReportsShowOptions) (*SecurityReportsShow, *http.Response, error) {
+	err := s.ValidateShowOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "security_reports/show", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(SecurityReportsShow)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}

--- a/sonar/security_reports_service_test.go
+++ b/sonar/security_reports_service_test.go
@@ -1,0 +1,131 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// Download
+// -----------------------------------------------------------------------------
+
+func TestSecurityReportsService_Download(t *testing.T) {
+	data := []byte(`%PDF test content`)
+	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/security_reports/download", http.StatusOK, "application/pdf", data))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.SecurityReports.Download(context.Background(), &SecurityReportsDownloadOptions{
+		Project: "my-project",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, result)
+}
+
+func TestSecurityReportsService_Download_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.SecurityReports.Download(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.SecurityReports.Download(context.Background(), &SecurityReportsDownloadOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}
+
+// -----------------------------------------------------------------------------
+// Show
+// -----------------------------------------------------------------------------
+
+func TestSecurityReportsService_Show(t *testing.T) {
+	response := SecurityReportsShow{
+		Categories: []SecurityReportCategory{
+			{
+				Category:                 "a1",
+				Version:                  "2017",
+				Vulnerabilities:          5,
+				SecurityReviewRating:     2,
+				ActiveRules:              10,
+				TotalRules:               12,
+				ToReviewSecurityHotspots: 3,
+				ReviewedSecurityHotspots: 2,
+				HasMoreRules:             true,
+				Distribution: []SecurityReportCWEDistribution{
+					{
+						CWE:                      "89",
+						Vulnerabilities:          1,
+						VulnerabilityRating:      3,
+						SecurityReviewRating:     2,
+						ActiveRules:              4,
+						TotalRules:               5,
+						ToReviewSecurityHotspots: 1,
+						ReviewedSecurityHotspots: 0,
+						HasMoreRules:             false,
+					},
+				},
+			},
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/security_reports/show", http.StatusOK, response))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.SecurityReports.Show(context.Background(), &SecurityReportsShowOptions{
+		Project:             "my-project",
+		Standard:            "owaspTop10",
+		IncludeDistribution: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Categories, 1)
+	assert.Equal(t, "a1", result.Categories[0].Category)
+	assert.Equal(t, "2017", result.Categories[0].Version)
+	assert.Equal(t, 5, result.Categories[0].Vulnerabilities)
+	assert.Equal(t, 2, result.Categories[0].SecurityReviewRating)
+	assert.Equal(t, 10, result.Categories[0].ActiveRules)
+	assert.Equal(t, 12, result.Categories[0].TotalRules)
+	assert.Equal(t, 3, result.Categories[0].ToReviewSecurityHotspots)
+	assert.Equal(t, 2, result.Categories[0].ReviewedSecurityHotspots)
+	assert.True(t, result.Categories[0].HasMoreRules)
+	require.Len(t, result.Categories[0].Distribution, 1)
+	assert.Equal(t, "89", result.Categories[0].Distribution[0].CWE)
+	assert.Equal(t, 1, result.Categories[0].Distribution[0].Vulnerabilities)
+	assert.Equal(t, 3, result.Categories[0].Distribution[0].VulnerabilityRating)
+	assert.Equal(t, 2, result.Categories[0].Distribution[0].SecurityReviewRating)
+	assert.Equal(t, 4, result.Categories[0].Distribution[0].ActiveRules)
+	assert.Equal(t, 5, result.Categories[0].Distribution[0].TotalRules)
+	assert.Equal(t, 1, result.Categories[0].Distribution[0].ToReviewSecurityHotspots)
+	assert.Equal(t, 0, result.Categories[0].Distribution[0].ReviewedSecurityHotspots)
+	assert.False(t, result.Categories[0].Distribution[0].HasMoreRules)
+}
+
+func TestSecurityReportsService_Show_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.SecurityReports.Show(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.SecurityReports.Show(context.Background(), &SecurityReportsShowOptions{Standard: "owaspTop10"})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.SecurityReports.Show(context.Background(), &SecurityReportsShowOptions{Project: "my-project"})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+
+	result, resp, err = client.SecurityReports.Show(context.Background(), &SecurityReportsShowOptions{Project: "my-project", Standard: "invalid-standard"})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+}


### PR DESCRIPTION
### Description of your changes

This PR adds the new "SecurityReports" Service to interact with the enterprise security reports endpoints.

Packaged with full mock api response unit tests

e2e tests are dummies for now.

Closes #216 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
