### PR TITLE
docs: document TransportConfig fields

### DIFF
--- a/sonar/transport.go
+++ b/sonar/transport.go
@@ -9,11 +9,25 @@ import (
 // TransportConfig holds configuration for the SDK-managed HTTP transport.
 // It is ignored when WithHTTPClient is also used.
 type TransportConfig struct {
-	TLSClientConfig     *tls.Config
-	MaxIdleConns        int
-	IdleConnTimeout     time.Duration
+	// TLSClientConfig customizes the TLS settings used for HTTPS connections.
+	//
+	// Security warning: setting TLSClientConfig.InsecureSkipVerify to true
+	// disables server certificate verification, which exposes the connection to
+	// man-in-the-middle attacks and can leak the auth token and source-code
+	// metadata exchanged with SonarQube. Only use it against a trusted local or
+	// development instance, never in production.
+	TLSClientConfig *tls.Config
+	// MaxIdleConns controls the maximum number of idle (keep-alive) connections
+	// across all hosts. Zero means no limit.
+	MaxIdleConns int
+	// IdleConnTimeout is the maximum time an idle connection is kept before
+	// closing. Zero means no limit.
+	IdleConnTimeout time.Duration
+	// TLSHandshakeTimeout is the maximum time to wait for a TLS handshake.
+	// Zero means no timeout.
 	TLSHandshakeTimeout time.Duration
-	DisableCompression  bool
+	// DisableCompression disables transparent gzip request/response compression.
+	DisableCompression bool
 }
 
 // buildTransport creates an *http.Transport from cfg.


### PR DESCRIPTION
### Description of your changes

This PR documents fields of the TransportConfig type. This adds a warning for the tls config skip verification.

Closes #254 

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- [ ] Made sure `make lint` passes to verify that the code style is correct.
- [ ] Made sure `make test` passes to verify that the code is working as intended.
- [ ] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [ ] Added unit tests to cover the code changes.
- [ ] Added end-to-end tests if necessary.
