### PR TITLE
fix: make package v2 compatible

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ formatters:
     - goimports
   settings:
     goimports:
-      # local-prefixes: github.com/boxboxjason/sonarqube-client-go
+      # local-prefixes: github.com/boxboxjason/sonarqube-client-go/v2
     gofmt:
       simplify: true
 
@@ -41,7 +41,7 @@ linters:
       sections:
         - standard
         - default
-        - prefix(github.com/boxboxjason/sonarqube-client-go)
+        - prefix(github.com/boxboxjason/sonarqube-client-go/v2)
       skip-generated: true
     wsl_v5:
       allow-first-in-block: true

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ e2e.enterprise: setup.sonar.enterprise
 # Version defaults to the latest git tag/commit. Override with: make build version=1.2.3
 # Build time is stamped automatically at build time.
 build:
-	go build -o bin/sonar-cli -ldflags "-X github.com/boxboxjason/sonarqube-client-go/internal/cli.version=$(version) -X github.com/boxboxjason/sonarqube-client-go/internal/cli.buildTime=$(build_time)" ./cmd/sonar-cli
+	go build -o bin/sonar-cli -ldflags "-X github.com/boxboxjason/sonarqube-client-go/v2/internal/cli.version=$(version) -X github.com/boxboxjason/sonarqube-client-go/v2/internal/cli.buildTime=$(build_time)" ./cmd/sonar-cli
 
 # Generate changelog using git-cliff
 changelog:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # SonarQube Go Client
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/boxboxjason/sonarqube-client-go.svg)](https://pkg.go.dev/github.com/boxboxjason/sonarqube-client-go)
-[![Go Report Card](https://goreportcard.com/badge/github.com/boxboxjason/sonarqube-client-go)](https://goreportcard.com/report/github.com/boxboxjason/sonarqube-client-go)
+[![Go Reference](https://pkg.go.dev/badge/github.com/boxboxjason/sonarqube-client-go/v2.svg)](https://pkg.go.dev/github.com/boxboxjason/sonarqube-client-go/v2)
 [![License](https://img.shields.io/github/license/BoxBoxJason/sonarqube-client-go)](LICENSE)
 
 A comprehensive, type-safe Go client library **and command-line interface** for the SonarQube Web API. Whether you're building automation tools, integrating SonarQube into your CI/CD pipeline, or managing your SonarQube instance from the terminal - this project has you covered.
@@ -59,7 +58,7 @@ A comprehensive, type-safe Go client library **and command-line interface** for 
 **From source:**
 
 ```bash
-go install github.com/boxboxjason/sonarqube-client-go/cmd/sonar-cli@latest
+go install github.com/boxboxjason/sonarqube-client-go/v2/cmd/sonar-cli@latest
 ```
 
 **From a release binary:**
@@ -215,7 +214,7 @@ sonar-cli completion powershell | Out-String | Invoke-Expression
 ### SDK Installation
 
 ```bash
-go get github.com/boxboxjason/sonarqube-client-go/sonar
+go get github.com/boxboxjason/sonarqube-client-go/v2/sonar
 ```
 
 **Requirements**: Go 1.25 or higher, access to a SonarQube instance (version 25+ recommended).
@@ -230,7 +229,7 @@ import (
  "fmt"
  "log"
 
- "github.com/boxboxjason/sonarqube-client-go/sonar"
+ "github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 func main() {
@@ -584,7 +583,7 @@ This project is licensed under the **Apache License 2.0** - see the [LICENSE](LI
 ## Additional Resources
 
 - [SonarQube Web API Documentation](https://docs.sonarsource.com/sonarqube/latest/extension-guide/web-api/)
-- [Go Package Documentation](https://pkg.go.dev/github.com/boxboxjason/sonarqube-client-go)
+- [Go Package Documentation](https://pkg.go.dev/github.com/boxboxjason/sonarqube-client-go/v2)
 - [Contributing Guide](CONTRIBUTING.md)
 - [GitHub Issues](https://github.com/BoxBoxJason/sonarqube-client-go/issues)
 

--- a/cmd/sonar-cli/main.go
+++ b/cmd/sonar-cli/main.go
@@ -4,7 +4,7 @@
 //
 // Install:
 //
-//	go install github.com/boxboxjason/sonarqube-client-go/cmd/sonar-cli@latest
+//	go install github.com/boxboxjason/sonarqube-client-go/v2/cmd/sonar-cli@latest
 //
 // Usage:
 //
@@ -14,7 +14,7 @@ package main
 import (
 	"os"
 
-	"github.com/boxboxjason/sonarqube-client-go/internal/cli"
+	"github.com/boxboxjason/sonarqube-client-go/v2/internal/cli"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/boxboxjason/sonarqube-client-go
+module github.com/boxboxjason/sonarqube-client-go/v2
 
 go 1.26.4
 

--- a/integration_testing/alm_integrations_test.go
+++ b/integration_testing/alm_integrations_test.go
@@ -5,8 +5,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("AlmIntegrations Service", Ordered, func() {

--- a/integration_testing/alm_settings_test.go
+++ b/integration_testing/alm_settings_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("AlmSettings Service", Ordered, func() {

--- a/integration_testing/analysis_cache_test.go
+++ b/integration_testing/analysis_cache_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("AnalysisCache Service", Ordered, func() {

--- a/integration_testing/analysis_reports_test.go
+++ b/integration_testing/analysis_reports_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("AnalysisReports Service", Ordered, func() {

--- a/integration_testing/applications_test.go
+++ b/integration_testing/applications_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Applications Service", Ordered, func() {

--- a/integration_testing/architecture_v2_test.go
+++ b/integration_testing/architecture_v2_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Architecture V2 Service", Ordered, func() {

--- a/integration_testing/audit_logs_test.go
+++ b/integration_testing/audit_logs_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Audit Logs Service", Ordered, func() {

--- a/integration_testing/authentication_test.go
+++ b/integration_testing/authentication_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Authentication Service", Ordered, func() {

--- a/integration_testing/batch_test.go
+++ b/integration_testing/batch_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Batch Service", Ordered, func() {

--- a/integration_testing/ce_test.go
+++ b/integration_testing/ce_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Ce Service", Ordered, func() {

--- a/integration_testing/components_test.go
+++ b/integration_testing/components_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Components Service", Ordered, func() {

--- a/integration_testing/developers_test.go
+++ b/integration_testing/developers_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Developers Service", Ordered, func() {

--- a/integration_testing/dismiss_message_test.go
+++ b/integration_testing/dismiss_message_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("DismissMessage Service", Ordered, func() {

--- a/integration_testing/duplications_test.go
+++ b/integration_testing/duplications_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Duplications Service", Ordered, func() {

--- a/integration_testing/editions_test.go
+++ b/integration_testing/editions_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("License Service", Ordered, func() {

--- a/integration_testing/emails_test.go
+++ b/integration_testing/emails_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Emails Service", Ordered, func() {

--- a/integration_testing/favorites_test.go
+++ b/integration_testing/favorites_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Favorites Service", Ordered, func() {

--- a/integration_testing/features_test.go
+++ b/integration_testing/features_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Features Service", Ordered, func() {

--- a/integration_testing/fix_suggestions_v2_test.go
+++ b/integration_testing/fix_suggestions_v2_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Fix Suggestions V2 Service", Ordered, func() {

--- a/integration_testing/github_provisioning_test.go
+++ b/integration_testing/github_provisioning_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("GithubProvisioning Service", Ordered, func() {

--- a/integration_testing/governance_reports_test.go
+++ b/integration_testing/governance_reports_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Governance Reports Service", Ordered, func() {

--- a/integration_testing/helpers/cleanup.go
+++ b/integration_testing/helpers/cleanup.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 // IgnoreNotFoundError returns nil if the error indicates a resource was not found,

--- a/integration_testing/helpers/client.go
+++ b/integration_testing/helpers/client.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 const (

--- a/integration_testing/hotspots_test.go
+++ b/integration_testing/hotspots_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Hotspots Service", Ordered, func() {

--- a/integration_testing/issues_test.go
+++ b/integration_testing/issues_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 const (

--- a/integration_testing/l10n_test.go
+++ b/integration_testing/l10n_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("L10N Service", Ordered, func() {

--- a/integration_testing/languages_test.go
+++ b/integration_testing/languages_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Languages Service", Ordered, func() {

--- a/integration_testing/measures_test.go
+++ b/integration_testing/measures_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Measures Service", Ordered, func() {

--- a/integration_testing/metrics_test.go
+++ b/integration_testing/metrics_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Metrics Service", Ordered, func() {

--- a/integration_testing/monitoring_test.go
+++ b/integration_testing/monitoring_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Monitoring Service", Ordered, func() {

--- a/integration_testing/navigation_test.go
+++ b/integration_testing/navigation_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Navigation Service", Ordered, func() {

--- a/integration_testing/new_code_periods_test.go
+++ b/integration_testing/new_code_periods_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("NewCodePeriods Service", Ordered, func() {

--- a/integration_testing/notifications_test.go
+++ b/integration_testing/notifications_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Notifications Service", Ordered, func() {

--- a/integration_testing/permissions_test.go
+++ b/integration_testing/permissions_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Permissions Service", Ordered, func() {

--- a/integration_testing/plugins_test.go
+++ b/integration_testing/plugins_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Plugins Service", Ordered, func() {

--- a/integration_testing/project_analyses_test.go
+++ b/integration_testing/project_analyses_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("ProjectAnalyses Service", Ordered, func() {

--- a/integration_testing/project_badges_test.go
+++ b/integration_testing/project_badges_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("ProjectBadges Service", Ordered, func() {

--- a/integration_testing/project_branches_test.go
+++ b/integration_testing/project_branches_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("ProjectBranches Service", Ordered, func() {

--- a/integration_testing/project_dump_test.go
+++ b/integration_testing/project_dump_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("ProjectDump Service", Ordered, func() {

--- a/integration_testing/project_links_test.go
+++ b/integration_testing/project_links_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("ProjectLinks Service", Ordered, func() {

--- a/integration_testing/project_pull_requests_test.go
+++ b/integration_testing/project_pull_requests_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Project Pull Requests Service", Ordered, func() {

--- a/integration_testing/project_tags_test.go
+++ b/integration_testing/project_tags_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("ProjectTags Service", Ordered, func() {

--- a/integration_testing/projects_test.go
+++ b/integration_testing/projects_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Projects Service", Ordered, func() {

--- a/integration_testing/push_test.go
+++ b/integration_testing/push_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Push Service", Ordered, func() {

--- a/integration_testing/qualitygates_test.go
+++ b/integration_testing/qualitygates_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Qualitygates Service", Ordered, func() {

--- a/integration_testing/qualityprofiles_test.go
+++ b/integration_testing/qualityprofiles_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Qualityprofiles Service", Ordered, func() {

--- a/integration_testing/regulatory_reports_test.go
+++ b/integration_testing/regulatory_reports_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Regulatory Reports Service", Ordered, func() {

--- a/integration_testing/rules_test.go
+++ b/integration_testing/rules_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Rules Service", Ordered, func() {

--- a/integration_testing/saml_test.go
+++ b/integration_testing/saml_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("SAML Service", Ordered, func() {

--- a/integration_testing/sca_v2_test.go
+++ b/integration_testing/sca_v2_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("SCA V2 Service", Ordered, func() {

--- a/integration_testing/scim_management_test.go
+++ b/integration_testing/scim_management_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("SCIM Management Service", Ordered, func() {

--- a/integration_testing/security_reports_test.go
+++ b/integration_testing/security_reports_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Security Reports Service", Ordered, func() {

--- a/integration_testing/server_test.go
+++ b/integration_testing/server_test.go
@@ -9,8 +9,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Server Service", Ordered, func() {

--- a/integration_testing/settings_test.go
+++ b/integration_testing/settings_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Settings Service", Ordered, func() {

--- a/integration_testing/sources_test.go
+++ b/integration_testing/sources_test.go
@@ -5,8 +5,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Sources Service", Ordered, func() {

--- a/integration_testing/suite_test.go
+++ b/integration_testing/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
 )
 
 var _ = BeforeSuite(func() {

--- a/integration_testing/support_test.go
+++ b/integration_testing/support_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Support Service", Ordered, func() {

--- a/integration_testing/system_test.go
+++ b/integration_testing/system_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("System Service", Ordered, func() {

--- a/integration_testing/user_groups_test.go
+++ b/integration_testing/user_groups_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("UserGroups Service", Ordered, func() {

--- a/integration_testing/user_tokens_test.go
+++ b/integration_testing/user_tokens_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("UserTokens Service", Ordered, func() {

--- a/integration_testing/users_test.go
+++ b/integration_testing/users_test.go
@@ -9,8 +9,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Users Service", Ordered, func() {

--- a/integration_testing/v2_analysis_test.go
+++ b/integration_testing/v2_analysis_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("V2 Analysis Service", Ordered, func() {

--- a/integration_testing/v2_authorizations_test.go
+++ b/integration_testing/v2_authorizations_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("V2 Authorizations Service", Ordered, func() {

--- a/integration_testing/v2_clean_code_policy_test.go
+++ b/integration_testing/v2_clean_code_policy_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("V2 Clean Code Policy Service", Ordered, func() {

--- a/integration_testing/v2_dop_translation_test.go
+++ b/integration_testing/v2_dop_translation_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("V2 DOP Translation Service", Ordered, func() {

--- a/integration_testing/v2_marketplace_test.go
+++ b/integration_testing/v2_marketplace_test.go
@@ -5,8 +5,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("V2 Marketplace Service", Ordered, func() {

--- a/integration_testing/v2_system_test.go
+++ b/integration_testing/v2_system_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("V2 System Service", Ordered, func() {

--- a/integration_testing/v2_users_test.go
+++ b/integration_testing/v2_users_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("V2 Users Management Service", Ordered, func() {

--- a/integration_testing/views_test.go
+++ b/integration_testing/views_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Views Service", Ordered, func() {

--- a/integration_testing/webhooks_test.go
+++ b/integration_testing/webhooks_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Webhooks Service", Ordered, func() {

--- a/integration_testing/webservices_test.go
+++ b/integration_testing/webservices_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/boxboxjason/sonarqube-client-go/integration_testing/helpers"
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/integration_testing/helpers"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 var _ = Describe("Webservices Service", Ordered, func() {

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/cli/pagination.go
+++ b/internal/cli/pagination.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"reflect"
 
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 const (

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -12,8 +12,8 @@ import (
 //
 //nolint:gochecknoglobals // intentional ldflags injection targets
 var (
-	version   string // set via -X github.com/boxboxjason/sonarqube-client-go/internal/cli.version=x.y.z
-	buildTime string // set via -X github.com/boxboxjason/sonarqube-client-go/internal/cli.buildTime=2006-01-02T15:04:05Z
+	version   string // set via -X github.com/boxboxjason/sonarqube-client-go/v2/internal/cli.version=x.y.z
+	buildTime string // set via -X github.com/boxboxjason/sonarqube-client-go/v2/internal/cli.buildTime=2006-01-02T15:04:05Z
 )
 
 // versionInfo returns a human-readable version string of the form:

--- a/sonar/example_observability_test.go
+++ b/sonar/example_observability_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 // roundTripperFunc adapts a function to http.RoundTripper.

--- a/sonar/example_test.go
+++ b/sonar/example_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/boxboxjason/sonarqube-client-go/sonar"
+	"github.com/boxboxjason/sonarqube-client-go/v2/sonar"
 )
 
 // Create a client with token authentication and search for projects.


### PR DESCRIPTION
### Description of your changes

This PR fixes an improper syntax that prevented v2+ package imports.

I have:

- [x] Followed the git conventional commit message format.
- [x] Made sure all changes are covered by proper tests, reaching a coverage of at least 80% when applicable.

### How has this code been tested

I have:

- [x] Made sure `make lint` passes to verify that the code style is correct.
- [x] Made sure `make test` passes to verify that the code is working as intended.
- [x] Made sure `make e2e` passes to verify that end-to-end tests pass against a real SonarQube instance.
- [ ] Added unit tests to cover the code changes.
- [ ] Added end-to-end tests if necessary.
