### PR TITLE
feat(enterprise): support support/info endpoint

### DIFF
--- a/integration_testing/support_test.go
+++ b/integration_testing/support_test.go
@@ -1,0 +1,45 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Support Service", Ordered, func() {
+	var (
+		client  *sonar.Client
+		cleanup *helpers.CleanupManager
+	)
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+		cleanup = helpers.NewCleanupManager(client)
+	})
+
+	AfterAll(func() {
+		cleanup.Cleanup()
+	})
+
+	Describe("Info", func() {
+		Context("Functional Tests", func() {
+			It("should return info or an enterprise-only error", func() {
+				result, resp, err := client.Support.Info(context.Background())
+				if err != nil {
+					// Enterprise-only endpoints return 4xx on Community Edition.
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+})

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -101,6 +101,7 @@ type Client struct {
 	Server              *ServerService
 	Settings            *SettingsService
 	Sources             *SourcesService
+	Support             *SupportService
 	System              *SystemService
 	UserGroups          *UserGroupsService
 	UserTokens          *UserTokensService
@@ -523,6 +524,7 @@ func initServices(client *Client) {
 	client.Server = &ServerService{client: client}
 	client.Settings = &SettingsService{client: client}
 	client.Sources = &SourcesService{client: client}
+	client.Support = &SupportService{client: client}
 	client.System = &SystemService{client: client}
 	client.UserGroups = &UserGroupsService{client: client}
 	client.UserTokens = &UserTokensService{client: client}

--- a/sonar/support_service.go
+++ b/sonar/support_service.go
@@ -1,7 +1,6 @@
 package sonar
 
 import (
-	"bytes"
 	"context"
 	"net/http"
 )
@@ -34,24 +33,32 @@ type SupportInfo struct {
 // Service Methods
 // -----------------------------------------------------------------------------
 
-// Info returns raw support information as bytes.
+// Info returns support information about the system and the currently
+// installed license.
 // Requires 'Administer System' permission.
 //
 // API endpoint: GET /api/support/info.
 // Since: 3.1.
 // Enterprise Edition only.
-func (s *SupportService) Info(ctx context.Context) ([]byte, *http.Response, error) {
+// WARNING: This is an internal API and may change without notice.
+// WARNING: Live-verified against SonarQube 2025.2 Enterprise: this endpoint
+// requires an actual installed commercial license to succeed, independent of
+// Enterprise Edition + 'Administer System' permission. Without one it fails
+// with HTTP 400 and body {"errors":[{"msg":"License not found"}]}, so the
+// success-path JSON shape of SupportInfo below could not be confirmed against
+// a live server and remains a best-effort guess (see .github/reviews/pr-265.md).
+func (s *SupportService) Info(ctx context.Context) (*SupportInfo, *http.Response, error) {
 	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "support/info", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var buf bytes.Buffer
+	result := new(SupportInfo)
 
-	resp, err := s.client.Do(req, &buf)
+	resp, err := s.client.Do(req, result)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return buf.Bytes(), resp, nil
+	return result, resp, nil
 }

--- a/sonar/support_service.go
+++ b/sonar/support_service.go
@@ -1,0 +1,57 @@
+package sonar
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+)
+
+// SupportService handles communication with the support related methods of
+// the SonarQube API. This service is only available in Enterprise Edition.
+type SupportService struct {
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Response Types
+// -----------------------------------------------------------------------------
+
+// SupportInfo contains system support information returned by the Info endpoint.
+//
+//nolint:tagliatelle // SonarQube API uses PascalCase JSON keys for these fields
+type SupportInfo struct {
+	// Database contains database-related support information.
+	Database map[string]any `json:"Database,omitempty"`
+	// SonarQube contains SonarQube application-level support information.
+	SonarQube map[string]any `json:"SonarQube,omitempty"`
+	// Statistics contains usage statistics information.
+	Statistics map[string]any `json:"Statistics,omitempty"`
+	// System contains system-level support information.
+	System map[string]any `json:"System,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// Info returns raw support information as bytes.
+// Requires 'Administer System' permission.
+//
+// API endpoint: GET /api/support/info.
+// Since: 3.1.
+// Enterprise Edition only.
+func (s *SupportService) Info(ctx context.Context) ([]byte, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "support/info", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var buf bytes.Buffer
+
+	resp, err := s.client.Do(req, &buf)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return buf.Bytes(), resp, nil
+}

--- a/sonar/support_service_test.go
+++ b/sonar/support_service_test.go
@@ -1,0 +1,21 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSupportService_Info(t *testing.T) {
+	data := []byte(`{"System":{"OS":"Linux"},"Database":{"Name":"PostgreSQL"}}`)
+	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/support/info", http.StatusOK, "application/json", data))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Support.Info(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, result)
+}

--- a/sonar/support_service_test.go
+++ b/sonar/support_service_test.go
@@ -10,12 +10,45 @@ import (
 )
 
 func TestSupportService_Info(t *testing.T) {
-	data := []byte(`{"System":{"OS":"Linux"},"Database":{"Name":"PostgreSQL"}}`)
-	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/support/info", http.StatusOK, "application/json", data))
+	response := &SupportInfo{
+		System:   map[string]any{"OS": "Linux"},
+		Database: map[string]any{"Name": "PostgreSQL"},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/support/info", http.StatusOK, response))
 	client := newTestClient(t, server.URL)
 
 	result, resp, err := client.Support.Info(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, data, result)
+	assert.Equal(t, response, result)
+}
+
+func TestSupportService_Info_ErrorResponse(t *testing.T) {
+	handler := mockHandler(t, http.MethodGet, "/support/info", http.StatusForbidden, `{"errors":[{"msg":"Insufficient privileges"}]}`)
+	server := newTestServer(t, handler)
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Support.Info(context.Background())
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Nil(t, result)
+}
+
+// TestSupportService_Info_LicenseNotFound mirrors the response observed when
+// live-verifying this endpoint against a real, unlicensed SonarQube 2025.2
+// Enterprise instance: GET /api/support/info returns HTTP 400 with
+// {"errors":[{"msg":"License not found"}]} even with full admin permissions,
+// because the endpoint requires an actually installed commercial license to
+// succeed (see .github/reviews/pr-265.md).
+func TestSupportService_Info_LicenseNotFound(t *testing.T) {
+	handler := mockHandler(t, http.MethodGet, "/support/info", http.StatusBadRequest, `{"errors":[{"msg":"License not found"}]}`)
+	server := newTestServer(t, handler)
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.Support.Info(context.Background())
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Nil(t, result)
 }


### PR DESCRIPTION
### Description of your changes

This PR adds the new "Support" Service to interact with the enterprise support / info endpoints.

Packaged with full mock api response unit tests

e2e tests are dummies for now.

Closes #217 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
