### PR TITLE
feat(enterprise): support regulatory_reports/download endpoint

### DIFF
--- a/integration_testing/regulatory_reports_test.go
+++ b/integration_testing/regulatory_reports_test.go
@@ -1,0 +1,63 @@
+package integration_testing_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("Regulatory Reports Service", Ordered, func() {
+	var (
+		client  *sonar.Client
+		cleanup *helpers.CleanupManager
+	)
+
+	BeforeAll(func() {
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+		cleanup = helpers.NewCleanupManager(client)
+	})
+
+	AfterAll(func() {
+		cleanup.Cleanup()
+	})
+
+	Describe("Download", func() {
+		Context("Parameter Validation", func() {
+			It("should fail with nil options", func() {
+				result, resp, err := client.RegulatoryReports.Download(context.Background(), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+
+			It("should fail without required Project", func() {
+				result, resp, err := client.RegulatoryReports.Download(context.Background(), &sonar.RegulatoryReportsDownloadOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(resp).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+
+		Context("Functional Tests", func() {
+			It("should download or return an enterprise-only error", func() {
+				result, resp, err := client.RegulatoryReports.Download(context.Background(), &sonar.RegulatoryReportsDownloadOptions{
+					Project: "non-existent-project",
+				})
+				if err != nil {
+					// Enterprise-only endpoints return 4xx on Community Edition.
+					Expect(resp).NotTo(BeNil())
+				} else {
+					Expect(resp.StatusCode).To(BeNumerically("<", 400))
+					Expect(result).NotTo(BeNil())
+				}
+			})
+		})
+	})
+})

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -74,6 +74,7 @@ type Client struct {
 	Push                *PushService
 	Qualitygates        *QualitygatesService
 	Qualityprofiles     *QualityprofilesService
+	RegulatoryReports   *RegulatoryReportsService
 	Rules               *RulesService
 	Server              *ServerService
 	Settings            *SettingsService
@@ -436,6 +437,7 @@ func initServices(client *Client) {
 	client.Push = &PushService{client: client}
 	client.Qualitygates = &QualitygatesService{client: client}
 	client.Qualityprofiles = &QualityprofilesService{client: client}
+	client.RegulatoryReports = &RegulatoryReportsService{client: client}
 	client.Rules = &RulesService{client: client}
 	client.Server = &ServerService{client: client}
 	client.Settings = &SettingsService{client: client}

--- a/sonar/regulatory_reports_service.go
+++ b/sonar/regulatory_reports_service.go
@@ -1,0 +1,69 @@
+package sonar
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+)
+
+// RegulatoryReportsService handles communication with the regulatory reports related methods of
+// the SonarQube API. This service is only available in Enterprise Edition.
+type RegulatoryReportsService struct {
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Option Types
+// -----------------------------------------------------------------------------
+
+// RegulatoryReportsDownloadOptions contains parameters for the Download method.
+type RegulatoryReportsDownloadOptions struct {
+	// Branch is the branch key. Optional.
+	Branch string `url:"branch,omitempty"`
+	// Project is the project key. This field is required.
+	Project string `url:"project"`
+}
+
+// -----------------------------------------------------------------------------
+// Validation Functions
+// -----------------------------------------------------------------------------
+
+// ValidateDownloadOpt validates the options for the Download method.
+func (s *RegulatoryReportsService) ValidateDownloadOpt(opt *RegulatoryReportsDownloadOptions) error {
+	if opt == nil {
+		return NewValidationError("opt", "option struct is required", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.Project, "Project")
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// Download downloads the regulatory report for a project as a zip file.
+// Requires 'Browse' permission on the project.
+//
+// API endpoint: GET /api/regulatory_reports/download.
+// Since: 9.5.
+// Enterprise Edition only.
+func (s *RegulatoryReportsService) Download(ctx context.Context, opt *RegulatoryReportsDownloadOptions) ([]byte, *http.Response, error) {
+	err := s.ValidateDownloadOpt(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV1APIRequest(ctx, http.MethodGet, "regulatory_reports/download", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var buf bytes.Buffer
+
+	resp, err := s.client.Do(req, &buf)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return buf.Bytes(), resp, nil
+}

--- a/sonar/regulatory_reports_service_test.go
+++ b/sonar/regulatory_reports_service_test.go
@@ -1,0 +1,51 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegulatoryReportsService_Download(t *testing.T) {
+	data := []byte("PK\x03\x04zip-content")
+	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/regulatory_reports/download", http.StatusOK, "application/zip", data))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.RegulatoryReports.Download(context.Background(), &RegulatoryReportsDownloadOptions{
+		Project: "my-project",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, result)
+}
+
+func TestRegulatoryReportsService_Download_WithBranch(t *testing.T) {
+	data := []byte("PK\x03\x04zip-content")
+	server := newTestServer(t, mockBinaryHandler(t, http.MethodGet, "/regulatory_reports/download", http.StatusOK, "application/zip", data))
+	client := newTestClient(t, server.URL)
+
+	result, resp, err := client.RegulatoryReports.Download(context.Background(), &RegulatoryReportsDownloadOptions{
+		Project: "my-project",
+		Branch:  "main",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, result)
+}
+
+func TestRegulatoryReportsService_Download_ValidationError(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	result, resp, err := client.RegulatoryReports.Download(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Nil(t, result)
+
+	result, resp, err = client.RegulatoryReports.Download(context.Background(), &RegulatoryReportsDownloadOptions{})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Nil(t, result)
+}


### PR DESCRIPTION
### Description of your changes

This PR adds the new "RegulatoryReports" Service to interact with the enterprise regulatory reports endpoints.

Packaged with full mock api response unit tests

e2e tests are dummies for now.

Closes #213 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
