### PR TITLE
feat: new client constructor from env

### DIFF
--- a/sonar/env.go
+++ b/sonar/env.go
@@ -1,0 +1,55 @@
+package sonar
+
+import "os"
+
+// Environment variable names read by NewClientFromEnv.
+const (
+	// EnvURL is the base API URL of the SonarQube instance.
+	EnvURL = "SONAR_URL"
+	// EnvToken is the authentication token (takes precedence over basic auth).
+	EnvToken = "SONAR_TOKEN"
+	// EnvUsername is the username for basic authentication.
+	EnvUsername = "SONAR_USERNAME"
+	// EnvPassword is the password for basic authentication.
+	EnvPassword = "SONAR_PASSWORD"
+	// EnvUserAgent overrides the default User-Agent header.
+	EnvUserAgent = "SONAR_USER_AGENT"
+)
+
+// NewClientFromEnv creates a Client configured from SONAR_* environment
+// variables, the convention used across the SDK and its integration tests:
+//
+//   - SONAR_URL        base API URL (defaults to the SDK default when unset)
+//   - SONAR_TOKEN      token authentication (takes precedence over basic auth)
+//   - SONAR_USERNAME   basic-auth username (used with SONAR_PASSWORD)
+//   - SONAR_PASSWORD   basic-auth password
+//   - SONAR_USER_AGENT optional User-Agent override
+//
+// Additional functional options can be supplied and are applied after the
+// environment is read, so they take precedence over the environment.
+func NewClientFromEnv(options ...ClientOptionFunc) (*Client, error) {
+	createOpts := &ClientCreateOptions{} //nolint:exhaustruct // populated from the environment below
+
+	if baseURL := os.Getenv(EnvURL); baseURL != "" {
+		createOpts.URL = &baseURL
+	}
+
+	if userAgent := os.Getenv(EnvUserAgent); userAgent != "" {
+		createOpts.UserAgent = &userAgent
+	}
+
+	// Token authentication takes precedence over basic auth when both are set.
+	if token := os.Getenv(EnvToken); token != "" {
+		createOpts.Token = &token
+	} else {
+		username := os.Getenv(EnvUsername)
+		password := os.Getenv(EnvPassword)
+
+		if username != "" && password != "" {
+			createOpts.Username = &username
+			createOpts.Password = &password
+		}
+	}
+
+	return NewClient(createOpts, options...)
+}

--- a/sonar/env.go
+++ b/sonar/env.go
@@ -1,6 +1,10 @@
 package sonar
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"time"
+)
 
 // Environment variable names read by NewClientFromEnv.
 const (
@@ -14,6 +18,8 @@ const (
 	EnvPassword = "SONAR_PASSWORD"
 	// EnvUserAgent overrides the default User-Agent header.
 	EnvUserAgent = "SONAR_USER_AGENT"
+	// EnvTimeout sets the HTTP request timeout (parsed as a Go duration string, e.g. "30s", "2m").
+	EnvTimeout = "SONAR_TIMEOUT"
 )
 
 // NewClientFromEnv creates a Client configured from SONAR_* environment
@@ -24,6 +30,7 @@ const (
 //   - SONAR_USERNAME   basic-auth username (used with SONAR_PASSWORD)
 //   - SONAR_PASSWORD   basic-auth password
 //   - SONAR_USER_AGENT optional User-Agent override
+//   - SONAR_TIMEOUT    HTTP request timeout as a Go duration string (e.g. "30s", "2m")
 //
 // Additional functional options can be supplied and are applied after the
 // environment is read, so they take precedence over the environment.
@@ -36,6 +43,15 @@ func NewClientFromEnv(options ...ClientOptionFunc) (*Client, error) {
 
 	if userAgent := os.Getenv(EnvUserAgent); userAgent != "" {
 		createOpts.UserAgent = &userAgent
+	}
+
+	if raw := os.Getenv(EnvTimeout); raw != "" {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s %q: %w", EnvTimeout, raw, err)
+		}
+
+		createOpts.Timeout = &d
 	}
 
 	// Token authentication takes precedence over basic auth when both are set.

--- a/sonar/env_test.go
+++ b/sonar/env_test.go
@@ -1,0 +1,75 @@
+package sonar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClientFromEnv_Token(t *testing.T) {
+	t.Setenv(EnvURL, "https://sonar.example.com/api/")
+	t.Setenv(EnvToken, "tok-123")
+
+	client, err := NewClientFromEnv()
+	require.NoError(t, err)
+
+	assert.Equal(t, privateToken, client.authType)
+	assert.Equal(t, "tok-123", client.token)
+	assert.Equal(t, "sonar.example.com", client.baseURL.Host)
+}
+
+func TestNewClientFromEnv_BasicAuth(t *testing.T) {
+	t.Setenv(EnvURL, "https://sonar.example.com/api/")
+	t.Setenv(EnvUsername, "alice")
+	t.Setenv(EnvPassword, "s3cret")
+
+	client, err := NewClientFromEnv()
+	require.NoError(t, err)
+
+	assert.Equal(t, basicAuth, client.authType)
+	assert.Equal(t, "alice", client.username)
+	assert.Equal(t, "s3cret", client.password)
+}
+
+func TestNewClientFromEnv_TokenTakesPrecedence(t *testing.T) {
+	t.Setenv(EnvToken, "tok-123")
+	t.Setenv(EnvUsername, "alice")
+	t.Setenv(EnvPassword, "s3cret")
+
+	client, err := NewClientFromEnv()
+	require.NoError(t, err)
+
+	assert.Equal(t, privateToken, client.authType, "token should take precedence over basic auth")
+	assert.Empty(t, client.username)
+}
+
+func TestNewClientFromEnv_UserAgentOverride(t *testing.T) {
+	t.Setenv(EnvUserAgent, "my-app/1.0")
+
+	client, err := NewClientFromEnv()
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-app/1.0", client.userAgent)
+}
+
+func TestNewClientFromEnv_OptionsOverrideEnv(t *testing.T) {
+	t.Setenv(EnvURL, "https://from-env.example.com/api/")
+
+	client, err := NewClientFromEnv(WithBaseURL("https://from-option.example.com/api/"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "from-option.example.com", client.baseURL.Host, "functional options should override the environment")
+}
+
+func TestNewClientFromEnv_NoEnvUsesDefaults(t *testing.T) {
+	t.Setenv(EnvURL, "")
+	t.Setenv(EnvToken, "")
+	t.Setenv(EnvUsername, "")
+	t.Setenv(EnvPassword, "")
+
+	client, err := NewClientFromEnv()
+	require.NoError(t, err)
+	require.NotNil(t, client.baseURL)
+	assert.Equal(t, "localhost:9000", client.baseURL.Host)
+}

--- a/sonar/env_test.go
+++ b/sonar/env_test.go
@@ -2,6 +2,7 @@ package sonar
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,6 +61,23 @@ func TestNewClientFromEnv_OptionsOverrideEnv(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "from-option.example.com", client.baseURL.Host, "functional options should override the environment")
+}
+
+func TestNewClientFromEnv_Timeout(t *testing.T) {
+	t.Setenv(EnvTimeout, "90s")
+
+	client, err := NewClientFromEnv()
+	require.NoError(t, err)
+
+	assert.Equal(t, 90*time.Second, client.timeout)
+}
+
+func TestNewClientFromEnv_TimeoutInvalid(t *testing.T) {
+	t.Setenv(EnvTimeout, "not-a-duration")
+
+	_, err := NewClientFromEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), EnvTimeout)
 }
 
 func TestNewClientFromEnv_NoEnvUsesDefaults(t *testing.T) {


### PR DESCRIPTION
### Description of your changes

This PR adds a new constructor for the SonarQube client. Using environment variables to provision 

Closes #250 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [x] Added unit tests to cover the code changes.
- [ ] Added end-to-end tests if necessary.
