### PR TITLE
perf: drain response body before close on the success path

### DIFF
--- a/sonar/client_util.go
+++ b/sonar/client_util.go
@@ -36,7 +36,9 @@ func Do(httpClient *http.Client, req *http.Request, dest any) (*http.Response, e
 		return nil, err
 	}
 
-	defer func() { _ = resp.Body.Close() }()
+	// Drain any unread body before closing so the underlying connection can be
+	// reused by the keep-alive pool, even when a decoder stops short of EOF.
+	defer drainAndClose(resp)
 
 	err = CheckResponse(resp)
 	if err != nil {

--- a/sonar/client_util_test.go
+++ b/sonar/client_util_test.go
@@ -121,6 +121,58 @@ func TestDo_DecodeError_WrapsRequestContext(t *testing.T) {
 	assert.Contains(t, err.Error(), "projects/search", "wrapped error should include the endpoint path")
 }
 
+// drainTrackingBody records whether it was fully read (to EOF) and closed.
+type drainTrackingBody struct {
+	r       io.Reader
+	readEOF bool
+	closed  bool
+}
+
+func (b *drainTrackingBody) Read(p []byte) (int, error) {
+	n, err := b.r.Read(p)
+	if err == io.EOF {
+		b.readEOF = true
+	}
+
+	return n, err //nolint:wrapcheck // test stub mirrors the underlying reader
+}
+
+func (b *drainTrackingBody) Close() error {
+	b.closed = true
+
+	return nil
+}
+
+// fixedRoundTripper returns a fixed response regardless of the request.
+type fixedRoundTripper struct{ resp *http.Response }
+
+func (t fixedRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return t.resp, nil
+}
+
+func TestDo_DrainsBodyOnSuccess(t *testing.T) {
+	// A JSON value followed by trailing bytes the decoder will not consume, so the
+	// drain (not the decode) is what reaches EOF.
+	payload := append([]byte(`{"foo":"bar"}`), bytes.Repeat([]byte(" "), 4096)...)
+	body := &drainTrackingBody{r: bytes.NewReader(payload)} //nolint:exhaustruct
+
+	resp := &http.Response{ //nolint:exhaustruct // only fields needed for the test
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       body,
+	}
+	client := &http.Client{Transport: fixedRoundTripper{resp: resp}} //nolint:exhaustruct
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", http.NoBody)
+
+	var v map[string]any
+	_, err := Do(client, req, &v)
+	require.NoError(t, err)
+	assert.Equal(t, "bar", v["foo"])
+	assert.True(t, body.readEOF, "body should be drained to EOF before close")
+	assert.True(t, body.closed, "body should be closed")
+}
+
 func TestNewRequest_WithQueryParams(t *testing.T) {
 	baseURL, _ := url.Parse("http://localhost/api/")
 	opt := struct {


### PR DESCRIPTION
### Description of your changes

This PR optimizes the behaviour of requests on success by adding the same drain mechanism the roundTripper has.
This allows to reuse the connection slot.

Closes #253 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [ ] Added end-to-end tests if necessary.
