### PR TITLE
feat: add version information to default user agent

### DIFF
--- a/sonar/client.go
+++ b/sonar/client.go
@@ -246,7 +246,7 @@ func setDefaults(client *Client) error {
 	}
 
 	if client.userAgent == "" {
-		client.userAgent = defaultUserAgent
+		client.userAgent = buildUserAgent()
 	}
 
 	return nil

--- a/sonar/client_test.go
+++ b/sonar/client_test.go
@@ -77,3 +77,21 @@ func TestNewClient_ServicesInitialized(t *testing.T) {
 	assert.NotNil(t, client.Rules)
 	assert.NotNil(t, client.Users)
 }
+func TestNewClient_DefaultUserAgentContainsVersion(t *testing.T) {
+	client, err := NewClient(nil)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	assert.Contains(t, client.userAgent, "sonarqube-client-go/")
+}
+func TestNewClient_WithUserAgent(t *testing.T) {
+	client, err := NewClient(
+		nil,
+		WithUserAgent("custom-agent"),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	assert.Equal(t, "custom-agent", client.userAgent)
+}

--- a/sonar/common.go
+++ b/sonar/common.go
@@ -8,8 +8,6 @@ import (
 const (
 	// defaultBaseURL is the default base URL for the SonarQube API.
 	defaultBaseURL = "http://localhost:9000/api/"
-	// defaultUserAgent is the default User-Agent header value.
-	defaultUserAgent = "sonarqube-client-go"
 
 	// MaxPageSize is the maximum allowed page size for pagination.
 	MaxPageSize = 500

--- a/sonar/version.go
+++ b/sonar/version.go
@@ -1,0 +1,52 @@
+package sonar
+
+import "runtime/debug"
+
+// buildUserAgent returns the default User-Agent string.
+func buildUserAgent() string {
+	return "sonarqube-client-go/" + resolveVersion()
+}
+
+// resolveVersion returns the most specific version string available.
+func resolveVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "dev"
+	}
+
+	if info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+
+	return vcsRevision(info)
+}
+
+// vcsRevision extracts the short VCS revision from build info.
+func vcsRevision(info *debug.BuildInfo) string {
+	var revision string
+
+	var dirty bool
+
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			if len(setting.Value) > 7 {//nolint:mnd // 7 is the conventional short-hash length
+				revision = setting.Value[:7]
+			} else {
+				revision = setting.Value
+			}
+		case "vcs.modified":
+			dirty = setting.Value == "true"
+		}
+	}
+
+	if revision == "" {
+		return "dev"
+	}
+
+	if dirty {
+		return revision + "-dirty"
+	}
+
+	return revision
+}

--- a/sonar/version.go
+++ b/sonar/version.go
@@ -30,7 +30,7 @@ func vcsRevision(info *debug.BuildInfo) string {
 	for _, setting := range info.Settings {
 		switch setting.Key {
 		case "vcs.revision":
-			if len(setting.Value) > 7 {//nolint:mnd // 7 is the conventional short-hash length
+			if len(setting.Value) > 7 { //nolint:mnd // 7 is the conventional short-hash length
 				revision = setting.Value[:7]
 			} else {
 				revision = setting.Value


### PR DESCRIPTION
### Description of my changes

Fixes #246 

This PR adds version information to the default User-Agent header.

Previously, the default User-Agent was a static string:

`sonarqube-client-go`
After this change, the default User-Agent includes version information resolved at runtime:
`sonarqube-client-go/<version>`

Version resolution uses `runtime/debug.ReadBuildInfo()` and falls back to VCS revision information or `dev` when version metadata is unavailable.

The change preserves existing custom User-Agent behavior. When `WithUserAgent(...)` is provided, the custom value continues to override the default User-Agent.

I have:

* [x] Followed the git conventional commit message format.
* [x] Added tests covering the new functionality.

### How has this code been tested

I have:

* [x] Added a unit test verifying that the default User-Agent contains version information.
* [x] Added a unit test verifying that `WithUserAgent(...)` continues to override the default User-Agent.
* [x] Run `go test ./sonar/...` successfully.

Verified behavior:

Before:
`sonarqube-client-go`
After:
`sonarqube-client-go/<version>`
