### PR TITLE
fix: limit error response body reads

### DIFF
--- a/sonar/client_util.go
+++ b/sonar/client_util.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 )
 
+const maxErrorResponseBodyBytes = 1 << 20
+
 // Do sends an API request and returns the API response. The API response is
 // JSON decoded and stored in the value pointed to by v, or returned as an
 // error if an API error has occurred. If v implements the io.Writer
@@ -135,8 +137,13 @@ func CheckResponse(resp *http.Response) error {
 		StatusCode: resp.StatusCode,
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorResponseBodyBytes+1))
 	if err == nil && data != nil {
+		truncated := len(data) > maxErrorResponseBodyBytes
+		if truncated {
+			data = data[:maxErrorResponseBodyBytes]
+		}
+
 		errorResponse.Body = data
 
 		var raw any
@@ -146,6 +153,14 @@ func CheckResponse(resp *http.Response) error {
 			errorResponse.Message = string(data)
 		} else {
 			errorResponse.Message = parseError(raw)
+		}
+
+		if truncated {
+			errorResponse.Message = fmt.Sprintf(
+				"%s\n(response body truncated after %d bytes)",
+				errorResponse.Message,
+				maxErrorResponseBodyBytes,
+			)
 		}
 	}
 

--- a/sonar/client_util_test.go
+++ b/sonar/client_util_test.go
@@ -148,6 +148,61 @@ func TestCheckResponse_PopulatesStatusCode(t *testing.T) {
 	}
 }
 
+func TestCheckResponse_PreservesJSONErrorBody(t *testing.T) {
+	body := []byte(`"api error"`)
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Request:    httptest.NewRequest(http.MethodGet, "/api/test", nil),
+	}
+
+	err := CheckResponse(resp)
+	require.Error(t, err)
+
+	var re *ResponseError
+	require.ErrorAs(t, err, &re)
+	assert.Equal(t, body, re.Body)
+	assert.Equal(t, "api error", re.Message)
+}
+
+func TestCheckResponse_PreservesTextErrorBody(t *testing.T) {
+	body := []byte("plain error")
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Request:    httptest.NewRequest(http.MethodGet, "/api/test", nil),
+	}
+
+	err := CheckResponse(resp)
+	require.Error(t, err)
+
+	var re *ResponseError
+	require.ErrorAs(t, err, &re)
+	assert.Equal(t, body, re.Body)
+	assert.Equal(t, string(body), re.Message)
+}
+
+func TestCheckResponse_TruncatesLargeErrorBody(t *testing.T) {
+	body := bytes.Repeat([]byte("x"), maxErrorResponseBodyBytes+1)
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Request:    httptest.NewRequest(http.MethodGet, "/api/test", nil),
+	}
+
+	err := CheckResponse(resp)
+	require.Error(t, err)
+
+	var re *ResponseError
+	require.ErrorAs(t, err, &re)
+	assert.Len(t, re.Body, maxErrorResponseBodyBytes)
+	assert.Equal(t, body[:maxErrorResponseBodyBytes], re.Body)
+	assert.Contains(t, re.Message, "(response body truncated after 1048576 bytes)")
+}
+
 func TestIsNotFound(t *testing.T) {
 	assert.True(t, IsNotFound(makeAPIError(http.StatusNotFound)))
 	assert.False(t, IsNotFound(makeAPIError(http.StatusUnauthorized)))


### PR DESCRIPTION
Closes #244.

This caps the body read in `CheckResponse` for non-2xx responses at 1 MiB plus one sentinel byte. When a response exceeds the cap, the stored `ResponseError.Body` is trimmed to the limit and the generated message includes a truncation note, so large upstream error pages cannot be buffered wholesale just to build an error string.

Normal-sized error handling is unchanged: JSON error bodies are still parsed through `parseError`, plain-text bodies still become the message, and `ResponseError.Body` still stores the bytes that were used to derive that message.

Verification:
- `git diff --check`
- `gofmt -w sonar/client_util.go sonar/client_util_test.go`
- `GOTOOLCHAIN=go1.26.3 go test ./sonar`
