### PR TITLE
fix: add request context to JSON decode errors

### DIFF
--- a/sonar/client_util.go
+++ b/sonar/client_util.go
@@ -67,8 +67,23 @@ func Do(httpClient *http.Client, req *http.Request, dest any) (*http.Response, e
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(dest)
+	if err != nil {
+		return resp, fmt.Errorf("failed to decode %s %s response body: %w", req.Method, requestEndpoint(req), err)
+	}
 
-	return resp, err
+	return resp, nil
+}
+
+// requestEndpoint formats a request's endpoint as scheme://host/path, with the
+// path unescaped and the query string omitted (it may carry sensitive values).
+func requestEndpoint(req *http.Request) string {
+	if req.URL == nil {
+		return ""
+	}
+
+	path, _ := url.PathUnescape(req.URL.Path)
+
+	return fmt.Sprintf("%s://%s%s", req.URL.Scheme, req.URL.Host, path)
 }
 
 // ResponseError represents an error response from the SonarQube API.
@@ -87,10 +102,7 @@ func (e *ResponseError) Error() string {
 		return fmt.Sprintf("%d %s", e.StatusCode, e.Message)
 	}
 
-	path, _ := url.PathUnescape(e.Response.Request.URL.Path)
-	urlStr := fmt.Sprintf("%s://%s%s", e.Response.Request.URL.Scheme, e.Response.Request.URL.Host, path)
-
-	return fmt.Sprintf("%s %s: %d %s", e.Response.Request.Method, urlStr, e.StatusCode, e.Message)
+	return fmt.Sprintf("%s %s: %d %s", e.Response.Request.Method, requestEndpoint(e.Response.Request), e.StatusCode, e.Message)
 }
 
 // IsNotFound reports whether err represents a 404 Not Found response.

--- a/sonar/client_util_test.go
+++ b/sonar/client_util_test.go
@@ -101,6 +101,26 @@ func TestDo_NoBody(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
+func TestDo_DecodeError_WrapsRequestContext(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not valid json`))
+	}))
+	t.Cleanup(ts.Close)
+
+	baseURL, _ := url.Parse(ts.URL + "/")
+	req, err := newRequest(http.MethodGet, "projects/search", baseURL, "u", "p", nil)
+	require.NoError(t, err)
+
+	var v map[string]any
+	_, err = Do(http.DefaultClient, req, &v)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to decode", "decode error should be wrapped with context")
+	assert.Contains(t, err.Error(), http.MethodGet, "wrapped error should include the method")
+	assert.Contains(t, err.Error(), "projects/search", "wrapped error should include the endpoint path")
+}
+
 func TestNewRequest_WithQueryParams(t *testing.T) {
 	baseURL, _ := url.Parse("http://localhost/api/")
 	opt := struct {


### PR DESCRIPTION
### Description of your changes

This PR passes some context about the HTTP error when a decode error happens at runtime.
This helps the user understand what went wrong properly.

Fixes #252 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [ ] Added end-to-end tests if necessary.
