### PR TITLE
Support fix suggestions V2 endpoints

### DIFF
--- a/integration_testing/fix_suggestions_v2_test.go
+++ b/integration_testing/fix_suggestions_v2_test.go
@@ -1,0 +1,47 @@
+package integration_testing_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/sonar"
+)
+
+var _ = Describe("V2 Fix Suggestions Service", Ordered, func() {
+	var client *sonar.Client
+
+	BeforeAll(func() {
+		if os.Getenv("SONAR_FIX_SUGGESTIONS_E2E") == "" {
+			Skip("set SONAR_FIX_SUGGESTIONS_E2E=1 to run Enterprise fix suggestions tests")
+		}
+
+		var err error
+		client, err = helpers.NewDefaultClient()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+	})
+
+	Describe("GetServiceInfo", func() {
+		It("should return fix suggestions service info", func() {
+			result, resp, err := client.V2.FixSuggestions.GetServiceInfo(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(result).NotTo(BeNil())
+			Expect(result.Status).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("ListSupportedLLMProviders", func() {
+		It("should return supported providers", func() {
+			result, resp, err := client.V2.FixSuggestions.ListSupportedLLMProviders(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(result).NotTo(BeNil())
+		})
+	})
+})

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -97,6 +97,8 @@ type ServicesV2 struct {
 	CleanCodePolicy *CleanCodePolicyService
 	// DopTranslation provides methods for the Dop Translation V2 API.
 	DopTranslation *DopTranslationService
+	// FixSuggestions provides methods for the Fix Suggestions V2 API.
+	FixSuggestions *FixSuggestionsService
 	// Marketplace provides methods for the Marketplace V2 API.
 	Marketplace *MarketplaceService
 	// System provides methods for the System V2 API.
@@ -453,6 +455,7 @@ func initServicesV2(client *Client) {
 		Authorizations:  &AuthorizationsService{client: client},
 		CleanCodePolicy: &CleanCodePolicyService{client: client},
 		DopTranslation:  &DopTranslationService{client: client},
+		FixSuggestions:  &FixSuggestionsService{client: client},
 		Marketplace:     &MarketplaceService{client: client},
 		System:          &SystemServiceV2{client: client},
 		UsersManagement: &UsersManagementService{client: client},

--- a/sonar/fix_suggestions_v2_service.go
+++ b/sonar/fix_suggestions_v2_service.go
@@ -1,0 +1,344 @@
+package sonar
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// FixSuggestionsService handles communication with the Fix Suggestions related
+// methods of the SonarQube V2 API.
+type FixSuggestionsService struct {
+	// client is used to communicate with the SonarQube API.
+	client *Client
+}
+
+// -----------------------------------------------------------------------------
+// Response Types
+// -----------------------------------------------------------------------------
+
+// FixSuggestionChange represents a code change proposed by a fix suggestion.
+//
+//nolint:govet // Field alignment less important than matching API field order.
+type FixSuggestionChange struct {
+	// StartLine is the first line affected by the change.
+	StartLine int32 `json:"startLine,omitempty"`
+	// EndLine is the last line affected by the change.
+	EndLine int32 `json:"endLine,omitempty"`
+	// NewCode is the suggested replacement code.
+	NewCode string `json:"newCode,omitempty"`
+}
+
+// FixSuggestionResponse represents a generated fix suggestion.
+type FixSuggestionResponse struct {
+	// Id is the unique identifier of the fix suggestion.
+	Id string `json:"id,omitempty"`
+	// IssueId is the issue key for which the suggestion was generated.
+	IssueId string `json:"issueId,omitempty"`
+	// Explanation describes the suggested fix.
+	Explanation string `json:"explanation,omitempty"`
+	// Changes contains the proposed code changes.
+	Changes []FixSuggestionChange `json:"changes,omitempty"`
+}
+
+// FixSuggestionIssueResponse represents suggestion availability for an issue.
+type FixSuggestionIssueResponse struct {
+	// IssueId is the issue key.
+	IssueId string `json:"issueId,omitempty"`
+	// AiSuggestion is the availability status for generating a suggestion.
+	AiSuggestion string `json:"aiSuggestion,omitempty"`
+}
+
+// ProviderResponse represents the configured provider for fix suggestions.
+type ProviderResponse struct {
+	// Key is the provider key.
+	Key string `json:"key,omitempty"`
+	// ModelKey is the configured model key.
+	ModelKey string `json:"modelKey,omitempty"`
+	// Endpoint is the configured provider endpoint.
+	Endpoint string `json:"endpoint,omitempty"`
+}
+
+// FeatureEnablementResponse represents the fix suggestions feature state.
+//
+//nolint:govet // Field alignment less important than matching API field order.
+type FeatureEnablementResponse struct {
+	// Enablement is the instance/project-level enablement state.
+	Enablement string `json:"enablement,omitempty"`
+	// EnabledProjectKeys contains project keys for which the feature is enabled.
+	EnabledProjectKeys []string `json:"enabledProjectKeys,omitempty"`
+	// Provider contains the configured provider, if any.
+	Provider *ProviderResponse `json:"provider,omitempty"`
+}
+
+// AwarenessBannerClickedResponse represents a recorded awareness banner interaction.
+type AwarenessBannerClickedResponse struct {
+	// Id is the recorded interaction identifier.
+	Id string `json:"id,omitempty"`
+}
+
+// LLMModel represents a supported model for a fix suggestions provider.
+type LLMModel struct {
+	// Key is the model key.
+	Key string `json:"key,omitempty"`
+	// Name is the display name of the model.
+	Name string `json:"name,omitempty"`
+	// Recommended indicates whether the model is recommended.
+	Recommended bool `json:"recommended,omitempty"`
+}
+
+// LLMProviderResponse represents a supported fix suggestions provider.
+//
+//nolint:govet // Field alignment less important than matching API field order.
+type LLMProviderResponse struct {
+	// Key is the provider key.
+	Key string `json:"key,omitempty"`
+	// Name is the display name of the provider.
+	Name string `json:"name,omitempty"`
+	// SelfHosted indicates whether the provider is self-hosted.
+	SelfHosted bool `json:"selfHosted,omitempty"`
+	// Models contains supported provider models.
+	Models []LLMModel `json:"models,omitempty"`
+}
+
+// FixSuggestionsServiceInfo represents status and subscription information.
+//
+//nolint:govet // Field alignment less important than matching API field order.
+type FixSuggestionsServiceInfo struct {
+	// Status is the service connectivity status.
+	Status string `json:"status,omitempty"`
+	// IsEnabled indicates whether fix suggestions are enabled.
+	IsEnabled bool `json:"isEnabled,omitempty"`
+	// SubscriptionType is the current subscription type.
+	SubscriptionType string `json:"subscriptionType,omitempty"`
+}
+
+// SubscriptionTypeResponse represents the current fix suggestions subscription type.
+type SubscriptionTypeResponse struct {
+	// SubscriptionType is the current subscription type.
+	SubscriptionType string `json:"subscriptionType,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// Request Types
+// -----------------------------------------------------------------------------
+
+// FixSuggestionPostRequest contains parameters for generating a fix suggestion.
+type FixSuggestionPostRequest struct {
+	// IssueId is the issue key for which to generate a fix suggestion.
+	// This field is required.
+	IssueId string `json:"issueId"`
+}
+
+// FeatureEnablementRequest contains parameters for updating feature enablement.
+type FeatureEnablementRequest struct {
+	// Enablement indicates whether the feature should be enabled.
+	Enablement bool `json:"enablement"`
+}
+
+// AwarenessBannerClickedRequest contains a recorded awareness banner interaction.
+type AwarenessBannerClickedRequest struct {
+	// BannerType is the awareness banner interaction type.
+	// Allowed values: ENABLE, LEARN_MORE.
+	BannerType string `json:"bannerType"`
+}
+
+// -----------------------------------------------------------------------------
+// Validation
+// -----------------------------------------------------------------------------
+
+// ValidateGenerateFixSuggestionRequest validates the FixSuggestionPostRequest.
+func (s *FixSuggestionsService) ValidateGenerateFixSuggestionRequest(opt *FixSuggestionPostRequest) error {
+	if opt == nil {
+		return NewValidationError("opt", "must not be nil", ErrMissingRequired)
+	}
+
+	return ValidateRequired(opt.IssueId, "IssueId")
+}
+
+// ValidateUpdateFeatureEnablementRequest validates the FeatureEnablementRequest.
+func (s *FixSuggestionsService) ValidateUpdateFeatureEnablementRequest(opt *FeatureEnablementRequest) error {
+	if opt == nil {
+		return NewValidationError("opt", "must not be nil", ErrMissingRequired)
+	}
+
+	return nil
+}
+
+// ValidateAwarenessBannerClickedRequest validates the AwarenessBannerClickedRequest.
+func (s *FixSuggestionsService) ValidateAwarenessBannerClickedRequest(opt *AwarenessBannerClickedRequest) error {
+	if opt == nil {
+		return NewValidationError("opt", "must not be nil", ErrMissingRequired)
+	}
+
+	err := ValidateRequired(opt.BannerType, "BannerType")
+	if err != nil {
+		return err
+	}
+
+	switch opt.BannerType {
+	case "ENABLE", "LEARN_MORE":
+		return nil
+	default:
+		return NewValidationError("BannerType", "must be one of: ENABLE, LEARN_MORE", ErrInvalidValue)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Service Methods
+// -----------------------------------------------------------------------------
+
+// GenerateFixSuggestion suggests a fix for the given issue.
+func (s *FixSuggestionsService) GenerateFixSuggestion(ctx context.Context, opt *FixSuggestionPostRequest) (*FixSuggestionResponse, *http.Response, error) {
+	err := s.ValidateGenerateFixSuggestionRequest(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPost, "fix-suggestions/ai-suggestions", nil, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	result := new(FixSuggestionResponse)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// GetIssueSuggestionAvailability fetches fix suggestion availability for an issue.
+func (s *FixSuggestionsService) GetIssueSuggestionAvailability(ctx context.Context, issueID string) (*FixSuggestionIssueResponse, *http.Response, error) {
+	err := ValidateRequired(issueID, "IssueId")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "fix-suggestions/issues/"+url.PathEscape(issueID), nil, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	result := new(FixSuggestionIssueResponse)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// GetFeatureEnablement fetches fix suggestions feature enablement configuration.
+func (s *FixSuggestionsService) GetFeatureEnablement(ctx context.Context) (*FeatureEnablementResponse, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "fix-suggestions/feature-enablements", nil, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	result := new(FeatureEnablementResponse)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// UpdateFeatureEnablement enables or disables fix suggestions.
+func (s *FixSuggestionsService) UpdateFeatureEnablement(ctx context.Context, opt *FeatureEnablementRequest) (*http.Response, error) {
+	err := s.ValidateUpdateFeatureEnablementRequest(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPatch, "fix-suggestions/feature-enablements", nil, opt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// RecordAwarenessBannerInteraction records a fix suggestions awareness banner interaction.
+func (s *FixSuggestionsService) RecordAwarenessBannerInteraction(ctx context.Context, opt *AwarenessBannerClickedRequest) (*AwarenessBannerClickedResponse, *http.Response, error) {
+	err := s.ValidateAwarenessBannerClickedRequest(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodPost, "fix-suggestions/feature-enablements/awareness-banner-interactions", nil, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	result := new(AwarenessBannerClickedResponse)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// ListSupportedLLMProviders lists the supported fix suggestions LLM providers.
+func (s *FixSuggestionsService) ListSupportedLLMProviders(ctx context.Context) ([]LLMProviderResponse, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "fix-suggestions/supported-llm-providers", nil, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	var result []LLMProviderResponse
+
+	resp, err := s.client.Do(req, &result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// GetServiceInfo requests status and subscription information.
+func (s *FixSuggestionsService) GetServiceInfo(ctx context.Context) (*FixSuggestionsServiceInfo, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "fix-suggestions/service-info", nil, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	result := new(FixSuggestionsServiceInfo)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// GetSubscriptionType requests fix suggestions subscription information.
+func (s *FixSuggestionsService) GetSubscriptionType(ctx context.Context) (*SubscriptionTypeResponse, *http.Response, error) {
+	req, err := s.client.NewSonarQubeV2APIRequest(ctx, http.MethodGet, "fix-suggestions/service-info/subscription-type", nil, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	result := new(SubscriptionTypeResponse)
+
+	resp, err := s.client.Do(req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}

--- a/sonar/fix_suggestions_v2_service_test.go
+++ b/sonar/fix_suggestions_v2_service_test.go
@@ -1,0 +1,187 @@
+package sonar
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixSuggestionsV2_GenerateFixSuggestion(t *testing.T) {
+	response := FixSuggestionResponse{
+		Id:          "550e8400-e29b-41d4-a716-446655440000",
+		IssueId:     "ISSUE-1",
+		Explanation: "Replace the unsafe call.",
+		Changes: []FixSuggestionChange{
+			{StartLine: 10, EndLine: 12, NewCode: "safeCall()"},
+		},
+	}
+	server := newTestServer(t, mockJSONBodyHandler(t, http.MethodPost, "/v2/fix-suggestions/ai-suggestions", http.StatusOK,
+		&FixSuggestionPostRequest{IssueId: "ISSUE-1"}, response))
+	client := newTestClient(t, server.url())
+
+	result, resp, err := client.V2.FixSuggestions.GenerateFixSuggestion(context.Background(), &FixSuggestionPostRequest{IssueId: "ISSUE-1"})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "ISSUE-1", result.IssueId)
+	require.Len(t, result.Changes, 1)
+	assert.Equal(t, int32(10), result.Changes[0].StartLine)
+}
+
+func TestFixSuggestionsV2_GenerateFixSuggestion_Validation(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	tests := []struct {
+		name string
+		opt  *FixSuggestionPostRequest
+	}{
+		{"nil opt", nil},
+		{"missing issue id", &FixSuggestionPostRequest{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := client.V2.FixSuggestions.GenerateFixSuggestion(context.Background(), tt.opt)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestFixSuggestionsV2_GetIssueSuggestionAvailability(t *testing.T) {
+	response := FixSuggestionIssueResponse{
+		IssueId:      "ISSUE-1",
+		AiSuggestion: "AVAILABLE",
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/fix-suggestions/issues/ISSUE-1", http.StatusOK, response))
+	client := newTestClient(t, server.url())
+
+	result, resp, err := client.V2.FixSuggestions.GetIssueSuggestionAvailability(context.Background(), "ISSUE-1")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "AVAILABLE", result.AiSuggestion)
+}
+
+func TestFixSuggestionsV2_GetIssueSuggestionAvailability_Validation(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	_, _, err := client.V2.FixSuggestions.GetIssueSuggestionAvailability(context.Background(), "")
+	assert.Error(t, err)
+}
+
+func TestFixSuggestionsV2_GetFeatureEnablement(t *testing.T) {
+	response := FeatureEnablementResponse{
+		Enablement:         "ENABLED_FOR_SOME_PROJECTS",
+		EnabledProjectKeys: []string{"project-a", "project-b"},
+		Provider:           &ProviderResponse{Key: "provider-1", ModelKey: "model-1", Endpoint: "https://example.com"},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/fix-suggestions/feature-enablements", http.StatusOK, response))
+	client := newTestClient(t, server.url())
+
+	result, resp, err := client.V2.FixSuggestions.GetFeatureEnablement(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "ENABLED_FOR_SOME_PROJECTS", result.Enablement)
+	assert.Equal(t, []string{"project-a", "project-b"}, result.EnabledProjectKeys)
+	require.NotNil(t, result.Provider)
+	assert.Equal(t, "provider-1", result.Provider.Key)
+}
+
+func TestFixSuggestionsV2_UpdateFeatureEnablement(t *testing.T) {
+	server := newTestServer(t, mockPatchHandler(t, "/v2/fix-suggestions/feature-enablements", http.StatusNoContent,
+		&FeatureEnablementRequest{Enablement: true}, nil))
+	client := newTestClient(t, server.url())
+
+	resp, err := client.V2.FixSuggestions.UpdateFeatureEnablement(context.Background(), &FeatureEnablementRequest{Enablement: true})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestFixSuggestionsV2_UpdateFeatureEnablement_Validation(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	_, err := client.V2.FixSuggestions.UpdateFeatureEnablement(context.Background(), nil)
+	assert.Error(t, err)
+}
+
+func TestFixSuggestionsV2_RecordAwarenessBannerInteraction(t *testing.T) {
+	response := AwarenessBannerClickedResponse{Id: "interaction-1"}
+	server := newTestServer(t, mockJSONBodyHandler(t, http.MethodPost, "/v2/fix-suggestions/feature-enablements/awareness-banner-interactions", http.StatusOK,
+		&AwarenessBannerClickedRequest{BannerType: "ENABLE"}, response))
+	client := newTestClient(t, server.url())
+
+	result, resp, err := client.V2.FixSuggestions.RecordAwarenessBannerInteraction(context.Background(), &AwarenessBannerClickedRequest{BannerType: "ENABLE"})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "interaction-1", result.Id)
+}
+
+func TestFixSuggestionsV2_RecordAwarenessBannerInteraction_Validation(t *testing.T) {
+	client := newLocalhostClient(t)
+
+	tests := []struct {
+		name string
+		opt  *AwarenessBannerClickedRequest
+	}{
+		{"nil opt", nil},
+		{"missing banner type", &AwarenessBannerClickedRequest{}},
+		{"invalid banner type", &AwarenessBannerClickedRequest{BannerType: "OTHER"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := client.V2.FixSuggestions.RecordAwarenessBannerInteraction(context.Background(), tt.opt)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestFixSuggestionsV2_ListSupportedLLMProviders(t *testing.T) {
+	response := []LLMProviderResponse{
+		{
+			Key:        "provider-1",
+			Name:       "Provider One",
+			SelfHosted: false,
+			Models:     []LLMModel{{Key: "model-1", Name: "Model One", Recommended: true}},
+		},
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/fix-suggestions/supported-llm-providers", http.StatusOK, response))
+	client := newTestClient(t, server.url())
+
+	result, resp, err := client.V2.FixSuggestions.ListSupportedLLMProviders(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, result, 1)
+	assert.Equal(t, "provider-1", result[0].Key)
+	require.Len(t, result[0].Models, 1)
+	assert.True(t, result[0].Models[0].Recommended)
+}
+
+func TestFixSuggestionsV2_GetServiceInfo(t *testing.T) {
+	response := FixSuggestionsServiceInfo{
+		Status:           "SUCCESS",
+		IsEnabled:        true,
+		SubscriptionType: "PAID",
+	}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/fix-suggestions/service-info", http.StatusOK, response))
+	client := newTestClient(t, server.url())
+
+	result, resp, err := client.V2.FixSuggestions.GetServiceInfo(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "SUCCESS", result.Status)
+	assert.True(t, result.IsEnabled)
+	assert.Equal(t, "PAID", result.SubscriptionType)
+}
+
+func TestFixSuggestionsV2_GetSubscriptionType(t *testing.T) {
+	response := SubscriptionTypeResponse{SubscriptionType: "EARLY_ACCESS"}
+	server := newTestServer(t, mockHandler(t, http.MethodGet, "/v2/fix-suggestions/service-info/subscription-type", http.StatusOK, response))
+	client := newTestClient(t, server.url())
+
+	result, resp, err := client.V2.FixSuggestions.GetSubscriptionType(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "EARLY_ACCESS", result.SubscriptionType)
+}


### PR DESCRIPTION
## Summary

- Add the V2 FixSuggestions service and register it under client.V2
- Expose the fix suggestions endpoints from the enterprise V2 API spec
- Add unit coverage for request paths, methods, JSON bodies, validation, and responses
- Add an opt-in Enterprise integration test for service info and supported providers

Fixes BoxBoxJason/sonarqube-client-go#219

## Testing

- make test target=sdk
- make lint target=sdk
- go test ./integration_testing -run TestNonExistent -count=0
