### PR TITLE
fix: only auto-retry idempotent methods by default

### DIFF
--- a/sonar/retry.go
+++ b/sonar/retry.go
@@ -28,6 +28,13 @@ type RetryOptions struct {
 	MaxDelay time.Duration
 	// RetryableStatusCodes lists HTTP status codes that should trigger a retry.
 	RetryableStatusCodes []int
+	// RetryNonIdempotent enables automatic retries for non-idempotent methods
+	// (POST, PATCH). It is disabled by default: only idempotent methods (GET,
+	// HEAD, PUT, DELETE, OPTIONS, TRACE) are retried, because resending a
+	// non-idempotent request after a network error or 5xx can duplicate a
+	// server-side side effect (for example creating a resource twice). Enable
+	// this only for endpoints you know are safe to repeat.
+	RetryNonIdempotent bool
 }
 
 // WithRetry is a ClientOptionFunc that enables opt-in retry with exponential
@@ -52,12 +59,22 @@ type retryRoundTripper struct {
 // errors with exponential backoff and full jitter. Retries stop immediately when
 // the request context is cancelled or its deadline is exceeded.
 //
+// Only idempotent methods are retried by default; non-idempotent methods (POST,
+// PATCH) are passed straight through unless RetryNonIdempotent is set, so a
+// resend cannot accidentally duplicate a server-side side effect.
+//
 // When retries occur, the final response carries an X-Retry-Attempts header with
 // the total number of attempts made.
 //
 //nolint:wrapcheck // pass-through transport: errors from base RoundTripper are intentionally not wrapped
 func (r *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if r.opts.MaxAttempts <= 1 {
+		return r.base.RoundTrip(req)
+	}
+
+	// Non-idempotent methods are not retried unless explicitly opted in, to avoid
+	// duplicating server-side side effects on a resend.
+	if !r.opts.RetryNonIdempotent && !isIdempotentMethod(req.Method) {
 		return r.base.RoundTrip(req)
 	}
 
@@ -68,6 +85,19 @@ func (r *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	}
 
 	return r.retryLoop(req, hasBody)
+}
+
+// isIdempotentMethod reports whether an HTTP method is safe to retry
+// automatically. Per RFC 7231, GET, HEAD, PUT, DELETE, OPTIONS and TRACE are
+// idempotent; POST and PATCH are not.
+func isIdempotentMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodPut,
+		http.MethodDelete, http.MethodOptions, http.MethodTrace:
+		return true
+	default:
+		return false
+	}
 }
 
 // retryLoop runs up to MaxAttempts, sleeping between retries.

--- a/sonar/retry_test.go
+++ b/sonar/retry_test.go
@@ -151,7 +151,9 @@ func TestRetryRoundTripper_NonReplayableBodyNotRetried(t *testing.T) {
 		opts: RetryOptions{MaxAttempts: 4, RetryableStatusCodes: []int{503}},
 	}
 
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", io.NopCloser(bytes.NewReader([]byte("body"))))
+	// Use an idempotent method so the non-replayable body is the reason the
+	// request is not retried, not the method.
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPut, "http://example.com", io.NopCloser(bytes.NewReader([]byte("body"))))
 	// GetBody is nil because we used io.NopCloser directly, not bytes.NewReader via http.NewRequest.
 	require.Nil(t, req.GetBody)
 
@@ -179,7 +181,8 @@ func TestRetryRoundTripper_ReplayableBodyRetried(t *testing.T) {
 	}
 
 	body := bytes.NewReader([]byte(`{"key":"value"}`))
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", body)
+	// PUT is idempotent and has a replayable body, so it is retried by default.
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPut, "http://example.com", body)
 	// http.NewRequest with bytes.Reader sets GetBody automatically.
 	require.NotNil(t, req.GetBody)
 
@@ -187,6 +190,78 @@ func TestRetryRoundTripper_ReplayableBodyRetried(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 2, transport.calls)
+}
+
+func TestRetryRoundTripper_NonIdempotentNotRetriedByDefault(t *testing.T) {
+	transport := &countingTransport{
+		responses: []*http.Response{
+			makeResponse(http.StatusServiceUnavailable),
+			makeResponse(http.StatusOK),
+		},
+	}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{
+			MaxAttempts:          3,
+			InitialDelay:         time.Millisecond,
+			MaxDelay:             5 * time.Millisecond,
+			RetryableStatusCodes: []int{503},
+		},
+	}
+
+	body := bytes.NewReader([]byte(`{"key":"value"}`))
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", body)
+	require.NotNil(t, req.GetBody)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	// POST is not retried by default even with a replayable body and a retryable status.
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, 1, transport.calls)
+}
+
+func TestRetryRoundTripper_NonIdempotentRetriedWhenOptedIn(t *testing.T) {
+	transport := &countingTransport{
+		responses: []*http.Response{
+			makeResponse(http.StatusServiceUnavailable),
+			makeResponse(http.StatusOK),
+		},
+	}
+	rt := &retryRoundTripper{
+		base: transport,
+		opts: RetryOptions{
+			MaxAttempts:          3,
+			InitialDelay:         time.Millisecond,
+			MaxDelay:             5 * time.Millisecond,
+			RetryableStatusCodes: []int{503},
+			RetryNonIdempotent:   true,
+		},
+	}
+
+	body := bytes.NewReader([]byte(`{"key":"value"}`))
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", body)
+	require.NotNil(t, req.GetBody)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, transport.calls)
+}
+
+func TestIsIdempotentMethod(t *testing.T) {
+	t.Parallel()
+
+	idempotent := []string{
+		http.MethodGet, http.MethodHead, http.MethodPut,
+		http.MethodDelete, http.MethodOptions, http.MethodTrace,
+	}
+	for _, method := range idempotent {
+		assert.True(t, isIdempotentMethod(method), "%s should be idempotent", method)
+	}
+
+	for _, method := range []string{http.MethodPost, http.MethodPatch} {
+		assert.False(t, isIdempotentMethod(method), "%s should not be idempotent", method)
+	}
 }
 
 func TestWithRetry_ClientIntegration(t *testing.T) {

--- a/sonar/retry_test.go
+++ b/sonar/retry_test.go
@@ -193,6 +193,8 @@ func TestRetryRoundTripper_ReplayableBodyRetried(t *testing.T) {
 }
 
 func TestRetryRoundTripper_NonIdempotentNotRetriedByDefault(t *testing.T) {
+	t.Parallel()
+
 	transport := &countingTransport{
 		responses: []*http.Response{
 			makeResponse(http.StatusServiceUnavailable),
@@ -221,6 +223,8 @@ func TestRetryRoundTripper_NonIdempotentNotRetriedByDefault(t *testing.T) {
 }
 
 func TestRetryRoundTripper_NonIdempotentRetriedWhenOptedIn(t *testing.T) {
+	t.Parallel()
+
 	transport := &countingTransport{
 		responses: []*http.Response{
 			makeResponse(http.StatusServiceUnavailable),


### PR DESCRIPTION
### Description of your changes

This PR corrects a potential bug that could appear when auto retry was configured, causing potential unknown effects on server side errors on non idempotent HTTP methods. This supposes that the SonarQube API abides by the HTTP conventions.

The client can be configured to retry on all methods.

Fixes #243 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [x] Added end-to-end tests if necessary.
