### PR TITLE
fix: protect mutable client fields for concurrent use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ endif
 test:
 	@command -v gotestsum >/dev/null 2>&1 || { echo "Installing gotestsum..."; go install gotest.tools/gotestsum@v1.13.0; }
 	@mkdir -p codequality
-	gotestsum --junitfile codequality/unit-tests.xml --format-icons octicons -- ${target_paths}
+	CGO_ENABLED=1 gotestsum --junitfile codequality/unit-tests.xml --format-icons octicons -- -race ${target_paths}
 
 # Run tests with coverage report (use target=sdk|cli|all to filter)
 coverage:

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/google/go-querystring/query"
 )
@@ -20,8 +21,19 @@ import (
 
 // Client is the SonarQube API client.
 //
+// A Client is safe for concurrent use by multiple goroutines, including while
+// its connection or authentication settings are reconfigured at runtime via the
+// SetBaseURL, SetHTTPClient, SetBasicAuth and SetPrivateToken methods (for
+// example to rotate a token). The mutable fields those methods touch are guarded
+// by mu; everything else is set once at construction and not mutated afterwards.
+//
 //nolint:govet // fieldalignment: keeping logical field grouping for readability
 type Client struct {
+	// mu guards the mutable connection and authentication fields below
+	// (baseURL, username, password, token, authType, httpClient) so they can be
+	// reconfigured concurrently with in-flight requests.
+	mu sync.RWMutex
+
 	baseURL         *url.URL
 	username        string
 	password        string
@@ -355,27 +367,35 @@ func (c *Client) SetBaseURL(urlStr *string) error {
 		return fmt.Errorf("failed to parse URL: %w", err)
 	}
 
+	c.mu.Lock()
 	c.baseURL = baseURL
+	c.mu.Unlock()
 
 	return nil
 }
 
 // SetHTTPClient sets the HTTP client for API requests.
 func (c *Client) SetHTTPClient(httpClient *http.Client) {
+	c.mu.Lock()
 	c.httpClient = httpClient
+	c.mu.Unlock()
 }
 
 // SetBasicAuth sets the username and password for basic authentication.
 func (c *Client) SetBasicAuth(username, password string) {
+	c.mu.Lock()
 	c.username = username
 	c.password = password
 	c.authType = basicAuth
+	c.mu.Unlock()
 }
 
 // SetPrivateToken sets the token for private token authentication.
 func (c *Client) SetPrivateToken(token string) {
+	c.mu.Lock()
 	c.token = token
 	c.authType = privateToken
+	c.mu.Unlock()
 }
 
 // =============================================
@@ -384,6 +404,9 @@ func (c *Client) SetPrivateToken(token string) {
 
 // BaseURL returns a copy of the base URL.
 func (c *Client) BaseURL() *url.URL {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	baseURLCopy := *c.baseURL
 
 	return &baseURLCopy
@@ -586,7 +609,11 @@ func (c *Client) NewSonarQubeV2APIRequest(ctx context.Context, method, path stri
 // interface, the raw response body will be written to v, without attempting to
 // first decode it.
 func (c *Client) Do(req *http.Request, dest any) (*http.Response, error) {
-	return Do(c.httpClient, req, dest)
+	c.mu.RLock()
+	httpClient := c.httpClient
+	c.mu.RUnlock()
+
+	return Do(httpClient, req, dest)
 }
 
 // =============================================
@@ -596,8 +623,11 @@ func (c *Client) Do(req *http.Request, dest any) (*http.Response, error) {
 // buildRequestURL constructs the full URL from the base URL, path and query
 // parameters provided in the request parameters.
 func (c *Client) buildRequestURL(params SonarAPIRequestParameters) string {
+	c.mu.RLock()
 	baseURLCopy := *c.baseURL
-	baseURLCopy.Path = c.baseURL.Path + params.Path
+	c.mu.RUnlock()
+
+	baseURLCopy.Path += params.Path
 
 	if params.RawQuery != nil {
 		baseURLCopy.RawQuery = params.RawQuery.Encode()
@@ -635,12 +665,20 @@ func (c *Client) setRequestHeaders(req *http.Request, method string, extraHeader
 
 	req.Header.Set("Accept", "application/json")
 
+	// Snapshot the authentication fields under the read lock so concurrent
+	// reconfiguration (e.g. a token rotation via SetPrivateToken) cannot race
+	// with request building.
+	c.mu.RLock()
+	authMethod := c.authType
+	username, password, token := c.username, c.password, c.token
+	c.mu.RUnlock()
+
 	// Set authentication headers.
-	switch c.authType {
+	switch authMethod {
 	case basicAuth, oAuthToken:
-		req.SetBasicAuth(c.username, c.password)
+		req.SetBasicAuth(username, password)
 	case privateToken:
-		req.SetBasicAuth(c.token, "")
+		req.SetBasicAuth(token, "")
 	}
 
 	req.Header.Set("User-Agent", c.userAgent)

--- a/sonar/client_concurrency_test.go
+++ b/sonar/client_concurrency_test.go
@@ -1,0 +1,68 @@
+package sonar
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+)
+
+// TestClient_ConcurrentReconfigurationIsRaceFree exercises the client from many
+// goroutines while its auth and base URL are reconfigured at runtime. It is
+// designed to surface data races when run under `go test -race`; without the
+// race detector it simply asserts that concurrent use does not panic.
+func TestClient_ConcurrentReconfigurationIsRaceFree(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	client := newTestClient(t, server.url())
+	baseURL := server.url()
+
+	const (
+		goroutines = 8
+		iterations = 50
+	)
+
+	var wg sync.WaitGroup
+
+	wg.Add(goroutines * 2)
+
+	// Writers continuously rotate credentials and reset the base URL.
+	for i := range goroutines {
+		go func(worker int) {
+			defer wg.Done()
+
+			for j := range iterations {
+				client.SetPrivateToken(fmt.Sprintf("token-%d-%d", worker, j))
+				client.SetBasicAuth("user", "pass")
+				_ = client.SetBaseURL(&baseURL)
+			}
+		}(i)
+	}
+
+	// Readers continuously build and send requests, reading the same fields.
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+
+			for range iterations {
+				req, err := client.NewSonarQubeV1APIRequest(context.Background(), http.MethodGet, "ping", nil)
+				if err != nil {
+					t.Errorf("failed to build request: %v", err)
+
+					return
+				}
+
+				_, _ = client.Do(req, nil)
+			}
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
### Description of your changes

This PR adds a sync Mutex in the client to prevent the concurrent update of its fields.
This fixes the problem of potential data race in high concurrency environments. 

It also updates the makefile `make test` command to always run in `-race` mode, this allows detecting race conditions directly from the tests, with the tradeoff of making the tests longer to run.

Fixes #241 
Closes #245 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
