### PR TITLE
fix: remove unreachable oAuthToken auth type

### DIFF
--- a/sonar/client.go
+++ b/sonar/client.go
@@ -729,7 +729,7 @@ func (c *Client) setRequestHeaders(req *http.Request, method string, extraHeader
 
 	// Set authentication headers.
 	switch authMethod {
-	case basicAuth, oAuthToken:
+	case basicAuth:
 		req.SetBasicAuth(username, password)
 	case privateToken:
 		req.SetBasicAuth(token, "")

--- a/sonar/common.go
+++ b/sonar/common.go
@@ -198,7 +198,6 @@ type authType int
 
 const (
 	basicAuth authType = iota
-	oAuthToken
 	privateToken
 )
 


### PR DESCRIPTION
### Description of your changes

This PR removes the dead OauthToken authentication method (it never existed in the first place)

Fixes #251 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- [ ] Made sure `make lint` passes to verify that the code style is correct.
- [ ] Made sure `make test` passes to verify that the code is working as intended.
- [ ] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [ ] Added unit tests to cover the code changes.
- [ ] Added end-to-end tests if necessary.
