### PR TITLE
fix: apply default 30s timeout to SDK-managed HTTP client

### DIFF
--- a/sonar/client.go
+++ b/sonar/client.go
@@ -212,10 +212,14 @@ func setDefaults(client *Client) error {
 
 	if client.httpClient == nil {
 		if client.transportConfig != nil {
-			//nolint:exhaustruct // Timeout, Jar, CheckRedirect intentionally left at zero values
-			client.httpClient = &http.Client{Transport: buildTransport(*client.transportConfig)}
+			client.httpClient = &http.Client{
+				Timeout:   defaultHTTPTimeout,
+				Transport: buildTransport(*client.transportConfig),
+			}
 		} else {
-			client.httpClient = http.DefaultClient
+			client.httpClient = &http.Client{
+				Timeout: defaultHTTPTimeout,
+			}
 		}
 	}
 

--- a/sonar/common.go
+++ b/sonar/common.go
@@ -3,6 +3,7 @@ package sonar
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 const (
@@ -10,6 +11,12 @@ const (
 	defaultBaseURL = "http://localhost:9000/api/"
 	// defaultUserAgent is the default User-Agent header value.
 	defaultUserAgent = "sonarqube-client-go"
+
+	// defaultHTTPTimeout is the default timeout applied to the SDK-managed
+	// HTTP client when the caller does not supply their own. A zero timeout
+	// means no limit, which can hang goroutines indefinitely behind load
+	// balancers or NAT gateways.
+	defaultHTTPTimeout = 30 * time.Second
 
 	// MaxPageSize is the maximum allowed page size for pagination.
 	MaxPageSize = 500

--- a/sonar/middleware_test.go
+++ b/sonar/middleware_test.go
@@ -101,14 +101,14 @@ func TestWithMiddleware_WithHTTPClient(t *testing.T) {
 }
 
 // TestWithMiddleware_NoMiddleware_DefaultUnchanged verifies that when no middleware is
-// provided the client uses http.DefaultClient without wrapping it.
+// provided the client uses a default http.Client with the standard timeout.
 func TestWithMiddleware_NoMiddleware_DefaultUnchanged(t *testing.T) {
 	t.Parallel()
 
 	client, err := NewClient(nil)
 	require.NoError(t, err)
 
-	assert.Same(t, http.DefaultClient, client.httpClient, "httpClient should be http.DefaultClient when no middleware is provided")
+	assert.Equal(t, defaultHTTPTimeout, client.httpClient.Timeout, "httpClient should have default timeout when no middleware is provided")
 }
 
 // roundTripFunc is a convenience type that implements http.RoundTripper via a function.

--- a/sonar/transport_test.go
+++ b/sonar/transport_test.go
@@ -58,7 +58,7 @@ func TestWithTransportConfig_DefaultUnchanged(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	assert.Same(t, http.DefaultClient, client.httpClient, "expected http.DefaultClient when no options are provided")
+	assert.Equal(t, defaultHTTPTimeout, client.httpClient.Timeout, "expected default timeout when no options are provided")
 }
 
 func TestWithTransportConfig_TLSConfig(t *testing.T) {


### PR DESCRIPTION
## Problem

When no HTTP client is supplied, `setDefaults` falls back to `http.DefaultClient` (`sonar/client.go:218`), whose `Timeout` is `0` (no limit). This means a half-open connection — routine behind k8s load balancers, proxies, and NAT gateways — can hang a request indefinitely and leak goroutines in long-running controllers and daemonsets.

## Fix

Both the plain-default and `TransportConfig` paths now create a dedicated `http.Client` with `defaultHTTPTimeout` (30 s). Callers can still override this by supplying their own `*http.Client` via `WithHTTPClient`.

### Changes

- **`sonar/common.go`**: Added `defaultHTTPTimeout = 30 * time.Second` constant
- **`sonar/client.go`**: `setDefaults` creates a new `http.Client{Timeout: defaultHTTPTimeout}` instead of using `http.DefaultClient`
- **`sonar/transport_test.go`**, **`sonar/middleware_test.go`**: Updated tests to verify the default timeout is applied

All existing tests pass.

Fixes #242